### PR TITLE
Use `origin` for string literal definitions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1664,6 +1664,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getResolvedSignature: (node, candidatesOutArray, argumentCount) => getResolvedSignatureWorker(node, candidatesOutArray, argumentCount, CheckMode.Normal),
         getCandidateSignaturesForStringLiteralCompletions,
         getResolvedSignatureForSignatureHelp: (node, candidatesOutArray, argumentCount) => runWithoutResolvedSignatureCaching(node, () => getResolvedSignatureWorker(node, candidatesOutArray, argumentCount, CheckMode.IsForSignatureHelp)),
+        getContextualOriginTypeForStringDefinition: (node: StringLiteralLike) => {
+            const contextualType = getContextualType(node, /*contextFlags*/ undefined);
+            return contextualType && contextualType.flags & TypeFlags.Union ? (contextualType as UnionType).origin : undefined;
+        },
         getExpandedParameters,
         hasEffectiveRestParameter,
         containsArgumentsReference,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4967,6 +4967,7 @@ export interface TypeChecker {
     /** @internal */ getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike): Type | undefined;
     /** @internal */ getContextualTypeForArgumentAtIndex(call: CallLikeExpression, argIndex: number): Type | undefined;
     /** @internal */ getContextualTypeForJsxAttribute(attribute: JsxAttribute | JsxSpreadAttribute): Type | undefined;
+    /** @internal */ getContextualOriginTypeForStringDefinition(node: StringLiteralLike): Type | undefined;
     /** @internal */ isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElementLike | JsxAttributeLike): boolean;
     /** @internal */ getTypeOfPropertyOfContextualType(type: Type, name: __String): Type | undefined;
 

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -69,6 +69,7 @@ import {
     isPropertyName,
     isRightSideOfPropertyAccess,
     isStaticModifier,
+    isStringLiteralLike,
     isSwitchStatement,
     isTypeAliasDeclaration,
     isTypeReferenceNode,
@@ -184,6 +185,16 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
             pos = skipTrivia(sourceFile.text, pos);
             return createDefinitionInfoFromName(typeChecker, staticBlock, ScriptElementKind.constructorImplementationElement, "static {}", containerName, /*unverified*/ false, failedAliasResolution, { start: pos, length: "static".length });
         });
+    }
+
+    if (isStringLiteralLike(node)) {
+        const contextualOriginType = typeChecker.getContextualOriginTypeForStringDefinition(node);
+        if (contextualOriginType?.isIndexType() && !contextualOriginType.type.isUnion()) {
+            const symbol = contextualOriginType.type.getProperty(node.text);
+            if (symbol) {
+                return getDefinitionFromSymbol(typeChecker, symbol, node);
+            }
+        }
     }
 
     let { symbol, failedAliasResolution } = getSymbol(node, typeChecker, stopAtAlias);

--- a/tests/baselines/reference/goToDefinitionStringLiteral1.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionStringLiteral1.baseline.jsonc
@@ -1,0 +1,24 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionStringLiteral1.ts ===
+// type User = {
+//   <|[|name|]: string;|>
+//   age: number;
+// };
+// 
+// declare function fn<T>(obj: T, key: keyof T): void;
+// 
+// declare const user: User;
+// 
+// fn(user, "name/*GOTO DEF*/");
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "name",
+    "containerName": "__type",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/cases/fourslash/goToDefinitionStringLiteral1.ts
+++ b/tests/cases/fourslash/goToDefinitionStringLiteral1.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+
+//// type User = {
+////   name: string;
+////   age: number;
+//// };
+////
+//// declare function fn<T>(obj: T, key: keyof T): void;
+////
+//// declare const user: User;
+////
+//// fn(user, "name/*1*/");
+
+verify.baselineGoToDefinition("1");


### PR DESCRIPTION
⚠️ this is a proof-of-concept right now. It's not a complete implementation.

`.origin` information often allows the compiler to track back how a union has been created. It's used for improved type displays by quick info and such. It's also used by some optimizations. It occurred to me that it could be used in more places - such as go to definition

Shortcomings of this:
- not every pattern is supported by `.origin`. IIRC, `T[K]` doesn't track this under any circumstances
- `keyof { 'anonymous': 'object' }` is not tracked today. Since `.origin` was first introduced for type-displaying purposes it didn't make sense to track this. It would make sense to track it now as it would be quite crucial to support this in inference contexts.
- `keyof SinglePropObject` is simplified to a string literal type as it's not a union so naturally `.origin` is not tracked in such a case. It's not impossible to track this but it would raise the memory footprint. Maybe this extra `.origin` tracking could only be done by the `tsserver`?
- "complicated" intersections/unions (such as `keyof Obj1 & keyof Obj2`) don't always track this information so it won't always work. Some of that is likely fixable. A good enough solution, oriented on a specific subset of patterns could also be an option (as in - without touching how and how often `.origin` gets created today).
- it's just about go to definition - other features such as reference finding are unaffected by this

closes https://github.com/microsoft/TypeScript/issues/49033