### PR TITLE
Revert PR 56087

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5740,12 +5740,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * Checks if two symbols, through aliasing and/or merging, refer to the same thing
      */
     function getSymbolIfSameReference(s1: Symbol, s2: Symbol) {
-        if (s1.flags & SymbolFlags.TypeAlias && s2.declarations?.find(isTypeAlias)) {
-            s2 = getDeclaredTypeOfTypeAlias(s2).aliasSymbol || s2;
-        }
-        if (s2.flags & SymbolFlags.TypeAlias && s1.declarations?.find(isTypeAlias)) {
-            s1 = getDeclaredTypeOfTypeAlias(s1).aliasSymbol || s1;
-        }
         if (getMergedSymbol(resolveSymbol(getMergedSymbol(s1))) === getMergedSymbol(resolveSymbol(getMergedSymbol(s2)))) {
             return s1;
         }

--- a/tests/baselines/reference/declarationEmitUsingTypeAlias1.errors.txt
+++ b/tests/baselines/reference/declarationEmitUsingTypeAlias1.errors.txt
@@ -1,0 +1,34 @@
+src/index.ts(3,14): error TS2742: The inferred type of 'foo' cannot be named without a reference to '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary.
+src/index.ts(7,14): error TS2742: The inferred type of 'bar' cannot be named without a reference to '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary.
+
+
+==== node_modules/some-dep/dist/inner.d.ts (0 errors) ====
+    export declare type Other = { other: string };
+    export declare type SomeType = { arg: Other };
+    
+==== node_modules/some-dep/dist/index.d.ts (0 errors) ====
+    export type OtherType = import('./inner').Other;
+    export type SomeType = import('./inner').SomeType;
+    
+==== node_modules/some-dep/package.json (0 errors) ====
+    {
+      "name": "some-dep",
+      "exports": {
+        ".": "./dist/index.js"
+      }
+    }
+    
+==== src/index.ts (2 errors) ====
+    import { SomeType } from "some-dep";
+    
+    export const foo = (thing: SomeType) => {
+                 ~~~
+!!! error TS2742: The inferred type of 'foo' cannot be named without a reference to '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary.
+      return thing;
+    };
+    
+    export const bar = (thing: SomeType) => {
+                 ~~~
+!!! error TS2742: The inferred type of 'bar' cannot be named without a reference to '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary.
+      return thing.arg;
+    };

--- a/tests/baselines/reference/declarationEmitUsingTypeAlias1.js
+++ b/tests/baselines/reference/declarationEmitUsingTypeAlias1.js
@@ -39,9 +39,3 @@ const bar = (thing) => {
     return thing.arg;
 };
 exports.bar = bar;
-
-
-//// [index.d.ts]
-import { SomeType } from "some-dep";
-export declare const foo: (thing: SomeType) => import("some-dep").SomeType;
-export declare const bar: (thing: SomeType) => import("some-dep").OtherType;

--- a/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.types
+++ b/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts] ////
 
-=== Performance Stats ===
-Type Count: 100 / 3,200 (nearest 100)
-Symbol count: 25,500 / 25,500 (nearest 500)
-
 === unusedTypeParametersCheckedByNoUnusedParameters.ts ===
 function f<T>() { }
 >f : <T>() => void

--- a/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.types
+++ b/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts] ////
 
-=== Performance Stats ===
-Type Count: 100 / 3,200 (nearest 100)
-Symbol count: 25,500 / 25,500 (nearest 500)
-
 === unusedTypeParametersNotCheckedByNoUnusedLocals.ts ===
 function f<T>() { }
 >f : <T>() => void


### PR DESCRIPTION
This reverts #56087. That PR was a fix for a bug present in all versions of TS, but caused 2 more bugs and a perf regression in 5.4. It may be the case that #57396 fixes all of these, but that PR introduces a lot more code and is still in discussion,

Fixes #57843
Fixes #57781
Fixes #57357
Reopens #49171

Not sure if I'm reading the baselines correctly, but since this is removing the perf baseline, I guess the new baselines would have caught this regression as before the revert, there are some 3.2k types, but after, it's under the 100 type threshold? And similarly for symbols.