### PR TITLE
fix54092: return replacement ranges for completions on unclosed strings

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2322,8 +2322,13 @@ export function createTextSpanFromNode(node: Node, sourceFile?: SourceFile, endN
 
 /** @internal */
 export function createTextSpanFromStringLiteralLikeContent(node: StringLiteralLike) {
-    if (node.isUnterminated) return undefined;
-    return createTextSpanFromBounds(node.getStart() + 1, node.getEnd() - 1);
+    let replacementEnd = node.getEnd() - 1;
+    if (node.isUnterminated) {
+        // we return no replacement range only if unterminated string is empty
+        if (node.getStart() === replacementEnd) return undefined;
+        replacementEnd = node.getEnd();
+    }
+    return createTextSpanFromBounds(node.getStart() + 1, replacementEnd);
 }
 
 /** @internal */

--- a/tests/cases/fourslash/stringCompletionsUnterminated.ts
+++ b/tests/cases/fourslash/stringCompletionsUnterminated.ts
@@ -1,12 +1,28 @@
 ///<reference path="fourslash.ts" />
 
-//// const a = { "foo.bar": 1}
+// @Filename: file1.ts
+//// const a = { "foo.bar": 1 }
 //// a["[|foo.b/*0*/|]
 //// a["[|foo.b           /*1*/|]
 //// a[    "[|foo.b/*2*/|]
 //// a["[|foo.b/*3*/|]"
 //// a["[|foo./*4*/b|]
+//// a['[|foo./*5*/b|]
+//// a[`[|foo./*6*/b|]
 
+// @Filename: file2.ts
+//// const a = { "foo.bar": 1 }
+//// a[`/*7*/
+
+// @Filename: file3.ts
+//// const a = { "foo.bar": 1 }
+//// a["/*8*/
+
+// @Filename: file4.ts
+//// const a = { "foo.bar": 1 }
+//// a['/*9*/
+
+// tests 7-9 should return no replacementSpan
 for (let i = 0; i < test.markers().length; i++) {
     verify.completions({
         marker: test.markers()[i],

--- a/tests/cases/fourslash/stringCompletionsUnterminated.ts
+++ b/tests/cases/fourslash/stringCompletionsUnterminated.ts
@@ -56,7 +56,7 @@
 //// const a = { "foo.bar": 1 }
 //// a['/*13*/
 
-// tests 7-9 should return no replacementSpan
+// tests 11-13 should return no replacementSpan
 const markers = test.markers();
 const ranges = test.ranges();
 

--- a/tests/cases/fourslash/stringCompletionsUnterminated.ts
+++ b/tests/cases/fourslash/stringCompletionsUnterminated.ts
@@ -1,0 +1,20 @@
+///<reference path="fourslash.ts" />
+
+//// const a = { "foo.bar": 1}
+//// a["[|foo.b/*0*/|]
+//// a["[|foo.b           /*1*/|]
+//// a[    "[|foo.b/*2*/|]
+//// a["[|foo.b/*3*/|]"
+//// a["[|foo./*4*/b|]
+
+for (let i = 0; i < test.markers().length; i++) {
+    verify.completions({
+        marker: test.markers()[i],
+        includes: [{
+            "name": "foo.bar",
+            "kind": "property",
+            "kindModifiers": "",
+            "replacementSpan": test.ranges()[i],
+        }],
+    });    
+}

--- a/tests/cases/fourslash/stringCompletionsUnterminated.ts
+++ b/tests/cases/fourslash/stringCompletionsUnterminated.ts
@@ -23,14 +23,17 @@
 //// a['/*9*/
 
 // tests 7-9 should return no replacementSpan
-for (let i = 0; i < test.markers().length; i++) {
+const markers = test.markers();
+const ranges = test.ranges();
+
+for (let i = 0; i < markers.length; i++) {
     verify.completions({
-        marker: test.markers()[i],
+        marker: markers[i],
         includes: [{
             "name": "foo.bar",
             "kind": "property",
             "kindModifiers": "",
-            "replacementSpan": test.ranges()[i],
+            "replacementSpan": ranges[i],
         }],
     });    
 }

--- a/tests/cases/fourslash/stringCompletionsUnterminated.ts
+++ b/tests/cases/fourslash/stringCompletionsUnterminated.ts
@@ -1,26 +1,60 @@
 ///<reference path="fourslash.ts" />
 
-// @Filename: file1.ts
+// @Filename: file0.ts
 //// const a = { "foo.bar": 1 }
 //// a["[|foo.b/*0*/|]
+
+// @Filename: file1.ts
+//// const a = { "foo.bar": 1 }
 //// a["[|foo.b           /*1*/|]
-//// a[    "[|foo.b/*2*/|]
-//// a["[|foo.b/*3*/|]"
-//// a["[|foo./*4*/b|]
-//// a['[|foo./*5*/b|]
-//// a[`[|foo./*6*/b|]
 
 // @Filename: file2.ts
 //// const a = { "foo.bar": 1 }
-//// a[`/*7*/
+//// a[    "[|foo.b/*2*/|]
 
 // @Filename: file3.ts
 //// const a = { "foo.bar": 1 }
-//// a["/*8*/
+//// a["[|foo.b/*3*/|]"
 
 // @Filename: file4.ts
 //// const a = { "foo.bar": 1 }
-//// a['/*9*/
+//// a["[|foo./*4*/b|]
+
+// @Filename: file5.ts
+//// const a = { "foo.bar": 1 }
+//// a['[|foo./*5*/b|]
+
+// @Filename: file6.ts
+//// const a = { "foo.bar": 1 }
+//// a[`[|foo./*6*/b|]
+
+// @Filename: file7.ts
+//// const a = { "foo.bar": 1 }
+//// a["[|foo./*7*/|]
+
+// @Filename: file8.ts
+//// const a = { "foo.bar": 1 }
+//// a["[|foo/*8*/|]
+
+// @Filename: file9.ts
+//// const a = { "foo.bar": 1 }
+//// a["[|foo./*9*/|]"
+
+// @Filename: file10.ts
+//// const a = { "foo.bar": 1 }
+//// a["[|foo/*10*/|]"
+
+// @Filename: empty1.ts
+//// const a = { "foo.bar": 1 }
+//// a[`/*11*/
+
+// @Filename: empty2.ts
+//// const a = { "foo.bar": 1 }
+//// a["/*12*/
+
+// @Filename: empty3.ts
+//// const a = { "foo.bar": 1 }
+//// a['/*13*/
 
 // tests 7-9 should return no replacementSpan
 const markers = test.markers();


### PR DESCRIPTION
fixes #54092.

Replacement ranges for string completions will be returned unless the closed string is empty (a single unclosed quote).