### PR TITLE
Update 'pack this' result script to update new status comment

### DIFF
--- a/scripts/post-vsts-artifact-comment.mjs
+++ b/scripts/post-vsts-artifact-comment.mjs
@@ -5,17 +5,29 @@ import assert from "assert";
 import ado from "azure-devops-node-api";
 import fetch from "node-fetch";
 
+/**
+ * @param {string} name
+ */
+function mustGetEnv(name) {
+    const value = process.env[name];
+    assert(value, `No ${name} specified`);
+    return value;
+}
+
+const REQUESTING_USER = mustGetEnv("REQUESTING_USER");
+const SOURCE_ISSUE = +mustGetEnv("SOURCE_ISSUE");
+const BUILD_BUILDID = +mustGetEnv("BUILD_BUILDID");
+const DISTINCT_ID = mustGetEnv("DISTINCT_ID");
+
+const gh = new Octokit({
+    auth: process.argv[2],
+});
+
 async function main() {
-    if (!process.env.SOURCE_ISSUE) {
-        throw new Error("No source issue specified");
-    }
-    if (!process.env.BUILD_BUILDID) {
-        throw new Error("No build ID specified");
-    }
     // The pipelines API does _not_ make getting the direct URL to a specific file _within_ an artifact trivial
     const cli = new ado.WebApi("https://typescript.visualstudio.com/defaultcollection", ado.getHandlerFromToken("")); // Empty token, anon auth
     const build = await cli.getBuildApi();
-    const artifact = await build.getArtifact("typescript", +process.env.BUILD_BUILDID, "tgz");
+    const artifact = await build.getArtifact("typescript", BUILD_BUILDID, "tgz");
     assert(artifact.resource?.url);
     const updatedUrl = new URL(artifact.resource.url);
     updatedUrl.search = `artifactName=tgz&fileId=${artifact.resource.data}&fileName=manifest`;
@@ -24,18 +36,11 @@ async function main() {
     const tgzUrl = new URL(artifact.resource.url);
     tgzUrl.search = `artifactName=tgz&fileId=${file.blob.id}&fileName=${file.path}`;
     const link = "" + tgzUrl;
-    const gh = new Octokit({
-        auth: process.argv[2],
-    });
 
     // Please keep the strings "an installable tgz" and "packed" in this message, as well as the devDependencies section,
     // so that the playgrounds deployment process can find these comments.
 
-    await gh.issues.createComment({
-        issue_number: +process.env.SOURCE_ISSUE,
-        owner: "Microsoft",
-        repo: "TypeScript",
-        body: `Hey @${process.env.REQUESTING_USER}, I've packed this into [an installable tgz](${link}). You can install it for testing by referencing it in your \`package.json\` like so:
+    const comment = `Hey @${REQUESTING_USER}, I've packed this into [an installable tgz](${link}). You can install it for testing by referencing it in your \`package.json\` like so:
 \`\`\`
 {
     "devDependencies": {
@@ -44,26 +49,65 @@ async function main() {
 }
 \`\`\`
 and then running \`npm install\`.
-`,
-    });
+`;
 
     // Temporarily disable until we get access controls set up right
     // Send a ping to https://github.com/microsoft/typescript-make-monaco-builds#pull-request-builds
-    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: process.env.SOURCE_ISSUE, headers: { Accept: "application/vnd.github.everest-preview+json" } });
+    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: SOURCE_ISSUE, headers: { Accept: "application/vnd.github.everest-preview+json" } });
+
+    return comment;
 }
 
-main().catch(async e => {
+let newComment;
+let emoji;
+
+try {
+    newComment = await main();
+    emoji = "✅";
+}
+catch (e) {
     console.error(e);
-    process.exitCode = 1;
-    if (process.env.SOURCE_ISSUE) {
-        const gh = new Octokit({
-            auth: process.argv[2],
-        });
-        await gh.issues.createComment({
-            issue_number: +process.env.SOURCE_ISSUE,
-            owner: "Microsoft",
-            repo: "TypeScript",
-            body: `Hey @${process.env.REQUESTING_USER}, something went wrong when looking for the build artifact. ([You can check the log here](https://typescript.visualstudio.com/TypeScript/_build/index?buildId=${process.env.BUILD_BUILDID}&_a=summary)).`,
-        });
-    }
+    newComment = `Hey @${REQUESTING_USER}, something went wrong when looking for the build artifact. ([You can check the log here](https://typescript.visualstudio.com/TypeScript/_build/index?buildId=${BUILD_BUILDID}&_a=summary)).`;
+    emoji = "❌";
+}
+
+const resultsComment = await gh.issues.createComment({
+    issue_number: SOURCE_ISSUE,
+    owner: "Microsoft",
+    repo: "TypeScript",
+    body: newComment,
 });
+
+const toReplace = `<!--result-${DISTINCT_ID}-->`;
+let posted = false;
+for (let i = 0; i < 5; i++) {
+    // Get status comment contents
+    const statusComment = await gh.rest.issues.getComment({
+        comment_id: SOURCE_ISSUE,
+        owner: "Microsoft",
+        repo: "TypeScript",
+    });
+
+    const oldComment = statusComment.data.body;
+    if (!oldComment?.includes(toReplace)) {
+        posted = true;
+        break;
+    }
+
+    const newComment = oldComment.replace(toReplace, `[${emoji} Results](${resultsComment.data.html_url})`);
+
+    // Update status comment
+    await gh.rest.issues.updateComment({
+        comment_id: SOURCE_ISSUE,
+        owner: "Microsoft",
+        repo: "TypeScript",
+        body: newComment,
+    });
+
+    // Repeat; someone may have edited the comment at the same time.
+    await new Promise(resolve => setTimeout(resolve, 1000));
+}
+
+if (!posted) {
+    throw new Error("Failed to update status comment");
+}

--- a/scripts/post-vsts-artifact-comment.mjs
+++ b/scripts/post-vsts-artifact-comment.mjs
@@ -53,7 +53,7 @@ and then running \`npm install\`.
 
     // Temporarily disable until we get access controls set up right
     // Send a ping to https://github.com/microsoft/typescript-make-monaco-builds#pull-request-builds
-    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: SOURCE_ISSUE, headers: { Accept: "application/vnd.github.everest-preview+json" } });
+    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: `${SOURCE_ISSUE}`, headers: { Accept: "application/vnd.github.everest-preview+json" } });
 
     return comment;
 }

--- a/scripts/post-vsts-artifact-comment.mjs
+++ b/scripts/post-vsts-artifact-comment.mjs
@@ -73,7 +73,7 @@ catch (e) {
 
 const resultsComment = await gh.issues.createComment({
     issue_number: SOURCE_ISSUE,
-    owner: "Microsoft",
+    owner: "microsoft",
     repo: "TypeScript",
     body: newComment,
 });
@@ -84,7 +84,7 @@ for (let i = 0; i < 5; i++) {
     // Get status comment contents
     const statusComment = await gh.rest.issues.getComment({
         comment_id: SOURCE_ISSUE,
-        owner: "Microsoft",
+        owner: "microsoft",
         repo: "TypeScript",
     });
 
@@ -99,7 +99,7 @@ for (let i = 0; i < 5; i++) {
     // Update status comment
     await gh.rest.issues.updateComment({
         comment_id: SOURCE_ISSUE,
-        owner: "Microsoft",
+        owner: "microsoft",
         repo: "TypeScript",
         body: newComment,
     });


### PR DESCRIPTION
I didn't do this originally because I wanted to change the way this build system works, but I probably won't have time for a bit. The fact that this job is the only one that doesn't update the status comment is more annoying in the meantime, so, fix that.