### PR TITLE
Use more universal ANSI sequence for 'clear screen and clear buffer'

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1619,7 +1619,7 @@ export let sys: System = (() => {
             setTimeout,
             clearTimeout,
             clearScreen: () => {
-                process.stdout.write("\x1B[2J\x1B[3J\x1BH\x1B[0f");
+                process.stdout.write("\x1B[2J\x1B[3J\x1B[H");
             },
             setBlocking: () => {
                 const handle = (process.stdout as any)?._handle as { setBlocking?: (value: boolean) => void; };

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1619,7 +1619,7 @@ export let sys: System = (() => {
             setTimeout,
             clearTimeout,
             clearScreen: () => {
-                process.stdout.write("\x1Bc");
+                process.stdout.write("\x1B[2J\x1B[3J\x1BH\x1B[0f");
             },
             setBlocking: () => {
                 const handle = (process.stdout as any)?._handle as { setBlocking?: (value: boolean) => void; };


### PR DESCRIPTION
Fixes #57700
Fixes #29829
Fixes #57894
Closes #59315

Tiny tiny patch to bring just a little more terminal support to `tsc --watch`. In my case, iTerm2 needs this `ESC [ 3J` sequence in order to clear screen _and remove scroll history_.

If there's a setting in iTerm2 to change this, I would happily do that, but I didn't see anything.

```
  92049 passing (6m)

Finished do-runtests-parallel in 6m 22.9s
Completed runtests-parallel in 6m 57.3s
✨  Done in 417.81s.
```