### PR TITLE
Update dprint, don't force multiline imports for imports of single name

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -19,7 +19,7 @@
         "arrowFunction.useParentheses": "preferNone",
         "conditionalExpression.linePerExpression": false, // Keep our "match/case"-ish conditionals.
         "functionExpression.spaceAfterFunctionKeyword": true,
-        "importDeclaration.forceMultiLine": "always",
+        "importDeclaration.forceMultiLine": "whenMultiple",
         "constructorType.spaceAfterNewKeyword": true,
         "constructSignature.spaceAfterNewKeyword": true,
 

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -19,7 +19,7 @@
         "arrowFunction.useParentheses": "preferNone",
         "conditionalExpression.linePerExpression": false, // Keep our "match/case"-ish conditionals.
         "functionExpression.spaceAfterFunctionKeyword": true,
-        "importDeclaration.forceMultiLine": true,
+        "importDeclaration.forceMultiLine": "always",
         "constructorType.spaceAfterNewKeyword": true,
         "constructSignature.spaceAfterNewKeyword": true,
 
@@ -57,8 +57,8 @@
     ],
     // Note: if adding new languages, make sure settings.template.json is updated too.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.88.9.wasm",
-        "https://plugins.dprint.dev/json-0.19.1.wasm",
-        "https://plugins.dprint.dev/prettier-0.35.0.json@0df49c4d878bb1051af2fa1d1f69ba6400f4b78633f49baa1f38954a6fd32b40"
+        "https://plugins.dprint.dev/typescript-0.90.0.wasm",
+        "https://plugins.dprint.dev/json-0.19.2.wasm",
+        "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c"
     ]
 }

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1,26 +1,16 @@
 // @ts-check
-import {
-    CancelToken,
-} from "@esfx/canceltoken";
+import { CancelToken } from "@esfx/canceltoken";
 import assert from "assert";
 import chalk from "chalk";
 import chokidar from "chokidar";
 import esbuild from "esbuild";
-import {
-    EventEmitter,
-} from "events";
+import { EventEmitter } from "events";
 import fs from "fs";
-import {
-    glob,
-} from "glob";
-import {
-    task,
-} from "hereby";
+import { glob } from "glob";
+import { task } from "hereby";
 import path from "path";
 
-import {
-    localizationDirectories,
-} from "./scripts/build/localization.mjs";
+import { localizationDirectories } from "./scripts/build/localization.mjs";
 import cmdLineOptions from "./scripts/build/options.mjs";
 import {
     buildProject,

--- a/scripts/browserIntegrationTest.mjs
+++ b/scripts/browserIntegrationTest.mjs
@@ -1,10 +1,6 @@
 import chalk from "chalk";
-import {
-    readFileSync,
-} from "fs";
-import {
-    join,
-} from "path";
+import { readFileSync } from "fs";
+import { join } from "path";
 import playwright from "playwright";
 
 // Turning this on will leave the Chromium browser open, giving you the

--- a/scripts/build/findUpDir.mjs
+++ b/scripts/build/findUpDir.mjs
@@ -1,6 +1,4 @@
-import {
-    existsSync,
-} from "fs";
+import { existsSync } from "fs";
 import {
     dirname,
     join,

--- a/scripts/build/projects.mjs
+++ b/scripts/build/projects.mjs
@@ -1,10 +1,6 @@
-import {
-    resolve,
-} from "path";
+import { resolve } from "path";
 
-import {
-    findUpRoot,
-} from "./findUpDir.mjs";
+import { findUpRoot } from "./findUpDir.mjs";
 import cmdLineOptions from "./options.mjs";
 import {
     Debouncer,

--- a/scripts/build/tests.mjs
+++ b/scripts/build/tests.mjs
@@ -1,6 +1,4 @@
-import {
-    CancelError,
-} from "@esfx/canceltoken";
+import { CancelError } from "@esfx/canceltoken";
 import chalk from "chalk";
 import fs from "fs";
 import os from "os";

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -1,11 +1,7 @@
-import {
-    CancelError,
-} from "@esfx/canceltoken";
+import { CancelError } from "@esfx/canceltoken";
 import assert from "assert";
 import chalk from "chalk";
-import {
-    spawn,
-} from "child_process";
+import { spawn } from "child_process";
 import fs from "fs";
 import JSONC from "jsonc-parser";
 import which from "which";

--- a/scripts/checkModuleFormat.mjs
+++ b/scripts/checkModuleFormat.mjs
@@ -1,13 +1,9 @@
-import {
-    createRequire,
-} from "module";
+import { createRequire } from "module";
 import {
     __importDefault,
     __importStar,
 } from "tslib";
-import {
-    pathToFileURL,
-} from "url";
+import { pathToFileURL } from "url";
 
 // This script tests that TypeScript's CJS API is structured
 // as expected. It calls "require" as though it were in CWD,

--- a/scripts/configurePrerelease.mjs
+++ b/scripts/configurePrerelease.mjs
@@ -1,7 +1,5 @@
 import assert from "assert";
-import {
-    execFileSync,
-} from "child_process";
+import { execFileSync } from "child_process";
 import {
     readFileSync,
     writeFileSync,

--- a/scripts/dtsBundler.mjs
+++ b/scripts/dtsBundler.mjs
@@ -5,9 +5,7 @@
  * bundle as namespaces again, even though the project is modules.
  */
 
-import assert, {
-    fail,
-} from "assert";
+import assert, { fail } from "assert";
 import cp from "child_process";
 import fs from "fs";
 import minimist from "minimist";

--- a/scripts/errorCheck.mjs
+++ b/scripts/errorCheck.mjs
@@ -1,8 +1,6 @@
 import fs from "fs";
 import fsPromises from "fs/promises";
-import {
-    glob,
-} from "glob";
+import { glob } from "glob";
 
 async function checkErrorBaselines() {
     const data = await fsPromises.readFile("src/compiler/diagnosticMessages.json", "utf-8");

--- a/scripts/find-unused-diganostic-messages.mjs
+++ b/scripts/find-unused-diganostic-messages.mjs
@@ -1,15 +1,9 @@
 // This file requires a modern version of node 14+, and grep to be available.
 
 // node scripts/find-unused-diagnostic-messages.mjs
-import {
-    execSync,
-} from "child_process";
-import {
-    readFileSync,
-} from "fs";
-import {
-    EOL,
-} from "os";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { EOL } from "os";
 
 const diags = readFileSync("src/compiler/diagnosticInformationMap.generated.ts", "utf8");
 const startOfDiags = diags.split("export const Diagnostics")[1];

--- a/scripts/generateLocalizedDiagnosticMessages.mjs
+++ b/scripts/generateLocalizedDiagnosticMessages.mjs
@@ -1,6 +1,4 @@
-import {
-    XMLParser,
-} from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import fs from "fs";
 import path from "path";
 

--- a/scripts/link-hooks.mjs
+++ b/scripts/link-hooks.mjs
@@ -2,9 +2,7 @@ import fs from "fs";
 import path from "path";
 import url from "url";
 
-import {
-    findUpRoot,
-} from "./build/findUpDir.mjs";
+import { findUpRoot } from "./build/findUpDir.mjs";
 
 const __filename = url.fileURLToPath(new URL(import.meta.url));
 const __dirname = path.dirname(__filename);

--- a/scripts/post-vsts-artifact-comment.mjs
+++ b/scripts/post-vsts-artifact-comment.mjs
@@ -1,6 +1,4 @@
-import {
-    Octokit,
-} from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import assert from "assert";
 import ado from "azure-devops-node-api";
 import fetch from "node-fetch";

--- a/scripts/produceLKG.mjs
+++ b/scripts/produceLKG.mjs
@@ -1,13 +1,9 @@
 import fs from "fs";
-import {
-    glob,
-} from "glob";
+import { glob } from "glob";
 import path from "path";
 import url from "url";
 
-import {
-    localizationDirectories,
-} from "./build/localization.mjs";
+import { localizationDirectories } from "./build/localization.mjs";
 
 const __filename = url.fileURLToPath(new URL(import.meta.url));
 const __dirname = path.dirname(__filename);

--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -1,6 +1,4 @@
-import {
-    isNodeLikeSystem,
-} from "./_namespaces/ts";
+import { isNodeLikeSystem } from "./_namespaces/ts";
 
 // The following definitions provide the minimum compatible support for the Web Performance User Timings API
 // between browsers and NodeJS:

--- a/src/deprecatedCompat/5.0/identifierProperties.ts
+++ b/src/deprecatedCompat/5.0/identifierProperties.ts
@@ -5,9 +5,7 @@ import {
     identifierToKeywordKind,
     NodeFlags,
 } from "../_namespaces/ts";
-import {
-    deprecate,
-} from "../deprecate";
+import { deprecate } from "../deprecate";
 
 declare module "../../compiler/types" {
     export interface Identifier {

--- a/src/deprecatedCompat/deprecations.ts
+++ b/src/deprecatedCompat/deprecations.ts
@@ -3,9 +3,7 @@ import {
     UnionToIntersection,
     Version,
 } from "./_namespaces/ts";
-import {
-    deprecate,
-} from "./deprecate";
+import { deprecate } from "./deprecate";
 
 /** @internal */
 export interface DeprecationOptions {

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -74,9 +74,7 @@ import {
     TodoCommentDescriptor,
     UserPreferences,
 } from "./_namespaces/ts";
-import {
-    protocol,
-} from "./_namespaces/ts.server";
+import { protocol } from "./_namespaces/ts.server";
 
 export interface SessionClientHost extends LanguageServiceHost {
     writeMessage(message: string): void;

--- a/src/harness/findUpDir.ts
+++ b/src/harness/findUpDir.ts
@@ -1,6 +1,4 @@
-import {
-    existsSync,
-} from "fs";
+import { existsSync } from "fs";
 import {
     dirname,
     join,

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -5,9 +5,7 @@ import * as ts from "./_namespaces/ts";
 import * as Utils from "./_namespaces/Utils";
 import * as vfs from "./_namespaces/vfs";
 import * as vpath from "./_namespaces/vpath";
-import {
-    LoggerWithInMemoryLogs,
-} from "./tsserverLogger";
+import { LoggerWithInMemoryLogs } from "./tsserverLogger";
 
 import ArrayOrSingle = FourSlashInterface.ArrayOrSingle;
 

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -6,25 +6,17 @@ import {
     virtualFileSystemRoot,
 } from "./_namespaces/Harness";
 import * as ts from "./_namespaces/ts";
-import {
-    getNewLineCharacter,
-} from "./_namespaces/ts";
+import { getNewLineCharacter } from "./_namespaces/ts";
 import * as vfs from "./_namespaces/vfs";
 import * as vpath from "./_namespaces/vpath";
-import {
-    incrementalVerifier,
-} from "./incrementalUtils";
-import {
-    patchServiceForStateBaseline,
-} from "./projectServiceStateLogger";
+import { incrementalVerifier } from "./incrementalUtils";
+import { patchServiceForStateBaseline } from "./projectServiceStateLogger";
 import {
     createLoggerWithInMemoryLogs,
     HarnessLSCouldNotResolveModule,
     LoggerWithInMemoryLogs,
 } from "./tsserverLogger";
-import {
-    createWatchUtils,
-} from "./watchUtils";
+import { createWatchUtils } from "./watchUtils";
 
 export function makeDefaultProxy(info: ts.server.PluginCreateInfo): ts.LanguageService {
     const proxy = Object.create(/*o*/ null); // eslint-disable-line no-null/no-null

--- a/src/harness/projectServiceStateLogger.ts
+++ b/src/harness/projectServiceStateLogger.ts
@@ -23,9 +23,7 @@ import {
     SourceMapFileWatcher,
     TextStorage,
 } from "./_namespaces/ts.server";
-import {
-    LoggerWithInMemoryLogs,
-} from "./tsserverLogger";
+import { LoggerWithInMemoryLogs } from "./tsserverLogger";
 
 interface ProjectData {
     projectStateVersion: Project["projectStateVersion"];

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -1,7 +1,5 @@
 import * as documents from "./_namespaces/documents";
-import {
-    Compiler,
-} from "./_namespaces/Harness";
+import { Compiler } from "./_namespaces/Harness";
 import * as ts from "./_namespaces/ts";
 import * as Utils from "./_namespaces/Utils";
 

--- a/src/harness/tsserverLogger.ts
+++ b/src/harness/tsserverLogger.ts
@@ -1,7 +1,5 @@
 import * as ts from "./_namespaces/ts";
-import {
-    Compiler,
-} from "./harnessIO";
+import { Compiler } from "./harnessIO";
 
 export const HarnessLSCouldNotResolveModule = "HarnessLanguageService:: Could not resolve module";
 

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -30,9 +30,7 @@ import {
     Version,
     versionMajorMinor,
 } from "./_namespaces/ts";
-import {
-    stringifyIndented,
-} from "./_namespaces/ts.server";
+import { stringifyIndented } from "./_namespaces/ts.server";
 
 export interface TypingResolutionHost {
     directoryExists(path: string): boolean;

--- a/src/jsTyping/shared.ts
+++ b/src/jsTyping/shared.ts
@@ -1,6 +1,4 @@
-import {
-    sys,
-} from "./_namespaces/ts";
+import { sys } from "./_namespaces/ts";
 
 export type ActionSet = "action::set";
 export type ActionInvalidate = "action::invalidate";

--- a/src/server/packageJsonCache.ts
+++ b/src/server/packageJsonCache.ts
@@ -9,9 +9,7 @@ import {
     Ternary,
     tryFileExists,
 } from "./_namespaces/ts";
-import {
-    ProjectService,
-} from "./_namespaces/ts.server";
+import { ProjectService } from "./_namespaces/ts.server";
 
 /** @internal */
 export interface PackageJsonCache {

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -9,9 +9,7 @@ import {
     TextSpan,
     unchangedTextChangeRange,
 } from "./_namespaces/ts";
-import {
-    emptyArray,
-} from "./_namespaces/ts.server";
+import { emptyArray } from "./_namespaces/ts.server";
 import * as protocol from "./protocol";
 
 const lineCollectionCapacity = 4;

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -111,9 +111,7 @@ import {
     visitNode,
     visitNodes,
 } from "../_namespaces/ts";
-import {
-    ImportAdder,
-} from "../_namespaces/ts.codefix";
+import { ImportAdder } from "../_namespaces/ts.codefix";
 
 /**
  * Finds members of the resolved type that are missing in the class pointed to by class decl

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -389,9 +389,7 @@ import {
     VariableDeclaration,
     walkUpParenthesizedExpressions,
 } from "./_namespaces/ts";
-import {
-    StringCompletions,
-} from "./_namespaces/ts.Completions";
+import { StringCompletions } from "./_namespaces/ts.Completions";
 
 // Exported only for tests
 /** @internal */

--- a/src/services/formatting/formattingContext.ts
+++ b/src/services/formatting/formattingContext.ts
@@ -6,9 +6,7 @@ import {
     SourceFileLike,
     SyntaxKind,
 } from "../_namespaces/ts";
-import {
-    TextRangeWithKind,
-} from "../_namespaces/ts.formatting";
+import { TextRangeWithKind } from "../_namespaces/ts.formatting";
 
 /** @internal */
 export const enum FormattingRequestKind {

--- a/src/services/formatting/rule.ts
+++ b/src/services/formatting/rule.ts
@@ -2,9 +2,7 @@ import {
     emptyArray,
     SyntaxKind,
 } from "../_namespaces/ts";
-import {
-    FormattingContext,
-} from "../_namespaces/ts.formatting";
+import { FormattingContext } from "../_namespaces/ts.formatting";
 
 /** @internal */
 export interface Rule {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -107,9 +107,7 @@ import {
     TypeReference,
     unescapeLeadingUnderscores,
 } from "./_namespaces/ts";
-import {
-    isContextWithStartAndEndNode,
-} from "./_namespaces/ts.FindAllReferences";
+import { isContextWithStartAndEndNode } from "./_namespaces/ts.FindAllReferences";
 
 /** @internal */
 export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile, position: number, searchOtherFilesOnly?: boolean, stopAtAlias?: boolean): readonly DefinitionInfo[] | undefined {

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -7,9 +7,7 @@ import {
     RefactorContext,
     RefactorEditInfo,
 } from "./_namespaces/ts";
-import {
-    refactorKindBeginsWith,
-} from "./_namespaces/ts.refactor";
+import { refactorKindBeginsWith } from "./_namespaces/ts.refactor";
 
 // A map with the refactor code as key, the refactor itself as value
 // e.g.  nonSuggestableRefactors[refactorCode] -> the refactor you want

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -40,9 +40,7 @@ import {
     textChanges,
     TupleTypeNode,
 } from "../_namespaces/ts";
-import {
-    registerRefactor,
-} from "../_namespaces/ts.refactor";
+import { registerRefactor } from "../_namespaces/ts.refactor";
 
 const refactorName = "Convert overload list to single signature";
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_overload_list_to_single_signature);

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -104,9 +104,7 @@ import {
     TypeNode,
     VariableDeclaration,
 } from "../_namespaces/ts";
-import {
-    registerRefactor,
-} from "../_namespaces/ts.refactor";
+import { registerRefactor } from "../_namespaces/ts.refactor";
 
 const refactorName = "Convert parameters to destructured object";
 const minimumParameterLength = 1;

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -37,9 +37,7 @@ import {
     textChanges,
     Token,
 } from "../_namespaces/ts";
-import {
-    registerRefactor,
-} from "../_namespaces/ts.refactor";
+import { registerRefactor } from "../_namespaces/ts.refactor";
 
 const refactorName = "Convert to template string";
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_to_template_string);

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -1,6 +1,4 @@
-import {
-    getModuleSpecifier,
-} from "../../compiler/moduleSpecifiers";
+import { getModuleSpecifier } from "../../compiler/moduleSpecifiers";
 import {
     AnyImportOrRequireStatement,
     append,
@@ -153,9 +151,7 @@ import {
     VariableDeclarationList,
     VariableStatement,
 } from "../_namespaces/ts";
-import {
-    registerRefactor,
-} from "../refactorProvider";
+import { registerRefactor } from "../refactorProvider";
 
 const refactorNameForMoveToFile = "Move to file";
 const description = getLocaleSpecificMessage(Diagnostics.Move_to_file);

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -1,6 +1,4 @@
-import {
-    getModuleSpecifierPreferences,
-} from "../compiler/moduleSpecifiers";
+import { getModuleSpecifierPreferences } from "../compiler/moduleSpecifiers";
 import {
     addToSeen,
     altDirectorySeparator,

--- a/src/testRunner/parallel/shared.ts
+++ b/src/testRunner/parallel/shared.ts
@@ -1,6 +1,4 @@
-import {
-    TestRunnerKind,
-} from "../_namespaces/Harness";
+import { TestRunnerKind } from "../_namespaces/Harness";
 import * as ts from "../_namespaces/ts";
 
 export interface RunnerTask {

--- a/src/testRunner/unittests/canWatch.ts
+++ b/src/testRunner/unittests/canWatch.ts
@@ -1,6 +1,4 @@
-import {
-    Baseline,
-} from "../_namespaces/Harness";
+import { Baseline } from "../_namespaces/Harness";
 import * as ts from "../_namespaces/ts";
 describe("unittests:: canWatch::", () => {
     baselineCanWatch(

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 
 describe("unittests:: config:: commandLineParsing:: parseCommandLine", () => {
     function assertParseResult(subScenario: string, commandLine: string[], workerDiagnostic?: () => ts.ParseCommandLineWorkerDiagnostics) {

--- a/src/testRunner/unittests/config/configurationExtension.ts
+++ b/src/testRunner/unittests/config/configurationExtension.ts
@@ -2,9 +2,7 @@ import * as fakes from "../../_namespaces/fakes";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineParseConfig,
     baselineParseConfigHost,

--- a/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
+++ b/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
@@ -1,11 +1,7 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    baselineParseConfig,
-} from "./helpers";
+import { jsonToReadableText } from "../helpers";
+import { baselineParseConfig } from "./helpers";
 
 describe("unittests:: config:: convertCompilerOptionsFromJson", () => {
     function baselineCompilerOptions(subScenario: string, json: any, configFileName: string) {

--- a/src/testRunner/unittests/config/convertTypeAcquisitionFromJson.ts
+++ b/src/testRunner/unittests/config/convertTypeAcquisitionFromJson.ts
@@ -1,11 +1,7 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    baselineParseConfig,
-} from "./helpers";
+import { jsonToReadableText } from "../helpers";
+import { baselineParseConfig } from "./helpers";
 
 describe("unittests:: config:: convertTypeAcquisitionFromJson", () => {
     function baselineTypeAcquisition(subScenario: string, json: any, configFileName: string) {

--- a/src/testRunner/unittests/config/matchFiles.ts
+++ b/src/testRunner/unittests/config/matchFiles.ts
@@ -1,12 +1,8 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    baselineParseConfig,
-} from "./helpers";
+import { jsonToReadableText } from "../helpers";
+import { baselineParseConfig } from "./helpers";
 
 const caseInsensitiveBasePath = "c:/dev/";
 const caseInsensitiveTsconfigPath = "c:/dev/tsconfig.json";

--- a/src/testRunner/unittests/config/tsconfigParsing.ts
+++ b/src/testRunner/unittests/config/tsconfigParsing.ts
@@ -2,12 +2,8 @@ import * as fakes from "../../_namespaces/fakes";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    baselineParseConfig,
-} from "./helpers";
+import { jsonToReadableText } from "../helpers";
+import { baselineParseConfig } from "./helpers";
 
 describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () => {
     function formatErrors(errors: readonly ts.Diagnostic[]) {

--- a/src/testRunner/unittests/config/tsconfigParsingWatchOptions.ts
+++ b/src/testRunner/unittests/config/tsconfigParsingWatchOptions.ts
@@ -1,12 +1,8 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    baselineParseConfig,
-} from "./helpers";
+import { jsonToReadableText } from "../helpers";
+import { baselineParseConfig } from "./helpers";
 
 describe("unittests:: config:: tsconfigParsingWatchOptions:: parseConfigFileTextToJson", () => {
     interface VerifyWatchOptions {

--- a/src/testRunner/unittests/debugDeprecation.ts
+++ b/src/testRunner/unittests/debugDeprecation.ts
@@ -1,6 +1,4 @@
-import {
-    deprecate,
-} from "../../deprecatedCompat/deprecate";
+import { deprecate } from "../../deprecatedCompat/deprecate";
 import * as ts from "../_namespaces/ts";
 
 describe("unittests:: debugDeprecation", () => {

--- a/src/testRunner/unittests/evaluation/esDecorators.ts
+++ b/src/testRunner/unittests/evaluation/esDecorators.ts
@@ -1,8 +1,6 @@
 import * as evaluator from "../../_namespaces/evaluator";
 import * as ts from "../../_namespaces/ts";
-import {
-    ScriptTarget,
-} from "../../_namespaces/ts";
+import { ScriptTarget } from "../../_namespaces/ts";
 
 describe("unittests:: evaluation:: esDecorators", () => {
     const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES2021 };

--- a/src/testRunner/unittests/evaluation/esDecoratorsMetadata.ts
+++ b/src/testRunner/unittests/evaluation/esDecoratorsMetadata.ts
@@ -1,8 +1,6 @@
 import * as evaluator from "../../_namespaces/evaluator";
 import * as ts from "../../_namespaces/ts";
-import {
-    ScriptTarget,
-} from "../../_namespaces/ts";
+import { ScriptTarget } from "../../_namespaces/ts";
 
 describe("unittests:: evaluation:: esDecoratorsMetadata", () => {
     const nodeVersion = new ts.Version(process.versions.node);

--- a/src/testRunner/unittests/helpers/alternateResult.ts
+++ b/src/testRunner/unittests/helpers/alternateResult.ts
@@ -1,15 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    FsContents,
-} from "./contents";
-import {
-    libFile,
-} from "./virtualFileSystemWithWatch";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { FsContents } from "./contents";
+import { libFile } from "./virtualFileSystemWithWatch";
 
 export function getFsConentsForAlternateResultAtTypesPackageJson(packageName: string, addTypesCondition: boolean) {
     return jsonToReadableText({

--- a/src/testRunner/unittests/helpers/baseline.ts
+++ b/src/testRunner/unittests/helpers/baseline.ts
@@ -1,15 +1,9 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    TscCompileSystem,
-} from "./tsc";
-import {
-    TestServerHost,
-} from "./virtualFileSystemWithWatch";
+import { jsonToReadableText } from "../helpers";
+import { TscCompileSystem } from "./tsc";
+import { TestServerHost } from "./virtualFileSystemWithWatch";
 
 export type CommandLineProgram = [ts.Program, ts.BuilderProgram?];
 export interface CommandLineCallbacks {

--- a/src/testRunner/unittests/helpers/contents.ts
+++ b/src/testRunner/unittests/helpers/contents.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    libFile,
-} from "./virtualFileSystemWithWatch";
+import { libFile } from "./virtualFileSystemWithWatch";
 
 export function compilerOptionsToConfigJson(options: ts.CompilerOptions) {
     return ts.optionMapToObject(ts.serializeCompilerOptions(options));

--- a/src/testRunner/unittests/helpers/demoProjectReferences.ts
+++ b/src/testRunner/unittests/helpers/demoProjectReferences.ts
@@ -1,16 +1,10 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     FsContents,
     libContent,
 } from "./contents";
-import {
-    loadProjectFromFiles,
-} from "./vfs";
+import { loadProjectFromFiles } from "./vfs";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/helpers/extends.ts
+++ b/src/testRunner/unittests/helpers/extends.ts
@@ -1,9 +1,5 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     createServerHost,
     createWatchedSystem,

--- a/src/testRunner/unittests/helpers/libraryResolution.ts
+++ b/src/testRunner/unittests/helpers/libraryResolution.ts
@@ -1,16 +1,10 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     FsContents,
     libContent,
 } from "./contents";
-import {
-    loadProjectFromFiles,
-} from "./vfs";
+import { loadProjectFromFiles } from "./vfs";
 import {
     createServerHost,
     createWatchedSystem,

--- a/src/testRunner/unittests/helpers/noEmitOnError.ts
+++ b/src/testRunner/unittests/helpers/noEmitOnError.ts
@@ -1,16 +1,10 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     FsContents,
     libContent,
 } from "./contents";
-import {
-    loadProjectFromFiles,
-} from "./vfs";
+import { loadProjectFromFiles } from "./vfs";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/helpers/sampleProjectReferences.ts
+++ b/src/testRunner/unittests/helpers/sampleProjectReferences.ts
@@ -1,16 +1,10 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     FsContents,
     getProjectConfigWithNodeNext,
 } from "./contents";
-import {
-    loadProjectFromFiles,
-} from "./vfs";
+import { loadProjectFromFiles } from "./vfs";
 import {
     createServerHost,
     createWatchedSystem,

--- a/src/testRunner/unittests/helpers/solutionBuilder.ts
+++ b/src/testRunner/unittests/helpers/solutionBuilder.ts
@@ -1,11 +1,7 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    commandLineCallbacks,
-} from "./baseline";
+import { jsonToReadableText } from "../helpers";
+import { commandLineCallbacks } from "./baseline";
 import {
     makeSystemReadyForBaseline,
     TscCompileSystem,

--- a/src/testRunner/unittests/helpers/transitiveReferences.ts
+++ b/src/testRunner/unittests/helpers/transitiveReferences.ts
@@ -1,17 +1,11 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     FsContents,
     getProjectConfigWithNodeNext,
     libContent,
 } from "./contents";
-import {
-    libFile,
-} from "./virtualFileSystemWithWatch";
+import { libFile } from "./virtualFileSystemWithWatch";
 
 export function getFsContentsForTransitiveReferencesRefsAdts() {
     return dedent`

--- a/src/testRunner/unittests/helpers/tsc.ts
+++ b/src/testRunner/unittests/helpers/tsc.ts
@@ -2,9 +2,7 @@ import * as fakes from "../../_namespaces/fakes";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselinePrograms,
     CommandLineCallbacks,

--- a/src/testRunner/unittests/helpers/tscWatch.ts
+++ b/src/testRunner/unittests/helpers/tscWatch.ts
@@ -2,12 +2,8 @@ import {
     verifyProgramStructure,
     verifyResolutionCache,
 } from "../../../harness/incrementalUtils";
-import {
-    patchHostForBuildInfoReadWrite,
-} from "../../_namespaces/fakes";
-import {
-    Baseline,
-} from "../../_namespaces/Harness";
+import { patchHostForBuildInfoReadWrite } from "../../_namespaces/fakes";
+import { Baseline } from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import {
     baselinePrograms,

--- a/src/testRunner/unittests/helpers/tsserver.ts
+++ b/src/testRunner/unittests/helpers/tsserver.ts
@@ -1,18 +1,12 @@
-import {
-    incrementalVerifier,
-} from "../../../harness/incrementalUtils";
-import {
-    patchServiceForStateBaseline,
-} from "../../../harness/projectServiceStateLogger";
+import { incrementalVerifier } from "../../../harness/incrementalUtils";
+import { patchServiceForStateBaseline } from "../../../harness/projectServiceStateLogger";
 import {
     createLoggerWithInMemoryLogs,
     LoggerWithInMemoryLogs,
 } from "../../../harness/tsserverLogger";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    ensureErrorFreeBuild,
-} from "./solutionBuilder";
+import { ensureErrorFreeBuild } from "./solutionBuilder";
 import {
     customTypesMap,
     TestTypingsInstallerAdapter,

--- a/src/testRunner/unittests/helpers/typingsInstaller.ts
+++ b/src/testRunner/unittests/helpers/typingsInstaller.ts
@@ -3,15 +3,9 @@ import {
     nowString,
 } from "../../../harness/tsserverLogger";
 import * as ts from "../../_namespaces/ts";
-import {
-    stringifyIndented,
-} from "../../_namespaces/ts.server";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    TestSession,
-} from "./tsserver";
+import { stringifyIndented } from "../../_namespaces/ts.server";
+import { jsonToReadableText } from "../helpers";
+import { TestSession } from "./tsserver";
 import {
     File,
     TestServerHost,

--- a/src/testRunner/unittests/helpers/vfs.ts
+++ b/src/testRunner/unittests/helpers/vfs.ts
@@ -1,10 +1,6 @@
-import {
-    getDirectoryPath,
-} from "../../_namespaces/ts";
+import { getDirectoryPath } from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    libContent,
-} from "./contents";
+import { libContent } from "./contents";
 
 export interface FsOptions {
     libContentToAppend?: string;

--- a/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
+++ b/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
@@ -44,12 +44,8 @@ import {
     sys,
     toPath,
 } from "../../_namespaces/ts";
-import {
-    typingsInstaller,
-} from "../../_namespaces/ts.server";
-import {
-    timeIncrements,
-} from "../../_namespaces/vfs";
+import { typingsInstaller } from "../../_namespaces/ts.server";
+import { timeIncrements } from "../../_namespaces/vfs";
 
 export const libFile: File = {
     path: "/a/lib/lib.d.ts",

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../_namespaces/Harness";
 import * as ts from "../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "./helpers";
+import { jsonToReadableText } from "./helpers";
 
 interface File {
     name: string;

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -3,9 +3,7 @@ import * as fakes from "../_namespaces/fakes";
 import * as Harness from "../_namespaces/Harness";
 import * as ts from "../_namespaces/ts";
 import * as vfs from "../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "./helpers";
+import { jsonToReadableText } from "./helpers";
 
 function verifyMissingFilePaths(missing: ReturnType<ts.Program["getMissingFilePaths"]>, expected: readonly string[]) {
     assert.isDefined(missing);

--- a/src/testRunner/unittests/services/extract/functions.ts
+++ b/src/testRunner/unittests/services/extract/functions.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    testExtractSymbol,
-} from "./helpers";
+import { testExtractSymbol } from "./helpers";
 
 describe("unittests:: services:: extract:: extractFunctions", () => {
     testExtractFunction(

--- a/src/testRunner/unittests/services/extract/helpers.ts
+++ b/src/testRunner/unittests/services/extract/helpers.ts
@@ -1,14 +1,8 @@
-import {
-    incrementalVerifier,
-} from "../../../../harness/incrementalUtils";
-import {
-    createHasErrorMessageLogger,
-} from "../../../../harness/tsserverLogger";
+import { incrementalVerifier } from "../../../../harness/incrementalUtils";
+import { createHasErrorMessageLogger } from "../../../../harness/tsserverLogger";
 import * as Harness from "../../../_namespaces/Harness";
 import * as ts from "../../../_namespaces/ts";
-import {
-    customTypesMap,
-} from "../../helpers/typingsInstaller";
+import { customTypesMap } from "../../helpers/typingsInstaller";
 import {
     createServerHost,
     libFile,

--- a/src/testRunner/unittests/services/extract/ranges.ts
+++ b/src/testRunner/unittests/services/extract/ranges.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    extractTest,
-} from "./helpers";
+import { extractTest } from "./helpers";
 
 function testExtractRangeFailed(caption: string, s: string, expectedErrors: string[]) {
     return it(caption, () => {

--- a/src/testRunner/unittests/services/languageService.ts
+++ b/src/testRunner/unittests/services/languageService.ts
@@ -1,11 +1,7 @@
-import {
-    expect,
-} from "chai";
+import { expect } from "chai";
 
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     createServerHost,
     File,

--- a/src/testRunner/unittests/services/preProcessFile.ts
+++ b/src/testRunner/unittests/services/preProcessFile.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 
 describe("unittests:: services:: PreProcessFile:", () => {
     function test(sourceText: string, readImportFile: boolean, detectJavaScriptImports: boolean, expectedPreProcess: ts.PreProcessedFileInfo): void {

--- a/src/testRunner/unittests/services/textChanges.ts
+++ b/src/testRunner/unittests/services/textChanges.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    notImplementedHost,
-} from "./extract/helpers";
+import { notImplementedHost } from "./extract/helpers";
 
 // Some tests have trailing whitespace
 

--- a/src/testRunner/unittests/sys/symlinkWatching.ts
+++ b/src/testRunner/unittests/sys/symlinkWatching.ts
@@ -1,8 +1,6 @@
 import * as fs from "fs";
 
-import {
-    IO,
-} from "../../_namespaces/Harness";
+import { IO } from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import {
     defer,

--- a/src/testRunner/unittests/tsbuild/amdModulesWithOut.ts
+++ b/src/testRunner/unittests/tsbuild/amdModulesWithOut.ts
@@ -1,13 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     appendText,
     loadProjectFromFiles,

--- a/src/testRunner/unittests/tsbuild/clean.ts
+++ b/src/testRunner/unittests/tsbuild/clean.ts
@@ -1,16 +1,10 @@
-import {
-    noop,
-} from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { noop } from "../../_namespaces/ts";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeRun,
     verifyTsc,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild - clean::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsbuild/commandLine.ts
+++ b/src/testRunner/unittests/tsbuild/commandLine.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    compilerOptionsToConfigJson,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { compilerOptionsToConfigJson } from "../helpers/contents";
 import {
     noChangeRun,
     TestTscEdit,

--- a/src/testRunner/unittests/tsbuild/configFileErrors.ts
+++ b/src/testRunner/unittests/tsbuild/configFileErrors.ts
@@ -1,9 +1,5 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeRun,
     verifyTsc,

--- a/src/testRunner/unittests/tsbuild/configFileExtends.ts
+++ b/src/testRunner/unittests/tsbuild/configFileExtends.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: configFileExtends:: when tsconfig extends another config", () => {
     function getConfigExtendsWithIncludeFs() {

--- a/src/testRunner/unittests/tsbuild/containerOnlyReferenced.ts
+++ b/src/testRunner/unittests/tsbuild/containerOnlyReferenced.ts
@@ -1,6 +1,4 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeOnlyRuns,
     verifyTsc,

--- a/src/testRunner/unittests/tsbuild/declarationEmit.ts
+++ b/src/testRunner/unittests/tsbuild/declarationEmit.ts
@@ -1,22 +1,12 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    FileSet,
-} from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    libContent,
-} from "../helpers/contents";
+import { dedent } from "../../_namespaces/Utils";
+import { FileSet } from "../../_namespaces/vfs";
+import { jsonToReadableText } from "../helpers";
+import { libContent } from "../helpers/contents";
 import {
     noChangeOnlyRuns,
     verifyTsc,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: declarationEmit", () => {
     function getFiles(): FileSet {

--- a/src/testRunner/unittests/tsbuild/demo.ts
+++ b/src/testRunner/unittests/tsbuild/demo.ts
@@ -3,12 +3,8 @@ import {
     getFsContentsForDemoProjectReferencesCoreConfig,
     getFsForDemoProjectReferences,
 } from "../helpers/demoProjectReferences";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    prependText,
-} from "../helpers/vfs";
+import { verifyTsc } from "../helpers/tsc";
+import { prependText } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: on demo project", () => {
     let projFs: vfs.FileSystem;

--- a/src/testRunner/unittests/tsbuild/emitDeclarationOnly.ts
+++ b/src/testRunner/unittests/tsbuild/emitDeclarationOnly.ts
@@ -1,13 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     loadProjectFromFiles,
     replaceText,

--- a/src/testRunner/unittests/tsbuild/emptyFiles.ts
+++ b/src/testRunner/unittests/tsbuild/emptyFiles.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild - empty files option in tsconfig", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsbuild/exitCodeOnBogusFile.ts
+++ b/src/testRunner/unittests/tsbuild/exitCodeOnBogusFile.ts
@@ -1,9 +1,5 @@
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 // https://github.com/microsoft/TypeScript/issues/33849
 describe("unittests:: tsbuild:: exitCodeOnBogusFile:: test exit code", () => {

--- a/src/testRunner/unittests/tsbuild/extends.ts
+++ b/src/testRunner/unittests/tsbuild/extends.ts
@@ -1,9 +1,5 @@
-import {
-    getSymlinkedExtendsSys,
-} from "../helpers/extends";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { getSymlinkedExtendsSys } from "../helpers/extends";
+import { verifyTscWatch } from "../helpers/tscWatch";
 
 describe("unittests:: tsbuild:: extends::", () => {
     verifyTscWatch({

--- a/src/testRunner/unittests/tsbuild/fileDelete.ts
+++ b/src/testRunner/unittests/tsbuild/fileDelete.ts
@@ -1,19 +1,9 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    compilerOptionsToConfigJson,
-} from "../helpers/contents";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { compilerOptionsToConfigJson } from "../helpers/contents";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: fileDelete::", () => {
     function fs(childOptions: ts.CompilerOptions, mainOptions?: ts.CompilerOptions) {

--- a/src/testRunner/unittests/tsbuild/graphOrdering.ts
+++ b/src/testRunner/unittests/tsbuild/graphOrdering.ts
@@ -1,9 +1,7 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 
 describe("unittests:: tsbuild - graph-ordering", () => {
     let host: fakes.SolutionBuilderHost | undefined;

--- a/src/testRunner/unittests/tsbuild/inferredTypeFromTransitiveModule.ts
+++ b/src/testRunner/unittests/tsbuild/inferredTypeFromTransitiveModule.ts
@@ -1,13 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     appendText,
     loadProjectFromFiles,

--- a/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
+++ b/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
@@ -1,13 +1,7 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    symbolLibContent,
-} from "../helpers/contents";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { symbolLibContent } from "../helpers/contents";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: javascriptProjectEmit::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsbuild/lateBoundSymbol.ts
+++ b/src/testRunner/unittests/tsbuild/lateBoundSymbol.ts
@@ -1,12 +1,6 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     appendText,
     loadProjectFromFiles,

--- a/src/testRunner/unittests/tsbuild/libraryResolution.ts
+++ b/src/testRunner/unittests/tsbuild/libraryResolution.ts
@@ -1,9 +1,5 @@
-import {
-    getFsForLibResolution,
-} from "../helpers/libraryResolution";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { getFsForLibResolution } from "../helpers/libraryResolution";
+import { verifyTsc } from "../helpers/tsc";
 
 describe("unittests:: tsbuild:: libraryResolution:: library file resolution", () => {
     function verify(libRedirection?: true) {

--- a/src/testRunner/unittests/tsbuild/moduleResolution.ts
+++ b/src/testRunner/unittests/tsbuild/moduleResolution.ts
@@ -1,18 +1,12 @@
 import * as ts from "../../_namespaces/ts";
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeOnlyRuns,
     verifyTsc,
 } from "../helpers/tsc";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { verifyTscWatch } from "../helpers/tscWatch";
+import { loadProjectFromFiles } from "../helpers/vfs";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tsbuild/moduleSpecifiers.ts
+++ b/src/testRunner/unittests/tsbuild/moduleSpecifiers.ts
@@ -1,16 +1,8 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    symbolLibContent,
-} from "../helpers/contents";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
-import {
-    libFile,
-} from "../helpers/virtualFileSystemWithWatch";
+import { symbolLibContent } from "../helpers/contents";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
+import { libFile } from "../helpers/virtualFileSystemWithWatch";
 
 // https://github.com/microsoft/TypeScript/issues/31696
 describe("unittests:: tsbuild:: moduleSpecifiers:: synthesized module specifiers to referenced projects resolve correctly", () => {

--- a/src/testRunner/unittests/tsbuild/noEmit.ts
+++ b/src/testRunner/unittests/tsbuild/noEmit.ts
@@ -1,13 +1,9 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeRun,
     verifyTsc,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: noEmit", () => {
     function verifyNoEmitWorker(subScenario: string, aTsContent: string, commandLineArgs: readonly string[]) {

--- a/src/testRunner/unittests/tsbuild/noEmitOnError.ts
+++ b/src/testRunner/unittests/tsbuild/noEmitOnError.ts
@@ -1,7 +1,5 @@
 import * as vfs from "../../_namespaces/vfs";
-import {
-    getFsForNoEmitOnError,
-} from "../helpers/noEmitOnError";
+import { getFsForNoEmitOnError } from "../helpers/noEmitOnError";
 import {
     noChangeRun,
     verifyTsc,

--- a/src/testRunner/unittests/tsbuild/outFile.ts
+++ b/src/testRunner/unittests/tsbuild/outFile.ts
@@ -1,15 +1,9 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    createSolutionBuilderHostForBaseline,
-} from "../helpers/solutionBuilder";
+import { jsonToReadableText } from "../helpers";
+import { createSolutionBuilderHostForBaseline } from "../helpers/solutionBuilder";
 import {
     noChangeOnlyRuns,
     testTscCompileLike,

--- a/src/testRunner/unittests/tsbuild/outputPaths.ts
+++ b/src/testRunner/unittests/tsbuild/outputPaths.ts
@@ -1,8 +1,6 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeRun,
     TestTscEdit,
@@ -10,9 +8,7 @@ import {
     verifyTsc,
     VerifyTscWithEditsInput,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild - output file paths", () => {
     const noChangeProject: TestTscEdit = {

--- a/src/testRunner/unittests/tsbuild/publicApi.ts
+++ b/src/testRunner/unittests/tsbuild/publicApi.ts
@@ -1,9 +1,7 @@
 import * as fakes from "../../_namespaces/fakes";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselinePrograms,
     commandLineCallbacks,
@@ -13,9 +11,7 @@ import {
     TscCompileSystem,
     verifyTscBaseline,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: Public API with custom transformers when passed to build", () => {
     let sys: TscCompileSystem;

--- a/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
+++ b/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
@@ -1,13 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     loadProjectFromFiles,
     replaceText,

--- a/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
+++ b/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
@@ -1,12 +1,6 @@
-import {
-    CompilerOptions,
-} from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { CompilerOptions } from "../../_namespaces/ts";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     noChangeOnlyRuns,
     verifyTsc,

--- a/src/testRunner/unittests/tsbuild/roots.ts
+++ b/src/testRunner/unittests/tsbuild/roots.ts
@@ -1,15 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsbuild:: roots::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -2,9 +2,7 @@ import * as fakes from "../../_namespaces/fakes";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     libContent,
     libPath,
@@ -13,9 +11,7 @@ import {
     getFsForSampleProjectReferences,
     getSysForSampleProjectReferences,
 } from "../helpers/sampleProjectReferences";
-import {
-    createSolutionBuilderHostForBaseline,
-} from "../helpers/solutionBuilder";
+import { createSolutionBuilderHostForBaseline } from "../helpers/solutionBuilder";
 import {
     noChangeOnlyRuns,
     noChangeRun,

--- a/src/testRunner/unittests/tsbuild/transitiveReferences.ts
+++ b/src/testRunner/unittests/tsbuild/transitiveReferences.ts
@@ -1,19 +1,9 @@
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    getFsContentsForTransitiveReferences,
-} from "../helpers/transitiveReferences";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
-import {
-    libFile,
-} from "../helpers/virtualFileSystemWithWatch";
+import { jsonToReadableText } from "../helpers";
+import { getFsContentsForTransitiveReferences } from "../helpers/transitiveReferences";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
+import { libFile } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsbuild:: when project reference is referenced transitively", () => {
     let projFs: vfs.FileSystem;

--- a/src/testRunner/unittests/tsbuildWatch/configFileErrors.ts
+++ b/src/testRunner/unittests/tsbuildWatch/configFileErrors.ts
@@ -1,12 +1,6 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tsbuildWatch/demo.ts
+++ b/src/testRunner/unittests/tsbuildWatch/demo.ts
@@ -1,13 +1,9 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import {
     getFsContentsForDemoProjectReferencesCoreConfig,
     getSysForDemoProjectReferences,
 } from "../helpers/demoProjectReferences";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { verifyTscWatch } from "../helpers/tscWatch";
 
 describe("unittests:: tsbuildWatch:: watchMode:: with demo project", () => {
     verifyTscWatch({

--- a/src/testRunner/unittests/tsbuildWatch/libraryResolution.ts
+++ b/src/testRunner/unittests/tsbuildWatch/libraryResolution.ts
@@ -1,9 +1,5 @@
-import {
-    getSysForLibResolution,
-} from "../helpers/libraryResolution";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { getSysForLibResolution } from "../helpers/libraryResolution";
+import { verifyTscWatch } from "../helpers/tscWatch";
 
 describe("unittests:: tsbuildWatch:: watchMode:: libraryResolution:: library file resolution", () => {
     function verify(libRedirection?: true) {

--- a/src/testRunner/unittests/tsbuildWatch/moduleResolution.ts
+++ b/src/testRunner/unittests/tsbuildWatch/moduleResolution.ts
@@ -1,12 +1,6 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tsbuildWatch/noEmit.ts
+++ b/src/testRunner/unittests/tsbuildWatch/noEmit.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    libContent,
-} from "../helpers/contents";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { jsonToReadableText } from "../helpers";
+import { libContent } from "../helpers/contents";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tsbuildWatch/noEmitOnError.ts
+++ b/src/testRunner/unittests/tsbuildWatch/noEmitOnError.ts
@@ -1,6 +1,4 @@
-import {
-    getSysForNoEmitOnError,
-} from "../helpers/noEmitOnError";
+import { getSysForNoEmitOnError } from "../helpers/noEmitOnError";
 import {
     TscWatchCompileChange,
     verifyTscWatch,

--- a/src/testRunner/unittests/tsbuildWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tsbuildWatch/programUpdates.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    FsContents,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { FsContents } from "../helpers/contents";
 import {
     getFsContentsForSampleProjectReferences,
     getFsContentsForSampleProjectReferencesLogicConfig,

--- a/src/testRunner/unittests/tsbuildWatch/projectsBuilding.ts
+++ b/src/testRunner/unittests/tsbuildWatch/projectsBuilding.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     noopChange,
     TscWatchCompileChange,

--- a/src/testRunner/unittests/tsbuildWatch/publicApi.ts
+++ b/src/testRunner/unittests/tsbuildWatch/publicApi.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     createBaseline,
     createSolutionBuilderWithWatchHostForBaseline,

--- a/src/testRunner/unittests/tsbuildWatch/reexport.ts
+++ b/src/testRunner/unittests/tsbuildWatch/reexport.ts
@@ -1,15 +1,7 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    libContent,
-} from "../helpers/contents";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { libContent } from "../helpers/contents";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tsbuildWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tsbuildWatch/watchEnvironment.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     createBaseline,
     createSolutionBuilderWithWatchHostForBaseline,

--- a/src/testRunner/unittests/tsc/cancellationToken.ts
+++ b/src/testRunner/unittests/tsc/cancellationToken.ts
@@ -1,9 +1,7 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineBuildInfo,
     CommandLineProgram,

--- a/src/testRunner/unittests/tsc/composite.ts
+++ b/src/testRunner/unittests/tsc/composite.ts
@@ -1,10 +1,6 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
 import {
     loadProjectFromFiles,
     replaceText,

--- a/src/testRunner/unittests/tsc/declarationEmit.ts
+++ b/src/testRunner/unittests/tsc/declarationEmit.ts
@@ -1,10 +1,6 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { jsonToReadableText } from "../helpers";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     FileOrFolderOrSymLink,

--- a/src/testRunner/unittests/tsc/extends.ts
+++ b/src/testRunner/unittests/tsc/extends.ts
@@ -1,9 +1,5 @@
-import {
-    getSymlinkedExtendsSys,
-} from "../helpers/extends";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { getSymlinkedExtendsSys } from "../helpers/extends";
+import { verifyTscWatch } from "../helpers/tscWatch";
 
 describe("unittests:: tsc:: extends::", () => {
     verifyTscWatch({

--- a/src/testRunner/unittests/tsc/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tsc/forceConsistentCasingInFileNames.ts
@@ -1,10 +1,6 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsc:: forceConsistentCasingInFileNames::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsc/incremental.ts
+++ b/src/testRunner/unittests/tsc/incremental.ts
@@ -1,16 +1,12 @@
 import * as ts from "../../_namespaces/ts";
 import * as Utils from "../../_namespaces/Utils";
 import * as vfs from "../../_namespaces/vfs";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     compilerOptionsToConfigJson,
     libContent,
 } from "../helpers/contents";
-import {
-    getFsForNoEmitOnError,
-} from "../helpers/noEmitOnError";
+import { getFsForNoEmitOnError } from "../helpers/noEmitOnError";
 import {
     noChangeOnlyRuns,
     noChangeRun,

--- a/src/testRunner/unittests/tsc/libraryResolution.ts
+++ b/src/testRunner/unittests/tsc/libraryResolution.ts
@@ -2,9 +2,7 @@ import {
     getCommandLineArgsForLibResolution,
     getFsForLibResolution,
 } from "../helpers/libraryResolution";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
+import { verifyTsc } from "../helpers/tsc";
 
 describe("unittests:: tsc:: libraryResolution:: library file resolution", () => {
     function verify(libRedirection?: true, withoutConfig?: true) {

--- a/src/testRunner/unittests/tsc/listFilesOnly.ts
+++ b/src/testRunner/unittests/tsc/listFilesOnly.ts
@@ -3,9 +3,7 @@ import {
     noChangeRun,
     verifyTsc,
 } from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsc:: listFilesOnly::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsc/moduleResolution.ts
+++ b/src/testRunner/unittests/tsc/moduleResolution.ts
@@ -1,30 +1,16 @@
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     getFsConentsForAlternateResultAtTypesPackageJson,
     getFsContentsForAlternateResult,
     getFsContentsForAlternateResultDts,
     getFsContentsForAlternateResultPackageJson,
 } from "../helpers/alternateResult";
-import {
-    libContent,
-} from "../helpers/contents";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
-import {
-    createWatchedSystem,
-} from "../helpers/virtualFileSystemWithWatch";
+import { libContent } from "../helpers/contents";
+import { verifyTsc } from "../helpers/tsc";
+import { verifyTscWatch } from "../helpers/tscWatch";
+import { loadProjectFromFiles } from "../helpers/vfs";
+import { createWatchedSystem } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsc:: moduleResolution::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsc/projectReferences.ts
+++ b/src/testRunner/unittests/tsc/projectReferences.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsc:: projectReferences::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsc/projectReferencesConfig.ts
+++ b/src/testRunner/unittests/tsc/projectReferencesConfig.ts
@@ -1,13 +1,7 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 function emptyModule() {
     return "export { };";

--- a/src/testRunner/unittests/tsc/redirect.ts
+++ b/src/testRunner/unittests/tsc/redirect.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { jsonToReadableText } from "../helpers";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsc:: redirect::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tsc/runWithoutArgs.ts
+++ b/src/testRunner/unittests/tsc/runWithoutArgs.ts
@@ -1,9 +1,5 @@
-import {
-    verifyTsc,
-} from "../helpers/tsc";
-import {
-    loadProjectFromFiles,
-} from "../helpers/vfs";
+import { verifyTsc } from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
 
 describe("unittests:: tsc:: runWithoutArgs::", () => {
     verifyTsc({

--- a/src/testRunner/unittests/tscWatch/consoleClearing.ts
+++ b/src/testRunner/unittests/tscWatch/consoleClearing.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     createBaseline,
     createWatchCompilerHostOfConfigFileForBaseline,

--- a/src/testRunner/unittests/tscWatch/emit.ts
+++ b/src/testRunner/unittests/tscWatch/emit.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     TscWatchCompileChange,
     verifyTscWatch,

--- a/src/testRunner/unittests/tscWatch/emitAndErrorUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/emitAndErrorUpdates.ts
@@ -1,12 +1,6 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    FsContents,
-} from "../helpers/contents";
-import {
-    getFsContentsForNoEmitOnError,
-} from "../helpers/noEmitOnError";
+import { jsonToReadableText } from "../helpers";
+import { FsContents } from "../helpers/contents";
+import { getFsContentsForNoEmitOnError } from "../helpers/noEmitOnError";
 import {
     TscWatchCompileChange,
     verifyTscWatch,

--- a/src/testRunner/unittests/tscWatch/extends.ts
+++ b/src/testRunner/unittests/tscWatch/extends.ts
@@ -1,9 +1,5 @@
-import {
-    getSymlinkedExtendsSys,
-} from "../helpers/extends";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { getSymlinkedExtendsSys } from "../helpers/extends";
+import { verifyTscWatch } from "../helpers/tscWatch";
 
 describe("unittests:: tsc-watch:: extends::", () => {
     verifyTscWatch({

--- a/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
@@ -1,7 +1,5 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     TscWatchCompileChange,
     verifyTscWatch,

--- a/src/testRunner/unittests/tscWatch/incremental.ts
+++ b/src/testRunner/unittests/tscWatch/incremental.ts
@@ -1,14 +1,8 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    CommandLineProgram,
-} from "../helpers/baseline";
-import {
-    libContent,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { CommandLineProgram } from "../helpers/baseline";
+import { libContent } from "../helpers/contents";
 import {
     applyEdit,
     createBaseline,

--- a/src/testRunner/unittests/tscWatch/libraryResolution.ts
+++ b/src/testRunner/unittests/tscWatch/libraryResolution.ts
@@ -1,6 +1,4 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     getCommandLineArgsForLibResolution,
     getSysForLibResolution,

--- a/src/testRunner/unittests/tscWatch/moduleResolution.ts
+++ b/src/testRunner/unittests/tscWatch/moduleResolution.ts
@@ -1,16 +1,12 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     getFsConentsForAlternateResultAtTypesPackageJson,
     getFsContentsForAlternateResult,
     getFsContentsForAlternateResultDts,
     getFsContentsForAlternateResultPackageJson,
 } from "../helpers/alternateResult";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     File,

--- a/src/testRunner/unittests/tscWatch/nodeNextWatch.ts
+++ b/src/testRunner/unittests/tscWatch/nodeNextWatch.ts
@@ -1,10 +1,6 @@
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { jsonToReadableText } from "../helpers";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     File,

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -1,14 +1,8 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    commandLineCallbacks,
-} from "../helpers/baseline";
-import {
-    compilerOptionsToConfigJson,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { commandLineCallbacks } from "../helpers/baseline";
+import { compilerOptionsToConfigJson } from "../helpers/contents";
 import {
     commonFile1,
     commonFile2,

--- a/src/testRunner/unittests/tscWatch/projectsWithReferences.ts
+++ b/src/testRunner/unittests/tscWatch/projectsWithReferences.ts
@@ -1,15 +1,7 @@
-import {
-    noop,
-} from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    getProjectConfigWithNodeNext,
-} from "../helpers/contents";
-import {
-    getSysForSampleProjectReferences,
-} from "../helpers/sampleProjectReferences";
+import { noop } from "../../_namespaces/ts";
+import { jsonToReadableText } from "../helpers";
+import { getProjectConfigWithNodeNext } from "../helpers/contents";
+import { getSysForSampleProjectReferences } from "../helpers/sampleProjectReferences";
 import {
     createSolutionBuilder,
     solutionBuildWithBaseline,
@@ -20,9 +12,7 @@ import {
     getFsContentsForTransitiveReferencesBConfig,
     getFsContentsForTransitiveReferencesRefsAdts,
 } from "../helpers/transitiveReferences";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tscWatch/resolutionCache.ts
+++ b/src/testRunner/unittests/tscWatch/resolutionCache.ts
@@ -1,11 +1,7 @@
 import * as ts from "../../_namespaces/ts";
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    libContent,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { libContent } from "../helpers/contents";
 import {
     createBaseline,
     createWatchCompilerHostOfFilesAndCompilerOptionsForBaseline,

--- a/src/testRunner/unittests/tscWatch/resolveJsonModuleWithIncremental.ts
+++ b/src/testRunner/unittests/tscWatch/resolveJsonModuleWithIncremental.ts
@@ -1,9 +1,5 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    verifyTscWatch,
-} from "../helpers/tscWatch";
+import { jsonToReadableText } from "../helpers";
+import { verifyTscWatch } from "../helpers/tscWatch";
 import {
     createWatchedSystem,
     libFile,

--- a/src/testRunner/unittests/tscWatch/sourceOfProjectReferenceRedirect.ts
+++ b/src/testRunner/unittests/tscWatch/sourceOfProjectReferenceRedirect.ts
@@ -1,16 +1,8 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    FsContents,
-} from "../helpers/contents";
-import {
-    getFsContentsForDemoProjectReferences,
-} from "../helpers/demoProjectReferences";
-import {
-    solutionBuildWithBaseline,
-} from "../helpers/solutionBuilder";
+import { jsonToReadableText } from "../helpers";
+import { FsContents } from "../helpers/contents";
+import { getFsContentsForDemoProjectReferences } from "../helpers/demoProjectReferences";
+import { solutionBuildWithBaseline } from "../helpers/solutionBuilder";
 import {
     createBaseline,
     createWatchCompilerHostOfConfigFileForBaseline,

--- a/src/testRunner/unittests/tscWatch/watchApi.ts
+++ b/src/testRunner/unittests/tscWatch/watchApi.ts
@@ -1,17 +1,9 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    commandLineCallbacks,
-} from "../helpers/baseline";
-import {
-    libContent,
-} from "../helpers/contents";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { commandLineCallbacks } from "../helpers/baseline";
+import { libContent } from "../helpers/contents";
 import {
     applyEdit,
     createBaseline,

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     commonFile1,
     commonFile2,

--- a/src/testRunner/unittests/tsserver/autoImportProvider.ts
+++ b/src/testRunner/unittests/tsserver/autoImportProvider.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/auxiliaryProject.ts
+++ b/src/testRunner/unittests/tsserver/auxiliaryProject.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/cachingFileSystemInformation.ts
+++ b/src/testRunner/unittests/tsserver/cachingFileSystemInformation.ts
@@ -1,13 +1,7 @@
-import {
-    IncrementalVerifierCallbacks,
-} from "../../../harness/incrementalUtils";
-import {
-    LoggerWithInMemoryLogs,
-} from "../../../harness/tsserverLogger";
+import { IncrementalVerifierCallbacks } from "../../../harness/incrementalUtils";
+import { LoggerWithInMemoryLogs } from "../../../harness/tsserverLogger";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     logDiagnostics,

--- a/src/testRunner/unittests/tsserver/cancellationToken.ts
+++ b/src/testRunner/unittests/tsserver/cancellationToken.ts
@@ -1,15 +1,11 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     TestSession,
     TestSessionRequest,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: cancellationToken", () => {
     // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test

--- a/src/testRunner/unittests/tsserver/codeFix.ts
+++ b/src/testRunner/unittests/tsserver/codeFix.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/compileOnSave.ts
+++ b/src/testRunner/unittests/tsserver/compileOnSave.ts
@@ -3,9 +3,7 @@ import {
     LoggerWithInMemoryLogs,
 } from "../../../harness/tsserverLogger";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openExternalProjectForSession,

--- a/src/testRunner/unittests/tsserver/completions.ts
+++ b/src/testRunner/unittests/tsserver/completions.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    ensureErrorFreeBuild,
-} from "../helpers/solutionBuilder";
+import { jsonToReadableText } from "../helpers";
+import { ensureErrorFreeBuild } from "../helpers/solutionBuilder";
 import {
     commonFile1,
     commonFile2,

--- a/src/testRunner/unittests/tsserver/declarationFileMaps.ts
+++ b/src/testRunner/unittests/tsserver/declarationFileMaps.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/documentRegistry.ts
+++ b/src/testRunner/unittests/tsserver/documentRegistry.ts
@@ -1,10 +1,6 @@
-import {
-    reportDocumentRegistryStats,
-} from "../../../harness/incrementalUtils";
+import { reportDocumentRegistryStats } from "../../../harness/incrementalUtils";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/duplicatePackages.ts
+++ b/src/testRunner/unittests/tsserver/duplicatePackages.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/events/largeFileReferenced.ts
+++ b/src/testRunner/unittests/tsserver/events/largeFileReferenced.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../../helpers";
+import { jsonToReadableText } from "../../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
+++ b/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../../helpers";
+import { jsonToReadableText } from "../../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/events/projectLoading.ts
+++ b/src/testRunner/unittests/tsserver/events/projectLoading.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../../helpers";
+import { jsonToReadableText } from "../../helpers";
 import {
     baselineTsserverLogs,
     createSessionWithCustomEventHandler,

--- a/src/testRunner/unittests/tsserver/events/projectUpdatedInBackground.ts
+++ b/src/testRunner/unittests/tsserver/events/projectUpdatedInBackground.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../../helpers";
+import { jsonToReadableText } from "../../helpers";
 import {
     baselineTsserverLogs,
     createSessionWithCustomEventHandler,

--- a/src/testRunner/unittests/tsserver/exportMapCache.ts
+++ b/src/testRunner/unittests/tsserver/exportMapCache.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/extends.ts
+++ b/src/testRunner/unittests/tsserver/extends.ts
@@ -1,6 +1,4 @@
-import {
-    getSymlinkedExtendsSys,
-} from "../helpers/extends";
+import { getSymlinkedExtendsSys } from "../helpers/extends";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/externalProjects.ts
+++ b/src/testRunner/unittests/tsserver/externalProjects.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/findAllReferences.ts
+++ b/src/testRunner/unittests/tsserver/findAllReferences.ts
@@ -1,6 +1,4 @@
-import {
-    protocol,
-} from "../../_namespaces/ts.server";
+import { protocol } from "../../_namespaces/ts.server";
 import {
     baselineTsserverLogs,
     TestSession,

--- a/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/formatSettings.ts
+++ b/src/testRunner/unittests/tsserver/formatSettings.ts
@@ -1,15 +1,11 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,
     TestSession,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: formatSettings", () => {
     it("can be set globally", () => {

--- a/src/testRunner/unittests/tsserver/getEditsForFileRename.ts
+++ b/src/testRunner/unittests/tsserver/getEditsForFileRename.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/getMoveToRefactoringFileSuggestions.ts
+++ b/src/testRunner/unittests/tsserver/getMoveToRefactoringFileSuggestions.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/goToDefinition.ts
+++ b/src/testRunner/unittests/tsserver/goToDefinition.ts
@@ -1,6 +1,4 @@
-import {
-    protocol,
-} from "../../_namespaces/ts.server";
+import { protocol } from "../../_namespaces/ts.server";
 import {
     baselineTsserverLogs,
     TestSession,

--- a/src/testRunner/unittests/tsserver/importHelpers.ts
+++ b/src/testRunner/unittests/tsserver/importHelpers.ts
@@ -4,9 +4,7 @@ import {
     TestSession,
     toExternalFile,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: importHelpers", () => {
     it("should not crash in tsserver", () => {

--- a/src/testRunner/unittests/tsserver/inconsistentErrorInEditor.ts
+++ b/src/testRunner/unittests/tsserver/inconsistentErrorInEditor.ts
@@ -4,9 +4,7 @@ import {
     TestSession,
     verifyGetErrRequest,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 describe("unittests:: tsserver:: inconsistentErrorInEditor", () => {
     it("should not error", () => {
         const host = createServerHost([]);

--- a/src/testRunner/unittests/tsserver/inferredProjects.ts
+++ b/src/testRunner/unittests/tsserver/inferredProjects.ts
@@ -1,13 +1,7 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    commonFile1,
-} from "../helpers/tscWatch";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { commonFile1 } from "../helpers/tscWatch";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/languageService.ts
+++ b/src/testRunner/unittests/tsserver/languageService.ts
@@ -5,9 +5,7 @@ import {
     openFilesForSession,
     TestSession,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: languageService", () => {
     it("should work correctly on case-sensitive file systems", () => {

--- a/src/testRunner/unittests/tsserver/libraryResolution.ts
+++ b/src/testRunner/unittests/tsserver/libraryResolution.ts
@@ -1,9 +1,5 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    getServerHostForLibResolution,
-} from "../helpers/libraryResolution";
+import { jsonToReadableText } from "../helpers";
+import { getServerHostForLibResolution } from "../helpers/libraryResolution";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/maxNodeModuleJsDepth.ts
+++ b/src/testRunner/unittests/tsserver/maxNodeModuleJsDepth.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/metadataInResponse.ts
+++ b/src/testRunner/unittests/tsserver/metadataInResponse.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/moduleResolution.ts
+++ b/src/testRunner/unittests/tsserver/moduleResolution.ts
@@ -1,22 +1,14 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     getFsConentsForAlternateResultAtTypesPackageJson,
     getFsContentsForAlternateResult,
     getFsContentsForAlternateResultDts,
     getFsContentsForAlternateResultPackageJson,
 } from "../helpers/alternateResult";
-import {
-    libContent,
-} from "../helpers/contents";
-import {
-    solutionBuildWithBaseline,
-} from "../helpers/solutionBuilder";
+import { libContent } from "../helpers/contents";
+import { solutionBuildWithBaseline } from "../helpers/solutionBuilder";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/moduleSpecifierCache.ts
+++ b/src/testRunner/unittests/tsserver/moduleSpecifierCache.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/navTo.ts
+++ b/src/testRunner/unittests/tsserver/navTo.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/packageJsonInfo.ts
+++ b/src/testRunner/unittests/tsserver/packageJsonInfo.ts
@@ -1,6 +1,4 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/plugins.ts
+++ b/src/testRunner/unittests/tsserver/plugins.ts
@@ -1,8 +1,6 @@
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/pluginsAsync.ts
+++ b/src/testRunner/unittests/tsserver/pluginsAsync.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    defer,
-} from "../../_namespaces/Utils";
+import { defer } from "../../_namespaces/Utils";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/projectErrors.ts
+++ b/src/testRunner/unittests/tsserver/projectErrors.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/projectReferenceCompileOnSave.ts
+++ b/src/testRunner/unittests/tsserver/projectReferenceCompileOnSave.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    ensureErrorFreeBuild,
-} from "../helpers/solutionBuilder";
+import { jsonToReadableText } from "../helpers";
+import { ensureErrorFreeBuild } from "../helpers/solutionBuilder";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/projectReferenceErrors.ts
+++ b/src/testRunner/unittests/tsserver/projectReferenceErrors.ts
@@ -1,13 +1,9 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     GetErrForProjectDiagnostics,
     verifyGetErrScenario,
 } from "../helpers/tsserver";
-import {
-    File,
-} from "../helpers/virtualFileSystemWithWatch";
+import { File } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: with project references and error reporting", () => {
     const dependecyLocation = `/user/username/projects/myproject/dependency`;

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1,13 +1,7 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    solutionBuildWithBaseline,
-} from "../helpers/solutionBuilder";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { solutionBuildWithBaseline } from "../helpers/solutionBuilder";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
+++ b/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1,10 +1,6 @@
-import {
-    createLoggerWithInMemoryLogs,
-} from "../../../harness/tsserverLogger";
+import { createLoggerWithInMemoryLogs } from "../../../harness/tsserverLogger";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     commonFile1,
     commonFile2,
@@ -22,9 +18,7 @@ import {
     toExternalFiles,
     verifyGetErrRequest,
 } from "../helpers/tsserver";
-import {
-    customTypesMap,
-} from "../helpers/typingsInstaller";
+import { customTypesMap } from "../helpers/typingsInstaller";
 import {
     createServerHost,
     File,

--- a/src/testRunner/unittests/tsserver/projectsWithReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectsWithReferences.ts
@@ -1,9 +1,5 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    getFsContentsForSampleProjectReferences,
-} from "../helpers/sampleProjectReferences";
+import { jsonToReadableText } from "../helpers";
+import { getFsContentsForSampleProjectReferences } from "../helpers/sampleProjectReferences";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/reloadProjects.ts
+++ b/src/testRunner/unittests/tsserver/reloadProjects.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openExternalProjectForSession,

--- a/src/testRunner/unittests/tsserver/rename.ts
+++ b/src/testRunner/unittests/tsserver/rename.ts
@@ -1,13 +1,7 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    libContent,
-} from "../helpers/contents";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import { libContent } from "../helpers/contents";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -1,11 +1,7 @@
 import * as ts from "../../_namespaces/ts";
 import * as Utils from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
-import {
-    compilerOptionsToConfigJson,
-} from "../helpers/contents";
+import { jsonToReadableText } from "../helpers";
+import { compilerOptionsToConfigJson } from "../helpers/contents";
 import {
     baselineTsserverLogs,
     openExternalProjectForSession,

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -1,10 +1,6 @@
-import {
-    expect,
-} from "chai";
+import { expect } from "chai";
 
-import {
-    incrementalVerifier,
-} from "../../../harness/incrementalUtils";
+import { incrementalVerifier } from "../../../harness/incrementalUtils";
 import {
     createHasErrorMessageLogger,
     nullLogger,

--- a/src/testRunner/unittests/tsserver/skipLibCheck.ts
+++ b/src/testRunner/unittests/tsserver/skipLibCheck.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openExternalProjectForSession,
@@ -9,9 +7,7 @@ import {
     TestSession,
     toExternalFiles,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: with skipLibCheck", () => {
     it("should be turned on for js-only inferred projects", () => {

--- a/src/testRunner/unittests/tsserver/symLinks.ts
+++ b/src/testRunner/unittests/tsserver/symLinks.ts
@@ -1,10 +1,6 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    dedent,
-} from "../../_namespaces/Utils";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/telemetry.ts
+++ b/src/testRunner/unittests/tsserver/telemetry.ts
@@ -1,7 +1,5 @@
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     closeFilesForSession,

--- a/src/testRunner/unittests/tsserver/textStorage.ts
+++ b/src/testRunner/unittests/tsserver/textStorage.ts
@@ -4,9 +4,7 @@ import {
     openFilesForSession,
     TestSession,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: Text storage", () => {
     const f = {

--- a/src/testRunner/unittests/tsserver/typeAquisition.ts
+++ b/src/testRunner/unittests/tsserver/typeAquisition.ts
@@ -1,6 +1,4 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openExternalProjectForSession,
@@ -8,9 +6,7 @@ import {
     TestSession,
     toExternalFile,
 } from "../helpers/tsserver";
-import {
-    createServerHost,
-} from "../helpers/virtualFileSystemWithWatch";
+import { createServerHost } from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsserver:: typeAquisition:: autoDiscovery", () => {
     it("does not depend on extension", () => {

--- a/src/testRunner/unittests/tsserver/typeReferenceDirectives.ts
+++ b/src/testRunner/unittests/tsserver/typeReferenceDirectives.ts
@@ -1,6 +1,4 @@
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     baselineTsserverLogs,
     openFilesForSession,

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -29,12 +29,8 @@ import {
 
 import validatePackageName = ts.JsTyping.validatePackageName;
 import NameValidationResult = ts.JsTyping.NameValidationResult;
-import {
-    stringifyIndented,
-} from "../../_namespaces/ts.server";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { stringifyIndented } from "../../_namespaces/ts.server";
+import { jsonToReadableText } from "../helpers";
 
 describe("unittests:: tsserver:: typingsInstaller:: local module", () => {
     it("should not be picked up", () => {

--- a/src/testRunner/unittests/tsserver/watchEnvironment.ts
+++ b/src/testRunner/unittests/tsserver/watchEnvironment.ts
@@ -3,9 +3,7 @@ import {
     LoggerWithInMemoryLogs,
 } from "../../../harness/tsserverLogger";
 import * as ts from "../../_namespaces/ts";
-import {
-    jsonToReadableText,
-} from "../helpers";
+import { jsonToReadableText } from "../helpers";
 import {
     commonFile1,
     commonFile2,

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -1,10 +1,6 @@
 import * as ts from "../typescript/typescript";
-import {
-    StartInput,
-} from "./common";
-import {
-    initializeNodeSystem,
-} from "./nodeServer";
+import { StartInput } from "./common";
+import { initializeNodeSystem } from "./nodeServer";
 
 function findArgumentStringArray(argName: string): readonly string[] {
     const arg = ts.server.findArgument(argName);


### PR DESCRIPTION
Enabled by https://github.com/dprint/dprint-plugin-typescript/pull/617, a follow-up to https://github.com/dprint/dprint-plugin-typescript/pull/473 which I added for this repo.

Now, imports of a single name (very common!) do not force a newline.

Thank you, @todor-a!