### PR TITLE
Require exactly 'true' for truthy reference directive prop

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -10511,7 +10511,7 @@ export function processPragmasIntoFields(context: PragmaContext, reportDiagnosti
                 const libReferenceDirectives = context.libReferenceDirectives;
                 forEach(toArray(entryOrList) as PragmaPseudoMap["reference"][], arg => {
                     const { types, lib, path, ["resolution-mode"]: res } = arg.arguments;
-                    if (arg.arguments["no-default-lib"]) {
+                    if (arg.arguments["no-default-lib"] === "true") {
                         context.hasNoDefaultLib = true;
                     }
                     else if (types) {


### PR DESCRIPTION
This is for #57681; noticed that we just say "if it's present it's true" rather than actually requiring the string true. Seems a little weird. No breaks locally, and didn't see much in https://github.com/search?q=%2Fno-default-lib%3D%22%2F+language%3Atypescript&type=code either.