### PR TITLE
Properly add assignees and reviewers for cherry picked PRs

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -115,7 +115,19 @@ jobs:
                 head: pickBranch,
                 title,
                 body,
+              });
+
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: newPr.data.number,
                 assignees: ["DanielRosenwasser"],
+              });
+
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: newPr.data.number,
                 reviewers: ["DanielRosenwasser", REQUESTING_USER],
               });
 


### PR DESCRIPTION
This string script code isn't checked, and I apparently didn't test that assignees and reviewers actually worked. To add assignees and reviewers, you have to do it after creation.