### PR TITLE
fix type import check for default-import/re-export in js files

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2704,7 +2704,8 @@ export function getCompletionEntriesFromSymbols(
     }
 
     function symbolAppearsToBeTypeOnly(symbol: Symbol): boolean {
-        return !(symbol.flags & SymbolFlags.Value) && (!isInJSFile(symbol.declarations?.[0]) || !!(symbol.flags & SymbolFlags.Type));
+        const flags = getCombinedLocalAndExportSymbolFlags(skipAlias(symbol, typeChecker));
+        return !(flags & SymbolFlags.Value) && (!isInJSFile(symbol.declarations?.[0]) || !!(flags & SymbolFlags.Type));
     }
 }
 

--- a/tests/cases/fourslash/jsFileImportNoTypes2.ts
+++ b/tests/cases/fourslash/jsFileImportNoTypes2.ts
@@ -1,0 +1,59 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /default.ts
+//// export default class TestDefaultClass {}
+
+// @Filename: /defaultType.ts
+//// export default interface TestDefaultInterface {}
+
+// @Filename: /reExport/toReExport.ts
+//// export class TestClassReExport {}
+//// export interface TestInterfaceReExport {}
+
+// @Filename: /reExport/index.ts
+//// export { TestClassReExport, TestInterfaceReExport } from './toReExport';
+
+// @Filename: /exportList.ts
+//// class TestClassExportList {};
+//// interface TestInterfaceExportList {};
+//// export { TestClassExportList, TestInterfaceExportList };
+
+// @Filename: /baseline.ts
+//// export class TestClassBaseline {}
+//// export interface TestInterfaceBaseline {}
+
+// @Filename: /a.js
+//// import /**/
+
+verify.completions({
+    marker: "",
+    isNewIdentifierLocation: true,
+    exact: [
+        {
+            name: "TestClassBaseline",
+            insertText: "import { TestClassBaseline } from \"./baseline\";",
+            source: "./baseline",
+        },
+        {
+            name: "TestClassExportList",
+            insertText: "import { TestClassExportList } from \"./exportList\";",
+            source: "./exportList",
+        },
+        {
+            name: "TestClassReExport",
+            insertText: "import { TestClassReExport } from \"./reExport\";",
+            source: "./reExport",
+        },
+        {
+            name: "TestDefaultClass",
+            insertText: "import TestDefaultClass from \"./default\";",
+            source: "./default",
+        },
+    ],
+    preferences: {
+        includeCompletionsForImportStatements: true,
+        includeCompletionsWithInsertText: true,
+    }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57740. Pretty much copied from `shouldIncludeSymbol`. `getCombinedLocalAndExportSymbolFlags` for the default export and `skipAlias` for `export { someFunciton }` and `export { someFunction } from './module'`. 
