### PR TITLE
Actually have a chance to reuse optional property signatures in the node builder

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8557,7 +8557,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (typeFromTypeNode === type) {
                 return true;
             }
-            if (annotatedDeclaration && (isParameter(annotatedDeclaration) || isPropertyDeclaration(annotatedDeclaration)) && annotatedDeclaration.questionToken) {
+            if (annotatedDeclaration && (isParameter(annotatedDeclaration) || isPropertySignature(annotatedDeclaration) || isPropertyDeclaration(annotatedDeclaration)) && annotatedDeclaration.questionToken) {
                 return getTypeWithFacts(type, TypeFacts.NEUndefined) === typeFromTypeNode;
             }
             return false;

--- a/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.types
+++ b/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.types
@@ -8,8 +8,8 @@ declare const foo: ["a", string, number] | ["b", string, boolean];
 export function test(arg: { index?: number }) {
 >test : (arg: { index?: number; }) => void
 >     : ^^^^^^                   ^^^^^^^^^
->arg : { index?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>arg : { index?: number; }
+>    : ^^^^^^^^^^      ^^^
 >index : number | undefined
 >      : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
@@ -23,8 +23,8 @@ declare class Component<P> {
 class C<T> extends Component<{ x?: boolean; } & T> {}
 >C : C<T>
 >  : ^^^^
->Component : Component<{ x?: boolean | undefined; } & T>
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Component : Component<{ x?: boolean; } & T>
+>          : ^^^^^^^^^^^^^^^^       ^^^^^^^^
 >x : boolean | undefined
 >  : ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.types
+++ b/tests/baselines/reference/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.types
@@ -16,8 +16,8 @@ declare class Component<P> {
 >        : ^^^
 
     readonly props: Readonly<P> & Readonly<{ children?: {} }>;
->props : Readonly<P> & Readonly<{ children?: {} | undefined; }>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : Readonly<P> & Readonly<{ children?: {}; }>
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 }
@@ -42,8 +42,8 @@ interface ComponentClass<P = {}> {
 }
 interface FunctionComponent<P = {}> {
     (props: P & { children?: {} }, context?: any): {} | null;
->props : P & { children?: {} | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: {}; }
+>      : ^^^^^^^^^^^^^^^^^  ^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 >context : any

--- a/tests/baselines/reference/contextualSignatureConditionalTypeInstantiationUsingDefault.types
+++ b/tests/baselines/reference/contextualSignatureConditionalTypeInstantiationUsingDefault.types
@@ -33,8 +33,8 @@ declare function createMachine<
   TTypesMeta extends TypegenEnabled | TypegenDisabled = TypegenDisabled
 >(
   config: {
->config : { types?: TTypesMeta | undefined; }
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>config : { types?: TTypesMeta; }
+>       : ^^^^^^^^^^          ^^^
 
     types?: TTypesMeta;
 >types : TTypesMeta | undefined

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
@@ -14,8 +14,8 @@ declare function match<T>(cb: (value: T) => boolean): T;
 declare function foo(pos: { x?: number; y?: number }): boolean;
 >foo : (pos: { x?: number; y?: number; }) => boolean
 >    : ^^^^^^                           ^^^^^       
->pos : { x?: number | undefined; y?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>pos : { x?: number; y?: number; }
+>    : ^^^^^^      ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : number | undefined

--- a/tests/baselines/reference/contextuallyTypedParametersWithInitializers1.types
+++ b/tests/baselines/reference/contextuallyTypedParametersWithInitializers1.types
@@ -28,8 +28,8 @@ declare function id3<T extends (x: { foo: any }) => any>(input: T): T;
 declare function id4<T extends (x: { foo?: number }) => any>(input: T): T;
 >id4 : <T extends (x: { foo?: number; }) => any>(input: T) => T
 >    : ^ ^^^^^^^^^^^^^                 ^^^^^   ^^^^^^^^^ ^^^^^ 
->x : { foo?: number | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { foo?: number; }
+>  : ^^^^^^^^      ^^^
 >foo : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
 >input : T

--- a/tests/baselines/reference/controlFlowAliasing.types
+++ b/tests/baselines/reference/controlFlowAliasing.types
@@ -1284,8 +1284,8 @@ class C11 {
 function f40(obj: { kind: 'foo', foo?: string } | { kind: 'bar', bar?: number }) {
 >f40 : (obj: { kind: 'foo'; foo?: string; } | { kind: 'bar'; bar?: number; }) => void
 >    : ^^^^^^                                                               ^^^^^^^^^
->obj : { kind: 'foo'; foo?: string | undefined; } | { kind: 'bar'; bar?: number | undefined; }
->    : ^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : { kind: 'foo'; foo?: string; } | { kind: 'bar'; bar?: number; }
+>    : ^^^^^^^^     ^^^^^^^^      ^^^^^^^^^^^^^^     ^^^^^^^^      ^^^
 >kind : "foo"
 >     : ^^^^^
 >foo : string | undefined

--- a/tests/baselines/reference/controlFlowDeleteOperator.types
+++ b/tests/baselines/reference/controlFlowDeleteOperator.types
@@ -6,8 +6,8 @@ function f() {
 >  : ^^^^^^^^^^
 
     let x: { a?: number | string, b: number | string } = { b: 1 };
->x : { a?: string | number | undefined; b: number | string; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^               ^^^
+>x : { a?: number | string; b: number | string; }
+>  : ^^^^^^               ^^^^^               ^^^
 >a : string | number | undefined
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >b : string | number

--- a/tests/baselines/reference/controlFlowInitializedDestructuringVariables.types
+++ b/tests/baselines/reference/controlFlowInitializedDestructuringVariables.types
@@ -2,8 +2,8 @@
 
 === controlFlowInitializedDestructuringVariables.ts ===
 declare const obj: { a?: string, b?: number };
->obj : { a?: string | undefined; b?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : { a?: string; b?: number; }
+>    : ^^^^^^      ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >b : number | undefined

--- a/tests/baselines/reference/controlFlowOptionalChain.types
+++ b/tests/baselines/reference/controlFlowOptionalChain.types
@@ -387,8 +387,8 @@ o3.x;
 >  : ^^^^^
 
 declare const o4: { x?: { y: boolean } };
->o4 : { x?: { y: boolean; } | undefined; }
->   : ^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^
+>o4 : { x?: { y: boolean; }; }
+>   : ^^^^^^               ^^^
 >x : { y: boolean; } | undefined
 >  : ^^^^^       ^^^^^^^^^^^^^^^
 >y : boolean
@@ -504,12 +504,12 @@ o4.x.y;
 >  : ^^^^^^^
 
 declare const o5: { x?: { y: { z?: { w: boolean } } } };
->o5 : { x?: { y: { z?: { w: boolean; }; }; } | undefined; }
->   : ^^^^^^^^^^^                        ^^^^^^^^^^^^^^^^^^
+>o5 : { x?: { y: { z?: { w: boolean; }; }; }; }
+>   : ^^^^^^                                ^^^
 >x : { y: { z?: { w: boolean; }; }; } | undefined
 >  : ^^^^^                        ^^^^^^^^^^^^^^^
->y : { z?: { w: boolean; } | undefined; }
->  : ^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^
+>y : { z?: { w: boolean; }; }
+>  : ^^^^^^               ^^^
 >z : { w: boolean; } | undefined
 >  : ^^^^^       ^^^^^^^^^^^^^^^
 >w : boolean

--- a/tests/baselines/reference/controlFlowOptionalChain3.types
+++ b/tests/baselines/reference/controlFlowOptionalChain3.types
@@ -135,8 +135,8 @@ function Test3({ foo }: { foo: Foo | undefined }) {
 function test4(options?: { a?: boolean; b?: boolean }) {
 >test4 : (options?: { a?: boolean; b?: boolean; }) => void
 >      : ^^^^^^^^^^^                             ^^^^^^^^^
->options : { a?: boolean | undefined; b?: boolean | undefined; } | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : { a?: boolean; b?: boolean; } | undefined
+>        : ^^^^^^       ^^^^^^       ^^^^^^^^^^^^^^^
 >a : boolean | undefined
 >  : ^^^^^^^^^^^^^^^^^^^
 >b : boolean | undefined

--- a/tests/baselines/reference/correlatedUnions.js
+++ b/tests/baselines/reference/correlatedUnions.js
@@ -528,12 +528,12 @@ declare function processEvents<K extends keyof DocumentEventMap>(events: Ev<K>[]
 declare function createEventListener<K extends keyof DocumentEventMap>({ name, once, callback }: Ev<K>): Ev<K>;
 declare const clickEvent: {
     readonly name: "click";
-    readonly once?: boolean | undefined;
+    readonly once?: boolean;
     readonly callback: (ev: MouseEvent) => void;
 };
 declare const scrollEvent: {
     readonly name: "scroll";
-    readonly once?: boolean | undefined;
+    readonly once?: boolean;
     readonly callback: (ev: Event) => void;
 };
 declare function ff1(): void;

--- a/tests/baselines/reference/declarationEmitOptionalMethod.types
+++ b/tests/baselines/reference/declarationEmitOptionalMethod.types
@@ -6,8 +6,8 @@ export const Foo = (opts: {
 >    : ^^^^^^^                               ^^^^^                               
 >(opts: {    a?(): void,    b?: () => void,}): {    c?(): void,    d?: () => void,} => ({  }) : (opts: { a?(): void; b?: () => void; }) => { c?(): void; d?: () => void; }
 >                                                                                             : ^^^^^^^                               ^^^^^                               
->opts : { a?(): void; b?: (() => void) | undefined; }
->     : ^^^^^^^^    ^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^
+>opts : { a?(): void; b?: () => void; }
+>     : ^^^^^^^^    ^^^^^^          ^^^
 
     a?(): void,
 >a : (() => void) | undefined

--- a/tests/baselines/reference/deleteChain.types
+++ b/tests/baselines/reference/deleteChain.types
@@ -106,12 +106,12 @@ delete (o3.b?.c);
 >  : ^^^^^^^^^^^^^^^^^^
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
->   : ^^^^^^^^^^^                       ^^^^^^^^^^^^^^^^^^
+>o4 : { b?: { c: { d?: { e: string; }; }; }; }
+>   : ^^^^^^                               ^^^
 >b : { c: { d?: { e: string; }; }; } | undefined
 >  : ^^^^^                       ^^^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string
@@ -192,8 +192,8 @@ declare const o5: { b?(): { c: { d?: { e: string } } } };
 >   : ^^^^^^^^                               ^^^
 >b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >  : ^^^^^^^                               ^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string
@@ -250,12 +250,12 @@ delete (o5.b?.().c.d?.e);
 >  : ^^^^^^^^^^^^^^^^^^
 
 declare const o6: { b?: { c: { d?: { e: string } } } };
->o6 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
->   : ^^^^^^^^^^^                       ^^^^^^^^^^^^^^^^^^
+>o6 : { b?: { c: { d?: { e: string; }; }; }; }
+>   : ^^^^^^                               ^^^
 >b : { c: { d?: { e: string; }; }; } | undefined
 >  : ^^^^^                       ^^^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string

--- a/tests/baselines/reference/destructuringAssignmentWithDefault.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault.types
@@ -2,8 +2,8 @@
 
 === destructuringAssignmentWithDefault.ts ===
 const a: { x?: number } = { };
->a : { x?: number | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { x?: number; }
+>  : ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >{ } : {}
@@ -34,8 +34,8 @@ let x = 0;
 function f1(options?: { color?: string, width?: number }) {
 >f1 : (options?: { color?: string; width?: number; }) => void
 >   : ^^^^^^^^^^^                                   ^^^^^^^^^
->options : { color?: string | undefined; width?: number | undefined; } | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : { color?: string; width?: number; } | undefined
+>        : ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
 >color : string | undefined
 >      : ^^^^^^^^^^^^^^^^^^
 >width : number | undefined

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.types
@@ -2,8 +2,8 @@
 
 === destructuringAssignmentWithDefault2.ts ===
 const a: { x?: number; y?: number } = { };
->a : { x?: number | undefined; y?: number | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { x?: number; y?: number; }
+>  : ^^^^^^      ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : number | undefined

--- a/tests/baselines/reference/destructuringControlFlow.types
+++ b/tests/baselines/reference/destructuringControlFlow.types
@@ -4,8 +4,8 @@
 function f1(obj: { a?: string }) {
 >f1 : (obj: { a?: string; }) => void
 >   : ^^^^^^               ^^^^^^^^^
->obj : { a?: string | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : { a?: string; }
+>    : ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
@@ -158,8 +158,8 @@ function f2(obj: [number, string] | null[]) {
 function f3(obj: { a?: number, b?: string }) {
 >f3 : (obj: { a?: number; b?: string; }) => void
 >   : ^^^^^^                           ^^^^^^^^^
->obj : { a?: number | undefined; b?: string | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : { a?: number; b?: string; }
+>    : ^^^^^^      ^^^^^^      ^^^
 >a : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >b : string | undefined

--- a/tests/baselines/reference/duplicateObjectLiteralProperty_computedNameNegative1.types
+++ b/tests/baselines/reference/duplicateObjectLiteralProperty_computedNameNegative1.types
@@ -6,8 +6,8 @@
 function bar(props: { x?: string; y?: string }) {
 >bar : (props: { x?: string; y?: string; }) => { [x: string]: number; }
 >    : ^^^^^^^^                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->props : { x?: string | undefined; y?: string | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : { x?: string; y?: string; }
+>      : ^^^^^^      ^^^^^^      ^^^
 >x : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : string | undefined

--- a/tests/baselines/reference/elementAccessChain.types
+++ b/tests/baselines/reference/elementAccessChain.types
@@ -80,12 +80,12 @@ o3.b?.["c"];
 >    : ^^^
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
->   : ^^^^^^^^^^^                       ^^^^^^^^^^^^^^^^^^
+>o4 : { b?: { c: { d?: { e: string; }; }; }; }
+>   : ^^^^^^                               ^^^
 >b : { c: { d?: { e: string; }; }; } | undefined
 >  : ^^^^^                       ^^^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string
@@ -136,8 +136,8 @@ declare const o5: { b?(): { c: { d?: { e: string } } } };
 >   : ^^^^^^^^                               ^^^
 >b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >  : ^^^^^^^                               ^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string

--- a/tests/baselines/reference/homomorphicMappedTypeIntersectionAssignability.types
+++ b/tests/baselines/reference/homomorphicMappedTypeIntersectionAssignability.types
@@ -6,8 +6,8 @@ function f<TType>(
 >  : ^     ^^^^^                                                      ^^^^^                                   ^^^^^                                   ^^^^^^^^^
 
     a: { weak?: string } & Readonly<TType> & { name: "ok" },
->a : { weak?: string | undefined; } & Readonly<TType> & { name: "ok"; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^
+>a : { weak?: string; } & Readonly<TType> & { name: "ok"; }
+>  : ^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^
 >weak : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
 >name : "ok"

--- a/tests/baselines/reference/inKeywordTypeguard(strict=true).types
+++ b/tests/baselines/reference/inKeywordTypeguard(strict=true).types
@@ -1492,8 +1492,8 @@ function f12(x: { a: string }) {
 function f13(x: { a?: string }) {
 >f13 : (x: { a?: string; }) => void
 >    : ^^^^               ^^^^^^^^^
->x : { a?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { a?: string; }
+>  : ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/indexSignatures1.types
+++ b/tests/baselines/reference/indexSignatures1.types
@@ -1328,8 +1328,8 @@ const directive = Symbol('directive');
 declare function foo<TArg, TRet, TDir>(options: { [x in string]: (arg: TArg) => TRet } & { [directive]?: TDir }): void;
 >foo : <TArg, TRet, TDir>(options: { [x in string]: (arg: TArg) => TRet; } & { [directive]?: TDir; }) => void
 >    : ^    ^^    ^^    ^^^^^^^^^^^                                                                 ^^^^^    
->options : { [x: string]: (arg: TArg) => TRet; } & { [directive]?: TDir | undefined; }
->        : ^^^^^^^^^^^^^^^^^^^^^    ^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : { [x: string]: (arg: TArg) => TRet; } & { [directive]?: TDir; }
+>        : ^^^^^^^^^^^^^^^^^^^^^    ^^^^^    ^^^^^^^^^^^^^^^^^^^^^^    ^^^
 >arg : TArg
 >    : ^^^^
 >[directive] : TDir | undefined

--- a/tests/baselines/reference/inferenceOptionalPropertiesToIndexSignatures.types
+++ b/tests/baselines/reference/inferenceOptionalPropertiesToIndexSignatures.types
@@ -26,8 +26,8 @@ declare const x2: { a: string, b: number | undefined };
 >  : ^^^^^^^^^^^^^^^^^^
 
 declare const x3: { a: string, b?: number };
->x3 : { a: string; b?: number | undefined; }
->   : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x3 : { a: string; b?: number; }
+>   : ^^^^^      ^^^^^^      ^^^
 >a : string
 >  : ^^^^^^
 >b : number | undefined

--- a/tests/baselines/reference/instantiateContextualTypes.types
+++ b/tests/baselines/reference/instantiateContextualTypes.types
@@ -324,8 +324,8 @@ interface ComponentClass<P = {}> {
 }
 
 type CreateElementChildren<P> =
->CreateElementChildren : P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown
->                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>CreateElementChildren : P extends { children?: infer C; } ? C extends any[] ? C : C[] : unknown
+>                      : ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   P extends { children?: infer C }
 >children : C | undefined

--- a/tests/baselines/reference/intersectionOfTypeVariableHasApparentSignatures.types
+++ b/tests/baselines/reference/intersectionOfTypeVariableHasApparentSignatures.types
@@ -3,8 +3,8 @@
 === intersectionOfTypeVariableHasApparentSignatures.ts ===
 interface Component<P> {
     props: Readonly<P> & Readonly<{ children?: {} }>;
->props : Readonly<P> & Readonly<{ children?: {} | undefined; }>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : Readonly<P> & Readonly<{ children?: {}; }>
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 }

--- a/tests/baselines/reference/intersectionPropertyCheck.types
+++ b/tests/baselines/reference/intersectionPropertyCheck.types
@@ -38,10 +38,10 @@ declare let wrong: { a: { y: string } };
 >  : ^^^^^^
 
 let weak: { a?: { x?: number } } & { c?: string } = wrong;  // Nested weak object type
->weak : { a?: { x?: number | undefined; } | undefined; } & { c?: string | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->a : { x?: number | undefined; } | undefined
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>weak : { a?: { x?: number; }; } & { c?: string; }
+>     : ^^^^^^               ^^^^^^^^^^^^      ^^^
+>a : { x?: number; } | undefined
+>  : ^^^^^^      ^^^^^^^^^^^^^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >c : string | undefined
@@ -52,8 +52,8 @@ let weak: { a?: { x?: number } } & { c?: string } = wrong;  // Nested weak objec
 function foo<T extends object>(x: { a?: string }, y: T & { a: boolean }) {
 >foo : <T extends object>(x: { a?: string; }, y: T & { a: boolean; }) => void
 >    : ^ ^^^^^^^^^^^^^^^^^^^^               ^^^^^                   ^^^^^^^^^
->x : { a?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { a?: string; }
+>  : ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : T & { a: boolean; }

--- a/tests/baselines/reference/intersectionsAndOptionalProperties.types
+++ b/tests/baselines/reference/intersectionsAndOptionalProperties.types
@@ -2,8 +2,8 @@
 
 === intersectionsAndOptionalProperties.ts ===
 declare let x: { a?: number, b: string };
->x : { a?: number | undefined; b: string; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>x : { a?: number; b: string; }
+>  : ^^^^^^      ^^^^^      ^^^
 >a : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >b : string

--- a/tests/baselines/reference/jsxCallbackWithDestructuring.types
+++ b/tests/baselines/reference/jsxCallbackWithDestructuring.types
@@ -17,8 +17,8 @@ declare class Component<P, S> {
 >       : ^^^^^^  
 
     props: Readonly<{ children?: {} }> & Readonly<P>;
->props : Readonly<{ children?: {} | undefined; }> & Readonly<P>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : Readonly<{ children?: {}; }> & Readonly<P>
+>      : ^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 }

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.types
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.types
@@ -35,8 +35,8 @@ declare global {
 interface MockComponentInterface {
 	new (): {
         __properties__: { bar?: number } & { __children__: () => number };
->__properties__ : { bar?: number | undefined; } & { __children__: () => number; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^            ^^^
+>__properties__ : { bar?: number; } & { __children__: () => number; }
+>               : ^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^            ^^^
 >bar : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
 >__children__ : () => number

--- a/tests/baselines/reference/jsxIntrinsicElementsCompatability.types
+++ b/tests/baselines/reference/jsxIntrinsicElementsCompatability.types
@@ -15,8 +15,8 @@ import * as React from "react";
 function SomeComponent<T extends 'button' | 'a'>(props: { element?: T } & JSX.IntrinsicElements[T]): JSX.Element {
 >SomeComponent : <T extends "a" | "button">(props: { element?: T; } & JSX.IntrinsicElements[T]) => JSX.Element
 >              : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^^^^^           
->props : { element?: T | undefined; } & JSX.IntrinsicElements[T]
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : { element?: T; } & JSX.IntrinsicElements[T]
+>      : ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >element : T | undefined
 >        : ^^^^^^^^^^^^^
 >JSX : any

--- a/tests/baselines/reference/jsxNamespaceGlobalReexport.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexport.types
@@ -118,8 +118,8 @@ export function jsx(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -145,8 +145,8 @@ export function jsx<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild },
->props : P & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^              ^^^
 >children : ComponentChild | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -165,8 +165,8 @@ export function jsxs(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -192,8 +192,8 @@ export function jsxs<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild[] },
->props : P & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^                ^^^
 >children : ComponentChild[] | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -212,8 +212,8 @@ export function jsxDEV(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -239,8 +239,8 @@ export function jsxDEV<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChildren },
->props : P & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^                 ^^^
 >children : ComponentChildren | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
@@ -121,8 +121,8 @@ export function jsx(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -148,8 +148,8 @@ export function jsx<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild },
->props : P & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^              ^^^
 >children : ComponentChild | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -168,8 +168,8 @@ export function jsxs(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -195,8 +195,8 @@ export function jsxs<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild[] },
->props : P & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^                ^^^
 >children : ComponentChild[] | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -215,8 +215,8 @@ export function jsxDEV(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -242,8 +242,8 @@ export function jsxDEV<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChildren },
->props : P & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^                 ^^^
 >children : ComponentChildren | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
+++ b/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
@@ -118,8 +118,8 @@ export function jsx(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -145,8 +145,8 @@ export function jsx<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild },
->props : P & { children?: ComponentChild | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild; }
+>      : ^^^^^^^^^^^^^^^^^              ^^^
 >children : ComponentChild | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -166,8 +166,8 @@ export function jsxs(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -193,8 +193,8 @@ export function jsxs<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChild[] },
->props : P & { children?: ComponentChild[] | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChild[]; }
+>      : ^^^^^^^^^^^^^^^^^                ^^^
 >children : ComponentChild[] | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -214,8 +214,8 @@ export function jsxDEV(
 >     : ^^^^^^
 
     props: JSXInternal.HTMLAttributes &
->props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 ^^^
 >JSXInternal : any
 >            : ^^^
 
@@ -241,8 +241,8 @@ export function jsxDEV<P>(
 >     : ^^^^^^^^^^^^^^^^
 
     props: Attributes & P & { children?: ComponentChildren },
->props : P & { children?: ComponentChildren | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: ComponentChildren; }
+>      : ^^^^^^^^^^^^^^^^^                 ^^^
 >children : ComponentChildren | undefined
 >         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/logicalAssignment8(target=es2015).types
+++ b/tests/baselines/reference/logicalAssignment8(target=es2015).types
@@ -2,8 +2,8 @@
 
 === logicalAssignment8.ts ===
 declare const bar: { value?: number[] } | undefined
->bar : { value?: number[] | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>bar : { value?: number[]; } | undefined
+>    : ^^^^^^^^^^        ^^^^^^^^^^^^^^^
 >value : number[] | undefined
 >      : ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/logicalAssignment8(target=es2020).types
+++ b/tests/baselines/reference/logicalAssignment8(target=es2020).types
@@ -2,8 +2,8 @@
 
 === logicalAssignment8.ts ===
 declare const bar: { value?: number[] } | undefined
->bar : { value?: number[] | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>bar : { value?: number[]; } | undefined
+>    : ^^^^^^^^^^        ^^^^^^^^^^^^^^^
 >value : number[] | undefined
 >      : ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/logicalAssignment8(target=es2021).types
+++ b/tests/baselines/reference/logicalAssignment8(target=es2021).types
@@ -2,8 +2,8 @@
 
 === logicalAssignment8.ts ===
 declare const bar: { value?: number[] } | undefined
->bar : { value?: number[] | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>bar : { value?: number[]; } | undefined
+>    : ^^^^^^^^^^        ^^^^^^^^^^^^^^^
 >value : number[] | undefined
 >      : ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/logicalAssignment8(target=esnext).types
+++ b/tests/baselines/reference/logicalAssignment8(target=esnext).types
@@ -2,8 +2,8 @@
 
 === logicalAssignment8.ts ===
 declare const bar: { value?: number[] } | undefined
->bar : { value?: number[] | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>bar : { value?: number[]; } | undefined
+>    : ^^^^^^^^^^        ^^^^^^^^^^^^^^^
 >value : number[] | undefined
 >      : ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/logicalAssignment9.types
+++ b/tests/baselines/reference/logicalAssignment9.types
@@ -2,8 +2,8 @@
 
 === logicalAssignment9.ts ===
 declare let x: { a?: boolean };
->x : { a?: boolean | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { a?: boolean; }
+>  : ^^^^^^       ^^^
 >a : boolean | undefined
 >  : ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/mappedTypesArraysTuples.types
+++ b/tests/baselines/reference/mappedTypesArraysTuples.types
@@ -206,8 +206,8 @@ let y21 = nonpartial(x21);
 >    : ^^^^^^^^^^^^^^^^^^^^^^
 
 declare let x22: { a: number | undefined, b?: string[] };
->x22 : { a: number | undefined; b?: string[] | undefined; }
->    : ^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x22 : { a: number | undefined; b?: string[]; }
+>    : ^^^^^                  ^^^^^^        ^^^
 >a : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >b : string[] | undefined

--- a/tests/baselines/reference/mergedInstantiationAssignment.types
+++ b/tests/baselines/reference/mergedInstantiationAssignment.types
@@ -15,10 +15,10 @@ class GenericObject<T = number> {
 }
 
 const v1 = new GenericObject() as GenericObject &
->v1 : GenericObject<number> & ({ a?: string | undefined; } | { b?: number | undefined; })
->   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new GenericObject() as GenericObject &  ({ a?: string } | { b?: number }) : GenericObject<number> & ({ a?: string | undefined; } | { b?: number | undefined; })
->                                                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>v1 : GenericObject<number> & ({ a?: string; } | { b?: number; })
+>   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
+>new GenericObject() as GenericObject &  ({ a?: string } | { b?: number }) : GenericObject<number> & ({ a?: string; } | { b?: number; })
+>                                                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
 >new GenericObject() : GenericObject<number>
 >                    : ^^^^^^^^^^^^^^^^^^^^^
 >GenericObject : typeof GenericObject
@@ -52,10 +52,10 @@ class GenericObjectWithoutSetter<T = number> {
 }
 
 const v2 = new GenericObjectWithoutSetter() as GenericObjectWithoutSetter &
->v2 : GenericObjectWithoutSetter<number> & ({ a?: string | undefined; } | { b?: number | undefined; })
->   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new GenericObjectWithoutSetter() as GenericObjectWithoutSetter &  ({ a?: string } | { b?: number }) : GenericObjectWithoutSetter<number> & ({ a?: string | undefined; } | { b?: number | undefined; })
->                                                                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>v2 : GenericObjectWithoutSetter<number> & ({ a?: string; } | { b?: number; })
+>   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
+>new GenericObjectWithoutSetter() as GenericObjectWithoutSetter &  ({ a?: string } | { b?: number }) : GenericObjectWithoutSetter<number> & ({ a?: string; } | { b?: number; })
+>                                                                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
 >new GenericObjectWithoutSetter() : GenericObjectWithoutSetter<number>
 >                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >GenericObjectWithoutSetter : typeof GenericObjectWithoutSetter
@@ -91,10 +91,10 @@ class NormalObject {
 }
 
 const v3 = new NormalObject() as NormalObject &
->v3 : NormalObject & ({ a?: string | undefined; } | { b?: number | undefined; })
->   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new NormalObject() as NormalObject &  ({ a?: string } | { b?: number }) : NormalObject & ({ a?: string | undefined; } | { b?: number | undefined; })
->                                                                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>v3 : NormalObject & ({ a?: string; } | { b?: number; })
+>   : ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
+>new NormalObject() as NormalObject &  ({ a?: string } | { b?: number }) : NormalObject & ({ a?: string; } | { b?: number; })
+>                                                                        : ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^      ^^^^
 >new NormalObject() : NormalObject
 >                   : ^^^^^^^^^^^^
 >NormalObject : typeof NormalObject

--- a/tests/baselines/reference/narrowingOfQualifiedNames.types
+++ b/tests/baselines/reference/narrowingOfQualifiedNames.types
@@ -85,12 +85,12 @@ function init(properties: IProperties) {
 
 interface DeepOptional {
     a?: {
->a : { b?: { c?: string | undefined; } | undefined; } | undefined
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b?: { c?: string; }; } | undefined
+>  : ^^^^^^               ^^^^^^^^^^^^^^^
 
         b?: {
->b : { c?: string | undefined; } | undefined
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { c?: string; } | undefined
+>  : ^^^^^^      ^^^^^^^^^^^^^^^
 
             c?: string
 >c : string | undefined

--- a/tests/baselines/reference/nestedExcessPropertyChecking.types
+++ b/tests/baselines/reference/nestedExcessPropertyChecking.types
@@ -4,16 +4,16 @@
 type A1 = { x: { a?: string } };
 >A1 : A1
 >   : ^^
->x : { a?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { a?: string; }
+>  : ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
 type B1 = { x: { b?: string } };
 >B1 : B1
 >   : ^^
->x : { b?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { b?: string; }
+>  : ^^^^^^      ^^^
 >b : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
@@ -103,8 +103,8 @@ const foo1: Partial<{ something: any }> & { variables: {
 >     : ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^                                                                          ^^^
 >something : any
 >          : ^^^
->variables : { overrides?: OverridesInput | undefined; } & Partial<{ overrides?: OverridesInput | undefined; }>
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>variables : { overrides?: OverridesInput; } & Partial<{ overrides?: OverridesInput; }>
+>          : ^^^^^^^^^^^^^^              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^^^^
 
     overrides?: OverridesInput;
 >overrides : OverridesInput | undefined
@@ -169,8 +169,8 @@ type T1 = {
 >   : ^^
 
     primary: { __typename?: 'Feature' } & { colors: { light: number, dark: number } },
->primary : { __typename?: "Feature" | undefined; } & { colors: { light: number; dark: number; }; }
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^
+>primary : { __typename?: 'Feature'; } & { colors: { light: number; dark: number; }; }
+>        : ^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^                                ^^^
 >__typename : "Feature" | undefined
 >           : ^^^^^^^^^^^^^^^^^^^^^
 >colors : { light: number; dark: number; }
@@ -187,8 +187,8 @@ type T2 = {
 >   : ^^
 
     primary: { __typename?: 'Feature' } & { colors: { light: number } },
->primary : { __typename?: "Feature" | undefined; } & { colors: { light: number; }; }
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                  ^^^
+>primary : { __typename?: 'Feature'; } & { colors: { light: number; }; }
+>        : ^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^                  ^^^
 >__typename : "Feature" | undefined
 >           : ^^^^^^^^^^^^^^^^^^^^^
 >colors : { light: number; }

--- a/tests/baselines/reference/normalizedIntersectionTooComplex.types
+++ b/tests/baselines/reference/normalizedIntersectionTooComplex.types
@@ -35,184 +35,184 @@ type CtorOf<T> = (arg: UnionToIntersection<T>) => T;
 
 interface Big {
     "0": { common?: string; "0"?: number, ref?: Obj<Big["0"]> | Func<Big["0"]>; }
->"0" : { common?: string | undefined; "0"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"0" : { common?: string; "0"?: number; ref?: Obj<Big["0"]> | Func<Big["0"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"0" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "0"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "0"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "0"?: number | undefined; ref?: Obj<Big["0"]> | Func<Big["0"]>; }> | Func<{ common?: string | undefined; "0"?: number | undefined; ref?: Obj<Big["0"]> | Func<Big["0"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "1": { common?: string; "1"?: number, ref?: Obj<Big["1"]> | Func<Big["1"]>; }
->"1" : { common?: string | undefined; "1"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"1" : { common?: string; "1"?: number; ref?: Obj<Big["1"]> | Func<Big["1"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"1" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "1"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "1"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "1"?: number | undefined; ref?: Obj<Big["1"]> | Func<Big["1"]>; }> | Func<{ common?: string | undefined; "1"?: number | undefined; ref?: Obj<Big["1"]> | Func<Big["1"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "2": { common?: string; "2"?: number, ref?: Obj<Big["2"]> | Func<Big["2"]>; }
->"2" : { common?: string | undefined; "2"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"2" : { common?: string; "2"?: number; ref?: Obj<Big["2"]> | Func<Big["2"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"2" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "2"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "2"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "2"?: number | undefined; ref?: Obj<Big["2"]> | Func<Big["2"]>; }> | Func<{ common?: string | undefined; "2"?: number | undefined; ref?: Obj<Big["2"]> | Func<Big["2"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "3": { common?: string; "3"?: number, ref?: Obj<Big["3"]> | Func<Big["3"]>; }
->"3" : { common?: string | undefined; "3"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"3" : { common?: string; "3"?: number; ref?: Obj<Big["3"]> | Func<Big["3"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"3" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "3"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "3"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "3"?: number | undefined; ref?: Obj<Big["3"]> | Func<Big["3"]>; }> | Func<{ common?: string | undefined; "3"?: number | undefined; ref?: Obj<Big["3"]> | Func<Big["3"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "4": { common?: string; "4"?: number, ref?: Obj<Big["4"]> | Func<Big["4"]>; }
->"4" : { common?: string | undefined; "4"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"4" : { common?: string; "4"?: number; ref?: Obj<Big["4"]> | Func<Big["4"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"4" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "4"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "4"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "4"?: number | undefined; ref?: Obj<Big["4"]> | Func<Big["4"]>; }> | Func<{ common?: string | undefined; "4"?: number | undefined; ref?: Obj<Big["4"]> | Func<Big["4"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "5": { common?: string; "5"?: number, ref?: Obj<Big["5"]> | Func<Big["5"]>; }
->"5" : { common?: string | undefined; "5"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"5" : { common?: string; "5"?: number; ref?: Obj<Big["5"]> | Func<Big["5"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"5" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "5"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "5"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "5"?: number | undefined; ref?: Obj<Big["5"]> | Func<Big["5"]>; }> | Func<{ common?: string | undefined; "5"?: number | undefined; ref?: Obj<Big["5"]> | Func<Big["5"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "6": { common?: string; "6"?: number, ref?: Obj<Big["6"]> | Func<Big["6"]>; }
->"6" : { common?: string | undefined; "6"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"6" : { common?: string; "6"?: number; ref?: Obj<Big["6"]> | Func<Big["6"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"6" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "6"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "6"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "6"?: number | undefined; ref?: Obj<Big["6"]> | Func<Big["6"]>; }> | Func<{ common?: string | undefined; "6"?: number | undefined; ref?: Obj<Big["6"]> | Func<Big["6"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "7": { common?: string; "7"?: number, ref?: Obj<Big["7"]> | Func<Big["7"]>; }
->"7" : { common?: string | undefined; "7"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"7" : { common?: string; "7"?: number; ref?: Obj<Big["7"]> | Func<Big["7"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"7" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "7"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "7"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "7"?: number | undefined; ref?: Obj<Big["7"]> | Func<Big["7"]>; }> | Func<{ common?: string | undefined; "7"?: number | undefined; ref?: Obj<Big["7"]> | Func<Big["7"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "8": { common?: string; "8"?: number, ref?: Obj<Big["8"]> | Func<Big["8"]>; }
->"8" : { common?: string | undefined; "8"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"8" : { common?: string; "8"?: number; ref?: Obj<Big["8"]> | Func<Big["8"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"8" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "8"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "8"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "8"?: number | undefined; ref?: Obj<Big["8"]> | Func<Big["8"]>; }> | Func<{ common?: string | undefined; "8"?: number | undefined; ref?: Obj<Big["8"]> | Func<Big["8"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "9": { common?: string; "9"?: number, ref?: Obj<Big["9"]> | Func<Big["9"]>; }
->"9" : { common?: string | undefined; "9"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"9" : { common?: string; "9"?: number; ref?: Obj<Big["9"]> | Func<Big["9"]>; }
+>    : ^^^^^^^^^^^      ^^^^^^^^      ^^^^^^^^                              ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"9" : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "9"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "9"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "9"?: number | undefined; ref?: Obj<Big["9"]> | Func<Big["9"]>; }> | Func<{ common?: string | undefined; "9"?: number | undefined; ref?: Obj<Big["9"]> | Func<Big["9"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              ^^^^^^^^^^^^^^^^
 
     "10": { common?: string; "10"?: number, ref?: Obj<Big["10"]> | Func<Big["10"]>; }
->"10" : { common?: string | undefined; "10"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"10" : { common?: string; "10"?: number; ref?: Obj<Big["10"]> | Func<Big["10"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"10" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "10"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "10"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "10"?: number | undefined; ref?: Obj<Big["10"]> | Func<Big["10"]>; }> | Func<{ common?: string | undefined; "10"?: number | undefined; ref?: Obj<Big["10"]> | Func<Big["10"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "11": { common?: string; "11"?: number, ref?: Obj<Big["11"]> | Func<Big["11"]>; }
->"11" : { common?: string | undefined; "11"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"11" : { common?: string; "11"?: number; ref?: Obj<Big["11"]> | Func<Big["11"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"11" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "11"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "11"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "11"?: number | undefined; ref?: Obj<Big["11"]> | Func<Big["11"]>; }> | Func<{ common?: string | undefined; "11"?: number | undefined; ref?: Obj<Big["11"]> | Func<Big["11"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "12": { common?: string; "12"?: number, ref?: Obj<Big["12"]> | Func<Big["12"]>; }
->"12" : { common?: string | undefined; "12"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"12" : { common?: string; "12"?: number; ref?: Obj<Big["12"]> | Func<Big["12"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"12" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "12"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "12"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "12"?: number | undefined; ref?: Obj<Big["12"]> | Func<Big["12"]>; }> | Func<{ common?: string | undefined; "12"?: number | undefined; ref?: Obj<Big["12"]> | Func<Big["12"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "13": { common?: string; "13"?: number, ref?: Obj<Big["13"]> | Func<Big["13"]>; }
->"13" : { common?: string | undefined; "13"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"13" : { common?: string; "13"?: number; ref?: Obj<Big["13"]> | Func<Big["13"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"13" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "13"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "13"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "13"?: number | undefined; ref?: Obj<Big["13"]> | Func<Big["13"]>; }> | Func<{ common?: string | undefined; "13"?: number | undefined; ref?: Obj<Big["13"]> | Func<Big["13"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "14": { common?: string; "14"?: number, ref?: Obj<Big["14"]> | Func<Big["14"]>; }
->"14" : { common?: string | undefined; "14"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"14" : { common?: string; "14"?: number; ref?: Obj<Big["14"]> | Func<Big["14"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"14" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "14"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "14"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "14"?: number | undefined; ref?: Obj<Big["14"]> | Func<Big["14"]>; }> | Func<{ common?: string | undefined; "14"?: number | undefined; ref?: Obj<Big["14"]> | Func<Big["14"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "15": { common?: string; "15"?: number, ref?: Obj<Big["15"]> | Func<Big["15"]>; }
->"15" : { common?: string | undefined; "15"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"15" : { common?: string; "15"?: number; ref?: Obj<Big["15"]> | Func<Big["15"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"15" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "15"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "15"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "15"?: number | undefined; ref?: Obj<Big["15"]> | Func<Big["15"]>; }> | Func<{ common?: string | undefined; "15"?: number | undefined; ref?: Obj<Big["15"]> | Func<Big["15"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "16": { common?: string; "16"?: number, ref?: Obj<Big["16"]> | Func<Big["16"]>; }
->"16" : { common?: string | undefined; "16"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"16" : { common?: string; "16"?: number; ref?: Obj<Big["16"]> | Func<Big["16"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"16" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "16"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "16"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "16"?: number | undefined; ref?: Obj<Big["16"]> | Func<Big["16"]>; }> | Func<{ common?: string | undefined; "16"?: number | undefined; ref?: Obj<Big["16"]> | Func<Big["16"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 
     "17": { common?: string; "17"?: number, ref?: Obj<Big["17"]> | Func<Big["17"]>; }
->"17" : { common?: string | undefined; "17"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"17" : { common?: string; "17"?: number; ref?: Obj<Big["17"]> | Func<Big["17"]>; }
+>     : ^^^^^^^^^^^      ^^^^^^^^^      ^^^^^^^^                                ^^^
 >common : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >"17" : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->ref : Obj<{ common?: string | undefined; "17"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | Func<{ common?: string | undefined; "17"?: number | undefined; ref?: Obj<any> | Func<any> | undefined; }> | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ref : Obj<{ common?: string | undefined; "17"?: number | undefined; ref?: Obj<Big["17"]> | Func<Big["17"]>; }> | Func<{ common?: string | undefined; "17"?: number | undefined; ref?: Obj<Big["17"]> | Func<Big["17"]>; }> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^^^^^^^^^^^^
 }
 declare function getCtor<T extends keyof Big>(comp: T): CtorOf<Big[T]>
 >getCtor : <T extends keyof Big>(comp: T) => CtorOf<Big[T]>

--- a/tests/baselines/reference/objectLiteralNormalization.js
+++ b/tests/baselines/reference/objectLiteralNormalization.js
@@ -158,14 +158,14 @@ declare let opts: {
     baz?: boolean;
 };
 declare let c1: {
-    foo?: string | undefined;
-    bar?: string | undefined;
-    baz?: boolean | undefined;
+    foo?: string;
+    bar?: string;
+    baz?: boolean;
 };
 declare let c2: {
-    foo?: string | undefined;
-    bar?: string | undefined;
-    baz?: boolean | undefined;
+    foo?: string;
+    bar?: string;
+    baz?: boolean;
 };
 declare let c3: {
     a: number;

--- a/tests/baselines/reference/objectLiteralNormalization.types
+++ b/tests/baselines/reference/objectLiteralNormalization.types
@@ -262,8 +262,8 @@ let b3 = { ...b2 };
 // Before widening {} acts like { [x: string]: undefined }, which is a
 // subtype of types with all optional properties
 declare let opts: { foo?: string, bar?: string, baz?: boolean };
->opts : { foo?: string | undefined; bar?: string | undefined; baz?: boolean | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>opts : { foo?: string; bar?: string; baz?: boolean; }
+>     : ^^^^^^^^      ^^^^^^^^      ^^^^^^^^       ^^^
 >foo : string | undefined
 >    : ^^^^^^^^^^^^^^^^^^
 >bar : string | undefined

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -665,14 +665,14 @@ function container(
 >   : ^^^^^^
 
     optionalString: { sn?: string },
->optionalString : { sn?: string | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalString : { sn?: string; }
+>               : ^^^^^^^      ^^^
 >sn : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
     optionalNumber: { sn?: number }) {
->optionalNumber : { sn?: number | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalNumber : { sn?: number; }
+>               : ^^^^^^^      ^^^
 >sn : number | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
@@ -707,8 +707,8 @@ function container(
 >               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     let allOptional: { sn?: string | number } = { ...optionalString, ...optionalNumber };
->allOptional : { sn?: string | number | undefined; }
->            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>allOptional : { sn?: string | number; }
+>            : ^^^^^^^               ^^^
 >sn : string | number | undefined
 >   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ ...optionalString, ...optionalNumber } : { sn?: string | number | undefined; }

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -61,14 +61,14 @@ let sn: number = o2.x; // error, x is private
 >  : ^^^
 
 declare let optionalString: { sn?: string };
->optionalString : { sn?: string | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalString : { sn?: string; }
+>               : ^^^^^^^      ^^^
 >sn : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
 declare let optionalNumber: { sn?: number };
->optionalNumber : { sn?: number | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalNumber : { sn?: number; }
+>               : ^^^^^^^      ^^^
 >sn : number | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/objectSpreadStrictNull.types
+++ b/tests/baselines/reference/objectSpreadStrictNull.types
@@ -18,14 +18,14 @@ function f(
 >   : ^^^^^^
 
     optionalString: { sn?: string },
->optionalString : { sn?: string | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalString : { sn?: string; }
+>               : ^^^^^^^      ^^^
 >sn : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
     optionalNumber: { sn?: number },
->optionalNumber : { sn?: number | undefined; }
->               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalNumber : { sn?: number; }
+>               : ^^^^^^^      ^^^
 >sn : number | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
@@ -73,8 +73,8 @@ function f(
 >               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     let allOptional: { sn?: string | number } = { ...optionalString, ...optionalNumber };
->allOptional : { sn?: string | number | undefined; }
->            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>allOptional : { sn?: string | number; }
+>            : ^^^^^^^               ^^^
 >sn : string | number | undefined
 >   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ ...optionalString, ...optionalNumber } : { sn?: string | number | undefined; }

--- a/tests/baselines/reference/optionalParameterInDestructuringWithInitializer.types
+++ b/tests/baselines/reference/optionalParameterInDestructuringWithInitializer.types
@@ -125,8 +125,8 @@ function func4( {a: {b, c}, d}: {a: {b: number,c?: number},d: number} = {a: {b: 
 >  : ^^^^^^^^^^^^^^^^^^
 >d : number
 >  : ^^^^^^
->a : { b: number; c?: number | undefined; }
->  : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b: number; c?: number; }
+>  : ^^^^^      ^^^^^^      ^^^
 >b : number
 >  : ^^^^^^
 >c : number | undefined
@@ -178,8 +178,8 @@ function func5({a: {b, c = 4}, d}: {a: {b: number,c?: number},d: number} = {a: {
 >  : ^
 >d : number
 >  : ^^^^^^
->a : { b: number; c?: number | undefined; }
->  : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b: number; c?: number; }
+>  : ^^^^^      ^^^^^^      ^^^
 >b : number
 >  : ^^^^^^
 >c : number | undefined
@@ -239,8 +239,8 @@ function func6( {a: {b, c} = {b: 4, c: 5}, d}: {a: {b: number, c?: number}, d: n
 >  : ^
 >d : number
 >  : ^^^^^^
->a : { b: number; c?: number | undefined; }
->  : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b: number; c?: number; }
+>  : ^^^^^      ^^^^^^      ^^^
 >b : number
 >  : ^^^^^^
 >c : number | undefined
@@ -302,8 +302,8 @@ function func7( {a: {b, c = 6} = {b: 4, c: 5}, d}: {a: {b: number, c?: number}, 
 >  : ^
 >d : number
 >  : ^^^^^^
->a : { b: number; c?: number | undefined; }
->  : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b: number; c?: number; }
+>  : ^^^^^      ^^^^^^      ^^^
 >b : number
 >  : ^^^^^^
 >c : number | undefined

--- a/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.types
+++ b/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.types
@@ -2,8 +2,8 @@
 
 === optionalPropertyAssignableToStringIndexSignature.ts ===
 declare let optionalProperties: { k1?: string };
->optionalProperties : { k1?: string | undefined; }
->                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>optionalProperties : { k1?: string; }
+>                   : ^^^^^^^      ^^^
 >k1 : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
 
@@ -42,8 +42,8 @@ declare let probablyArray: { [key: number]: string };
 >    : ^^^^^^
 
 declare let numberLiteralKeys: { 1?: string };
->numberLiteralKeys : { 1?: string | undefined; }
->                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>numberLiteralKeys : { 1?: string; }
+>                  : ^^^^^^      ^^^
 >1 : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
@@ -74,8 +74,8 @@ function f<T>() {
 >  : ^^^^^^^^^^^^^
 
 	let optional: { k1?: T } = undefined!;
->optional : { k1?: T | undefined; }
->         : ^^^^^^^^^^^^^^^^^^^^^^^
+>optional : { k1?: T; }
+>         : ^^^^^^^ ^^^
 >k1 : T | undefined
 >   : ^^^^^^^^^^^^^
 >undefined! : never

--- a/tests/baselines/reference/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.types
+++ b/tests/baselines/reference/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.types
@@ -74,8 +74,8 @@ export function appendToOptionalArray<
 
 // e.g.
 const foo: {x?: number[]; y?: string[]; } = {};
->foo : { x?: number[] | undefined; y?: string[] | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>foo : { x?: number[]; y?: string[]; }
+>    : ^^^^^^        ^^^^^^        ^^^
 >x : number[] | undefined
 >  : ^^^^^^^^^^^^^^^^^^^^
 >y : string[] | undefined

--- a/tests/baselines/reference/primitiveUnionDetection.types
+++ b/tests/baselines/reference/primitiveUnionDetection.types
@@ -10,8 +10,8 @@ type Kind = "one" | "two" | "three";
 declare function getInterfaceFromString<T extends Kind>(options?: { type?: T } & { type?: Kind }): T;
 >getInterfaceFromString : <T extends Kind>(options?: { type?: T; } & { type?: Kind; }) => T
 >                       : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^                                ^^^^^ 
->options : ({ type?: T | undefined; } & { type?: Kind | undefined; }) | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : ({ type?: T; } & { type?: Kind; }) | undefined
+>        : ^^^^^^^^^^ ^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^
 >type : T | undefined
 >     : ^^^^^^^^^^^^^
 >type : Kind | undefined

--- a/tests/baselines/reference/propTypeValidatorInference.types
+++ b/tests/baselines/reference/propTypeValidatorInference.types
@@ -129,8 +129,8 @@ interface Props {
 >     : ^^^^^^^
 
     shape: {
->shape : { foo: string; bar?: boolean | undefined; baz?: any; }
->      : ^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^
+>shape : { foo: string; bar?: boolean; baz?: any; }
+>      : ^^^^^^^      ^^^^^^^^       ^^^^^^^^   ^^^
 
         foo: string;
 >foo : string
@@ -145,8 +145,8 @@ interface Props {
 
     };
     oneOfType: string | boolean | {
->oneOfType : string | boolean | { foo?: string | undefined; bar: number; }
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>oneOfType : string | boolean | { foo?: string; bar: number; }
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^      ^^^
 
         foo?: string;
 >foo : string | undefined

--- a/tests/baselines/reference/propertyAccessChain.types
+++ b/tests/baselines/reference/propertyAccessChain.types
@@ -56,12 +56,12 @@ o3.b?.c;
 >  : ^^^^^^^^^^^^^^^^^^
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
->   : ^^^^^^^^^^^                       ^^^^^^^^^^^^^^^^^^
+>o4 : { b?: { c: { d?: { e: string; }; }; }; }
+>   : ^^^^^^                               ^^^
 >b : { c: { d?: { e: string; }; }; } | undefined
 >  : ^^^^^                       ^^^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string
@@ -92,8 +92,8 @@ declare const o5: { b?(): { c: { d?: { e: string } } } };
 >   : ^^^^^^^^                               ^^^
 >b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >  : ^^^^^^^                               ^^^^^^^^^^^^^
->c : { d?: { e: string; } | undefined; }
->  : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^
+>c : { d?: { e: string; }; }
+>  : ^^^^^^              ^^^
 >d : { e: string; } | undefined
 >  : ^^^^^      ^^^^^^^^^^^^^^^
 >e : string

--- a/tests/baselines/reference/reactReduxLikeDeferredInferenceAllowsAssignment.types
+++ b/tests/baselines/reference/reactReduxLikeDeferredInferenceAllowsAssignment.types
@@ -22,8 +22,8 @@ declare class Component<P> {
 >        : ^^^
 
   readonly props: Readonly<P> & Readonly<{ children?: {} }>;
->props : Readonly<P> & Readonly<{ children?: {} | undefined; }>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : Readonly<P> & Readonly<{ children?: {}; }>
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 }
@@ -48,8 +48,8 @@ interface ComponentClass<P = {}> {
 }
 interface FunctionComponent<P = {}> {
   (props: P & { children?: {} }, context?: any): {} | null;
->props : P & { children?: {} | undefined; }
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>props : P & { children?: {}; }
+>      : ^^^^^^^^^^^^^^^^^  ^^^
 >children : {} | undefined
 >         : ^^^^^^^^^^^^^^
 >context : any

--- a/tests/baselines/reference/reverseMappedTypeIntersectionConstraint.types
+++ b/tests/baselines/reference/reverseMappedTypeIntersectionConstraint.types
@@ -539,8 +539,8 @@ type DistributeActors<TActor> = TActor extends { src: infer TSrc }
 
 interface MachineConfig<TActor extends ProvidedActor> {
   types?: {
->types : { actors?: TActor | undefined; } | undefined
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>types : { actors?: TActor; } | undefined
+>      : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
 
     actors?: TActor;
 >actors : TActor | undefined

--- a/tests/baselines/reference/spreadDuplicate.types
+++ b/tests/baselines/reference/spreadDuplicate.types
@@ -10,8 +10,8 @@ declare let a: { a: string };
 >  : ^^^^^^
 
 declare let b: { a?: string };
->b : { a?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { a?: string; }
+>  : ^^^^^^      ^^^
 >a : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).types
@@ -8,8 +8,8 @@ declare const a: { x: string | number };
 >  : ^^^^^^^^^^^^^^^
 
 declare const b: { x?: string | number };
->b : { x?: string | number | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { x?: string | number; }
+>  : ^^^^^^               ^^^
 >x : string | number | undefined
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/spreadOverwritesPropertyStrict.types
+++ b/tests/baselines/reference/spreadOverwritesPropertyStrict.types
@@ -10,8 +10,8 @@ declare var ab: { a: number, b: number };
 >  : ^^^^^^
 
 declare var abq: { a: number, b?: number };
->abq : { a: number; b?: number | undefined; }
->    : ^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>abq : { a: number; b?: number; }
+>    : ^^^^^      ^^^^^^      ^^^
 >a : number
 >  : ^^^^^^
 >b : number | undefined

--- a/tests/baselines/reference/strictSubtypeAndNarrowing.types
+++ b/tests/baselines/reference/strictSubtypeAndNarrowing.types
@@ -410,12 +410,12 @@ function checkD(f: FnTypes) {
 function fx10(obj1: { x?: number }, obj2: { x?: number, y?: number }) {
 >fx10 : (obj1: { x?: number; }, obj2: { x?: number; y?: number; }) => void
 >     : ^^^^^^^               ^^^^^^^^                           ^^^^^^^^^
->obj1 : { x?: number | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj1 : { x?: number; }
+>     : ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
->obj2 : { x?: number | undefined; y?: number | undefined; }
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj2 : { x?: number; y?: number; }
+>     : ^^^^^^      ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : number | undefined
@@ -469,8 +469,8 @@ function fx11(): { x?: number } {
 >  : ^^^^^^^^^^^^^^^^^^
 
     let obj: { x?: number, y?: number };
->obj : { x?: number | undefined; y?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : { x?: number; y?: number; }
+>    : ^^^^^^      ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >y : number | undefined

--- a/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).types
@@ -27,8 +27,8 @@ someVal.fn("");
 >   : ^^
 
 declare const someVal2: Required<{
->someVal2 : Required<{ fn?: ((key: string) => string | null) | undefined; }>
->         : ^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^             ^^^^^^^^^^^^^^^^^
+>someVal2 : Required<{ fn?: (key: string) => string | null; }>
+>         : ^^^^^^^^^^^^^^^^                              ^^^^
 
     fn?: (key: string) => string | null;
 >fn : ((key: string) => string | null) | undefined

--- a/tests/baselines/reference/tsxInvokeComponentType.types
+++ b/tests/baselines/reference/tsxInvokeComponentType.types
@@ -39,8 +39,8 @@ const good = <Elem someKey="ok" />;
 >        : ^^^^^^
 
 declare const Elem2: ComponentType<{ opt?: number }>;
->Elem2 : React.ComponentType<{ opt?: number | undefined; }>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Elem2 : React.ComponentType<{ opt?: number; }>
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
 >opt : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/tsxSfcReturnNullStrictNullChecks.types
+++ b/tests/baselines/reference/tsxSfcReturnNullStrictNullChecks.types
@@ -15,8 +15,8 @@ const Foo = (props: any) => null;
 function Greet(x: {name?: string}) {
 >Greet : (x: { name?: string; }) => null
 >      : ^^^^                  ^^^^^^^^^
->x : { name?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { name?: string; }
+>  : ^^^^^^^^^      ^^^
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/tsxSfcReturnUndefinedStrictNullChecks.types
+++ b/tests/baselines/reference/tsxSfcReturnUndefinedStrictNullChecks.types
@@ -18,8 +18,8 @@ const Foo = (props: any) => undefined;
 function Greet(x: {name?: string}) {
 >Greet : (x: { name?: string; }) => undefined
 >      : ^^^^                  ^^^^^^^^^^^^^^
->x : { name?: string | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : { name?: string; }
+>  : ^^^^^^^^^      ^^^
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty2.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty2.types
@@ -2,8 +2,8 @@
 
 === typeGuardNarrowsIndexedAccessOfKnownProperty2.ts ===
 const foo: { key?: number } = {};
->foo : { key?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>foo : { key?: number; }
+>    : ^^^^^^^^      ^^^
 >key : number | undefined
 >    : ^^^^^^^^^^^^^^^^^^
 >{} : {}

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty5.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty5.types
@@ -2,10 +2,10 @@
 
 === typeGuardNarrowsIndexedAccessOfKnownProperty5.ts ===
 const a: { key?: { x?: number } } = {};
->a : { key?: { x?: number | undefined; } | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->key : { x?: number | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { key?: { x?: number; }; }
+>  : ^^^^^^^^               ^^^
+>key : { x?: number; } | undefined
+>    : ^^^^^^      ^^^^^^^^^^^^^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >{} : {}
@@ -53,8 +53,8 @@ if (a[aIndex] && a[aIndex].x) {
 const b: { key: { x?: number } } = { key: {} };
 >b : { key: { x?: number; }; }
 >  : ^^^^^^^               ^^^
->key : { x?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>key : { x?: number; }
+>    : ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >{ key: {} } : { key: {}; }

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty6.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty6.types
@@ -6,10 +6,10 @@ declare const aIndex: "key";
 >       : ^^^^^
 
 const a: { key?: { x?: number } } = {};
->a : { key?: { x?: number | undefined; } | undefined; }
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->key : { x?: number | undefined; } | undefined
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { key?: { x?: number; }; }
+>  : ^^^^^^^^               ^^^
+>key : { x?: number; } | undefined
+>    : ^^^^^^      ^^^^^^^^^^^^^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >{} : {}
@@ -55,8 +55,8 @@ declare const bIndex: "key";
 const b: { key: { x?: number } } = { key: {} };
 >b : { key: { x?: number; }; }
 >  : ^^^^^^^               ^^^
->key : { x?: number | undefined; }
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>key : { x?: number; }
+>    : ^^^^^^      ^^^
 >x : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >{ key: {} } : { key: {}; }

--- a/tests/baselines/reference/typePredicatesOptionalChaining1.types
+++ b/tests/baselines/reference/typePredicatesOptionalChaining1.types
@@ -6,8 +6,8 @@ type X = {
 >  : ^
 
   y?: {
->y : { z?: string | undefined; } | undefined
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>y : { z?: string; } | undefined
+>  : ^^^^^^      ^^^^^^^^^^^^^^^
 
     z?: string;
 >z : string | undefined

--- a/tests/baselines/reference/typeofThis.types
+++ b/tests/baselines/reference/typeofThis.types
@@ -431,8 +431,8 @@ class Test10 {
 >       : ^^^^^^
 
     a?: { b?: string }
->a : { b?: string | undefined; } | undefined
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b?: string; } | undefined
+>  : ^^^^^^      ^^^^^^^^^^^^^^^
 >b : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
@@ -533,8 +533,8 @@ class Test11 {
 >       : ^^^^^^
 
     this?: { x?: string };
->this : { x?: string | undefined; } | undefined
->     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : { x?: string; } | undefined
+>     : ^^^^^^      ^^^^^^^^^^^^^^^
 >x : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
     

--- a/tests/baselines/reference/variadicTuples1.types
+++ b/tests/baselines/reference/variadicTuples1.types
@@ -2200,8 +2200,8 @@ declare function getUser(id: string, options?: { x?: string }): string;
 >        : ^^^^^      ^^^^^^^^^^^^               ^^^^^      
 >id : string
 >   : ^^^^^^
->options : { x?: string | undefined; } | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : { x?: string; } | undefined
+>        : ^^^^^^      ^^^^^^^^^^^^^^^
 >x : string | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 
@@ -2212,8 +2212,8 @@ declare function getOrgUser(id: string, orgId: number, options?: { y?: number, z
 >   : ^^^^^^
 >orgId : number
 >      : ^^^^^^
->options : { y?: number | undefined; z?: boolean | undefined; } | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>options : { y?: number; z?: boolean; } | undefined
+>        : ^^^^^^      ^^^^^^       ^^^^^^^^^^^^^^^
 >y : number | undefined
 >  : ^^^^^^^^^^^^^^^^^^
 >z : boolean | undefined


### PR DESCRIPTION
As you can see, I'd forgotten `PropertyDeclaration` and `PropertySignature` were not caught by the same check when I originally wrote this comparison, so optional property signatures (that didn't have an explicit `undefined` written out) never got reused in the node builder. And `PropertySignature`s are the ones actually within type nodes!