### PR TITLE
Disallow string as `regexp` argument to `String#{match,search}`

### DIFF
--- a/src/lib/es2020.string.d.ts
+++ b/src/lib/es2020.string.d.ts
@@ -4,7 +4,7 @@ interface String {
     /**
      * Matches a string with a regular expression, and returns an iterable of matches
      * containing the results of that search.
-     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     * @param regexp The regular expression to match against.
      */
     matchAll(regexp: RegExp): IterableIterator<RegExpExecArray>;
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -433,9 +433,9 @@ interface String {
 
     /**
      * Matches a string with a regular expression, and returns an array containing the results of that search.
-     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     * @param regexp The regular expression to match against.
      */
-    match(regexp: string | RegExp): RegExpMatchArray | null;
+    match(regexp: RegExp): RegExpMatchArray | null;
 
     /**
      * Replaces text in a string, using a regular expression or search string.
@@ -452,10 +452,10 @@ interface String {
     replace(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;
 
     /**
-     * Finds the first substring match in a regular expression search.
-     * @param regexp The regular expression pattern and applicable flags.
+     * Finds the index of the first substring match of a regular expression search.
+     * @param regexp The regular expression to match against.
      */
-    search(regexp: string | RegExp): number;
+    search(regexp: RegExp): number;
 
     /**
      * Returns a section of a string.

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -2259,7 +2259,7 @@ export class Session<TMessage = string> implements EventSender {
         // add edits necessary to properly indent the current line.
         if ((args.key === "\n") && ((!edits) || (edits.length === 0) || allEditsBeforePos(edits, position))) {
             const { lineText, absolutePosition } = scriptInfo.textStorage.getAbsolutePositionAndLineText(args.line);
-            if (lineText && lineText.search("\\S") < 0) {
+            if (lineText && lineText.search(/\S/) < 0) {
                 const preferredIndent = languageService.getIndentationAtPosition(file, position, formatOptions);
                 let hasIndent = 0;
                 let i: number, len: number;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2702,7 +2702,7 @@ export function createLanguageService(
                 pos = commentRange.end + 1;
             }
             else { // If it's not in a comment range, then we need to comment the uncommented portions.
-                const newPos = text.substring(pos, textRange.end).search(`(${openMultilineRegex})|(${closeMultilineRegex})`);
+                const newPos = text.substring(pos, textRange.end).search(new RegExp(`(${openMultilineRegex})|(${closeMultilineRegex})`));
 
                 isCommenting = insertComment !== undefined
                     ? insertComment

--- a/tests/baselines/reference/1.0lib-noErrors.js
+++ b/tests/baselines/reference/1.0lib-noErrors.js
@@ -318,13 +318,7 @@ interface String {
 
     /** 
       * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A variable name or string literal containing the regular expression pattern and flags.
-      */
-    match(regexp: string): string[];
-
-    /** 
-      * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     match(regexp: RegExp): string[];
 
@@ -358,13 +352,7 @@ interface String {
 
     /**
       * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
-      */
-    search(regexp: string): number;
-
-    /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     search(regexp: RegExp): number;
 
@@ -1143,7 +1131,8 @@ declare var Array: {
     <T>(...items: T[]): T[];
     isArray(arg: any): boolean;
     prototype: Array<any>;
-}
+}
+
 
 //// [1.0lib-noErrors.js]
 /* *****************************************************************************

--- a/tests/baselines/reference/1.0lib-noErrors.symbols
+++ b/tests/baselines/reference/1.0lib-noErrors.symbols
@@ -409,7 +409,7 @@ interface IArguments {
 }
 
 interface String {
->String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 429, 11))
+>String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 417, 11))
 
     /** Returns a string representation of a string. */
     toString(): string;
@@ -469,20 +469,12 @@ interface String {
 
     /** 
       * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A variable name or string literal containing the regular expression pattern and flags.
-      */
-    match(regexp: string): string[];
->match : Symbol(String.match, Decl(1.0lib-noErrors.ts, 313, 40), Decl(1.0lib-noErrors.ts, 319, 36))
->regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 319, 10))
-
-    /** 
-      * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     match(regexp: RegExp): string[];
->match : Symbol(String.match, Decl(1.0lib-noErrors.ts, 313, 40), Decl(1.0lib-noErrors.ts, 319, 36))
->regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 325, 10))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>match : Symbol(String.match, Decl(1.0lib-noErrors.ts, 313, 40))
+>regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 319, 10))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     /**
       * Replaces text in a string, using a regular expression or search string.
@@ -490,9 +482,9 @@ interface String {
       * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
       */
     replace(searchValue: string, replaceValue: string): string;
->replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 325, 36), Decl(1.0lib-noErrors.ts, 332, 63), Decl(1.0lib-noErrors.ts, 339, 102), Decl(1.0lib-noErrors.ts, 346, 63))
->searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 332, 12))
->replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 332, 32))
+>replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 319, 36), Decl(1.0lib-noErrors.ts, 326, 63), Decl(1.0lib-noErrors.ts, 333, 102), Decl(1.0lib-noErrors.ts, 340, 63))
+>searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 326, 12))
+>replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 326, 32))
 
     /**
       * Replaces text in a string, using a regular expression or search string.
@@ -500,11 +492,11 @@ interface String {
       * @param replaceValue A function that returns the replacement text.
       */
     replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
->replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 325, 36), Decl(1.0lib-noErrors.ts, 332, 63), Decl(1.0lib-noErrors.ts, 339, 102), Decl(1.0lib-noErrors.ts, 346, 63))
->searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 339, 12))
->replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 339, 32))
->substring : Symbol(substring, Decl(1.0lib-noErrors.ts, 339, 48))
->args : Symbol(args, Decl(1.0lib-noErrors.ts, 339, 66))
+>replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 319, 36), Decl(1.0lib-noErrors.ts, 326, 63), Decl(1.0lib-noErrors.ts, 333, 102), Decl(1.0lib-noErrors.ts, 340, 63))
+>searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 333, 12))
+>replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 333, 32))
+>substring : Symbol(substring, Decl(1.0lib-noErrors.ts, 333, 48))
+>args : Symbol(args, Decl(1.0lib-noErrors.ts, 333, 66))
 
     /**
       * Replaces text in a string, using a regular expression or search string.
@@ -512,10 +504,10 @@ interface String {
       * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
       */
     replace(searchValue: RegExp, replaceValue: string): string;
->replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 325, 36), Decl(1.0lib-noErrors.ts, 332, 63), Decl(1.0lib-noErrors.ts, 339, 102), Decl(1.0lib-noErrors.ts, 346, 63))
->searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 346, 12))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
->replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 346, 32))
+>replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 319, 36), Decl(1.0lib-noErrors.ts, 326, 63), Decl(1.0lib-noErrors.ts, 333, 102), Decl(1.0lib-noErrors.ts, 340, 63))
+>searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 340, 12))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
+>replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 340, 32))
 
     /**
       * Replaces text in a string, using a regular expression or search string.
@@ -523,29 +515,21 @@ interface String {
       * @param replaceValue A function that returns the replacement text.
       */
     replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
->replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 325, 36), Decl(1.0lib-noErrors.ts, 332, 63), Decl(1.0lib-noErrors.ts, 339, 102), Decl(1.0lib-noErrors.ts, 346, 63))
->searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 353, 12))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
->replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 353, 32))
->substring : Symbol(substring, Decl(1.0lib-noErrors.ts, 353, 48))
->args : Symbol(args, Decl(1.0lib-noErrors.ts, 353, 66))
+>replace : Symbol(String.replace, Decl(1.0lib-noErrors.ts, 319, 36), Decl(1.0lib-noErrors.ts, 326, 63), Decl(1.0lib-noErrors.ts, 333, 102), Decl(1.0lib-noErrors.ts, 340, 63))
+>searchValue : Symbol(searchValue, Decl(1.0lib-noErrors.ts, 347, 12))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
+>replaceValue : Symbol(replaceValue, Decl(1.0lib-noErrors.ts, 347, 32))
+>substring : Symbol(substring, Decl(1.0lib-noErrors.ts, 347, 48))
+>args : Symbol(args, Decl(1.0lib-noErrors.ts, 347, 66))
 
     /**
       * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
-      */
-    search(regexp: string): number;
->search : Symbol(String.search, Decl(1.0lib-noErrors.ts, 353, 102), Decl(1.0lib-noErrors.ts, 359, 35))
->regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 359, 11))
-
-    /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     search(regexp: RegExp): number;
->search : Symbol(String.search, Decl(1.0lib-noErrors.ts, 353, 102), Decl(1.0lib-noErrors.ts, 359, 35))
->regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 365, 11))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>search : Symbol(String.search, Decl(1.0lib-noErrors.ts, 347, 102))
+>regexp : Symbol(regexp, Decl(1.0lib-noErrors.ts, 353, 11))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     /**
       * Returns a section of a string.
@@ -554,9 +538,9 @@ interface String {
       * If this value is not specified, the substring continues to the end of stringObj.
       */
     slice(start?: number, end?: number): string;
->slice : Symbol(String.slice, Decl(1.0lib-noErrors.ts, 365, 35))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 373, 10))
->end : Symbol(end, Decl(1.0lib-noErrors.ts, 373, 25))
+>slice : Symbol(String.slice, Decl(1.0lib-noErrors.ts, 353, 35))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 361, 10))
+>end : Symbol(end, Decl(1.0lib-noErrors.ts, 361, 25))
 
     /**
       * Split a string into substrings using the specified separator and return them as an array.
@@ -564,9 +548,9 @@ interface String {
       * @param limit A value used to limit the number of elements returned in the array.
       */
     split(separator: string, limit?: number): string[];
->split : Symbol(String.split, Decl(1.0lib-noErrors.ts, 373, 48), Decl(1.0lib-noErrors.ts, 380, 55))
->separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 380, 10))
->limit : Symbol(limit, Decl(1.0lib-noErrors.ts, 380, 28))
+>split : Symbol(String.split, Decl(1.0lib-noErrors.ts, 361, 48), Decl(1.0lib-noErrors.ts, 368, 55))
+>separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 368, 10))
+>limit : Symbol(limit, Decl(1.0lib-noErrors.ts, 368, 28))
 
     /**
       * Split a string into substrings using the specified separator and return them as an array.
@@ -574,10 +558,10 @@ interface String {
       * @param limit A value used to limit the number of elements returned in the array.
       */
     split(separator: RegExp, limit?: number): string[];
->split : Symbol(String.split, Decl(1.0lib-noErrors.ts, 373, 48), Decl(1.0lib-noErrors.ts, 380, 55))
->separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 387, 10))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
->limit : Symbol(limit, Decl(1.0lib-noErrors.ts, 387, 28))
+>split : Symbol(String.split, Decl(1.0lib-noErrors.ts, 361, 48), Decl(1.0lib-noErrors.ts, 368, 55))
+>separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 375, 10))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
+>limit : Symbol(limit, Decl(1.0lib-noErrors.ts, 375, 28))
 
     /**
       * Returns the substring at the specified location within a String object. 
@@ -586,33 +570,33 @@ interface String {
       * If end is omitted, the characters from start through the end of the original string are returned.
       */
     substring(start: number, end?: number): string;
->substring : Symbol(String.substring, Decl(1.0lib-noErrors.ts, 387, 55))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 395, 14))
->end : Symbol(end, Decl(1.0lib-noErrors.ts, 395, 28))
+>substring : Symbol(String.substring, Decl(1.0lib-noErrors.ts, 375, 55))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 383, 14))
+>end : Symbol(end, Decl(1.0lib-noErrors.ts, 383, 28))
 
     /** Converts all the alphabetic characters in a string to lowercase. */
     toLowerCase(): string;
->toLowerCase : Symbol(String.toLowerCase, Decl(1.0lib-noErrors.ts, 395, 51))
+>toLowerCase : Symbol(String.toLowerCase, Decl(1.0lib-noErrors.ts, 383, 51))
 
     /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
     toLocaleLowerCase(): string;
->toLocaleLowerCase : Symbol(String.toLocaleLowerCase, Decl(1.0lib-noErrors.ts, 398, 26))
+>toLocaleLowerCase : Symbol(String.toLocaleLowerCase, Decl(1.0lib-noErrors.ts, 386, 26))
 
     /** Converts all the alphabetic characters in a string to uppercase. */
     toUpperCase(): string;
->toUpperCase : Symbol(String.toUpperCase, Decl(1.0lib-noErrors.ts, 401, 32))
+>toUpperCase : Symbol(String.toUpperCase, Decl(1.0lib-noErrors.ts, 389, 32))
 
     /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
     toLocaleUpperCase(): string;
->toLocaleUpperCase : Symbol(String.toLocaleUpperCase, Decl(1.0lib-noErrors.ts, 404, 26))
+>toLocaleUpperCase : Symbol(String.toLocaleUpperCase, Decl(1.0lib-noErrors.ts, 392, 26))
 
     /** Removes the leading and trailing white space and line terminator characters from a string. */
     trim(): string;
->trim : Symbol(String.trim, Decl(1.0lib-noErrors.ts, 407, 32))
+>trim : Symbol(String.trim, Decl(1.0lib-noErrors.ts, 395, 32))
 
     /** Returns the length of a String object. */
     length: number;
->length : Symbol(String.length, Decl(1.0lib-noErrors.ts, 410, 19))
+>length : Symbol(String.length, Decl(1.0lib-noErrors.ts, 398, 19))
 
     // IE extensions
     /**
@@ -621,169 +605,169 @@ interface String {
       * @param length The number of characters to include in the returned substring.
       */
     substr(from: number, length?: number): string;
->substr : Symbol(String.substr, Decl(1.0lib-noErrors.ts, 413, 19))
->from : Symbol(from, Decl(1.0lib-noErrors.ts, 421, 11))
->length : Symbol(length, Decl(1.0lib-noErrors.ts, 421, 24))
+>substr : Symbol(String.substr, Decl(1.0lib-noErrors.ts, 401, 19))
+>from : Symbol(from, Decl(1.0lib-noErrors.ts, 409, 11))
+>length : Symbol(length, Decl(1.0lib-noErrors.ts, 409, 24))
 
     [index: number]: string;
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 423, 5))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 411, 5))
 }
 
 /** 
   * Allows manipulation and formatting of text strings and determination and location of substrings within strings. 
   */
 declare var String: {
->String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 429, 11))
+>String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 417, 11))
 
     new (value?: any): String;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 430, 9))
->String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 429, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 418, 9))
+>String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 417, 11))
 
     (value?: any): string;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 431, 5))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 419, 5))
 
     prototype: String;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 431, 26))
->String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 429, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 419, 26))
+>String : Symbol(String, Decl(1.0lib-noErrors.ts, 271, 1), Decl(1.0lib-noErrors.ts, 417, 11))
 
     fromCharCode(...codes: number[]): string;
->fromCharCode : Symbol(fromCharCode, Decl(1.0lib-noErrors.ts, 432, 22))
->codes : Symbol(codes, Decl(1.0lib-noErrors.ts, 433, 17))
+>fromCharCode : Symbol(fromCharCode, Decl(1.0lib-noErrors.ts, 420, 22))
+>codes : Symbol(codes, Decl(1.0lib-noErrors.ts, 421, 17))
 }
 
 interface Boolean {
->Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 434, 1), Decl(1.0lib-noErrors.ts, 438, 11))
+>Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 422, 1), Decl(1.0lib-noErrors.ts, 426, 11))
 }
 declare var Boolean: {
->Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 434, 1), Decl(1.0lib-noErrors.ts, 438, 11))
+>Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 422, 1), Decl(1.0lib-noErrors.ts, 426, 11))
 
     new (value?: any): Boolean;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 439, 9))
->Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 434, 1), Decl(1.0lib-noErrors.ts, 438, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 427, 9))
+>Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 422, 1), Decl(1.0lib-noErrors.ts, 426, 11))
 
     (value?: any): boolean;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 440, 5))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 428, 5))
 
     prototype: Boolean;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 440, 27))
->Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 434, 1), Decl(1.0lib-noErrors.ts, 438, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 428, 27))
+>Boolean : Symbol(Boolean, Decl(1.0lib-noErrors.ts, 422, 1), Decl(1.0lib-noErrors.ts, 426, 11))
 }
 
 interface Number {
->Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 442, 1), Decl(1.0lib-noErrors.ts, 471, 11))
+>Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 430, 1), Decl(1.0lib-noErrors.ts, 459, 11))
 
     /**
       * Returns a string representation of an object.
       * @param radix Specifies a radix for converting numeric values to strings. This value is only used for numbers.
       */
     toString(radix?: number): string;
->toString : Symbol(Number.toString, Decl(1.0lib-noErrors.ts, 444, 18))
->radix : Symbol(radix, Decl(1.0lib-noErrors.ts, 449, 13))
+>toString : Symbol(Number.toString, Decl(1.0lib-noErrors.ts, 432, 18))
+>radix : Symbol(radix, Decl(1.0lib-noErrors.ts, 437, 13))
 
     /** 
       * Returns a string representing a number in fixed-point notation.
       * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
       */
     toFixed(fractionDigits?: number): string;
->toFixed : Symbol(Number.toFixed, Decl(1.0lib-noErrors.ts, 449, 37))
->fractionDigits : Symbol(fractionDigits, Decl(1.0lib-noErrors.ts, 455, 12))
+>toFixed : Symbol(Number.toFixed, Decl(1.0lib-noErrors.ts, 437, 37))
+>fractionDigits : Symbol(fractionDigits, Decl(1.0lib-noErrors.ts, 443, 12))
 
     /**
       * Returns a string containing a number represented in exponential notation.
       * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
       */
     toExponential(fractionDigits?: number): string;
->toExponential : Symbol(Number.toExponential, Decl(1.0lib-noErrors.ts, 455, 45))
->fractionDigits : Symbol(fractionDigits, Decl(1.0lib-noErrors.ts, 461, 18))
+>toExponential : Symbol(Number.toExponential, Decl(1.0lib-noErrors.ts, 443, 45))
+>fractionDigits : Symbol(fractionDigits, Decl(1.0lib-noErrors.ts, 449, 18))
 
     /**
       * Returns a string containing a number represented either in exponential or fixed-point notation with a specified number of digits.
       * @param precision Number of significant digits. Must be in the range 1 - 21, inclusive.
       */
     toPrecision(precision?: number): string;
->toPrecision : Symbol(Number.toPrecision, Decl(1.0lib-noErrors.ts, 461, 51))
->precision : Symbol(precision, Decl(1.0lib-noErrors.ts, 467, 16))
+>toPrecision : Symbol(Number.toPrecision, Decl(1.0lib-noErrors.ts, 449, 51))
+>precision : Symbol(precision, Decl(1.0lib-noErrors.ts, 455, 16))
 }
 
 /** An object that represents a number of any kind. All JavaScript numbers are 64-bit floating-point numbers. */
 declare var Number: {
->Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 442, 1), Decl(1.0lib-noErrors.ts, 471, 11))
+>Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 430, 1), Decl(1.0lib-noErrors.ts, 459, 11))
 
     new (value?: any): Number;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 472, 9))
->Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 442, 1), Decl(1.0lib-noErrors.ts, 471, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 460, 9))
+>Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 430, 1), Decl(1.0lib-noErrors.ts, 459, 11))
 
     (value?: any): number;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 473, 5))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 461, 5))
 
     prototype: Number;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 473, 26))
->Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 442, 1), Decl(1.0lib-noErrors.ts, 471, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 461, 26))
+>Number : Symbol(Number, Decl(1.0lib-noErrors.ts, 430, 1), Decl(1.0lib-noErrors.ts, 459, 11))
 
     /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
     MAX_VALUE: number;
->MAX_VALUE : Symbol(MAX_VALUE, Decl(1.0lib-noErrors.ts, 474, 22))
+>MAX_VALUE : Symbol(MAX_VALUE, Decl(1.0lib-noErrors.ts, 462, 22))
 
     /** The closest number to zero that can be represented in JavaScript. Equal to approximately 5.00E-324. */
     MIN_VALUE: number;
->MIN_VALUE : Symbol(MIN_VALUE, Decl(1.0lib-noErrors.ts, 477, 22))
+>MIN_VALUE : Symbol(MIN_VALUE, Decl(1.0lib-noErrors.ts, 465, 22))
 
     /** 
       * A value that is not a number.
       * In equality comparisons, NaN does not equal any value, including itself. To test whether a value is equivalent to NaN, use the isNaN function.
       */
     NaN: number;
->NaN : Symbol(NaN, Decl(1.0lib-noErrors.ts, 480, 22))
+>NaN : Symbol(NaN, Decl(1.0lib-noErrors.ts, 468, 22))
 
     /** 
       * A value that is less than the largest negative number that can be represented in JavaScript.
       * JavaScript displays NEGATIVE_INFINITY values as -infinity. 
       */
     NEGATIVE_INFINITY: number;
->NEGATIVE_INFINITY : Symbol(NEGATIVE_INFINITY, Decl(1.0lib-noErrors.ts, 486, 16))
+>NEGATIVE_INFINITY : Symbol(NEGATIVE_INFINITY, Decl(1.0lib-noErrors.ts, 474, 16))
 
     /**
       * A value greater than the largest number that can be represented in JavaScript. 
       * JavaScript displays POSITIVE_INFINITY values as infinity. 
       */
     POSITIVE_INFINITY: number;
->POSITIVE_INFINITY : Symbol(POSITIVE_INFINITY, Decl(1.0lib-noErrors.ts, 492, 30))
+>POSITIVE_INFINITY : Symbol(POSITIVE_INFINITY, Decl(1.0lib-noErrors.ts, 480, 30))
 }
 
 interface Math {
->Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 499, 1), Decl(1.0lib-noErrors.ts, 610, 11))
+>Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 487, 1), Decl(1.0lib-noErrors.ts, 598, 11))
 
     /** The mathematical constant e. This is Euler's number, the base of natural logarithms. */
     E: number;
->E : Symbol(Math.E, Decl(1.0lib-noErrors.ts, 501, 16))
+>E : Symbol(Math.E, Decl(1.0lib-noErrors.ts, 489, 16))
 
     /** The natural logarithm of 10. */
     LN10: number;
->LN10 : Symbol(Math.LN10, Decl(1.0lib-noErrors.ts, 503, 14))
+>LN10 : Symbol(Math.LN10, Decl(1.0lib-noErrors.ts, 491, 14))
 
     /** The natural logarithm of 2. */
     LN2: number;
->LN2 : Symbol(Math.LN2, Decl(1.0lib-noErrors.ts, 505, 17))
+>LN2 : Symbol(Math.LN2, Decl(1.0lib-noErrors.ts, 493, 17))
 
     /** The base-2 logarithm of e. */
     LOG2E: number;
->LOG2E : Symbol(Math.LOG2E, Decl(1.0lib-noErrors.ts, 507, 16))
+>LOG2E : Symbol(Math.LOG2E, Decl(1.0lib-noErrors.ts, 495, 16))
 
     /** The base-10 logarithm of e. */
     LOG10E: number;
->LOG10E : Symbol(Math.LOG10E, Decl(1.0lib-noErrors.ts, 509, 18))
+>LOG10E : Symbol(Math.LOG10E, Decl(1.0lib-noErrors.ts, 497, 18))
 
     /** Pi. This is the ratio of the circumference of a circle to its diameter. */
     PI: number;
->PI : Symbol(Math.PI, Decl(1.0lib-noErrors.ts, 511, 19))
+>PI : Symbol(Math.PI, Decl(1.0lib-noErrors.ts, 499, 19))
 
     /** The square root of 0.5, or, equivalently, one divided by the square root of 2. */
     SQRT1_2: number;
->SQRT1_2 : Symbol(Math.SQRT1_2, Decl(1.0lib-noErrors.ts, 513, 15))
+>SQRT1_2 : Symbol(Math.SQRT1_2, Decl(1.0lib-noErrors.ts, 501, 15))
 
     /** The square root of 2. */
     SQRT2: number;
->SQRT2 : Symbol(Math.SQRT2, Decl(1.0lib-noErrors.ts, 515, 20))
+>SQRT2 : Symbol(Math.SQRT2, Decl(1.0lib-noErrors.ts, 503, 20))
 
     /**
       * Returns the absolute value of a number (the value without regard to whether it is positive or negative). 
@@ -791,32 +775,32 @@ interface Math {
       * @param x A numeric expression for which the absolute value is needed.
       */
     abs(x: number): number;
->abs : Symbol(Math.abs, Decl(1.0lib-noErrors.ts, 517, 18))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 523, 8))
+>abs : Symbol(Math.abs, Decl(1.0lib-noErrors.ts, 505, 18))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 511, 8))
 
     /**
       * Returns the arc cosine (or inverse cosine) of a number. 
       * @param x A numeric expression.
       */
     acos(x: number): number;
->acos : Symbol(Math.acos, Decl(1.0lib-noErrors.ts, 523, 27))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 528, 9))
+>acos : Symbol(Math.acos, Decl(1.0lib-noErrors.ts, 511, 27))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 516, 9))
 
     /** 
       * Returns the arcsine of a number. 
       * @param x A numeric expression.
       */
     asin(x: number): number;
->asin : Symbol(Math.asin, Decl(1.0lib-noErrors.ts, 528, 28))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 533, 9))
+>asin : Symbol(Math.asin, Decl(1.0lib-noErrors.ts, 516, 28))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 521, 9))
 
     /**
       * Returns the arctangent of a number. 
       * @param x A numeric expression for which the arctangent is needed.
       */
     atan(x: number): number;
->atan : Symbol(Math.atan, Decl(1.0lib-noErrors.ts, 533, 28))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 538, 9))
+>atan : Symbol(Math.atan, Decl(1.0lib-noErrors.ts, 521, 28))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 526, 9))
 
     /**
       * Returns the angle (in radians) from the X axis to a point (y,x).
@@ -824,65 +808,65 @@ interface Math {
       * @param x A numeric expression representing the cartesian x-coordinate.
       */
     atan2(y: number, x: number): number;
->atan2 : Symbol(Math.atan2, Decl(1.0lib-noErrors.ts, 538, 28))
->y : Symbol(y, Decl(1.0lib-noErrors.ts, 544, 10))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 544, 20))
+>atan2 : Symbol(Math.atan2, Decl(1.0lib-noErrors.ts, 526, 28))
+>y : Symbol(y, Decl(1.0lib-noErrors.ts, 532, 10))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 532, 20))
 
     /**
       * Returns the smallest number greater than or equal to its numeric argument. 
       * @param x A numeric expression.
       */
     ceil(x: number): number;
->ceil : Symbol(Math.ceil, Decl(1.0lib-noErrors.ts, 544, 40))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 549, 9))
+>ceil : Symbol(Math.ceil, Decl(1.0lib-noErrors.ts, 532, 40))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 537, 9))
 
     /**
       * Returns the cosine of a number. 
       * @param x A numeric expression that contains an angle measured in radians.
       */
     cos(x: number): number;
->cos : Symbol(Math.cos, Decl(1.0lib-noErrors.ts, 549, 28))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 554, 8))
+>cos : Symbol(Math.cos, Decl(1.0lib-noErrors.ts, 537, 28))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 542, 8))
 
     /**
       * Returns e (the base of natural logarithms) raised to a power. 
       * @param x A numeric expression representing the power of e.
       */
     exp(x: number): number;
->exp : Symbol(Math.exp, Decl(1.0lib-noErrors.ts, 554, 27))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 559, 8))
+>exp : Symbol(Math.exp, Decl(1.0lib-noErrors.ts, 542, 27))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 547, 8))
 
     /**
       * Returns the greatest number less than or equal to its numeric argument. 
       * @param x A numeric expression.
       */
     floor(x: number): number;
->floor : Symbol(Math.floor, Decl(1.0lib-noErrors.ts, 559, 27))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 564, 10))
+>floor : Symbol(Math.floor, Decl(1.0lib-noErrors.ts, 547, 27))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 552, 10))
 
     /**
       * Returns the natural logarithm (base e) of a number. 
       * @param x A numeric expression.
       */
     log(x: number): number;
->log : Symbol(Math.log, Decl(1.0lib-noErrors.ts, 564, 29))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 569, 8))
+>log : Symbol(Math.log, Decl(1.0lib-noErrors.ts, 552, 29))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 557, 8))
 
     /**
       * Returns the larger of a set of supplied numeric expressions. 
       * @param values Numeric expressions to be evaluated.
       */
     max(...values: number[]): number;
->max : Symbol(Math.max, Decl(1.0lib-noErrors.ts, 569, 27))
->values : Symbol(values, Decl(1.0lib-noErrors.ts, 574, 8))
+>max : Symbol(Math.max, Decl(1.0lib-noErrors.ts, 557, 27))
+>values : Symbol(values, Decl(1.0lib-noErrors.ts, 562, 8))
 
     /**
       * Returns the smaller of a set of supplied numeric expressions. 
       * @param values Numeric expressions to be evaluated.
       */
     min(...values: number[]): number;
->min : Symbol(Math.min, Decl(1.0lib-noErrors.ts, 574, 37))
->values : Symbol(values, Decl(1.0lib-noErrors.ts, 579, 8))
+>min : Symbol(Math.min, Decl(1.0lib-noErrors.ts, 562, 37))
+>values : Symbol(values, Decl(1.0lib-noErrors.ts, 567, 8))
 
     /**
       * Returns the value of a base expression taken to a specified power. 
@@ -890,178 +874,178 @@ interface Math {
       * @param y The exponent value of the expression.
       */
     pow(x: number, y: number): number;
->pow : Symbol(Math.pow, Decl(1.0lib-noErrors.ts, 579, 37))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 585, 8))
->y : Symbol(y, Decl(1.0lib-noErrors.ts, 585, 18))
+>pow : Symbol(Math.pow, Decl(1.0lib-noErrors.ts, 567, 37))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 573, 8))
+>y : Symbol(y, Decl(1.0lib-noErrors.ts, 573, 18))
 
     /** Returns a pseudorandom number between 0 and 1. */
     random(): number;
->random : Symbol(Math.random, Decl(1.0lib-noErrors.ts, 585, 38))
+>random : Symbol(Math.random, Decl(1.0lib-noErrors.ts, 573, 38))
 
     /** 
       * Returns a supplied numeric expression rounded to the nearest number.
       * @param x The value to be rounded to the nearest number.
       */
     round(x: number): number;
->round : Symbol(Math.round, Decl(1.0lib-noErrors.ts, 587, 21))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 592, 10))
+>round : Symbol(Math.round, Decl(1.0lib-noErrors.ts, 575, 21))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 580, 10))
 
     /**
       * Returns the sine of a number.
       * @param x A numeric expression that contains an angle measured in radians.
       */
     sin(x: number): number;
->sin : Symbol(Math.sin, Decl(1.0lib-noErrors.ts, 592, 29))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 597, 8))
+>sin : Symbol(Math.sin, Decl(1.0lib-noErrors.ts, 580, 29))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 585, 8))
 
     /**
       * Returns the square root of a number.
       * @param x A numeric expression.
       */
     sqrt(x: number): number;
->sqrt : Symbol(Math.sqrt, Decl(1.0lib-noErrors.ts, 597, 27))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 602, 9))
+>sqrt : Symbol(Math.sqrt, Decl(1.0lib-noErrors.ts, 585, 27))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 590, 9))
 
     /**
       * Returns the tangent of a number.
       * @param x A numeric expression that contains an angle measured in radians.
       */
     tan(x: number): number;
->tan : Symbol(Math.tan, Decl(1.0lib-noErrors.ts, 602, 28))
->x : Symbol(x, Decl(1.0lib-noErrors.ts, 607, 8))
+>tan : Symbol(Math.tan, Decl(1.0lib-noErrors.ts, 590, 28))
+>x : Symbol(x, Decl(1.0lib-noErrors.ts, 595, 8))
 }
 /** An intrinsic object that provides basic mathematics functionality and constants. */
 declare var Math: Math;
->Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 499, 1), Decl(1.0lib-noErrors.ts, 610, 11))
->Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 499, 1), Decl(1.0lib-noErrors.ts, 610, 11))
+>Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 487, 1), Decl(1.0lib-noErrors.ts, 598, 11))
+>Math : Symbol(Math, Decl(1.0lib-noErrors.ts, 487, 1), Decl(1.0lib-noErrors.ts, 598, 11))
 
 /** Enables basic storage and retrieval of dates and times. */
 interface Date {
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     /** Returns a string representation of a date. The format of the string depends on the locale. */
     toString(): string;
->toString : Symbol(Date.toString, Decl(1.0lib-noErrors.ts, 613, 16))
+>toString : Symbol(Date.toString, Decl(1.0lib-noErrors.ts, 601, 16))
 
     /** Returns a date as a string value. */
     toDateString(): string;
->toDateString : Symbol(Date.toDateString, Decl(1.0lib-noErrors.ts, 615, 23))
+>toDateString : Symbol(Date.toDateString, Decl(1.0lib-noErrors.ts, 603, 23))
 
     /** Returns a time as a string value. */
     toTimeString(): string;
->toTimeString : Symbol(Date.toTimeString, Decl(1.0lib-noErrors.ts, 617, 27))
+>toTimeString : Symbol(Date.toTimeString, Decl(1.0lib-noErrors.ts, 605, 27))
 
     /** Returns a value as a string value appropriate to the host environment's current locale. */
     toLocaleString(): string;
->toLocaleString : Symbol(Date.toLocaleString, Decl(1.0lib-noErrors.ts, 619, 27))
+>toLocaleString : Symbol(Date.toLocaleString, Decl(1.0lib-noErrors.ts, 607, 27))
 
     /** Returns a date as a string value appropriate to the host environment's current locale. */
     toLocaleDateString(): string;
->toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(1.0lib-noErrors.ts, 621, 29))
+>toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(1.0lib-noErrors.ts, 609, 29))
 
     /** Returns a time as a string value appropriate to the host environment's current locale. */
     toLocaleTimeString(): string;
->toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(1.0lib-noErrors.ts, 623, 33))
+>toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(1.0lib-noErrors.ts, 611, 33))
 
     /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
     valueOf(): number;
->valueOf : Symbol(Date.valueOf, Decl(1.0lib-noErrors.ts, 625, 33))
+>valueOf : Symbol(Date.valueOf, Decl(1.0lib-noErrors.ts, 613, 33))
 
     /** Gets the time value in milliseconds. */
     getTime(): number;
->getTime : Symbol(Date.getTime, Decl(1.0lib-noErrors.ts, 627, 22))
+>getTime : Symbol(Date.getTime, Decl(1.0lib-noErrors.ts, 615, 22))
 
     /** Gets the year, using local time. */
     getFullYear(): number;
->getFullYear : Symbol(Date.getFullYear, Decl(1.0lib-noErrors.ts, 629, 22))
+>getFullYear : Symbol(Date.getFullYear, Decl(1.0lib-noErrors.ts, 617, 22))
 
     /** Gets the year using Universal Coordinated Time (UTC). */
     getUTCFullYear(): number;
->getUTCFullYear : Symbol(Date.getUTCFullYear, Decl(1.0lib-noErrors.ts, 631, 26))
+>getUTCFullYear : Symbol(Date.getUTCFullYear, Decl(1.0lib-noErrors.ts, 619, 26))
 
     /** Gets the month, using local time. */
     getMonth(): number;
->getMonth : Symbol(Date.getMonth, Decl(1.0lib-noErrors.ts, 633, 29))
+>getMonth : Symbol(Date.getMonth, Decl(1.0lib-noErrors.ts, 621, 29))
 
     /** Gets the month of a Date object using Universal Coordinated Time (UTC). */
     getUTCMonth(): number;
->getUTCMonth : Symbol(Date.getUTCMonth, Decl(1.0lib-noErrors.ts, 635, 23))
+>getUTCMonth : Symbol(Date.getUTCMonth, Decl(1.0lib-noErrors.ts, 623, 23))
 
     /** Gets the day-of-the-month, using local time. */
     getDate(): number;
->getDate : Symbol(Date.getDate, Decl(1.0lib-noErrors.ts, 637, 26))
+>getDate : Symbol(Date.getDate, Decl(1.0lib-noErrors.ts, 625, 26))
 
     /** Gets the day-of-the-month, using Universal Coordinated Time (UTC). */
     getUTCDate(): number;
->getUTCDate : Symbol(Date.getUTCDate, Decl(1.0lib-noErrors.ts, 639, 22))
+>getUTCDate : Symbol(Date.getUTCDate, Decl(1.0lib-noErrors.ts, 627, 22))
 
     /** Gets the day of the week, using local time. */
     getDay(): number;
->getDay : Symbol(Date.getDay, Decl(1.0lib-noErrors.ts, 641, 25))
+>getDay : Symbol(Date.getDay, Decl(1.0lib-noErrors.ts, 629, 25))
 
     /** Gets the day of the week using Universal Coordinated Time (UTC). */
     getUTCDay(): number;
->getUTCDay : Symbol(Date.getUTCDay, Decl(1.0lib-noErrors.ts, 643, 21))
+>getUTCDay : Symbol(Date.getUTCDay, Decl(1.0lib-noErrors.ts, 631, 21))
 
     /** Gets the hours in a date, using local time. */
     getHours(): number;
->getHours : Symbol(Date.getHours, Decl(1.0lib-noErrors.ts, 645, 24))
+>getHours : Symbol(Date.getHours, Decl(1.0lib-noErrors.ts, 633, 24))
 
     /** Gets the hours value in a Date object using Universal Coordinated Time (UTC). */
     getUTCHours(): number;
->getUTCHours : Symbol(Date.getUTCHours, Decl(1.0lib-noErrors.ts, 647, 23))
+>getUTCHours : Symbol(Date.getUTCHours, Decl(1.0lib-noErrors.ts, 635, 23))
 
     /** Gets the minutes of a Date object, using local time. */
     getMinutes(): number;
->getMinutes : Symbol(Date.getMinutes, Decl(1.0lib-noErrors.ts, 649, 26))
+>getMinutes : Symbol(Date.getMinutes, Decl(1.0lib-noErrors.ts, 637, 26))
 
     /** Gets the minutes of a Date object using Universal Coordinated Time (UTC). */
     getUTCMinutes(): number;
->getUTCMinutes : Symbol(Date.getUTCMinutes, Decl(1.0lib-noErrors.ts, 651, 25))
+>getUTCMinutes : Symbol(Date.getUTCMinutes, Decl(1.0lib-noErrors.ts, 639, 25))
 
     /** Gets the seconds of a Date object, using local time. */
     getSeconds(): number;
->getSeconds : Symbol(Date.getSeconds, Decl(1.0lib-noErrors.ts, 653, 28))
+>getSeconds : Symbol(Date.getSeconds, Decl(1.0lib-noErrors.ts, 641, 28))
 
     /** Gets the seconds of a Date object using Universal Coordinated Time (UTC). */
     getUTCSeconds(): number;
->getUTCSeconds : Symbol(Date.getUTCSeconds, Decl(1.0lib-noErrors.ts, 655, 25))
+>getUTCSeconds : Symbol(Date.getUTCSeconds, Decl(1.0lib-noErrors.ts, 643, 25))
 
     /** Gets the milliseconds of a Date, using local time. */
     getMilliseconds(): number;
->getMilliseconds : Symbol(Date.getMilliseconds, Decl(1.0lib-noErrors.ts, 657, 28))
+>getMilliseconds : Symbol(Date.getMilliseconds, Decl(1.0lib-noErrors.ts, 645, 28))
 
     /** Gets the milliseconds of a Date object using Universal Coordinated Time (UTC). */
     getUTCMilliseconds(): number;
->getUTCMilliseconds : Symbol(Date.getUTCMilliseconds, Decl(1.0lib-noErrors.ts, 659, 30))
+>getUTCMilliseconds : Symbol(Date.getUTCMilliseconds, Decl(1.0lib-noErrors.ts, 647, 30))
 
     /** Gets the difference in minutes between the time on the local computer and Universal Coordinated Time (UTC). */
     getTimezoneOffset(): number;
->getTimezoneOffset : Symbol(Date.getTimezoneOffset, Decl(1.0lib-noErrors.ts, 661, 33))
+>getTimezoneOffset : Symbol(Date.getTimezoneOffset, Decl(1.0lib-noErrors.ts, 649, 33))
 
     /** 
       * Sets the date and time value in the Date object.
       * @param time A numeric value representing the number of elapsed milliseconds since midnight, January 1, 1970 GMT. 
       */
     setTime(time: number): number;
->setTime : Symbol(Date.setTime, Decl(1.0lib-noErrors.ts, 663, 32))
->time : Symbol(time, Decl(1.0lib-noErrors.ts, 668, 12))
+>setTime : Symbol(Date.setTime, Decl(1.0lib-noErrors.ts, 651, 32))
+>time : Symbol(time, Decl(1.0lib-noErrors.ts, 656, 12))
 
     /**
       * Sets the milliseconds value in the Date object using local time. 
       * @param ms A numeric value equal to the millisecond value.
       */
     setMilliseconds(ms: number): number;
->setMilliseconds : Symbol(Date.setMilliseconds, Decl(1.0lib-noErrors.ts, 668, 34))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 673, 20))
+>setMilliseconds : Symbol(Date.setMilliseconds, Decl(1.0lib-noErrors.ts, 656, 34))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 661, 20))
 
     /** 
       * Sets the milliseconds value in the Date object using Universal Coordinated Time (UTC).
       * @param ms A numeric value equal to the millisecond value. 
       */
     setUTCMilliseconds(ms: number): number;
->setUTCMilliseconds : Symbol(Date.setUTCMilliseconds, Decl(1.0lib-noErrors.ts, 673, 40))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 678, 23))
+>setUTCMilliseconds : Symbol(Date.setUTCMilliseconds, Decl(1.0lib-noErrors.ts, 661, 40))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 666, 23))
 
     /**
       * Sets the seconds value in the Date object using local time. 
@@ -1069,9 +1053,9 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setSeconds(sec: number, ms?: number): number;
->setSeconds : Symbol(Date.setSeconds, Decl(1.0lib-noErrors.ts, 678, 43))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 685, 15))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 685, 27))
+>setSeconds : Symbol(Date.setSeconds, Decl(1.0lib-noErrors.ts, 666, 43))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 673, 15))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 673, 27))
 
     /**
       * Sets the seconds value in the Date object using Universal Coordinated Time (UTC).
@@ -1079,9 +1063,9 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setUTCSeconds(sec: number, ms?: number): number;
->setUTCSeconds : Symbol(Date.setUTCSeconds, Decl(1.0lib-noErrors.ts, 685, 49))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 691, 18))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 691, 30))
+>setUTCSeconds : Symbol(Date.setUTCSeconds, Decl(1.0lib-noErrors.ts, 673, 49))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 679, 18))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 679, 30))
 
     /**
       * Sets the minutes value in the Date object using local time. 
@@ -1090,10 +1074,10 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setMinutes(min: number, sec?: number, ms?: number): number;
->setMinutes : Symbol(Date.setMinutes, Decl(1.0lib-noErrors.ts, 691, 52))
->min : Symbol(min, Decl(1.0lib-noErrors.ts, 698, 15))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 698, 27))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 698, 41))
+>setMinutes : Symbol(Date.setMinutes, Decl(1.0lib-noErrors.ts, 679, 52))
+>min : Symbol(min, Decl(1.0lib-noErrors.ts, 686, 15))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 686, 27))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 686, 41))
 
     /**
       * Sets the minutes value in the Date object using Universal Coordinated Time (UTC).
@@ -1102,10 +1086,10 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setUTCMinutes(min: number, sec?: number, ms?: number): number;
->setUTCMinutes : Symbol(Date.setUTCMinutes, Decl(1.0lib-noErrors.ts, 698, 63))
->min : Symbol(min, Decl(1.0lib-noErrors.ts, 705, 18))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 705, 30))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 705, 44))
+>setUTCMinutes : Symbol(Date.setUTCMinutes, Decl(1.0lib-noErrors.ts, 686, 63))
+>min : Symbol(min, Decl(1.0lib-noErrors.ts, 693, 18))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 693, 30))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 693, 44))
 
     /**
       * Sets the hour value in the Date object using local time.
@@ -1115,11 +1099,11 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setHours(hours: number, min?: number, sec?: number, ms?: number): number;
->setHours : Symbol(Date.setHours, Decl(1.0lib-noErrors.ts, 705, 66))
->hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 713, 13))
->min : Symbol(min, Decl(1.0lib-noErrors.ts, 713, 27))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 713, 41))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 713, 55))
+>setHours : Symbol(Date.setHours, Decl(1.0lib-noErrors.ts, 693, 66))
+>hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 701, 13))
+>min : Symbol(min, Decl(1.0lib-noErrors.ts, 701, 27))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 701, 41))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 701, 55))
 
     /**
       * Sets the hours value in the Date object using Universal Coordinated Time (UTC).
@@ -1129,27 +1113,27 @@ interface Date {
       * @param ms A numeric value equal to the milliseconds value.
       */
     setUTCHours(hours: number, min?: number, sec?: number, ms?: number): number;
->setUTCHours : Symbol(Date.setUTCHours, Decl(1.0lib-noErrors.ts, 713, 77))
->hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 721, 16))
->min : Symbol(min, Decl(1.0lib-noErrors.ts, 721, 30))
->sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 721, 44))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 721, 58))
+>setUTCHours : Symbol(Date.setUTCHours, Decl(1.0lib-noErrors.ts, 701, 77))
+>hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 709, 16))
+>min : Symbol(min, Decl(1.0lib-noErrors.ts, 709, 30))
+>sec : Symbol(sec, Decl(1.0lib-noErrors.ts, 709, 44))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 709, 58))
 
     /**
       * Sets the numeric day-of-the-month value of the Date object using local time. 
       * @param date A numeric value equal to the day of the month.
       */
     setDate(date: number): number;
->setDate : Symbol(Date.setDate, Decl(1.0lib-noErrors.ts, 721, 80))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 726, 12))
+>setDate : Symbol(Date.setDate, Decl(1.0lib-noErrors.ts, 709, 80))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 714, 12))
 
     /** 
       * Sets the numeric day of the month in the Date object using Universal Coordinated Time (UTC).
       * @param date A numeric value equal to the day of the month. 
       */
     setUTCDate(date: number): number;
->setUTCDate : Symbol(Date.setUTCDate, Decl(1.0lib-noErrors.ts, 726, 34))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 731, 15))
+>setUTCDate : Symbol(Date.setUTCDate, Decl(1.0lib-noErrors.ts, 714, 34))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 719, 15))
 
     /** 
       * Sets the month value in the Date object using local time. 
@@ -1157,9 +1141,9 @@ interface Date {
       * @param date A numeric value representing the day of the month. If this value is not supplied, the value from a call to the getDate method is used.
       */
     setMonth(month: number, date?: number): number;
->setMonth : Symbol(Date.setMonth, Decl(1.0lib-noErrors.ts, 731, 37))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 737, 13))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 737, 27))
+>setMonth : Symbol(Date.setMonth, Decl(1.0lib-noErrors.ts, 719, 37))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 725, 13))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 725, 27))
 
     /**
       * Sets the month value in the Date object using Universal Coordinated Time (UTC).
@@ -1167,9 +1151,9 @@ interface Date {
       * @param date A numeric value representing the day of the month. If it is not supplied, the value from a call to the getUTCDate method is used.
       */
     setUTCMonth(month: number, date?: number): number;
->setUTCMonth : Symbol(Date.setUTCMonth, Decl(1.0lib-noErrors.ts, 737, 51))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 743, 16))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 743, 30))
+>setUTCMonth : Symbol(Date.setUTCMonth, Decl(1.0lib-noErrors.ts, 725, 51))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 731, 16))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 731, 30))
 
     /**
       * Sets the year of the Date object using local time.
@@ -1178,10 +1162,10 @@ interface Date {
       * @param date A numeric value equal for the day of the month.
       */
     setFullYear(year: number, month?: number, date?: number): number;
->setFullYear : Symbol(Date.setFullYear, Decl(1.0lib-noErrors.ts, 743, 54))
->year : Symbol(year, Decl(1.0lib-noErrors.ts, 750, 16))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 750, 29))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 750, 45))
+>setFullYear : Symbol(Date.setFullYear, Decl(1.0lib-noErrors.ts, 731, 54))
+>year : Symbol(year, Decl(1.0lib-noErrors.ts, 738, 16))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 738, 29))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 738, 45))
 
     /**
       * Sets the year value in the Date object using Universal Coordinated Time (UTC).
@@ -1190,61 +1174,61 @@ interface Date {
       * @param date A numeric value equal to the day of the month.
       */
     setUTCFullYear(year: number, month?: number, date?: number): number;
->setUTCFullYear : Symbol(Date.setUTCFullYear, Decl(1.0lib-noErrors.ts, 750, 69))
->year : Symbol(year, Decl(1.0lib-noErrors.ts, 757, 19))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 757, 32))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 757, 48))
+>setUTCFullYear : Symbol(Date.setUTCFullYear, Decl(1.0lib-noErrors.ts, 738, 69))
+>year : Symbol(year, Decl(1.0lib-noErrors.ts, 745, 19))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 745, 32))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 745, 48))
 
     /** Returns a date converted to a string using Universal Coordinated Time (UTC). */
     toUTCString(): string;
->toUTCString : Symbol(Date.toUTCString, Decl(1.0lib-noErrors.ts, 757, 72))
+>toUTCString : Symbol(Date.toUTCString, Decl(1.0lib-noErrors.ts, 745, 72))
 
     /** Returns a date as a string value in ISO format. */
     toISOString(): string;
->toISOString : Symbol(Date.toISOString, Decl(1.0lib-noErrors.ts, 759, 26))
+>toISOString : Symbol(Date.toISOString, Decl(1.0lib-noErrors.ts, 747, 26))
 
     /** Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization. */
     toJSON(key?: any): string;
->toJSON : Symbol(Date.toJSON, Decl(1.0lib-noErrors.ts, 761, 26))
->key : Symbol(key, Decl(1.0lib-noErrors.ts, 763, 11))
+>toJSON : Symbol(Date.toJSON, Decl(1.0lib-noErrors.ts, 749, 26))
+>key : Symbol(key, Decl(1.0lib-noErrors.ts, 751, 11))
 }
 
 declare var Date: {
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     new (): Date;
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     new (value: number): Date;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 768, 9))
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 756, 9))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     new (value: string): Date;
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 769, 9))
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 757, 9))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;
->year : Symbol(year, Decl(1.0lib-noErrors.ts, 770, 9))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 770, 22))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 770, 37))
->hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 770, 52))
->minutes : Symbol(minutes, Decl(1.0lib-noErrors.ts, 770, 68))
->seconds : Symbol(seconds, Decl(1.0lib-noErrors.ts, 770, 86))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 770, 104))
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>year : Symbol(year, Decl(1.0lib-noErrors.ts, 758, 9))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 758, 22))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 758, 37))
+>hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 758, 52))
+>minutes : Symbol(minutes, Decl(1.0lib-noErrors.ts, 758, 68))
+>seconds : Symbol(seconds, Decl(1.0lib-noErrors.ts, 758, 86))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 758, 104))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     (): string;
     prototype: Date;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 771, 15))
->Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 610, 23), Decl(1.0lib-noErrors.ts, 766, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 759, 15))
+>Date : Symbol(Date, Decl(1.0lib-noErrors.ts, 598, 23), Decl(1.0lib-noErrors.ts, 754, 11))
 
     /**
       * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.
       * @param s A date string
       */
     parse(s: string): number;
->parse : Symbol(parse, Decl(1.0lib-noErrors.ts, 772, 20))
->s : Symbol(s, Decl(1.0lib-noErrors.ts, 777, 10))
+>parse : Symbol(parse, Decl(1.0lib-noErrors.ts, 760, 20))
+>s : Symbol(s, Decl(1.0lib-noErrors.ts, 765, 10))
 
     /**
       * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date. 
@@ -1257,392 +1241,392 @@ declare var Date: {
       * @param ms An number from 0 to 999 that specifies the milliseconds.
       */
     UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
->UTC : Symbol(UTC, Decl(1.0lib-noErrors.ts, 777, 29))
->year : Symbol(year, Decl(1.0lib-noErrors.ts, 788, 8))
->month : Symbol(month, Decl(1.0lib-noErrors.ts, 788, 21))
->date : Symbol(date, Decl(1.0lib-noErrors.ts, 788, 36))
->hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 788, 51))
->minutes : Symbol(minutes, Decl(1.0lib-noErrors.ts, 788, 67))
->seconds : Symbol(seconds, Decl(1.0lib-noErrors.ts, 788, 85))
->ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 788, 103))
+>UTC : Symbol(UTC, Decl(1.0lib-noErrors.ts, 765, 29))
+>year : Symbol(year, Decl(1.0lib-noErrors.ts, 776, 8))
+>month : Symbol(month, Decl(1.0lib-noErrors.ts, 776, 21))
+>date : Symbol(date, Decl(1.0lib-noErrors.ts, 776, 36))
+>hours : Symbol(hours, Decl(1.0lib-noErrors.ts, 776, 51))
+>minutes : Symbol(minutes, Decl(1.0lib-noErrors.ts, 776, 67))
+>seconds : Symbol(seconds, Decl(1.0lib-noErrors.ts, 776, 85))
+>ms : Symbol(ms, Decl(1.0lib-noErrors.ts, 776, 103))
 
     now(): number;
->now : Symbol(now, Decl(1.0lib-noErrors.ts, 788, 125))
+>now : Symbol(now, Decl(1.0lib-noErrors.ts, 776, 125))
 }
 
 interface RegExpExecArray {
->RegExpExecArray : Symbol(RegExpExecArray, Decl(1.0lib-noErrors.ts, 790, 1))
+>RegExpExecArray : Symbol(RegExpExecArray, Decl(1.0lib-noErrors.ts, 778, 1))
 
     [index: number]: string;
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 793, 5))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 781, 5))
 
     length: number;
->length : Symbol(RegExpExecArray.length, Decl(1.0lib-noErrors.ts, 793, 28))
+>length : Symbol(RegExpExecArray.length, Decl(1.0lib-noErrors.ts, 781, 28))
 
     index: number;
->index : Symbol(RegExpExecArray.index, Decl(1.0lib-noErrors.ts, 794, 19))
+>index : Symbol(RegExpExecArray.index, Decl(1.0lib-noErrors.ts, 782, 19))
 
     input: string;
->input : Symbol(RegExpExecArray.input, Decl(1.0lib-noErrors.ts, 796, 18))
+>input : Symbol(RegExpExecArray.input, Decl(1.0lib-noErrors.ts, 784, 18))
 
     toString(): string;
->toString : Symbol(RegExpExecArray.toString, Decl(1.0lib-noErrors.ts, 797, 18))
+>toString : Symbol(RegExpExecArray.toString, Decl(1.0lib-noErrors.ts, 785, 18))
 
     toLocaleString(): string;
->toLocaleString : Symbol(RegExpExecArray.toLocaleString, Decl(1.0lib-noErrors.ts, 799, 23))
+>toLocaleString : Symbol(RegExpExecArray.toLocaleString, Decl(1.0lib-noErrors.ts, 787, 23))
 
     concat(...items: string[][]): string[];
->concat : Symbol(RegExpExecArray.concat, Decl(1.0lib-noErrors.ts, 800, 29))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 801, 11))
+>concat : Symbol(RegExpExecArray.concat, Decl(1.0lib-noErrors.ts, 788, 29))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 789, 11))
 
     join(separator?: string): string;
->join : Symbol(RegExpExecArray.join, Decl(1.0lib-noErrors.ts, 801, 43))
->separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 802, 9))
+>join : Symbol(RegExpExecArray.join, Decl(1.0lib-noErrors.ts, 789, 43))
+>separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 790, 9))
 
     pop(): string;
->pop : Symbol(RegExpExecArray.pop, Decl(1.0lib-noErrors.ts, 802, 37))
+>pop : Symbol(RegExpExecArray.pop, Decl(1.0lib-noErrors.ts, 790, 37))
 
     push(...items: string[]): number;
->push : Symbol(RegExpExecArray.push, Decl(1.0lib-noErrors.ts, 803, 18))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 804, 9))
+>push : Symbol(RegExpExecArray.push, Decl(1.0lib-noErrors.ts, 791, 18))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 792, 9))
 
     reverse(): string[];
->reverse : Symbol(RegExpExecArray.reverse, Decl(1.0lib-noErrors.ts, 804, 37))
+>reverse : Symbol(RegExpExecArray.reverse, Decl(1.0lib-noErrors.ts, 792, 37))
 
     shift(): string;
->shift : Symbol(RegExpExecArray.shift, Decl(1.0lib-noErrors.ts, 805, 24))
+>shift : Symbol(RegExpExecArray.shift, Decl(1.0lib-noErrors.ts, 793, 24))
 
     slice(start?: number, end?: number): string[];
->slice : Symbol(RegExpExecArray.slice, Decl(1.0lib-noErrors.ts, 806, 20))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 807, 10))
->end : Symbol(end, Decl(1.0lib-noErrors.ts, 807, 25))
+>slice : Symbol(RegExpExecArray.slice, Decl(1.0lib-noErrors.ts, 794, 20))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 795, 10))
+>end : Symbol(end, Decl(1.0lib-noErrors.ts, 795, 25))
 
     sort(compareFn?: (a: string, b: string) => number): string[];
->sort : Symbol(RegExpExecArray.sort, Decl(1.0lib-noErrors.ts, 807, 50))
->compareFn : Symbol(compareFn, Decl(1.0lib-noErrors.ts, 808, 9))
->a : Symbol(a, Decl(1.0lib-noErrors.ts, 808, 22))
->b : Symbol(b, Decl(1.0lib-noErrors.ts, 808, 32))
+>sort : Symbol(RegExpExecArray.sort, Decl(1.0lib-noErrors.ts, 795, 50))
+>compareFn : Symbol(compareFn, Decl(1.0lib-noErrors.ts, 796, 9))
+>a : Symbol(a, Decl(1.0lib-noErrors.ts, 796, 22))
+>b : Symbol(b, Decl(1.0lib-noErrors.ts, 796, 32))
 
     splice(start: number): string[];
->splice : Symbol(RegExpExecArray.splice, Decl(1.0lib-noErrors.ts, 808, 65), Decl(1.0lib-noErrors.ts, 809, 36))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 809, 11))
+>splice : Symbol(RegExpExecArray.splice, Decl(1.0lib-noErrors.ts, 796, 65), Decl(1.0lib-noErrors.ts, 797, 36))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 797, 11))
 
     splice(start: number, deleteCount: number, ...items: string[]): string[];
->splice : Symbol(RegExpExecArray.splice, Decl(1.0lib-noErrors.ts, 808, 65), Decl(1.0lib-noErrors.ts, 809, 36))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 810, 11))
->deleteCount : Symbol(deleteCount, Decl(1.0lib-noErrors.ts, 810, 25))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 810, 46))
+>splice : Symbol(RegExpExecArray.splice, Decl(1.0lib-noErrors.ts, 796, 65), Decl(1.0lib-noErrors.ts, 797, 36))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 798, 11))
+>deleteCount : Symbol(deleteCount, Decl(1.0lib-noErrors.ts, 798, 25))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 798, 46))
 
     unshift(...items: string[]): number;
->unshift : Symbol(RegExpExecArray.unshift, Decl(1.0lib-noErrors.ts, 810, 77))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 811, 12))
+>unshift : Symbol(RegExpExecArray.unshift, Decl(1.0lib-noErrors.ts, 798, 77))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 799, 12))
 
     indexOf(searchElement: string, fromIndex?: number): number;
->indexOf : Symbol(RegExpExecArray.indexOf, Decl(1.0lib-noErrors.ts, 811, 40))
->searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 813, 12))
->fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 813, 34))
+>indexOf : Symbol(RegExpExecArray.indexOf, Decl(1.0lib-noErrors.ts, 799, 40))
+>searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 801, 12))
+>fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 801, 34))
 
     lastIndexOf(searchElement: string, fromIndex?: number): number;
->lastIndexOf : Symbol(RegExpExecArray.lastIndexOf, Decl(1.0lib-noErrors.ts, 813, 63))
->searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 814, 16))
->fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 814, 38))
+>lastIndexOf : Symbol(RegExpExecArray.lastIndexOf, Decl(1.0lib-noErrors.ts, 801, 63))
+>searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 802, 16))
+>fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 802, 38))
 
     every(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
->every : Symbol(RegExpExecArray.every, Decl(1.0lib-noErrors.ts, 814, 67))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 815, 10))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 815, 23))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 815, 37))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 815, 52))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 815, 81))
+>every : Symbol(RegExpExecArray.every, Decl(1.0lib-noErrors.ts, 802, 67))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 803, 10))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 803, 23))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 803, 37))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 803, 52))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 803, 81))
 
     some(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
->some : Symbol(RegExpExecArray.some, Decl(1.0lib-noErrors.ts, 815, 106))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 816, 9))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 816, 22))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 816, 36))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 816, 51))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 816, 80))
+>some : Symbol(RegExpExecArray.some, Decl(1.0lib-noErrors.ts, 803, 106))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 804, 9))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 804, 22))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 804, 36))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 804, 51))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 804, 80))
 
     forEach(callbackfn: (value: string, index: number, array: string[]) => void, thisArg?: any): void;
->forEach : Symbol(RegExpExecArray.forEach, Decl(1.0lib-noErrors.ts, 816, 105))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 817, 12))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 817, 25))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 817, 39))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 817, 54))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 817, 80))
+>forEach : Symbol(RegExpExecArray.forEach, Decl(1.0lib-noErrors.ts, 804, 105))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 805, 12))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 805, 25))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 805, 39))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 805, 54))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 805, 80))
 
     map(callbackfn: (value: string, index: number, array: string[]) => any, thisArg?: any): any[];
->map : Symbol(RegExpExecArray.map, Decl(1.0lib-noErrors.ts, 817, 102))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 818, 8))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 818, 21))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 818, 35))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 818, 50))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 818, 75))
+>map : Symbol(RegExpExecArray.map, Decl(1.0lib-noErrors.ts, 805, 102))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 806, 8))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 806, 21))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 806, 35))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 806, 50))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 806, 75))
 
     filter(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): string[];
->filter : Symbol(RegExpExecArray.filter, Decl(1.0lib-noErrors.ts, 818, 98))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 819, 11))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 819, 24))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 819, 38))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 819, 53))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 819, 82))
+>filter : Symbol(RegExpExecArray.filter, Decl(1.0lib-noErrors.ts, 806, 98))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 807, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 807, 24))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 807, 38))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 807, 53))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 807, 82))
 
     reduce(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
->reduce : Symbol(RegExpExecArray.reduce, Decl(1.0lib-noErrors.ts, 819, 108))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 820, 11))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 820, 24))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 820, 43))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 820, 62))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 820, 84))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 820, 109))
+>reduce : Symbol(RegExpExecArray.reduce, Decl(1.0lib-noErrors.ts, 807, 108))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 808, 11))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 808, 24))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 808, 43))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 808, 62))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 808, 84))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 808, 109))
 
     reduceRight(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
->reduceRight : Symbol(RegExpExecArray.reduceRight, Decl(1.0lib-noErrors.ts, 820, 135))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 821, 16))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 821, 29))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 821, 48))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 821, 67))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 821, 89))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 821, 114))
+>reduceRight : Symbol(RegExpExecArray.reduceRight, Decl(1.0lib-noErrors.ts, 808, 135))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 809, 16))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 809, 29))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 809, 48))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 809, 67))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 809, 89))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 809, 114))
 }
 
 
 interface RegExp {
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     /** 
       * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
       * @param string The String object or string literal on which to perform the search.
       */
     exec(string: string): RegExpExecArray;
->exec : Symbol(RegExp.exec, Decl(1.0lib-noErrors.ts, 825, 18))
->string : Symbol(string, Decl(1.0lib-noErrors.ts, 830, 9))
->RegExpExecArray : Symbol(RegExpExecArray, Decl(1.0lib-noErrors.ts, 790, 1))
+>exec : Symbol(RegExp.exec, Decl(1.0lib-noErrors.ts, 813, 18))
+>string : Symbol(string, Decl(1.0lib-noErrors.ts, 818, 9))
+>RegExpExecArray : Symbol(RegExpExecArray, Decl(1.0lib-noErrors.ts, 778, 1))
 
     /** 
       * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
       * @param string String on which to perform the search.
       */
     test(string: string): boolean;
->test : Symbol(RegExp.test, Decl(1.0lib-noErrors.ts, 830, 42))
->string : Symbol(string, Decl(1.0lib-noErrors.ts, 836, 9))
+>test : Symbol(RegExp.test, Decl(1.0lib-noErrors.ts, 818, 42))
+>string : Symbol(string, Decl(1.0lib-noErrors.ts, 824, 9))
 
     /** Returns a copy of the text of the regular expression pattern. Read-only. The rgExp argument is a Regular expression object. It can be a variable name or a literal. */
     source: string;
->source : Symbol(RegExp.source, Decl(1.0lib-noErrors.ts, 836, 34))
+>source : Symbol(RegExp.source, Decl(1.0lib-noErrors.ts, 824, 34))
 
     /** Returns a Boolean value indicating the state of the global flag (g) used with a regular expression. Default is false. Read-only. */
     global: boolean;
->global : Symbol(RegExp.global, Decl(1.0lib-noErrors.ts, 839, 19))
+>global : Symbol(RegExp.global, Decl(1.0lib-noErrors.ts, 827, 19))
 
     /** Returns a Boolean value indicating the state of the ignoreCase flag (i) used with a regular expression. Default is false. Read-only. */
     ignoreCase: boolean;
->ignoreCase : Symbol(RegExp.ignoreCase, Decl(1.0lib-noErrors.ts, 842, 20))
+>ignoreCase : Symbol(RegExp.ignoreCase, Decl(1.0lib-noErrors.ts, 830, 20))
 
     /** Returns a Boolean value indicating the state of the multiline flag (m) used with a regular expression. Default is false. Read-only. */
     multiline: boolean;
->multiline : Symbol(RegExp.multiline, Decl(1.0lib-noErrors.ts, 845, 24))
+>multiline : Symbol(RegExp.multiline, Decl(1.0lib-noErrors.ts, 833, 24))
 
     lastIndex: number;
->lastIndex : Symbol(RegExp.lastIndex, Decl(1.0lib-noErrors.ts, 848, 23))
+>lastIndex : Symbol(RegExp.lastIndex, Decl(1.0lib-noErrors.ts, 836, 23))
 
     // Non-standard extensions
     compile(): RegExp;
->compile : Symbol(RegExp.compile, Decl(1.0lib-noErrors.ts, 850, 22))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>compile : Symbol(RegExp.compile, Decl(1.0lib-noErrors.ts, 838, 22))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 }
 declare var RegExp: {
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     new (pattern: string, flags?: string): RegExp;
->pattern : Symbol(pattern, Decl(1.0lib-noErrors.ts, 856, 9))
->flags : Symbol(flags, Decl(1.0lib-noErrors.ts, 856, 25))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>pattern : Symbol(pattern, Decl(1.0lib-noErrors.ts, 844, 9))
+>flags : Symbol(flags, Decl(1.0lib-noErrors.ts, 844, 25))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     (pattern: string, flags?: string): RegExp;
->pattern : Symbol(pattern, Decl(1.0lib-noErrors.ts, 857, 5))
->flags : Symbol(flags, Decl(1.0lib-noErrors.ts, 857, 21))
->RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 822, 1), Decl(1.0lib-noErrors.ts, 855, 11))
+>pattern : Symbol(pattern, Decl(1.0lib-noErrors.ts, 845, 5))
+>flags : Symbol(flags, Decl(1.0lib-noErrors.ts, 845, 21))
+>RegExp : Symbol(RegExp, Decl(1.0lib-noErrors.ts, 810, 1), Decl(1.0lib-noErrors.ts, 843, 11))
 
     // Non-standard extensions
     $1: string;
->$1 : Symbol($1, Decl(1.0lib-noErrors.ts, 857, 46))
+>$1 : Symbol($1, Decl(1.0lib-noErrors.ts, 845, 46))
 
     $2: string;
->$2 : Symbol($2, Decl(1.0lib-noErrors.ts, 860, 15))
+>$2 : Symbol($2, Decl(1.0lib-noErrors.ts, 848, 15))
 
     $3: string;
->$3 : Symbol($3, Decl(1.0lib-noErrors.ts, 861, 15))
+>$3 : Symbol($3, Decl(1.0lib-noErrors.ts, 849, 15))
 
     $4: string;
->$4 : Symbol($4, Decl(1.0lib-noErrors.ts, 862, 15))
+>$4 : Symbol($4, Decl(1.0lib-noErrors.ts, 850, 15))
 
     $5: string;
->$5 : Symbol($5, Decl(1.0lib-noErrors.ts, 863, 15))
+>$5 : Symbol($5, Decl(1.0lib-noErrors.ts, 851, 15))
 
     $6: string;
->$6 : Symbol($6, Decl(1.0lib-noErrors.ts, 864, 15))
+>$6 : Symbol($6, Decl(1.0lib-noErrors.ts, 852, 15))
 
     $7: string;
->$7 : Symbol($7, Decl(1.0lib-noErrors.ts, 865, 15))
+>$7 : Symbol($7, Decl(1.0lib-noErrors.ts, 853, 15))
 
     $8: string;
->$8 : Symbol($8, Decl(1.0lib-noErrors.ts, 866, 15))
+>$8 : Symbol($8, Decl(1.0lib-noErrors.ts, 854, 15))
 
     $9: string;
->$9 : Symbol($9, Decl(1.0lib-noErrors.ts, 867, 15))
+>$9 : Symbol($9, Decl(1.0lib-noErrors.ts, 855, 15))
 
     lastMatch: string;
->lastMatch : Symbol(lastMatch, Decl(1.0lib-noErrors.ts, 868, 15))
+>lastMatch : Symbol(lastMatch, Decl(1.0lib-noErrors.ts, 856, 15))
 }
 
 interface Error {
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 
     name: string;
->name : Symbol(Error.name, Decl(1.0lib-noErrors.ts, 872, 17))
+>name : Symbol(Error.name, Decl(1.0lib-noErrors.ts, 860, 17))
 
     message: string;
->message : Symbol(Error.message, Decl(1.0lib-noErrors.ts, 873, 17))
+>message : Symbol(Error.message, Decl(1.0lib-noErrors.ts, 861, 17))
 }
 declare var Error: {
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 
     new (message?: string): Error;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 877, 9))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 865, 9))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 
     (message?: string): Error;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 878, 5))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 866, 5))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 
     prototype: Error;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 878, 30))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 866, 30))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 
 interface EvalError extends Error {
->EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 880, 1), Decl(1.0lib-noErrors.ts, 884, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 868, 1), Decl(1.0lib-noErrors.ts, 872, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var EvalError: {
->EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 880, 1), Decl(1.0lib-noErrors.ts, 884, 11))
+>EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 868, 1), Decl(1.0lib-noErrors.ts, 872, 11))
 
     new (message?: string): EvalError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 885, 9))
->EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 880, 1), Decl(1.0lib-noErrors.ts, 884, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 873, 9))
+>EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 868, 1), Decl(1.0lib-noErrors.ts, 872, 11))
 
     (message?: string): EvalError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 886, 5))
->EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 880, 1), Decl(1.0lib-noErrors.ts, 884, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 874, 5))
+>EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 868, 1), Decl(1.0lib-noErrors.ts, 872, 11))
 
     prototype: EvalError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 886, 34))
->EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 880, 1), Decl(1.0lib-noErrors.ts, 884, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 874, 34))
+>EvalError : Symbol(EvalError, Decl(1.0lib-noErrors.ts, 868, 1), Decl(1.0lib-noErrors.ts, 872, 11))
 }
 
 interface RangeError extends Error {
->RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 888, 1), Decl(1.0lib-noErrors.ts, 892, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 876, 1), Decl(1.0lib-noErrors.ts, 880, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var RangeError: {
->RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 888, 1), Decl(1.0lib-noErrors.ts, 892, 11))
+>RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 876, 1), Decl(1.0lib-noErrors.ts, 880, 11))
 
     new (message?: string): RangeError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 893, 9))
->RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 888, 1), Decl(1.0lib-noErrors.ts, 892, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 881, 9))
+>RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 876, 1), Decl(1.0lib-noErrors.ts, 880, 11))
 
     (message?: string): RangeError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 894, 5))
->RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 888, 1), Decl(1.0lib-noErrors.ts, 892, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 882, 5))
+>RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 876, 1), Decl(1.0lib-noErrors.ts, 880, 11))
 
     prototype: RangeError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 894, 35))
->RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 888, 1), Decl(1.0lib-noErrors.ts, 892, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 882, 35))
+>RangeError : Symbol(RangeError, Decl(1.0lib-noErrors.ts, 876, 1), Decl(1.0lib-noErrors.ts, 880, 11))
 }
 
 interface ReferenceError extends Error {
->ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 896, 1), Decl(1.0lib-noErrors.ts, 900, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 884, 1), Decl(1.0lib-noErrors.ts, 888, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var ReferenceError: {
->ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 896, 1), Decl(1.0lib-noErrors.ts, 900, 11))
+>ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 884, 1), Decl(1.0lib-noErrors.ts, 888, 11))
 
     new (message?: string): ReferenceError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 901, 9))
->ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 896, 1), Decl(1.0lib-noErrors.ts, 900, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 889, 9))
+>ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 884, 1), Decl(1.0lib-noErrors.ts, 888, 11))
 
     (message?: string): ReferenceError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 902, 5))
->ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 896, 1), Decl(1.0lib-noErrors.ts, 900, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 890, 5))
+>ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 884, 1), Decl(1.0lib-noErrors.ts, 888, 11))
 
     prototype: ReferenceError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 902, 39))
->ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 896, 1), Decl(1.0lib-noErrors.ts, 900, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 890, 39))
+>ReferenceError : Symbol(ReferenceError, Decl(1.0lib-noErrors.ts, 884, 1), Decl(1.0lib-noErrors.ts, 888, 11))
 }
 
 interface SyntaxError extends Error {
->SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 904, 1), Decl(1.0lib-noErrors.ts, 908, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 892, 1), Decl(1.0lib-noErrors.ts, 896, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var SyntaxError: {
->SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 904, 1), Decl(1.0lib-noErrors.ts, 908, 11))
+>SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 892, 1), Decl(1.0lib-noErrors.ts, 896, 11))
 
     new (message?: string): SyntaxError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 909, 9))
->SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 904, 1), Decl(1.0lib-noErrors.ts, 908, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 897, 9))
+>SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 892, 1), Decl(1.0lib-noErrors.ts, 896, 11))
 
     (message?: string): SyntaxError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 910, 5))
->SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 904, 1), Decl(1.0lib-noErrors.ts, 908, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 898, 5))
+>SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 892, 1), Decl(1.0lib-noErrors.ts, 896, 11))
 
     prototype: SyntaxError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 910, 36))
->SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 904, 1), Decl(1.0lib-noErrors.ts, 908, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 898, 36))
+>SyntaxError : Symbol(SyntaxError, Decl(1.0lib-noErrors.ts, 892, 1), Decl(1.0lib-noErrors.ts, 896, 11))
 }
 
 interface TypeError extends Error {
->TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 912, 1), Decl(1.0lib-noErrors.ts, 916, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 900, 1), Decl(1.0lib-noErrors.ts, 904, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var TypeError: {
->TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 912, 1), Decl(1.0lib-noErrors.ts, 916, 11))
+>TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 900, 1), Decl(1.0lib-noErrors.ts, 904, 11))
 
     new (message?: string): TypeError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 917, 9))
->TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 912, 1), Decl(1.0lib-noErrors.ts, 916, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 905, 9))
+>TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 900, 1), Decl(1.0lib-noErrors.ts, 904, 11))
 
     (message?: string): TypeError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 918, 5))
->TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 912, 1), Decl(1.0lib-noErrors.ts, 916, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 906, 5))
+>TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 900, 1), Decl(1.0lib-noErrors.ts, 904, 11))
 
     prototype: TypeError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 918, 34))
->TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 912, 1), Decl(1.0lib-noErrors.ts, 916, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 906, 34))
+>TypeError : Symbol(TypeError, Decl(1.0lib-noErrors.ts, 900, 1), Decl(1.0lib-noErrors.ts, 904, 11))
 }
 
 interface URIError extends Error {
->URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 920, 1), Decl(1.0lib-noErrors.ts, 924, 11))
->Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 870, 1), Decl(1.0lib-noErrors.ts, 876, 11))
+>URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 908, 1), Decl(1.0lib-noErrors.ts, 912, 11))
+>Error : Symbol(Error, Decl(1.0lib-noErrors.ts, 858, 1), Decl(1.0lib-noErrors.ts, 864, 11))
 }
 declare var URIError: {
->URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 920, 1), Decl(1.0lib-noErrors.ts, 924, 11))
+>URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 908, 1), Decl(1.0lib-noErrors.ts, 912, 11))
 
     new (message?: string): URIError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 925, 9))
->URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 920, 1), Decl(1.0lib-noErrors.ts, 924, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 913, 9))
+>URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 908, 1), Decl(1.0lib-noErrors.ts, 912, 11))
 
     (message?: string): URIError;
->message : Symbol(message, Decl(1.0lib-noErrors.ts, 926, 5))
->URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 920, 1), Decl(1.0lib-noErrors.ts, 924, 11))
+>message : Symbol(message, Decl(1.0lib-noErrors.ts, 914, 5))
+>URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 908, 1), Decl(1.0lib-noErrors.ts, 912, 11))
 
     prototype: URIError;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 926, 33))
->URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 920, 1), Decl(1.0lib-noErrors.ts, 924, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 914, 33))
+>URIError : Symbol(URIError, Decl(1.0lib-noErrors.ts, 908, 1), Decl(1.0lib-noErrors.ts, 912, 11))
 }
 
 interface JSON {
->JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 928, 1), Decl(1.0lib-noErrors.ts, 973, 11))
+>JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 916, 1), Decl(1.0lib-noErrors.ts, 961, 11))
 
     /**
       * Converts a JavaScript Object Notation (JSON) string into an object.
@@ -1651,19 +1635,19 @@ interface JSON {
       * If a member contains nested objects, the nested objects are transformed before the parent object is. 
       */
     parse(text: string, reviver?: (key: any, value: any) => any): any;
->parse : Symbol(JSON.parse, Decl(1.0lib-noErrors.ts, 930, 16))
->text : Symbol(text, Decl(1.0lib-noErrors.ts, 937, 10))
->reviver : Symbol(reviver, Decl(1.0lib-noErrors.ts, 937, 23))
->key : Symbol(key, Decl(1.0lib-noErrors.ts, 937, 35))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 937, 44))
+>parse : Symbol(JSON.parse, Decl(1.0lib-noErrors.ts, 918, 16))
+>text : Symbol(text, Decl(1.0lib-noErrors.ts, 925, 10))
+>reviver : Symbol(reviver, Decl(1.0lib-noErrors.ts, 925, 23))
+>key : Symbol(key, Decl(1.0lib-noErrors.ts, 925, 35))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 925, 44))
 
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.
       */
     stringify(value: any): string;
->stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 937, 70), Decl(1.0lib-noErrors.ts, 942, 34), Decl(1.0lib-noErrors.ts, 948, 78), Decl(1.0lib-noErrors.ts, 954, 51), Decl(1.0lib-noErrors.ts, 961, 90))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 942, 14))
+>stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 925, 70), Decl(1.0lib-noErrors.ts, 930, 34), Decl(1.0lib-noErrors.ts, 936, 78), Decl(1.0lib-noErrors.ts, 942, 51), Decl(1.0lib-noErrors.ts, 949, 90))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 930, 14))
 
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -1671,11 +1655,11 @@ interface JSON {
       * @param replacer A function that transforms the results.
       */
     stringify(value: any, replacer: (key: string, value: any) => any): string;
->stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 937, 70), Decl(1.0lib-noErrors.ts, 942, 34), Decl(1.0lib-noErrors.ts, 948, 78), Decl(1.0lib-noErrors.ts, 954, 51), Decl(1.0lib-noErrors.ts, 961, 90))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 948, 14))
->replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 948, 25))
->key : Symbol(key, Decl(1.0lib-noErrors.ts, 948, 37))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 948, 49))
+>stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 925, 70), Decl(1.0lib-noErrors.ts, 930, 34), Decl(1.0lib-noErrors.ts, 936, 78), Decl(1.0lib-noErrors.ts, 942, 51), Decl(1.0lib-noErrors.ts, 949, 90))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 936, 14))
+>replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 936, 25))
+>key : Symbol(key, Decl(1.0lib-noErrors.ts, 936, 37))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 936, 49))
 
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -1683,9 +1667,9 @@ interface JSON {
       * @param replacer Array that transforms the results.
       */
     stringify(value: any, replacer: any[]): string;
->stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 937, 70), Decl(1.0lib-noErrors.ts, 942, 34), Decl(1.0lib-noErrors.ts, 948, 78), Decl(1.0lib-noErrors.ts, 954, 51), Decl(1.0lib-noErrors.ts, 961, 90))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 954, 14))
->replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 954, 25))
+>stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 925, 70), Decl(1.0lib-noErrors.ts, 930, 34), Decl(1.0lib-noErrors.ts, 936, 78), Decl(1.0lib-noErrors.ts, 942, 51), Decl(1.0lib-noErrors.ts, 949, 90))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 942, 14))
+>replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 942, 25))
 
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -1694,12 +1678,12 @@ interface JSON {
       * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
       */
     stringify(value: any, replacer: (key: string, value: any) => any, space: any): string;
->stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 937, 70), Decl(1.0lib-noErrors.ts, 942, 34), Decl(1.0lib-noErrors.ts, 948, 78), Decl(1.0lib-noErrors.ts, 954, 51), Decl(1.0lib-noErrors.ts, 961, 90))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 961, 14))
->replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 961, 25))
->key : Symbol(key, Decl(1.0lib-noErrors.ts, 961, 37))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 961, 49))
->space : Symbol(space, Decl(1.0lib-noErrors.ts, 961, 69))
+>stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 925, 70), Decl(1.0lib-noErrors.ts, 930, 34), Decl(1.0lib-noErrors.ts, 936, 78), Decl(1.0lib-noErrors.ts, 942, 51), Decl(1.0lib-noErrors.ts, 949, 90))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 949, 14))
+>replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 949, 25))
+>key : Symbol(key, Decl(1.0lib-noErrors.ts, 949, 37))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 949, 49))
+>space : Symbol(space, Decl(1.0lib-noErrors.ts, 949, 69))
 
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -1708,17 +1692,17 @@ interface JSON {
       * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
       */
     stringify(value: any, replacer: any[], space: any): string;
->stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 937, 70), Decl(1.0lib-noErrors.ts, 942, 34), Decl(1.0lib-noErrors.ts, 948, 78), Decl(1.0lib-noErrors.ts, 954, 51), Decl(1.0lib-noErrors.ts, 961, 90))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 968, 14))
->replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 968, 25))
->space : Symbol(space, Decl(1.0lib-noErrors.ts, 968, 42))
+>stringify : Symbol(JSON.stringify, Decl(1.0lib-noErrors.ts, 925, 70), Decl(1.0lib-noErrors.ts, 930, 34), Decl(1.0lib-noErrors.ts, 936, 78), Decl(1.0lib-noErrors.ts, 942, 51), Decl(1.0lib-noErrors.ts, 949, 90))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 956, 14))
+>replacer : Symbol(replacer, Decl(1.0lib-noErrors.ts, 956, 25))
+>space : Symbol(space, Decl(1.0lib-noErrors.ts, 956, 42))
 }
 /**
   * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
   */
 declare var JSON: JSON;
->JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 928, 1), Decl(1.0lib-noErrors.ts, 973, 11))
->JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 928, 1), Decl(1.0lib-noErrors.ts, 973, 11))
+>JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 916, 1), Decl(1.0lib-noErrors.ts, 961, 11))
+>JSON : Symbol(JSON, Decl(1.0lib-noErrors.ts, 916, 1), Decl(1.0lib-noErrors.ts, 961, 11))
 
 
 /////////////////////////////
@@ -1726,77 +1710,77 @@ declare var JSON: JSON;
 /////////////////////////////
 
 interface Array<T> {
->Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 973, 23), Decl(1.0lib-noErrors.ts, 1133, 11))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 961, 23), Decl(1.0lib-noErrors.ts, 1121, 11))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Returns a string representation of an array.
       */
     toString(): string;
->toString : Symbol(Array.toString, Decl(1.0lib-noErrors.ts, 980, 20))
+>toString : Symbol(Array.toString, Decl(1.0lib-noErrors.ts, 968, 20))
 
     toLocaleString(): string;
->toLocaleString : Symbol(Array.toLocaleString, Decl(1.0lib-noErrors.ts, 984, 23))
+>toLocaleString : Symbol(Array.toLocaleString, Decl(1.0lib-noErrors.ts, 972, 23))
 
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
     concat<U extends T[]>(...items: U[]): T[];
->concat : Symbol(Array.concat, Decl(1.0lib-noErrors.ts, 985, 29), Decl(1.0lib-noErrors.ts, 990, 46))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 990, 11))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 990, 26))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 990, 11))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>concat : Symbol(Array.concat, Decl(1.0lib-noErrors.ts, 973, 29), Decl(1.0lib-noErrors.ts, 978, 46))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 978, 11))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 978, 26))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 978, 11))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
     concat(...items: T[]): T[];
->concat : Symbol(Array.concat, Decl(1.0lib-noErrors.ts, 985, 29), Decl(1.0lib-noErrors.ts, 990, 46))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 995, 11))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>concat : Symbol(Array.concat, Decl(1.0lib-noErrors.ts, 973, 29), Decl(1.0lib-noErrors.ts, 978, 46))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 983, 11))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Adds all the elements of an array separated by the specified separator string.
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
       */
     join(separator?: string): string;
->join : Symbol(Array.join, Decl(1.0lib-noErrors.ts, 995, 31))
->separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 1000, 9))
+>join : Symbol(Array.join, Decl(1.0lib-noErrors.ts, 983, 31))
+>separator : Symbol(separator, Decl(1.0lib-noErrors.ts, 988, 9))
 
     /**
       * Removes the last element from an array and returns it.
       */
     pop(): T;
->pop : Symbol(Array.pop, Decl(1.0lib-noErrors.ts, 1000, 37))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>pop : Symbol(Array.pop, Decl(1.0lib-noErrors.ts, 988, 37))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Appends new elements to an array, and returns the new length of the array.
       * @param items New elements of the Array.
       */
     push(...items: T[]): number;
->push : Symbol(Array.push, Decl(1.0lib-noErrors.ts, 1004, 13))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 1009, 9))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>push : Symbol(Array.push, Decl(1.0lib-noErrors.ts, 992, 13))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 997, 9))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Reverses the elements in an Array. 
       */
     reverse(): T[];
->reverse : Symbol(Array.reverse, Decl(1.0lib-noErrors.ts, 1009, 32))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>reverse : Symbol(Array.reverse, Decl(1.0lib-noErrors.ts, 997, 32))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Removes the first element from an array and returns it.
       */
     shift(): T;
->shift : Symbol(Array.shift, Decl(1.0lib-noErrors.ts, 1013, 19))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>shift : Symbol(Array.shift, Decl(1.0lib-noErrors.ts, 1001, 19))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /** 
       * Returns a section of an array.
@@ -1804,32 +1788,32 @@ interface Array<T> {
       * @param end The end of the specified portion of the array.
       */
     slice(start?: number, end?: number): T[];
->slice : Symbol(Array.slice, Decl(1.0lib-noErrors.ts, 1017, 15))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 1023, 10))
->end : Symbol(end, Decl(1.0lib-noErrors.ts, 1023, 25))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>slice : Symbol(Array.slice, Decl(1.0lib-noErrors.ts, 1005, 15))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 1011, 10))
+>end : Symbol(end, Decl(1.0lib-noErrors.ts, 1011, 25))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
       */
     sort(compareFn?: (a: T, b: T) => number): T[];
->sort : Symbol(Array.sort, Decl(1.0lib-noErrors.ts, 1023, 45))
->compareFn : Symbol(compareFn, Decl(1.0lib-noErrors.ts, 1029, 9))
->a : Symbol(a, Decl(1.0lib-noErrors.ts, 1029, 22))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->b : Symbol(b, Decl(1.0lib-noErrors.ts, 1029, 27))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>sort : Symbol(Array.sort, Decl(1.0lib-noErrors.ts, 1011, 45))
+>compareFn : Symbol(compareFn, Decl(1.0lib-noErrors.ts, 1017, 9))
+>a : Symbol(a, Decl(1.0lib-noErrors.ts, 1017, 22))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>b : Symbol(b, Decl(1.0lib-noErrors.ts, 1017, 27))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
       * @param start The zero-based location in the array from which to start removing elements.
       */
     splice(start: number): T[];
->splice : Symbol(Array.splice, Decl(1.0lib-noErrors.ts, 1029, 50), Decl(1.0lib-noErrors.ts, 1035, 31))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 1035, 11))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>splice : Symbol(Array.splice, Decl(1.0lib-noErrors.ts, 1017, 50), Decl(1.0lib-noErrors.ts, 1023, 31))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 1023, 11))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
@@ -1838,21 +1822,21 @@ interface Array<T> {
       * @param items Elements to insert into the array in place of the deleted elements.
       */
     splice(start: number, deleteCount: number, ...items: T[]): T[];
->splice : Symbol(Array.splice, Decl(1.0lib-noErrors.ts, 1029, 50), Decl(1.0lib-noErrors.ts, 1035, 31))
->start : Symbol(start, Decl(1.0lib-noErrors.ts, 1043, 11))
->deleteCount : Symbol(deleteCount, Decl(1.0lib-noErrors.ts, 1043, 25))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 1043, 46))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>splice : Symbol(Array.splice, Decl(1.0lib-noErrors.ts, 1017, 50), Decl(1.0lib-noErrors.ts, 1023, 31))
+>start : Symbol(start, Decl(1.0lib-noErrors.ts, 1031, 11))
+>deleteCount : Symbol(deleteCount, Decl(1.0lib-noErrors.ts, 1031, 25))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 1031, 46))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Inserts new elements at the start of an array.
       * @param items  Elements to insert at the start of the Array.
       */
     unshift(...items: T[]): number;
->unshift : Symbol(Array.unshift, Decl(1.0lib-noErrors.ts, 1043, 67))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 1049, 12))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>unshift : Symbol(Array.unshift, Decl(1.0lib-noErrors.ts, 1031, 67))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 1037, 12))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -1860,10 +1844,10 @@ interface Array<T> {
       * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
       */
     indexOf(searchElement: T, fromIndex?: number): number;
->indexOf : Symbol(Array.indexOf, Decl(1.0lib-noErrors.ts, 1049, 35))
->searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 1056, 12))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 1056, 29))
+>indexOf : Symbol(Array.indexOf, Decl(1.0lib-noErrors.ts, 1037, 35))
+>searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 1044, 12))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 1044, 29))
 
     /**
       * Returns the index of the last occurrence of a specified value in an array.
@@ -1871,10 +1855,10 @@ interface Array<T> {
       * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
       */
     lastIndexOf(searchElement: T, fromIndex?: number): number;
->lastIndexOf : Symbol(Array.lastIndexOf, Decl(1.0lib-noErrors.ts, 1056, 58))
->searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 1063, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 1063, 33))
+>lastIndexOf : Symbol(Array.lastIndexOf, Decl(1.0lib-noErrors.ts, 1044, 58))
+>searchElement : Symbol(searchElement, Decl(1.0lib-noErrors.ts, 1051, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>fromIndex : Symbol(fromIndex, Decl(1.0lib-noErrors.ts, 1051, 33))
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -1882,14 +1866,14 @@ interface Array<T> {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
     every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
->every : Symbol(Array.every, Decl(1.0lib-noErrors.ts, 1063, 62))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1070, 10))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 1070, 23))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 1070, 32))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1070, 47))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1070, 71))
+>every : Symbol(Array.every, Decl(1.0lib-noErrors.ts, 1051, 62))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1058, 10))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 1058, 23))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 1058, 32))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1058, 47))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1058, 71))
 
     /**
       * Determines whether the specified callback function returns true for any element of an array.
@@ -1897,14 +1881,14 @@ interface Array<T> {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
     some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
->some : Symbol(Array.some, Decl(1.0lib-noErrors.ts, 1070, 96))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1077, 9))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 1077, 22))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 1077, 31))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1077, 46))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1077, 70))
+>some : Symbol(Array.some, Decl(1.0lib-noErrors.ts, 1058, 96))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1065, 9))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 1065, 22))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 1065, 31))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1065, 46))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1065, 70))
 
     /**
       * Performs the specified action for each element in an array.
@@ -1912,14 +1896,14 @@ interface Array<T> {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
     forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
->forEach : Symbol(Array.forEach, Decl(1.0lib-noErrors.ts, 1077, 95))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1084, 12))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 1084, 25))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 1084, 34))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1084, 49))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1084, 70))
+>forEach : Symbol(Array.forEach, Decl(1.0lib-noErrors.ts, 1065, 95))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1072, 12))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 1072, 25))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 1072, 34))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1072, 49))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1072, 70))
 
     /**
       * Calls a defined callback function on each element of an array, and returns an array that contains the results.
@@ -1927,17 +1911,17 @@ interface Array<T> {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
     map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
->map : Symbol(Array.map, Decl(1.0lib-noErrors.ts, 1084, 92))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1091, 8))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1091, 11))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 1091, 24))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 1091, 33))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1091, 48))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1091, 8))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1091, 66))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1091, 8))
+>map : Symbol(Array.map, Decl(1.0lib-noErrors.ts, 1072, 92))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1079, 8))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1079, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 1079, 24))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 1079, 33))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1079, 48))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1079, 8))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1079, 66))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1079, 8))
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -1945,15 +1929,15 @@ interface Array<T> {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
     filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
->filter : Symbol(Array.filter, Decl(1.0lib-noErrors.ts, 1091, 87))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1098, 11))
->value : Symbol(value, Decl(1.0lib-noErrors.ts, 1098, 24))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->index : Symbol(index, Decl(1.0lib-noErrors.ts, 1098, 33))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1098, 48))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1098, 72))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>filter : Symbol(Array.filter, Decl(1.0lib-noErrors.ts, 1079, 87))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1086, 11))
+>value : Symbol(value, Decl(1.0lib-noErrors.ts, 1086, 24))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>index : Symbol(index, Decl(1.0lib-noErrors.ts, 1086, 33))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1086, 48))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>thisArg : Symbol(thisArg, Decl(1.0lib-noErrors.ts, 1086, 72))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
@@ -1961,19 +1945,19 @@ interface Array<T> {
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduce : Symbol(Array.reduce, Decl(1.0lib-noErrors.ts, 1098, 93), Decl(1.0lib-noErrors.ts, 1105, 120))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1105, 11))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1105, 24))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1105, 41))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1105, 58))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1105, 80))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1105, 98))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>reduce : Symbol(Array.reduce, Decl(1.0lib-noErrors.ts, 1086, 93), Decl(1.0lib-noErrors.ts, 1093, 120))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1093, 11))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1093, 24))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1093, 41))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1093, 58))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1093, 80))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1093, 98))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
@@ -1981,20 +1965,20 @@ interface Array<T> {
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
     reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduce : Symbol(Array.reduce, Decl(1.0lib-noErrors.ts, 1098, 93), Decl(1.0lib-noErrors.ts, 1105, 120))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1111, 11))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1111, 14))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1111, 27))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1111, 11))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1111, 44))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1111, 61))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1111, 83))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1111, 11))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1111, 101))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1111, 11))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1111, 11))
+>reduce : Symbol(Array.reduce, Decl(1.0lib-noErrors.ts, 1086, 93), Decl(1.0lib-noErrors.ts, 1093, 120))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1099, 11))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1099, 14))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1099, 27))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1099, 11))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1099, 44))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1099, 61))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1099, 83))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1099, 11))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1099, 101))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1099, 11))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1099, 11))
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
@@ -2002,19 +1986,19 @@ interface Array<T> {
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduceRight : Symbol(Array.reduceRight, Decl(1.0lib-noErrors.ts, 1111, 122), Decl(1.0lib-noErrors.ts, 1118, 125))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1118, 16))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1118, 29))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1118, 46))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1118, 63))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1118, 85))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1118, 103))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>reduceRight : Symbol(Array.reduceRight, Decl(1.0lib-noErrors.ts, 1099, 122), Decl(1.0lib-noErrors.ts, 1106, 125))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1106, 16))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1106, 29))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1106, 46))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1106, 63))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1106, 85))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1106, 103))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
@@ -2022,68 +2006,68 @@ interface Array<T> {
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
     reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduceRight : Symbol(Array.reduceRight, Decl(1.0lib-noErrors.ts, 1111, 122), Decl(1.0lib-noErrors.ts, 1118, 125))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1124, 16))
->callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1124, 19))
->previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1124, 32))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1124, 16))
->currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1124, 49))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1124, 66))
->array : Symbol(array, Decl(1.0lib-noErrors.ts, 1124, 88))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1124, 16))
->initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1124, 106))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1124, 16))
->U : Symbol(U, Decl(1.0lib-noErrors.ts, 1124, 16))
+>reduceRight : Symbol(Array.reduceRight, Decl(1.0lib-noErrors.ts, 1099, 122), Decl(1.0lib-noErrors.ts, 1106, 125))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1112, 16))
+>callbackfn : Symbol(callbackfn, Decl(1.0lib-noErrors.ts, 1112, 19))
+>previousValue : Symbol(previousValue, Decl(1.0lib-noErrors.ts, 1112, 32))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1112, 16))
+>currentValue : Symbol(currentValue, Decl(1.0lib-noErrors.ts, 1112, 49))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>currentIndex : Symbol(currentIndex, Decl(1.0lib-noErrors.ts, 1112, 66))
+>array : Symbol(array, Decl(1.0lib-noErrors.ts, 1112, 88))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1112, 16))
+>initialValue : Symbol(initialValue, Decl(1.0lib-noErrors.ts, 1112, 106))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1112, 16))
+>U : Symbol(U, Decl(1.0lib-noErrors.ts, 1112, 16))
 
     /**
       * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
       */
     length: number;
->length : Symbol(Array.length, Decl(1.0lib-noErrors.ts, 1124, 127))
+>length : Symbol(Array.length, Decl(1.0lib-noErrors.ts, 1112, 127))
 
     [n: number]: T;
->n : Symbol(n, Decl(1.0lib-noErrors.ts, 1131, 5))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 980, 16))
+>n : Symbol(n, Decl(1.0lib-noErrors.ts, 1119, 5))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 968, 16))
 }
 declare var Array: {
->Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 973, 23), Decl(1.0lib-noErrors.ts, 1133, 11))
+>Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 961, 23), Decl(1.0lib-noErrors.ts, 1121, 11))
 
     new (arrayLength?: number): any[];
->arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1134, 9))
+>arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1122, 9))
 
     new <T>(arrayLength: number): T[];
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1135, 9))
->arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1135, 12))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1135, 9))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1123, 9))
+>arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1123, 12))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1123, 9))
 
     new <T>(...items: T[]): T[];
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1136, 9))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 1136, 12))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1136, 9))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1136, 9))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1124, 9))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 1124, 12))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1124, 9))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1124, 9))
 
     (arrayLength?: number): any[];
->arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1137, 5))
+>arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1125, 5))
 
     <T>(arrayLength: number): T[];
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1138, 5))
->arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1138, 8))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1138, 5))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1126, 5))
+>arrayLength : Symbol(arrayLength, Decl(1.0lib-noErrors.ts, 1126, 8))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1126, 5))
 
     <T>(...items: T[]): T[];
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1139, 5))
->items : Symbol(items, Decl(1.0lib-noErrors.ts, 1139, 8))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1139, 5))
->T : Symbol(T, Decl(1.0lib-noErrors.ts, 1139, 5))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1127, 5))
+>items : Symbol(items, Decl(1.0lib-noErrors.ts, 1127, 8))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1127, 5))
+>T : Symbol(T, Decl(1.0lib-noErrors.ts, 1127, 5))
 
     isArray(arg: any): boolean;
->isArray : Symbol(isArray, Decl(1.0lib-noErrors.ts, 1139, 28))
->arg : Symbol(arg, Decl(1.0lib-noErrors.ts, 1140, 12))
+>isArray : Symbol(isArray, Decl(1.0lib-noErrors.ts, 1127, 28))
+>arg : Symbol(arg, Decl(1.0lib-noErrors.ts, 1128, 12))
 
     prototype: Array<any>;
->prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 1140, 31))
->Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 973, 23), Decl(1.0lib-noErrors.ts, 1133, 11))
+>prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 1128, 31))
+>Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 961, 23), Decl(1.0lib-noErrors.ts, 1121, 11))
 }
 

--- a/tests/baselines/reference/1.0lib-noErrors.types
+++ b/tests/baselines/reference/1.0lib-noErrors.types
@@ -442,18 +442,10 @@ interface String {
 
     /** 
       * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A variable name or string literal containing the regular expression pattern and flags.
-      */
-    match(regexp: string): string[];
->match : { (regexp: string): string[]; (regexp: RegExp): string[]; }
->regexp : string
-
-    /** 
-      * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     match(regexp: RegExp): string[];
->match : { (regexp: string): string[]; (regexp: RegExp): string[]; }
+>match : (regexp: RegExp) => string[]
 >regexp : RegExp
 
     /**
@@ -502,18 +494,10 @@ interface String {
 
     /**
       * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
-      */
-    search(regexp: string): number;
->search : { (regexp: string): number; (regexp: RegExp): number; }
->regexp : string
-
-    /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     search(regexp: RegExp): number;
->search : { (regexp: string): number; (regexp: RegExp): number; }
+>search : (regexp: RegExp) => number
 >regexp : RegExp
 
     /**

--- a/tests/baselines/reference/assignFromStringInterface2.errors.txt
+++ b/tests/baselines/reference/assignFromStringInterface2.errors.txt
@@ -1,6 +1,6 @@
-assignFromStringInterface2.ts(47,1): error TS2322: Type 'String' is not assignable to type 'string'.
+assignFromStringInterface2.ts(45,1): error TS2322: Type 'String' is not assignable to type 'string'.
   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
-assignFromStringInterface2.ts(48,1): error TS2322: Type 'NotString' is not assignable to type 'string'.
+assignFromStringInterface2.ts(46,1): error TS2322: Type 'NotString' is not assignable to type 'string'.
 
 
 ==== assignFromStringInterface2.ts (2 errors) ====
@@ -17,13 +17,11 @@ assignFromStringInterface2.ts(48,1): error TS2322: Type 'NotString' is not assig
         indexOf(searchString: string, position?: number): number;
         lastIndexOf(searchString: string, position?: number): number;
         localeCompare(that: string): number;
-        match(regexp: string): RegExpMatchArray;
         match(regexp: RegExp): RegExpMatchArray;
         replace(searchValue: string, replaceValue: string): string;
         replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
         replace(searchValue: RegExp, replaceValue: string): string;
         replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
-        search(regexp: string): number;
         search(regexp: RegExp): number;
         slice(start?: number, end?: number): string;
         split(separator: string, limit?: number): string[];

--- a/tests/baselines/reference/assignFromStringInterface2.js
+++ b/tests/baselines/reference/assignFromStringInterface2.js
@@ -14,13 +14,11 @@ interface NotString {
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     localeCompare(that: string): number;
-    match(regexp: string): RegExpMatchArray;
     match(regexp: RegExp): RegExpMatchArray;
     replace(searchValue: string, replaceValue: string): string;
     replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
     replace(searchValue: RegExp, replaceValue: string): string;
     replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
-    search(regexp: string): number;
     search(regexp: RegExp): number;
     slice(start?: number, end?: number): string;
     split(separator: string, limit?: number): string[];

--- a/tests/baselines/reference/assignFromStringInterface2.symbols
+++ b/tests/baselines/reference/assignFromStringInterface2.symbols
@@ -43,136 +43,127 @@ interface NotString {
 >localeCompare : Symbol(NotString.localeCompare, Decl(assignFromStringInterface2.ts, 11, 65))
 >that : Symbol(that, Decl(assignFromStringInterface2.ts, 12, 18))
 
-    match(regexp: string): RegExpMatchArray;
->match : Symbol(NotString.match, Decl(assignFromStringInterface2.ts, 12, 40), Decl(assignFromStringInterface2.ts, 13, 44))
->regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 13, 10))
->RegExpMatchArray : Symbol(RegExpMatchArray, Decl(lib.es5.d.ts, --, --))
-
     match(regexp: RegExp): RegExpMatchArray;
->match : Symbol(NotString.match, Decl(assignFromStringInterface2.ts, 12, 40), Decl(assignFromStringInterface2.ts, 13, 44))
->regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 14, 10))
+>match : Symbol(NotString.match, Decl(assignFromStringInterface2.ts, 12, 40))
+>regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 13, 10))
 >RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >RegExpMatchArray : Symbol(RegExpMatchArray, Decl(lib.es5.d.ts, --, --))
 
     replace(searchValue: string, replaceValue: string): string;
->replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 14, 44), Decl(assignFromStringInterface2.ts, 15, 63), Decl(assignFromStringInterface2.ts, 16, 102), Decl(assignFromStringInterface2.ts, 17, 63))
->searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 15, 12))
->replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 15, 32))
+>replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 13, 44), Decl(assignFromStringInterface2.ts, 14, 63), Decl(assignFromStringInterface2.ts, 15, 102), Decl(assignFromStringInterface2.ts, 16, 63))
+>searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 14, 12))
+>replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 14, 32))
 
     replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
->replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 14, 44), Decl(assignFromStringInterface2.ts, 15, 63), Decl(assignFromStringInterface2.ts, 16, 102), Decl(assignFromStringInterface2.ts, 17, 63))
->searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 16, 12))
->replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 16, 32))
->substring : Symbol(substring, Decl(assignFromStringInterface2.ts, 16, 48))
->args : Symbol(args, Decl(assignFromStringInterface2.ts, 16, 66))
+>replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 13, 44), Decl(assignFromStringInterface2.ts, 14, 63), Decl(assignFromStringInterface2.ts, 15, 102), Decl(assignFromStringInterface2.ts, 16, 63))
+>searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 15, 12))
+>replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 15, 32))
+>substring : Symbol(substring, Decl(assignFromStringInterface2.ts, 15, 48))
+>args : Symbol(args, Decl(assignFromStringInterface2.ts, 15, 66))
 
     replace(searchValue: RegExp, replaceValue: string): string;
->replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 14, 44), Decl(assignFromStringInterface2.ts, 15, 63), Decl(assignFromStringInterface2.ts, 16, 102), Decl(assignFromStringInterface2.ts, 17, 63))
+>replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 13, 44), Decl(assignFromStringInterface2.ts, 14, 63), Decl(assignFromStringInterface2.ts, 15, 102), Decl(assignFromStringInterface2.ts, 16, 63))
+>searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 16, 12))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 16, 32))
+
+    replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
+>replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 13, 44), Decl(assignFromStringInterface2.ts, 14, 63), Decl(assignFromStringInterface2.ts, 15, 102), Decl(assignFromStringInterface2.ts, 16, 63))
 >searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 17, 12))
 >RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 17, 32))
-
-    replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
->replace : Symbol(NotString.replace, Decl(assignFromStringInterface2.ts, 14, 44), Decl(assignFromStringInterface2.ts, 15, 63), Decl(assignFromStringInterface2.ts, 16, 102), Decl(assignFromStringInterface2.ts, 17, 63))
->searchValue : Symbol(searchValue, Decl(assignFromStringInterface2.ts, 18, 12))
->RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->replaceValue : Symbol(replaceValue, Decl(assignFromStringInterface2.ts, 18, 32))
->substring : Symbol(substring, Decl(assignFromStringInterface2.ts, 18, 48))
->args : Symbol(args, Decl(assignFromStringInterface2.ts, 18, 66))
-
-    search(regexp: string): number;
->search : Symbol(NotString.search, Decl(assignFromStringInterface2.ts, 18, 102), Decl(assignFromStringInterface2.ts, 19, 35))
->regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 19, 11))
+>substring : Symbol(substring, Decl(assignFromStringInterface2.ts, 17, 48))
+>args : Symbol(args, Decl(assignFromStringInterface2.ts, 17, 66))
 
     search(regexp: RegExp): number;
->search : Symbol(NotString.search, Decl(assignFromStringInterface2.ts, 18, 102), Decl(assignFromStringInterface2.ts, 19, 35))
->regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 20, 11))
+>search : Symbol(NotString.search, Decl(assignFromStringInterface2.ts, 17, 102))
+>regexp : Symbol(regexp, Decl(assignFromStringInterface2.ts, 18, 11))
 >RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
     slice(start?: number, end?: number): string;
->slice : Symbol(NotString.slice, Decl(assignFromStringInterface2.ts, 20, 35))
->start : Symbol(start, Decl(assignFromStringInterface2.ts, 21, 10))
->end : Symbol(end, Decl(assignFromStringInterface2.ts, 21, 25))
+>slice : Symbol(NotString.slice, Decl(assignFromStringInterface2.ts, 18, 35))
+>start : Symbol(start, Decl(assignFromStringInterface2.ts, 19, 10))
+>end : Symbol(end, Decl(assignFromStringInterface2.ts, 19, 25))
 
     split(separator: string, limit?: number): string[];
->split : Symbol(NotString.split, Decl(assignFromStringInterface2.ts, 21, 48), Decl(assignFromStringInterface2.ts, 22, 55))
->separator : Symbol(separator, Decl(assignFromStringInterface2.ts, 22, 10))
->limit : Symbol(limit, Decl(assignFromStringInterface2.ts, 22, 28))
+>split : Symbol(NotString.split, Decl(assignFromStringInterface2.ts, 19, 48), Decl(assignFromStringInterface2.ts, 20, 55))
+>separator : Symbol(separator, Decl(assignFromStringInterface2.ts, 20, 10))
+>limit : Symbol(limit, Decl(assignFromStringInterface2.ts, 20, 28))
 
     split(separator: RegExp, limit?: number): string[];
->split : Symbol(NotString.split, Decl(assignFromStringInterface2.ts, 21, 48), Decl(assignFromStringInterface2.ts, 22, 55))
->separator : Symbol(separator, Decl(assignFromStringInterface2.ts, 23, 10))
+>split : Symbol(NotString.split, Decl(assignFromStringInterface2.ts, 19, 48), Decl(assignFromStringInterface2.ts, 20, 55))
+>separator : Symbol(separator, Decl(assignFromStringInterface2.ts, 21, 10))
 >RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->limit : Symbol(limit, Decl(assignFromStringInterface2.ts, 23, 28))
+>limit : Symbol(limit, Decl(assignFromStringInterface2.ts, 21, 28))
 
     substring(start: number, end?: number): string;
->substring : Symbol(NotString.substring, Decl(assignFromStringInterface2.ts, 23, 55))
->start : Symbol(start, Decl(assignFromStringInterface2.ts, 24, 14))
->end : Symbol(end, Decl(assignFromStringInterface2.ts, 24, 28))
+>substring : Symbol(NotString.substring, Decl(assignFromStringInterface2.ts, 21, 55))
+>start : Symbol(start, Decl(assignFromStringInterface2.ts, 22, 14))
+>end : Symbol(end, Decl(assignFromStringInterface2.ts, 22, 28))
 
     toLowerCase(): string;
->toLowerCase : Symbol(NotString.toLowerCase, Decl(assignFromStringInterface2.ts, 24, 51))
+>toLowerCase : Symbol(NotString.toLowerCase, Decl(assignFromStringInterface2.ts, 22, 51))
 
     toLocaleLowerCase(): string;
->toLocaleLowerCase : Symbol(NotString.toLocaleLowerCase, Decl(assignFromStringInterface2.ts, 25, 26))
+>toLocaleLowerCase : Symbol(NotString.toLocaleLowerCase, Decl(assignFromStringInterface2.ts, 23, 26))
 
     toUpperCase(): string;
->toUpperCase : Symbol(NotString.toUpperCase, Decl(assignFromStringInterface2.ts, 26, 32))
+>toUpperCase : Symbol(NotString.toUpperCase, Decl(assignFromStringInterface2.ts, 24, 32))
 
     toLocaleUpperCase(): string;
->toLocaleUpperCase : Symbol(NotString.toLocaleUpperCase, Decl(assignFromStringInterface2.ts, 27, 26))
+>toLocaleUpperCase : Symbol(NotString.toLocaleUpperCase, Decl(assignFromStringInterface2.ts, 25, 26))
 
     trim(): string;
->trim : Symbol(NotString.trim, Decl(assignFromStringInterface2.ts, 28, 32))
+>trim : Symbol(NotString.trim, Decl(assignFromStringInterface2.ts, 26, 32))
 
     length: number;
->length : Symbol(NotString.length, Decl(assignFromStringInterface2.ts, 29, 19))
+>length : Symbol(NotString.length, Decl(assignFromStringInterface2.ts, 27, 19))
 
     substr(from: number, length?: number): string;
->substr : Symbol(NotString.substr, Decl(assignFromStringInterface2.ts, 30, 19))
->from : Symbol(from, Decl(assignFromStringInterface2.ts, 31, 11))
->length : Symbol(length, Decl(assignFromStringInterface2.ts, 31, 24))
+>substr : Symbol(NotString.substr, Decl(assignFromStringInterface2.ts, 28, 19))
+>from : Symbol(from, Decl(assignFromStringInterface2.ts, 29, 11))
+>length : Symbol(length, Decl(assignFromStringInterface2.ts, 29, 24))
 
     valueOf(): string;
->valueOf : Symbol(NotString.valueOf, Decl(assignFromStringInterface2.ts, 31, 50))
+>valueOf : Symbol(NotString.valueOf, Decl(assignFromStringInterface2.ts, 29, 50))
 
     [index: number]: string;
->index : Symbol(index, Decl(assignFromStringInterface2.ts, 33, 5))
+>index : Symbol(index, Decl(assignFromStringInterface2.ts, 31, 5))
 }
 
 var x = '';
->x : Symbol(x, Decl(assignFromStringInterface2.ts, 36, 3))
+>x : Symbol(x, Decl(assignFromStringInterface2.ts, 34, 3))
 
 var a: String;
->a : Symbol(a, Decl(assignFromStringInterface2.ts, 37, 3))
+>a : Symbol(a, Decl(assignFromStringInterface2.ts, 35, 3))
 >String : Symbol(String, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(assignFromStringInterface2.ts, 0, 0))
 
 var b: NotString;
->b : Symbol(b, Decl(assignFromStringInterface2.ts, 38, 3))
+>b : Symbol(b, Decl(assignFromStringInterface2.ts, 36, 3))
 >NotString : Symbol(NotString, Decl(assignFromStringInterface2.ts, 2, 1))
 
 a = x;
->a : Symbol(a, Decl(assignFromStringInterface2.ts, 37, 3))
->x : Symbol(x, Decl(assignFromStringInterface2.ts, 36, 3))
+>a : Symbol(a, Decl(assignFromStringInterface2.ts, 35, 3))
+>x : Symbol(x, Decl(assignFromStringInterface2.ts, 34, 3))
 
 a = b;
->a : Symbol(a, Decl(assignFromStringInterface2.ts, 37, 3))
->b : Symbol(b, Decl(assignFromStringInterface2.ts, 38, 3))
+>a : Symbol(a, Decl(assignFromStringInterface2.ts, 35, 3))
+>b : Symbol(b, Decl(assignFromStringInterface2.ts, 36, 3))
 
 b = a;
->b : Symbol(b, Decl(assignFromStringInterface2.ts, 38, 3))
->a : Symbol(a, Decl(assignFromStringInterface2.ts, 37, 3))
+>b : Symbol(b, Decl(assignFromStringInterface2.ts, 36, 3))
+>a : Symbol(a, Decl(assignFromStringInterface2.ts, 35, 3))
 
 b = x;
->b : Symbol(b, Decl(assignFromStringInterface2.ts, 38, 3))
->x : Symbol(x, Decl(assignFromStringInterface2.ts, 36, 3))
+>b : Symbol(b, Decl(assignFromStringInterface2.ts, 36, 3))
+>x : Symbol(x, Decl(assignFromStringInterface2.ts, 34, 3))
 
 x = a; // expected error
->x : Symbol(x, Decl(assignFromStringInterface2.ts, 36, 3))
->a : Symbol(a, Decl(assignFromStringInterface2.ts, 37, 3))
+>x : Symbol(x, Decl(assignFromStringInterface2.ts, 34, 3))
+>a : Symbol(a, Decl(assignFromStringInterface2.ts, 35, 3))
 
 x = b; // expected error
->x : Symbol(x, Decl(assignFromStringInterface2.ts, 36, 3))
->b : Symbol(b, Decl(assignFromStringInterface2.ts, 38, 3))
+>x : Symbol(x, Decl(assignFromStringInterface2.ts, 34, 3))
+>b : Symbol(b, Decl(assignFromStringInterface2.ts, 36, 3))
 
 

--- a/tests/baselines/reference/assignFromStringInterface2.types
+++ b/tests/baselines/reference/assignFromStringInterface2.types
@@ -39,12 +39,8 @@ interface NotString {
 >localeCompare : (that: string) => number
 >that : string
 
-    match(regexp: string): RegExpMatchArray;
->match : { (regexp: string): RegExpMatchArray; (regexp: RegExp): RegExpMatchArray; }
->regexp : string
-
     match(regexp: RegExp): RegExpMatchArray;
->match : { (regexp: string): RegExpMatchArray; (regexp: RegExp): RegExpMatchArray; }
+>match : (regexp: RegExp) => RegExpMatchArray
 >regexp : RegExp
 
     replace(searchValue: string, replaceValue: string): string;
@@ -71,12 +67,8 @@ interface NotString {
 >substring : string
 >args : any[]
 
-    search(regexp: string): number;
->search : { (regexp: string): number; (regexp: RegExp): number; }
->regexp : string
-
     search(regexp: RegExp): number;
->search : { (regexp: string): number; (regexp: RegExp): number; }
+>search : (regexp: RegExp) => number
 >regexp : RegExp
 
     slice(start?: number, end?: number): string;

--- a/tests/baselines/reference/bestChoiceType.types
+++ b/tests/baselines/reference/bestChoiceType.types
@@ -9,9 +9,9 @@
 >(''.match(/ /) || []) : RegExpMatchArray | []
 >''.match(/ /) || [] : RegExpMatchArray | []
 >''.match(/ /) : RegExpMatchArray | null
->''.match : (regexp: string | RegExp) => RegExpMatchArray | null
+>''.match : (regexp: RegExp) => RegExpMatchArray | null
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray | null
+>match : (regexp: RegExp) => RegExpMatchArray | null
 >/ / : RegExp
 >[] : []
 >map : (<U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]) | (<U_1>(callbackfn: (value: never, index: number, array: never[]) => U_1, thisArg?: any) => U_1[])
@@ -30,9 +30,9 @@ function f1() {
     let x = ''.match(/ /);
 >x : RegExpMatchArray | null
 >''.match(/ /) : RegExpMatchArray | null
->''.match : (regexp: string | RegExp) => RegExpMatchArray | null
+>''.match : (regexp: RegExp) => RegExpMatchArray | null
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray | null
+>match : (regexp: RegExp) => RegExpMatchArray | null
 >/ / : RegExp
 
     let y = x || [];
@@ -61,9 +61,9 @@ function f2() {
     let x = ''.match(/ /);
 >x : RegExpMatchArray | null
 >''.match(/ /) : RegExpMatchArray | null
->''.match : (regexp: string | RegExp) => RegExpMatchArray | null
+>''.match : (regexp: RegExp) => RegExpMatchArray | null
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray | null
+>match : (regexp: RegExp) => RegExpMatchArray | null
 >/ / : RegExp
 
     let y = x ? x : [];

--- a/tests/baselines/reference/completionsStringMethods.baseline
+++ b/tests/baselines/reference/completionsStringMethods.baseline
@@ -10,9 +10,9 @@
 // | (method) String.lastIndexOf(searchString: string, position?: number): number
 // | (property) String.length: number
 // | (method) String.localeCompare(that: string): number (+1 overload)
-// | (method) String.match(regexp: string | RegExp): RegExpMatchArray
+// | (method) String.match(regexp: RegExp): RegExpMatchArray
 // | (method) String.replace(searchValue: string | RegExp, replaceValue: string): string (+1 overload)
-// | (method) String.search(regexp: string | RegExp): number
+// | (method) String.search(regexp: RegExp): number
 // | (method) String.slice(start?: number, end?: number): string
 // | (method) String.split(separator: string | RegExp, limit?: number): string[]
 // | (method) String.substring(start: number, end?: number): string
@@ -856,22 +856,6 @@
               "kind": "space"
             },
             {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "space"
-            },
-            {
-              "text": "|",
-              "kind": "punctuation"
-            },
-            {
-              "text": " ",
-              "kind": "space"
-            },
-            {
               "text": "RegExp",
               "kind": "localName"
             },
@@ -911,7 +895,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "A variable name or string literal containing the regular expression pattern and flags.",
+                  "text": "The regular expression to match against.",
                   "kind": "text"
                 }
               ]
@@ -1197,22 +1181,6 @@
               "kind": "space"
             },
             {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "space"
-            },
-            {
-              "text": "|",
-              "kind": "punctuation"
-            },
-            {
-              "text": " ",
-              "kind": "space"
-            },
-            {
               "text": "RegExp",
               "kind": "localName"
             },
@@ -1235,7 +1203,7 @@
           ],
           "documentation": [
             {
-              "text": "Finds the first substring match in a regular expression search.",
+              "text": "Finds the index of the first substring match of a regular expression search.",
               "kind": "text"
             }
           ],
@@ -1252,7 +1220,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "The regular expression pattern and applicable flags.",
+                  "text": "The regular expression to match against.",
                   "kind": "text"
                 }
               ]

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.types
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.types
@@ -95,9 +95,9 @@ const testRegExpMatchArrayGroups = "2019-04-30".match(/(?<year>[0-9]{4})-(?<mont
 >testRegExpMatchArrayGroups : any
 >"2019-04-30".match(/(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/g).groups : any
 >"2019-04-30".match(/(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/g) : RegExpMatchArray
->"2019-04-30".match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>"2019-04-30".match : { (regexp: RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
 >"2019-04-30" : "2019-04-30"
->match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>match : { (regexp: RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
 >/(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/g : RegExp
 >groups : any
 

--- a/tests/baselines/reference/firstMatchRegExpMatchArray.types
+++ b/tests/baselines/reference/firstMatchRegExpMatchArray.types
@@ -4,9 +4,9 @@
 const match = ''.match(/ /)
 >match : RegExpMatchArray | null
 >''.match(/ /) : RegExpMatchArray | null
->''.match : (regexp: string | RegExp) => RegExpMatchArray | null
+>''.match : (regexp: RegExp) => RegExpMatchArray | null
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray | null
+>match : (regexp: RegExp) => RegExpMatchArray | null
 >/ / : RegExp
 
 if (match !== null) {

--- a/tests/baselines/reference/flatArrayNoExcessiveStackDepth.types
+++ b/tests/baselines/reference/flatArrayNoExcessiveStackDepth.types
@@ -41,9 +41,9 @@ const repro_43249 = (value: unknown) => {
 >match : [] | RegExpMatchArray
 >value.match(/anything/) || [] : RegExpMatchArray | []
 >value.match(/anything/) : RegExpMatchArray | null
->value.match : { (regexp: string | RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
+>value.match : { (regexp: RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
 >value : string
->match : { (regexp: string | RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
+>match : { (regexp: RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
 >/anything/ : RegExp
 >[] : []
 

--- a/tests/baselines/reference/initializedDestructuringAssignmentTypes.errors.txt
+++ b/tests/baselines/reference/initializedDestructuringAssignmentTypes.errors.txt
@@ -1,8 +1,11 @@
+initializedDestructuringAssignmentTypes.ts(1,29): error TS2345: Argument of type 'string' is not assignable to parameter of type 'RegExp'.
 initializedDestructuringAssignmentTypes.ts(3,3): error TS2339: Property 'toFixed' does not exist on type 'string'.
 
 
-==== initializedDestructuringAssignmentTypes.ts (1 errors) ====
+==== initializedDestructuringAssignmentTypes.ts (2 errors) ====
     const [, a = ''] = ''.match('') || [];
+                                ~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'RegExp'.
     
     a.toFixed()
       ~~~~~~~

--- a/tests/baselines/reference/initializedDestructuringAssignmentTypes.types
+++ b/tests/baselines/reference/initializedDestructuringAssignmentTypes.types
@@ -7,9 +7,9 @@ const [, a = ''] = ''.match('') || [];
 >'' : ""
 >''.match('') || [] : RegExpMatchArray | []
 >''.match('') : RegExpMatchArray
->''.match : (regexp: string | RegExp) => RegExpMatchArray
+>''.match : (regexp: RegExp) => RegExpMatchArray
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >'' : ""
 >[] : []
 

--- a/tests/baselines/reference/narrowingWithNonNullExpression.js
+++ b/tests/baselines/reference/narrowingWithNonNullExpression.js
@@ -1,12 +1,12 @@
 //// [tests/cases/compiler/narrowingWithNonNullExpression.ts] ////
 
 //// [narrowingWithNonNullExpression.ts]
-const m = ''.match('');
+const m = ''.match(/(?:)/);
 m! && m[0];
 m?.[0]! && m[0];
 
 
 //// [narrowingWithNonNullExpression.js]
-var m = ''.match('');
+var m = ''.match(/(?:)/);
 m && m[0];
 (m === null || m === void 0 ? void 0 : m[0]) && m[0];

--- a/tests/baselines/reference/narrowingWithNonNullExpression.symbols
+++ b/tests/baselines/reference/narrowingWithNonNullExpression.symbols
@@ -1,7 +1,7 @@
 //// [tests/cases/compiler/narrowingWithNonNullExpression.ts] ////
 
 === narrowingWithNonNullExpression.ts ===
-const m = ''.match('');
+const m = ''.match(/(?:)/);
 >m : Symbol(m, Decl(narrowingWithNonNullExpression.ts, 0, 5))
 >''.match : Symbol(String.match, Decl(lib.es5.d.ts, --, --))
 >match : Symbol(String.match, Decl(lib.es5.d.ts, --, --))

--- a/tests/baselines/reference/narrowingWithNonNullExpression.types
+++ b/tests/baselines/reference/narrowingWithNonNullExpression.types
@@ -1,13 +1,13 @@
 //// [tests/cases/compiler/narrowingWithNonNullExpression.ts] ////
 
 === narrowingWithNonNullExpression.ts ===
-const m = ''.match('');
+const m = ''.match(/(?:)/);
 >m : RegExpMatchArray
->''.match('') : RegExpMatchArray
->''.match : (regexp: string | RegExp) => RegExpMatchArray
+>''.match(/(?:)/) : RegExpMatchArray
+>''.match : (regexp: RegExp) => RegExpMatchArray
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray
->'' : ""
+>match : (regexp: RegExp) => RegExpMatchArray
+>/(?:)/ : RegExp
 
 m! && m[0];
 >m! && m[0] : string

--- a/tests/baselines/reference/parser630933.types
+++ b/tests/baselines/reference/parser630933.types
@@ -8,8 +8,8 @@ var a = "Hello";
 var b = a.match(/\/ver=([^/]+)/);
 >b : RegExpMatchArray
 >a.match(/\/ver=([^/]+)/) : RegExpMatchArray
->a.match : (regexp: string | RegExp) => RegExpMatchArray
+>a.match : (regexp: RegExp) => RegExpMatchArray
 >a : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/\/ver=([^/]+)/ : RegExp
 

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -280,9 +280,9 @@ module Harness {
             var bugs = content.match(/\bbug (\d+)/i);
 >bugs : RegExpMatchArray
 >content.match(/\bbug (\d+)/i) : RegExpMatchArray
->content.match : (regexp: string | RegExp) => RegExpMatchArray
+>content.match : (regexp: RegExp) => RegExpMatchArray
 >content : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/\bbug (\d+)/i : RegExp
 
             if (bugs) {
@@ -4840,11 +4840,11 @@ module Harness {
                         var match = errorLines[i].match(/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/);
 >match : RegExpMatchArray
 >errorLines[i].match(/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/) : RegExpMatchArray
->errorLines[i].match : (regexp: string | RegExp) => RegExpMatchArray
+>errorLines[i].match : (regexp: RegExp) => RegExpMatchArray
 >errorLines[i] : string
 >errorLines : string[]
 >i : number
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/ : RegExp
 
                         if (match) {
@@ -5264,9 +5264,9 @@ module Harness {
 >filename : string
 >path.match(/[^\/]*$/)[0] : string
 >path.match(/[^\/]*$/) : RegExpMatchArray
->path.match : (regexp: string | RegExp) => RegExpMatchArray
+>path.match : (regexp: RegExp) => RegExpMatchArray
 >path : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/[^\/]*$/ : RegExp
 >0 : 0
 
@@ -5446,13 +5446,13 @@ module Harness {
 >unitName : string
 >switchToForwardSlashes(lastUnit.name).match(/[^\/]*$/)[0] : string
 >switchToForwardSlashes(lastUnit.name).match(/[^\/]*$/) : RegExpMatchArray
->switchToForwardSlashes(lastUnit.name).match : (regexp: string | RegExp) => RegExpMatchArray
+>switchToForwardSlashes(lastUnit.name).match : (regexp: RegExp) => RegExpMatchArray
 >switchToForwardSlashes(lastUnit.name) : string
 >switchToForwardSlashes : (path: string) => string
 >lastUnit.name : string
 >lastUnit : TestCaseParser.TestUnitData
 >name : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/[^\/]*$/ : RegExp
 >0 : 0
 
@@ -5945,9 +5945,9 @@ module Harness {
                     var isRef = line.match(/reference\spath='(\w*_?\w*\.?d?\.ts)'/);
 >isRef : RegExpMatchArray
 >line.match(/reference\spath='(\w*_?\w*\.?d?\.ts)'/) : RegExpMatchArray
->line.match : (regexp: string | RegExp) => RegExpMatchArray
+>line.match : (regexp: RegExp) => RegExpMatchArray
 >line : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/reference\spath='(\w*_?\w*\.?d?\.ts)'/ : RegExp
 
                     if (isRef) {
@@ -7678,9 +7678,9 @@ module Harness {
 >path : string
 >path.match(/[^\/]*$/)[0] : string
 >path.match(/[^\/]*$/) : RegExpMatchArray
->path.match : (regexp: string | RegExp) => RegExpMatchArray
+>path.match : (regexp: RegExp) => RegExpMatchArray
 >path : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: RegExp) => RegExpMatchArray
 >/[^\/]*$/ : RegExp
 >0 : 0
 >callback : (error: Error, result: any) => void

--- a/tests/baselines/reference/useRegexpGroups.types
+++ b/tests/baselines/reference/useRegexpGroups.types
@@ -67,9 +67,9 @@ let foo = "foo".match(/(?<bar>foo)/)!.groups.foo;
 >"foo".match(/(?<bar>foo)/)!.groups : { [key: string]: string; }
 >"foo".match(/(?<bar>foo)/)! : RegExpMatchArray
 >"foo".match(/(?<bar>foo)/) : RegExpMatchArray
->"foo".match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>"foo".match : { (regexp: RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
 >"foo" : "foo"
->match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>match : { (regexp: RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
 >/(?<bar>foo)/ : RegExp
 >groups : { [key: string]: string; }
 >foo : string

--- a/tests/cases/compiler/narrowingWithNonNullExpression.ts
+++ b/tests/cases/compiler/narrowingWithNonNullExpression.ts
@@ -1,3 +1,3 @@
-const m = ''.match('');
+const m = ''.match(/(?:)/);
 m! && m[0];
 m?.[0]! && m[0];

--- a/tests/cases/conformance/decorators/1.0lib-noErrors.ts
+++ b/tests/cases/conformance/decorators/1.0lib-noErrors.ts
@@ -316,13 +316,7 @@ interface String {
 
     /** 
       * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A variable name or string literal containing the regular expression pattern and flags.
-      */
-    match(regexp: string): string[];
-
-    /** 
-      * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     match(regexp: RegExp): string[];
 
@@ -356,13 +350,7 @@ interface String {
 
     /**
       * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
-      */
-    search(regexp: string): number;
-
-    /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags. 
+      * @param regexp The regular expression to match against.
       */
     search(regexp: RegExp): number;
 
@@ -1141,4 +1129,4 @@ declare var Array: {
     <T>(...items: T[]): T[];
     isArray(arg: any): boolean;
     prototype: Array<any>;
-}
+}

--- a/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
+++ b/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
@@ -11,13 +11,11 @@ interface NotString {
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     localeCompare(that: string): number;
-    match(regexp: string): RegExpMatchArray;
     match(regexp: RegExp): RegExpMatchArray;
     replace(searchValue: string, replaceValue: string): string;
     replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
     replace(searchValue: RegExp, replaceValue: string): string;
     replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
-    search(regexp: string): number;
     search(regexp: RegExp): number;
     slice(start?: number, end?: number): string;
     split(separator: string, limit?: number): string[];

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -331,13 +331,7 @@ interface String {
 
     /**
       * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A variable name or string literal containing the regular expression pattern and flags.
-      */
-    match(regexp: string): RegExpMatchArray;
-
-    /**
-      * Matches a string with a regular expression, and returns an array containing the results of that search.
-      * @param regexp A regular expression object that contains the regular expression pattern and applicable flags.
+      * @param regexp The regular expression to match against.
       */
     match(regexp: RegExp): RegExpMatchArray;
 
@@ -370,14 +364,8 @@ interface String {
     replace(searchValue: RegExp, replacer: (substring: string, ...args: any[]) => string): string;
 
     /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags.
-      */
-    search(regexp: string): number;
-
-    /**
-      * Finds the first substring match in a regular expression search.
-      * @param regexp The regular expression pattern and applicable flags.
+      * Finds the index of the first substring match of a regular expression search.
+      * @param regexp The regular expression to match against.
       */
     search(regexp: RegExp): number;
 


### PR DESCRIPTION
> I think we can take a PR and assess what the breaks look like
> _Originally posted by @RyanCavanaugh in https://github.com/microsoft/TypeScript/issues/56109#issuecomment-1764791186_

Fixes #56109