### PR TITLE
Remove sys.bufferFrom, duplicate Buffer declarations, etc

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1323,85 +1323,6 @@ export function patchWriteFileEnsuringDirectory(sys: System) {
 
 export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
 
-/** @internal */
-export interface NodeBuffer extends Uint8Array {
-    constructor: any;
-    write(str: string, encoding?: BufferEncoding): number;
-    write(str: string, offset: number, encoding?: BufferEncoding): number;
-    write(str: string, offset: number, length: number, encoding?: BufferEncoding): number;
-    toString(encoding?: string, start?: number, end?: number): string;
-    toJSON(): { type: "Buffer"; data: number[]; };
-    equals(otherBuffer: Uint8Array): boolean;
-    compare(
-        otherBuffer: Uint8Array,
-        targetStart?: number,
-        targetEnd?: number,
-        sourceStart?: number,
-        sourceEnd?: number,
-    ): number;
-    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(begin?: number, end?: number): Buffer;
-    subarray(begin?: number, end?: number): Buffer;
-    writeUIntLE(value: number, offset: number, byteLength: number): number;
-    writeUIntBE(value: number, offset: number, byteLength: number): number;
-    writeIntLE(value: number, offset: number, byteLength: number): number;
-    writeIntBE(value: number, offset: number, byteLength: number): number;
-    readUIntLE(offset: number, byteLength: number): number;
-    readUIntBE(offset: number, byteLength: number): number;
-    readIntLE(offset: number, byteLength: number): number;
-    readIntBE(offset: number, byteLength: number): number;
-    readUInt8(offset: number): number;
-    readUInt16LE(offset: number): number;
-    readUInt16BE(offset: number): number;
-    readUInt32LE(offset: number): number;
-    readUInt32BE(offset: number): number;
-    readInt8(offset: number): number;
-    readInt16LE(offset: number): number;
-    readInt16BE(offset: number): number;
-    readInt32LE(offset: number): number;
-    readInt32BE(offset: number): number;
-    readFloatLE(offset: number): number;
-    readFloatBE(offset: number): number;
-    readDoubleLE(offset: number): number;
-    readDoubleBE(offset: number): number;
-    reverse(): this;
-    swap16(): Buffer;
-    swap32(): Buffer;
-    swap64(): Buffer;
-    writeUInt8(value: number, offset: number): number;
-    writeUInt16LE(value: number, offset: number): number;
-    writeUInt16BE(value: number, offset: number): number;
-    writeUInt32LE(value: number, offset: number): number;
-    writeUInt32BE(value: number, offset: number): number;
-    writeInt8(value: number, offset: number): number;
-    writeInt16LE(value: number, offset: number): number;
-    writeInt16BE(value: number, offset: number): number;
-    writeInt32LE(value: number, offset: number): number;
-    writeInt32BE(value: number, offset: number): number;
-    writeFloatLE(value: number, offset: number): number;
-    writeFloatBE(value: number, offset: number): number;
-    writeDoubleLE(value: number, offset: number): number;
-    writeDoubleBE(value: number, offset: number): number;
-    readBigUInt64BE?(offset?: number): bigint;
-    readBigUInt64LE?(offset?: number): bigint;
-    readBigInt64BE?(offset?: number): bigint;
-    readBigInt64LE?(offset?: number): bigint;
-    writeBigInt64BE?(value: bigint, offset?: number): number;
-    writeBigInt64LE?(value: bigint, offset?: number): number;
-    writeBigUInt64BE?(value: bigint, offset?: number): number;
-    writeBigUInt64LE?(value: bigint, offset?: number): number;
-    fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-    indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
-    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
-    entries(): IterableIterator<[number, number]>;
-    includes(value: string | number | Buffer, byteOffset?: number, encoding?: BufferEncoding): boolean;
-    keys(): IterableIterator<number>;
-    values(): IterableIterator<number>;
-}
-
-/** @internal */
-export interface Buffer extends NodeBuffer {}
-
 // TODO: GH#18217 Methods on System are often used as if they are certainly defined
 export interface System {
     args: string[];
@@ -1453,7 +1374,6 @@ export interface System {
     /** @internal */ setBlocking?(): void;
     base64decode?(input: string): string;
     base64encode?(input: string): string;
-    /** @internal */ bufferFrom?(input: string, encoding?: string): Buffer;
     /** @internal */ require?(baseDir: string, moduleName: string): ModuleImportResult;
 
     // For testing
@@ -1491,11 +1411,6 @@ export let sys: System = (() => {
         }
         let activeSession: import("inspector").Session | "stopping" | undefined;
         let profilePath = "./profile.cpuprofile";
-
-        const Buffer: {
-            new (input: string, encoding?: string): any;
-            from?(input: string, encoding?: string): any;
-        } = require("buffer").Buffer;
 
         const isMacOs = process.platform === "darwin";
         const isLinuxOrMacOs = process.platform === "linux" || isMacOs;
@@ -1627,9 +1542,8 @@ export let sys: System = (() => {
                     handle.setBlocking(true);
                 }
             },
-            bufferFrom,
-            base64decode: input => bufferFrom(input, "base64").toString("utf8"),
-            base64encode: input => bufferFrom(input).toString("base64"),
+            base64decode: input => Buffer.from(input, "base64").toString("utf8"),
+            base64encode: input => Buffer.from(input).toString("base64"),
             require: (baseDir, moduleName) => {
                 try {
                     const modulePath = resolveJSModule(moduleName, baseDir, nodeSystem);
@@ -1736,13 +1650,6 @@ export let sys: System = (() => {
                 cb();
                 return false;
             }
-        }
-
-        function bufferFrom(input: string, encoding?: string): Buffer {
-            // See https://github.com/Microsoft/TypeScript/issues/25652
-            return Buffer.from && Buffer.from !== Int8Array.from
-                ? Buffer.from(input, encoding)
-                : new Buffer(input, encoding);
         }
 
         function isFileSystemCaseSensitive(): boolean {

--- a/src/harness/harnessUtils.ts
+++ b/src/harness/harnessUtils.ts
@@ -2,7 +2,7 @@ import * as Harness from "./_namespaces/Harness";
 import * as ts from "./_namespaces/ts";
 
 export function encodeString(s: string): string {
-    return ts.sys.bufferFrom!(s).toString("utf8");
+    return Buffer.from(s).toString("utf8");
 }
 
 export function evalFile(fileContents: string, fileName: string, nodeContext?: any) {

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -1459,10 +1459,10 @@ type FileDataBuffer = { encoding?: undefined; data: Buffer; } | { encoding: Buff
 function ensureBufferEncoding(fileBuffer: FileDataBuffer, encoding: BufferEncoding | undefined) {
     if (fileBuffer.encoding === encoding) return;
 
-    const buffer = !fileBuffer.encoding ? fileBuffer.data : ts.sys.bufferFrom!(fileBuffer.data, fileBuffer.encoding);
+    const buffer = !fileBuffer.encoding ? fileBuffer.data : Buffer.from(fileBuffer.data, fileBuffer.encoding);
 
     fileBuffer.encoding = encoding;
-    fileBuffer.data = !encoding ? buffer as Buffer : buffer.toString(encoding);
+    fileBuffer.data = !encoding ? buffer : buffer.toString(encoding);
 }
 
 interface FileInode {

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -242,9 +242,9 @@ export function initializeNodeSystem(): StartInput {
         }
         protected write(s: string, _type: ts.server.Msg) {
             if (this.fd >= 0) {
-                const buf = sys.bufferFrom!(s);
+                const buf = Buffer.from(s);
                 // eslint-disable-next-line no-null/no-null
-                fs.writeSync(this.fd, buf as globalThis.Buffer, 0, buf.length, /*position*/ null!); // TODO: GH#18217
+                fs.writeSync(this.fd, buf, 0, buf.length, /*position*/ null!); // TODO: GH#18217
             }
             if (this.traceToConsole) {
                 console.warn(s);
@@ -324,7 +324,7 @@ export function initializeNodeSystem(): StartInput {
     }
 
     // Override sys.write because fs.writeSync is not reliable on Node 4
-    sys.write = (s: string) => writeMessage(sys.bufferFrom!(s, "utf8") as globalThis.Buffer);
+    sys.write = (s: string) => writeMessage(Buffer.from(s, "utf8"));
 
     /* eslint-disable no-restricted-globals */
     sys.setTimeout = setTimeout;


### PR DESCRIPTION
Direct use of `Buffer` was added in #22658 for base64. Later, #25659 added `bufferFrom` to work around a bug in Node v5. #29813 added a duplicate declaration of `Buffer` to get the project to compile properly.

These days, none of this appears to be needed. We can just use the global `Buffer` directly and drop all of the duplicate declarations and wrapping.

`BufferEncoding` unfortunately remains due to its use in the tsserver `Session` interface.