### PR TITLE
fix: correct mtime for useFsEventsOnParentDirectory events

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1286,7 +1286,12 @@ export function createSystemWatchFunctions({
         }
     }
 
-    function fsWatchWorkerHandlingTimestamp(fileOrDirectory: string, entryKind: FileSystemEntryKind, recursive: boolean, callback: FsWatchCallback): FsWatchWorkerWatcher {
+    function fsWatchWorkerHandlingTimestamp(
+        fileOrDirectory: string,
+        entryKind: FileSystemEntryKind,
+        recursive: boolean,
+        callback: FsWatchCallback,
+    ): FsWatchWorkerWatcher {
         const initialModifiedTime = getModifiedTime(fileOrDirectory) ?? missingFileModifiedTime;
         const modifiedTime: Record<string, Date | undefined> = {};
         return fsWatchWorker(fileOrDirectory, recursive, (eventName, relativeFileName, currentModifiedTime) => {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1295,9 +1295,9 @@ export function createSystemWatchFunctions({
         const initialModifiedTime = getModifiedTime(fileOrDirectory) ?? missingFileModifiedTime;
         const modifiedTime: Record<string, Date | undefined> = {};
         return fsWatchWorker(fileOrDirectory, recursive, (eventName, relativeFileName, currentModifiedTime) => {
-            const filename = entryKind === FileSystemEntryKind.File
-                ? fileOrDirectory
-                : (relativeFileName ? combinePaths(fileOrDirectory, relativeFileName) : fileOrDirectory);
+            const filename = entryKind === FileSystemEntryKind.Directory && relativeFileName
+                ? combinePaths(fileOrDirectory, relativeFileName)
+                : fileOrDirectory;
             currentModifiedTime ??= getModifiedTime(filename) ?? missingFileModifiedTime;
             const prevModifiedTime = modifiedTime[filename] ?? initialModifiedTime;
             if (eventName === "change" && currentModifiedTime.getTime() === prevModifiedTime?.getTime()) return;

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -725,7 +725,7 @@ describe("unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different po
         verify(/*fsWatchWithTimestamp*/ false);
     });
 
-    describe("with fsWatch with fsWatchWithTimestamp with useFsEventsOnParentDirectory", () => {
+    describe("with fsWatch with fsWatchWithTimestamp with useFsEventsOnParentDirectory (GH#57877)", () => {
         verifyTscWatch({
             scenario,
             subScenario: "fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory",
@@ -744,13 +744,12 @@ describe("unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different po
                 ),
             edits: [
                 {
-                    caption: "emulate access",
-                    edit: sys => sys.invokeFsWatches("/user/username/projects/myproject/main.ts", "change", /*modifiedTime*/ undefined, /*useTildeSuffix*/ undefined),
-                    timeouts: sys => sys.runQueuedTimeoutCallbacks(),
-                },
-                {
                     caption: "modify file contents",
-                    edit: sys => sys.appendFile("/user/username/projects/myproject/main.ts", "export const y = 10;"),
+                    edit: sys => sys.appendFile(
+                        "/user/username/projects/myproject/main.ts",
+                        "export const y = 10;",
+                        { omitModifiedTime: true, unmodifiedDirectoryMtime: true },
+                    ),
                     timeouts: sys => sys.runQueuedTimeoutCallbacks(),
                 },
             ],

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -734,22 +734,20 @@ describe("unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different po
                 createWatchedSystem(
                     {
                         [libFile.path]: libFile.content,
+                        "/user/username/projects/myproject/main.js": `export const x = 10;`,
                         "/user/username/projects/myproject/main.ts": `export const x = 10;`,
                         "/user/username/projects/myproject/tsconfig.json": jsonToReadableText({ files: ["main.ts"] }),
                     },
                     {
                         currentDirectory: "/user/username/projects/myproject",
                         fsWatchWithTimestamp: true,
+                        modifyFileWithoutModifyDirectory: true,
                     },
                 ),
             edits: [
                 {
                     caption: "modify file contents",
-                    edit: sys => sys.appendFile(
-                        "/user/username/projects/myproject/main.ts",
-                        "export const y = 10;",
-                        { omitModifiedTime: true, unmodifiedDirectoryMtime: true },
-                    ),
+                    edit: sys => sys.appendFile("/user/username/projects/myproject/main.ts", "export const y = 10;"),
                     timeouts: sys => sys.runQueuedTimeoutCallbacks(),
                 },
             ],

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -750,6 +750,11 @@ describe("unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different po
                     edit: sys => sys.appendFile("/user/username/projects/myproject/main.ts", "export const y = 10;"),
                     timeouts: sys => sys.runQueuedTimeoutCallbacks(),
                 },
+                {
+                    caption: "emulate access",
+                    edit: sys => sys.invokeFsWatches("/user/username/projects/myproject/main.ts", "change", /*modifiedTime*/ undefined, /*useTildeSuffix*/ undefined),
+                    timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+                },
             ],
         });
     });

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -725,6 +725,38 @@ describe("unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different po
         verify(/*fsWatchWithTimestamp*/ false);
     });
 
+    describe("with fsWatch with fsWatchWithTimestamp with useFsEventsOnParentDirectory", () => {
+        verifyTscWatch({
+            scenario,
+            subScenario: "fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory",
+            commandLineArgs: ["-w", "--watchFile", "usefseventsonparentdirectory", "--extendedDiagnostics"],
+            sys: () =>
+                createWatchedSystem(
+                    {
+                        [libFile.path]: libFile.content,
+                        "/user/username/projects/myproject/main.ts": `export const x = 10;`,
+                        "/user/username/projects/myproject/tsconfig.json": jsonToReadableText({ files: ["main.ts"] }),
+                    },
+                    {
+                        currentDirectory: "/user/username/projects/myproject",
+                        fsWatchWithTimestamp: true,
+                    },
+                ),
+            edits: [
+                {
+                    caption: "emulate access",
+                    edit: sys => sys.invokeFsWatches("/user/username/projects/myproject/main.ts", "change", /*modifiedTime*/ undefined, /*useTildeSuffix*/ undefined),
+                    timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+                },
+                {
+                    caption: "modify file contents",
+                    edit: sys => sys.appendFile("/user/username/projects/myproject/main.ts", "export const y = 10;"),
+                    timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+                },
+            ],
+        });
+    });
+
     verifyTscWatch({
         scenario,
         subScenario: "fsEvent for change is repeated",

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
@@ -87,9 +87,12 @@ Shape signatures in builder refreshed for::
 
 exitCode:: ExitStatus.undefined
 
-Change:: emulate access
+Change:: modify file contents
 
 Input::
+//// [/user/username/projects/myproject/main.ts]
+export const x = 10;export const y = 10;
+
 
 Output::
 FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
@@ -106,40 +109,12 @@ Before running Timeout callback:: count: 1
 After running Timeout callback:: count: 0
 Output::
 Synchronizing program
-
-
-
-
-exitCode:: ExitStatus.undefined
-
-Change:: modify file contents
-
-Input::
-//// [/user/username/projects/myproject/main.ts]
-export const x = 10;export const y = 10;
-
-
-Output::
-FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
-Scheduling update
-Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
-
-
-Timeout callback:: count: 1
-2: timerToUpdateProgram *new*
-
-Before running Timeout callback:: count: 1
-2: timerToUpdateProgram
-
-After running Timeout callback:: count: 0
-Output::
-Synchronizing program
-[[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
+[[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
 
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/main.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
+[[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
@@ -151,3 +151,14 @@ Shape signatures in builder refreshed for::
 /user/username/projects/myproject/main.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined
+
+Change:: emulate access
+
+Input::
+
+Before running Timeout callback:: count: 0
+
+After running Timeout callback:: count: 0
+
+
+exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
@@ -13,6 +13,9 @@ interface RegExp {}
 interface String { charAt: any; }
 interface Array<T> { length: number; [n: number]: T; }
 
+//// [/user/username/projects/myproject/main.js]
+export const x = 10;
+
 //// [/user/username/projects/myproject/main.ts]
 export const x = 10;
 
@@ -26,7 +29,7 @@ export const x = 10;
 
 /a/lib/tsc.js -w --watchFile usefseventsonparentdirectory --extendedDiagnostics
 Output::
-[[90m12:00:21 AM[0m] Starting compilation in watch mode...
+[[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
 Current directory: /user/username/projects/myproject CaseSensitiveFileNames: false
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 {"watchFile":5} Config file
@@ -40,7 +43,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_mod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"watchFile":5} Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 {"watchFile":5} Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 {"watchFile":5} Type roots
-[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+[[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
 
@@ -109,12 +112,12 @@ Before running Timeout callback:: count: 1
 After running Timeout callback:: count: 0
 Output::
 Synchronizing program
-[[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
+[[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/main.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
+[[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/fsWatchWithTimestamp/useFsEventsOnParentDirectory.js
@@ -1,0 +1,175 @@
+currentDirectory:: /user/username/projects/myproject useCaseSensitiveFileNames: false
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/main.ts]
+export const x = 10;
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{
+  "files": [
+    "main.ts"
+  ]
+}
+
+
+/a/lib/tsc.js -w --watchFile usefseventsonparentdirectory --extendedDiagnostics
+Output::
+[[90m12:00:21 AM[0m] Starting compilation in watch mode...
+
+Current directory: /user/username/projects/myproject CaseSensitiveFileNames: false
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 {"watchFile":5} Config file
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/main.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 {"watchFile":5} Source file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"watchFile":5} Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"watchFile":5} Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 {"watchFile":5} Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 {"watchFile":5} Type roots
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+//// [/user/username/projects/myproject/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = void 0;
+exports.x = 10;
+
+
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types: *new*
+  {"pollingInterval":500}
+/user/username/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib: *new*
+  {}
+/user/username/projects/myproject: *new*
+  {}
+
+Program root files: [
+  "/user/username/projects/myproject/main.ts"
+]
+Program options: {
+  "watch": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/user/username/projects/myproject/main.ts (used version)
+
+exitCode:: ExitStatus.undefined
+
+Change:: emulate access
+
+Input::
+
+Output::
+FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
+
+
+Timeout callback:: count: 1
+1: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+1: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Synchronizing program
+
+
+
+
+exitCode:: ExitStatus.undefined
+
+Change:: modify file contents
+
+Input::
+//// [/user/username/projects/myproject/main.ts]
+export const x = 10;export const y = 10;
+
+
+Output::
+FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/main.ts 1:: WatchInfo: /user/username/projects/myproject/main.ts 250 {"watchFile":5} Source file
+
+
+Timeout callback:: count: 1
+2: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+2: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Synchronizing program
+[[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/main.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+//// [/user/username/projects/myproject/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.y = exports.x = void 0;
+exports.x = 10;
+exports.y = 10;
+
+
+
+
+Program root files: [
+  "/user/username/projects/myproject/main.ts"
+]
+Program options: {
+  "watch": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/main.ts
+
+Shape signatures in builder refreshed for::
+/user/username/projects/myproject/main.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined


### PR DESCRIPTION
Fixes #57792

## Problem
On macOS Sonoma, `getModifiedTime(fileOrDirectory)` will return the wrong mtime for file change events in `FileSystemEntryKind.Directory` watchers, since `foo/bar.ts` modification will not bump `foo/` mtime nor will the event itself specify an mtime. This will cause file modifications to not be picked up when running `tsc --watch --watchFile usefseventsonparentdirectory`.

## Solution
Change `getModifiedTime(fileOrDirectory)` to `getModifiedTime(filename)`, where `filename` is calculated by passing through `entryKind`.

## Testing
Provided regression test which fails on `main`. The macOS Sonoma behavior is modeled by the mock filesystem using a new option `modifyFileWithoutModifyDirectory`.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->
