### PR TITLE
Print baseline diffs on test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Print baseline diff on failure
         if: ${{ failure() && steps.test.conclusion == 'failure' }}
-        run: git diff --no-index -- ./tests/baselines/reference ./tests/baselines/local
+        run: git diff --diff-filter=AM --no-index -- ./tests/baselines/reference ./tests/baselines/local
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,13 @@ jobs:
       - run: npm ci
 
       - name: Tests
+        id: test
         # run tests, but lint separately
         run: npm run test -- --no-lint --bundle=${{ matrix.bundle }}
+
+      - name: Print baseline diff on failure
+        if: ${{ failure() && steps.test.conclusion == 'failure' }}
+        run: git diff --no-index -- ./tests/baselines/reference ./tests/baselines/local
 
   lint:
     runs-on: ubuntu-latest

--- a/tests/cases/compiler/2dArrays.ts
+++ b/tests/cases/compiler/2dArrays.ts
@@ -13,3 +13,5 @@ class Board {
         return this.ships.every(function (val) { return val.isSunk; });
     }    
 }
+
+console.log("revert me");

--- a/tests/cases/compiler/2dArrays.ts
+++ b/tests/cases/compiler/2dArrays.ts
@@ -13,5 +13,3 @@ class Board {
         return this.ships.every(function (val) { return val.isSunk; });
     }    
 }
-
-console.log("revert me");


### PR DESCRIPTION
Just on Windows/Node14, we're seeing this test flake:

```
92286 passing (9m)
  1 failing

  1) 
       
         unittests:: tsserver:: events:: ProjectsUpdatedInBackground
           when event handler is not set but session is created with canUseEvents = true
             without noGetErrOnBackgroundUpdate, diagnostics for open files are queued
               with --outFile setting
                 when both options are not set:
     Error: New baseline created at tests\baselines\local\tsserver\events\projectUpdatedInBackground\without-noGetErrOnBackgroundUpdate-and-when-both-options-are-not-set.js
      at writeComparison (src\harness\harnessIO.ts:1470:27)
      at Object.runBaseline2 [as runBaseline] (src\harness\harnessIO.ts:1489:9)
      at baselineTsserverLogs (src\testRunner\unittests\helpers\tsserver.ts:34:22)
      at Context.<anonymous> (src\testRunner\unittests\tsserver\events\projectUpdatedInBackground.ts:78:21)
      at processImmediate (internal/timers.js:[46](https://github.com/microsoft/TypeScript/actions/runs/8347717870/job/22847975351#step:5:47)4:21)
```

I'm not sure we can figure this out locally, but we can at least print out the baseline diff when tests fail.