### PR TITLE
Preserve resolution-mode as-written too

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4183,10 +4183,10 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
         function writeDirectives(kind: "path" | "types" | "lib", directives: readonly FileReference[]) {
             for (const directive of directives) {
-                const preserve = directive.preserve ? `preserve="true" ` : "";
-                const resolutionMode = directive.resolutionMode && directive.resolutionMode !== currentSourceFile?.impliedNodeFormat
+                const resolutionMode = directive.resolutionMode
                     ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}" `
                     : "";
+                const preserve = directive.preserve ? `preserve="true" ` : "";
                 writeComment(`/// <reference ${kind}="${directive.fileName}" ${resolutionMode}${preserve}/>`);
                 writeLine();
             }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node16).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node16).js
@@ -33,6 +33,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 /// <reference types="pkg" resolution-mode="import" preserve="true" />
-/// <reference types="pkg" preserve="true" />
+/// <reference types="pkg" resolution-mode="require" preserve="true" />
 export interface LocalInterface extends ImportInterface, RequireInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
@@ -33,6 +33,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 /// <reference types="pkg" resolution-mode="import" preserve="true" />
-/// <reference types="pkg" preserve="true" />
+/// <reference types="pkg" resolution-mode="require" preserve="true" />
 export interface LocalInterface extends ImportInterface, RequireInterface {
 }


### PR DESCRIPTION
I lost this change while working on #57681 and meant for it to be there; my understanding is that we want reference directives to be basically written verbatim. Conditionally emitting `resolution-mode` based on `impliedNodeFormat` breaks that rule.

Also, while here, put `const preserve = ...` after `const = resolutionMode`. Not sure why I added it out of order.