### PR TITLE
Fix baselines after baseline change in main

### DIFF
--- a/tests/baselines/reference/jsxElementTypeLiteralWithGeneric.types
+++ b/tests/baselines/reference/jsxElementTypeLiteralWithGeneric.types
@@ -2,7 +2,7 @@
 
 === Performance Stats ===
 Assignability cache: 2,100 / 2,100 (nearest 100)
-Type Count: 7,800 / 7,800 (nearest 100)
+Type Count: 7,700 / 7,700 (nearest 100)
 Instantiation count: 91,500 / 91,500 (nearest 500)
 Symbol count: 66,500 / 66,500 (nearest 500)
 

--- a/tests/baselines/reference/jsxIssuesErrorWhenTagExpectsTooManyArguments.types
+++ b/tests/baselines/reference/jsxIssuesErrorWhenTagExpectsTooManyArguments.types
@@ -2,7 +2,7 @@
 
 === Performance Stats ===
 Assignability cache: 2,100 / 2,100 (nearest 100)
-Type Count: 6,800 / 6,800 (nearest 100)
+Type Count: 6,700 / 6,700 (nearest 100)
 Instantiation count: 73,000 / 73,000 (nearest 500)
 Symbol count: 66,500 / 66,500 (nearest 500)
 


### PR DESCRIPTION
#57665 and #57730 raced. Nice to know that my cleanup did lower the work the compiler was doing...