### PR TITLE
dprint exclude .git

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -44,6 +44,7 @@
         "trailingCommas": "never"
     },
     "excludes": [
+        "**/.git",
         "**/node_modules",
         "**/*-lock.json",
         "coverage/**",


### PR DESCRIPTION
So my branch refs named `.ts` don't get formatted.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
