### PR TITLE
Exclude generic string-like types from intersection reduction

### DIFF
--- a/tests/baselines/reference/intersectionReductionGenericStringLikeType.symbols
+++ b/tests/baselines/reference/intersectionReductionGenericStringLikeType.symbols
@@ -1,0 +1,77 @@
+//// [tests/cases/compiler/intersectionReductionGenericStringLikeType.ts] ////
+
+=== intersectionReductionGenericStringLikeType.ts ===
+// https://github.com/microsoft/TypeScript/issues/57736
+
+type obj = {
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+
+    foo: 1;
+>foo : Symbol(foo, Decl(intersectionReductionGenericStringLikeType.ts, 2, 12))
+
+    bar: 2;
+>bar : Symbol(bar, Decl(intersectionReductionGenericStringLikeType.ts, 3, 11))
+
+};
+
+type keyContaining1<
+>keyContaining1 : Symbol(keyContaining1, Decl(intersectionReductionGenericStringLikeType.ts, 5, 2))
+
+    str extends string,
+>str : Symbol(str, Decl(intersectionReductionGenericStringLikeType.ts, 7, 20))
+
+    keys extends keyof obj = keyof obj,
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 8, 23))
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+
+> = keys extends infer key extends keyof obj
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 8, 23))
+>key : Symbol(key, Decl(intersectionReductionGenericStringLikeType.ts, 10, 22))
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+
+    ? key extends `${string}${str}${string}`
+>key : Symbol(key, Decl(intersectionReductionGenericStringLikeType.ts, 10, 22))
+>str : Symbol(str, Decl(intersectionReductionGenericStringLikeType.ts, 7, 20))
+
+    ? obj[key]
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+>key : Symbol(key, Decl(intersectionReductionGenericStringLikeType.ts, 10, 22))
+
+    : never
+    : never;
+
+type _1 = keyContaining1<"foo">;  // 1
+>_1 : Symbol(_1, Decl(intersectionReductionGenericStringLikeType.ts, 14, 12))
+>keyContaining1 : Symbol(keyContaining1, Decl(intersectionReductionGenericStringLikeType.ts, 5, 2))
+
+type keyContaining2<
+>keyContaining2 : Symbol(keyContaining2, Decl(intersectionReductionGenericStringLikeType.ts, 16, 32))
+
+    str extends string,
+>str : Symbol(str, Decl(intersectionReductionGenericStringLikeType.ts, 18, 20))
+
+    keys extends keyof obj = keyof obj,
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 19, 23))
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+
+> = keys extends keys
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 19, 23))
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 19, 23))
+
+    ? keys extends `${string}${str}${string}`
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 19, 23))
+>str : Symbol(str, Decl(intersectionReductionGenericStringLikeType.ts, 18, 20))
+
+    ? obj[keys]
+>obj : Symbol(obj, Decl(intersectionReductionGenericStringLikeType.ts, 0, 0))
+>keys : Symbol(keys, Decl(intersectionReductionGenericStringLikeType.ts, 19, 23))
+
+    : never
+    : never;
+
+type _2 = keyContaining2<"foo">;  // 1
+>_2 : Symbol(_2, Decl(intersectionReductionGenericStringLikeType.ts, 25, 12))
+>keyContaining2 : Symbol(keyContaining2, Decl(intersectionReductionGenericStringLikeType.ts, 16, 32))
+

--- a/tests/baselines/reference/intersectionReductionGenericStringLikeType.types
+++ b/tests/baselines/reference/intersectionReductionGenericStringLikeType.types
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/intersectionReductionGenericStringLikeType.ts] ////
+
+=== intersectionReductionGenericStringLikeType.ts ===
+// https://github.com/microsoft/TypeScript/issues/57736
+
+type obj = {
+>obj : { foo: 1; bar: 2; }
+
+    foo: 1;
+>foo : 1
+
+    bar: 2;
+>bar : 2
+
+};
+
+type keyContaining1<
+>keyContaining1 : keyContaining1<str, keys>
+
+    str extends string,
+    keys extends keyof obj = keyof obj,
+> = keys extends infer key extends keyof obj
+    ? key extends `${string}${str}${string}`
+    ? obj[key]
+    : never
+    : never;
+
+type _1 = keyContaining1<"foo">;  // 1
+>_1 : 1
+
+type keyContaining2<
+>keyContaining2 : keyContaining2<str, keys>
+
+    str extends string,
+    keys extends keyof obj = keyof obj,
+> = keys extends keys
+    ? keys extends `${string}${str}${string}`
+    ? obj[keys]
+    : never
+    : never;
+
+type _2 = keyContaining2<"foo">;  // 1
+>_2 : 1
+

--- a/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
+++ b/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
@@ -1,0 +1,31 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/57736
+
+type obj = {
+    foo: 1;
+    bar: 2;
+};
+
+type keyContaining1<
+    str extends string,
+    keys extends keyof obj = keyof obj,
+> = keys extends infer key extends keyof obj
+    ? key extends `${string}${str}${string}`
+    ? obj[key]
+    : never
+    : never;
+
+type _1 = keyContaining1<"foo">;  // 1
+
+type keyContaining2<
+    str extends string,
+    keys extends keyof obj = keyof obj,
+> = keys extends keys
+    ? keys extends `${string}${str}${string}`
+    ? obj[keys]
+    : never
+    : never;
+
+type _2 = keyContaining2<"foo">;  // 1


### PR DESCRIPTION
Fixes #57736.