### PR TITLE
Tweak CI failure diffing, produce an artifact for fixing baseline errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
 
       - name: Print baseline diff on failure
         if: ${{ failure() && steps.test.conclusion == 'failure' }}
-        run: git diff --diff-filter=AM --no-index -- ./tests/baselines/reference ./tests/baselines/local
+        run: |
+          npx hereby baseline-accept
+          git add tests/baselines/reference
+          git diff --staged
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           npx hereby baseline-accept
           git add tests/baselines/reference
-          git diff --staged
+          git diff --staged --exit-code
 
   lint:
     runs-on: ubuntu-latest
@@ -277,6 +277,7 @@ jobs:
           git add tests/baselines/reference
 
       - name: Check baselines
+        id: check-baselines
         run: |
           function print_diff() {
             if ! git diff --staged --exit-code --quiet --diff-filter=$1; then
@@ -289,5 +290,13 @@ jobs:
             print_diff ACR "Missing baselines"
             print_diff MTUXB "Modified baselines"
             print_diff D "Unused baselines"
+            git diff --staged > fix_baselines.patch
             exit 1
           fi
+
+      - name: Upload baseline diff artifact
+        if: ${{ failure() && steps.check-baselines.conclusion == 'failure' }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: fix_baselines.patch
+          path: fix_baselines.patch


### PR DESCRIPTION
Comparing after adding was suggested by @weswigham, and I should have done that instead of the diff from the contributing guide (since I already did it in the baseline job).

Then, the baseline job, upload the diff as a patch artifact which is a quicker way to pull down a change to accept the baselines.

In the future, we can probably use the latter to auto-send a PR when it fails on main, but that requires a little more thought to prevent races.