### PR TITLE
Allow `target`-only ES decorators

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34447,7 +34447,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getDecoratorArgumentCount(node: Decorator, signature: Signature) {
         return compilerOptions.experimentalDecorators ?
             getLegacyDecoratorArgumentCount(node, signature) :
-            2;
+            // Allow the runtime to oversupply arguments to an ES decorator as long as there's at least one parameter.
+            Math.min(Math.max(getParameterCount(signature), 1), 2);
     }
 
     /**

--- a/tests/baselines/reference/esDecorators-arguments.errors.txt
+++ b/tests/baselines/reference/esDecorators-arguments.errors.txt
@@ -1,22 +1,17 @@
 esDecorators-arguments.ts(1,2): error TS1238: Unable to resolve signature of class decorator when called as an expression.
   The runtime will invoke the decorator with 2 arguments, but the decorator expects 0.
-esDecorators-arguments.ts(2,2): error TS1238: Unable to resolve signature of class decorator when called as an expression.
-  The runtime will invoke the decorator with 2 arguments, but the decorator expects 1.
 esDecorators-arguments.ts(4,1): error TS1238: Unable to resolve signature of class decorator when called as an expression.
   The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.
 esDecorators-arguments.ts(5,1): error TS1238: Unable to resolve signature of class decorator when called as an expression.
   The runtime will invoke the decorator with 2 arguments, but the decorator expects at least 3.
 
 
-==== esDecorators-arguments.ts (4 errors) ====
+==== esDecorators-arguments.ts (3 errors) ====
     @(() => {})
      ~~~~~~~~~~
 !!! error TS1238: Unable to resolve signature of class decorator when called as an expression.
 !!! error TS1238:   The runtime will invoke the decorator with 2 arguments, but the decorator expects 0.
     @((a: any) => {})
-     ~~~~~~~~~~~~~~~~
-!!! error TS1238: Unable to resolve signature of class decorator when called as an expression.
-!!! error TS1238:   The runtime will invoke the decorator with 2 arguments, but the decorator expects 1.
     @((a: any, b: any) => {})
     @((a: any, b: any, c: any) => {})
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
@@ -39,13 +39,7 @@ Output::
 
 [91merror[0m[90m TS2318: [0mCannot find global type 'ClassDecoratorContext'.
 
-[96ma.ts[0m:[93m2[0m:[93m2[0m - [91merror[0m[90m TS1238: [0mUnable to resolve signature of class decorator when called as an expression.
-  The runtime will invoke the decorator with 2 arguments, but the decorator expects 1.
-
-[7m2[0m @((_) => {})
-[7m [0m [91m ~~~~~~~~~~~[0m
-
-[[90m12:00:20 AM[0m] Found 2 errors. Watching for file changes.
+[[90m12:00:20 AM[0m] Found 1 error. Watching for file changes.
 
 
 


### PR DESCRIPTION
This allows users to write ES decorators that contain only a `target` parameter.

Fixes #53208 
