### PR TITLE
Don't indirect through _namespaces in tsserver/typingsInstaller

### DIFF
--- a/src/tsserver/_namespaces/ts.ts
+++ b/src/tsserver/_namespaces/ts.ts
@@ -1,1 +1,0 @@
-export * from "../../typescript/typescript";

--- a/src/tsserver/common.ts
+++ b/src/tsserver/common.ts
@@ -1,4 +1,4 @@
-import * as ts from "./_namespaces/ts";
+import * as ts from "../typescript/typescript";
 
 /** @internal */
 export function getLogLevel(level: string | undefined) {

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -23,8 +23,8 @@ import {
     validateLocaleAndSetLanguage,
     versionMajorMinor,
     WatchOptions,
-} from "./_namespaces/ts";
-import * as ts from "./_namespaces/ts";
+} from "../typescript/typescript";
+import * as ts from "../typescript/typescript";
 import {
     getLogLevel,
     StartInput,

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -1,4 +1,4 @@
-import * as ts from "./_namespaces/ts";
+import * as ts from "../typescript/typescript";
 import {
     StartInput,
 } from "./common";

--- a/src/typingsInstaller/_namespaces/ts.ts
+++ b/src/typingsInstaller/_namespaces/ts.ts
@@ -1,1 +1,0 @@
-export * from "../../typescript/typescript";

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -11,8 +11,8 @@ import {
     sys,
     toPath,
     version,
-} from "./_namespaces/ts";
-import * as ts from "./_namespaces/ts";
+} from "../typescript/typescript";
+import * as ts from "../typescript/typescript";
 
 class FileLog implements ts.server.typingsInstaller.Log {
     constructor(private logFile: string | undefined) {


### PR DESCRIPTION
A follow-up to #55326 which directly pulls from the public API project rather than indirecting through `_namespaces`, which incurs an extra copy due to esbuild's helpers.

I expect the bundle size to get larger due to the name esbuild chooses for the module, but potentially faster to load as it's not recreating a public API object.

This also likely locks off using named imports for nested modules as asked about in https://github.com/microsoft/TypeScript/pull/55326#pullrequestreview-1940018989, but I have not found a way to do those within our current import syntax.