### PR TITLE
Update an error message to match TypeScript’s behaviour which allows spreading non objects in objects

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3581,7 +3581,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))
                 ) {
                     const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result);
-                    if (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum) {
+                    if (exportOrLocalSymbol && (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum)) {
                         checkResolvedBlockScopedVariable(exportOrLocalSymbol, errorLocation);
                     }
                 }
@@ -31930,7 +31930,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     spread = getSpreadType(spread, mergedType, node.symbol, objectFlags, inConstContext);
                 }
                 else {
-                    error(memberDecl, Diagnostics.Spread_types_may_only_be_created_from_object_types);
+                    error(memberDecl, Diagnostics.Spread_appears_unintentional_because_this_value_is_not_possibly_an_object);
                     spread = errorType;
                 }
                 continue;
@@ -32180,7 +32180,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 else {
-                    error(attributeDecl.expression, Diagnostics.Spread_types_may_only_be_created_from_object_types);
+                    error(attributeDecl.expression, Diagnostics.Spread_appears_unintentional_because_this_value_is_not_possibly_an_object);
                     typeToIntersect = typeToIntersect ? getIntersectionType([typeToIntersect, exprType]) : exprType;
                 }
             }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3115,7 +3115,7 @@
         "category": "Error",
         "code": 2697
     },
-    "Spread types may only be created from object types.": {
+    "Spread appears unintentional because this value is not possibly an object.": {
         "category": "Error",
         "code": 2698
     },

--- a/tests/baselines/reference/correctlyMarkAliasAsReferences3.errors.txt
+++ b/tests/baselines/reference/correctlyMarkAliasAsReferences3.errors.txt
@@ -1,4 +1,4 @@
-0.tsx(6,21): error TS2698: Spread types may only be created from object types.
+0.tsx(6,21): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== 0.tsx (1 errors) ====
@@ -9,7 +9,7 @@
     let buttonProps;
     let k = <button {...buttonProps}>
                         ~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
                 <span className={cx('class1', { class2: true })} />
             </button>;
     

--- a/tests/baselines/reference/jsxExcessPropsAndAssignability.errors.txt
+++ b/tests/baselines/reference/jsxExcessPropsAndAssignability.errors.txt
@@ -1,7 +1,7 @@
-jsxExcessPropsAndAssignability.tsx(13,27): error TS2698: Spread types may only be created from object types.
+jsxExcessPropsAndAssignability.tsx(13,27): error TS2698: Spread appears unintentional because this value is not possibly an object.
 jsxExcessPropsAndAssignability.tsx(14,6): error TS2322: Type 'ComposedComponentProps & { myProp: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<WrapperComponentProps, any, any>> & Readonly<{ children?: ReactNode; }> & Readonly<WrapperComponentProps>'.
   Type 'ComposedComponentProps & { myProp: number; }' is not assignable to type 'Readonly<WrapperComponentProps>'.
-jsxExcessPropsAndAssignability.tsx(14,27): error TS2698: Spread types may only be created from object types.
+jsxExcessPropsAndAssignability.tsx(14,27): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== jsxExcessPropsAndAssignability.tsx (3 errors) ====
@@ -19,12 +19,12 @@ jsxExcessPropsAndAssignability.tsx(14,27): error TS2698: Spread types may only b
     
         <WrapperComponent {...props} myProp={'1000000'} />;
                               ~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         <WrapperComponent {...props} myProp={1000000} />;
          ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'ComposedComponentProps & { myProp: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<WrapperComponentProps, any, any>> & Readonly<{ children?: ReactNode; }> & Readonly<WrapperComponentProps>'.
 !!! error TS2322:   Type 'ComposedComponentProps & { myProp: number; }' is not assignable to type 'Readonly<WrapperComponentProps>'.
                               ~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     };
     

--- a/tests/baselines/reference/jsxNamespacePrefixInName.errors.txt
+++ b/tests/baselines/reference/jsxNamespacePrefixInName.errors.txt
@@ -17,7 +17,7 @@ jsxNamespacePrefixInName.tsx(11,73): error TS1005: ',' expected.
 jsxNamespacePrefixInName.tsx(11,74): error TS1109: Expression expected.
 jsxNamespacePrefixInName.tsx(21,27): error TS1003: Identifier expected.
 jsxNamespacePrefixInName.tsx(21,29): error TS1005: '...' expected.
-jsxNamespacePrefixInName.tsx(21,29): error TS2698: Spread types may only be created from object types.
+jsxNamespacePrefixInName.tsx(21,29): error TS2698: Spread appears unintentional because this value is not possibly an object.
 jsxNamespacePrefixInName.tsx(22,27): error TS1003: Identifier expected.
 jsxNamespacePrefixInName.tsx(24,21): error TS1109: Expression expected.
 jsxNamespacePrefixInName.tsx(24,22): error TS1109: Expression expected.
@@ -28,7 +28,7 @@ jsxNamespacePrefixInName.tsx(24,41): error TS1109: Expression expected.
 jsxNamespacePrefixInName.tsx(24,42): error TS1109: Expression expected.
 jsxNamespacePrefixInName.tsx(25,29): error TS1003: Identifier expected.
 jsxNamespacePrefixInName.tsx(25,31): error TS1005: '...' expected.
-jsxNamespacePrefixInName.tsx(25,31): error TS2698: Spread types may only be created from object types.
+jsxNamespacePrefixInName.tsx(25,31): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== jsxNamespacePrefixInName.tsx (31 errors) ====
@@ -92,7 +92,7 @@ jsxNamespacePrefixInName.tsx(25,31): error TS2698: Spread types may only be crea
                                 ~~~~~~~
 !!! error TS1005: '...' expected.
                                 ~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     var endOfIdent2 = <a attr:={"value"} />;
                               ~
 !!! error TS1003: Identifier expected.
@@ -118,7 +118,7 @@ jsxNamespacePrefixInName.tsx(25,31): error TS2698: Spread types may only be crea
                                   ~~~~~~~
 !!! error TS1005: '...' expected.
                                   ~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
     var upcaseComponent1 = <ns:Upcase />;  // Parsed as intrinsic
     var upcaseComponent2 = <Upcase:element />;  // Parsed as instrinsic

--- a/tests/baselines/reference/jsxNamespacePrefixInNameReact.errors.txt
+++ b/tests/baselines/reference/jsxNamespacePrefixInNameReact.errors.txt
@@ -17,7 +17,7 @@ jsxNamespacePrefixInNameReact.tsx(13,73): error TS1005: ',' expected.
 jsxNamespacePrefixInNameReact.tsx(13,74): error TS1109: Expression expected.
 jsxNamespacePrefixInNameReact.tsx(23,27): error TS1003: Identifier expected.
 jsxNamespacePrefixInNameReact.tsx(23,29): error TS1005: '...' expected.
-jsxNamespacePrefixInNameReact.tsx(23,29): error TS2698: Spread types may only be created from object types.
+jsxNamespacePrefixInNameReact.tsx(23,29): error TS2698: Spread appears unintentional because this value is not possibly an object.
 jsxNamespacePrefixInNameReact.tsx(24,27): error TS1003: Identifier expected.
 jsxNamespacePrefixInNameReact.tsx(26,21): error TS1109: Expression expected.
 jsxNamespacePrefixInNameReact.tsx(26,22): error TS1109: Expression expected.
@@ -28,7 +28,7 @@ jsxNamespacePrefixInNameReact.tsx(26,41): error TS1109: Expression expected.
 jsxNamespacePrefixInNameReact.tsx(26,42): error TS1109: Expression expected.
 jsxNamespacePrefixInNameReact.tsx(27,29): error TS1003: Identifier expected.
 jsxNamespacePrefixInNameReact.tsx(27,31): error TS1005: '...' expected.
-jsxNamespacePrefixInNameReact.tsx(27,31): error TS2698: Spread types may only be created from object types.
+jsxNamespacePrefixInNameReact.tsx(27,31): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== jsxNamespacePrefixInNameReact.tsx (31 errors) ====
@@ -94,7 +94,7 @@ jsxNamespacePrefixInNameReact.tsx(27,31): error TS2698: Spread types may only be
                                 ~~~~~~~
 !!! error TS1005: '...' expected.
                                 ~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     var endOfIdent2 = <a attr:={"value"} />;
                               ~
 !!! error TS1003: Identifier expected.
@@ -120,7 +120,7 @@ jsxNamespacePrefixInNameReact.tsx(27,31): error TS2698: Spread types may only be
                                   ~~~~~~~
 !!! error TS1005: '...' expected.
                                   ~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
     var upcaseComponent1 = <ns:Upcase />;  // Parsed as intrinsic
     var upcaseComponent2 = <Upcase:element />;  // Parsed as instrinsic

--- a/tests/baselines/reference/objectSpreadNegative.errors.txt
+++ b/tests/baselines/reference/objectSpreadNegative.errors.txt
@@ -14,11 +14,11 @@ objectSpreadNegative.ts(39,14): error TS2783: 'b' is specified more than once, s
 objectSpreadNegative.ts(41,53): error TS2783: 'd' is specified more than once, so this usage will be overwritten.
 objectSpreadNegative.ts(43,7): error TS2783: 'a' is specified more than once, so this usage will be overwritten.
 objectSpreadNegative.ts(45,37): error TS2783: 'b' is specified more than once, so this usage will be overwritten.
-objectSpreadNegative.ts(48,19): error TS2698: Spread types may only be created from object types.
-objectSpreadNegative.ts(49,19): error TS2698: Spread types may only be created from object types.
-objectSpreadNegative.ts(50,20): error TS2698: Spread types may only be created from object types.
-objectSpreadNegative.ts(52,20): error TS2698: Spread types may only be created from object types.
-objectSpreadNegative.ts(54,19): error TS2698: Spread types may only be created from object types.
+objectSpreadNegative.ts(48,19): error TS2698: Spread appears unintentional because this value is not possibly an object.
+objectSpreadNegative.ts(49,19): error TS2698: Spread appears unintentional because this value is not possibly an object.
+objectSpreadNegative.ts(50,20): error TS2698: Spread appears unintentional because this value is not possibly an object.
+objectSpreadNegative.ts(52,20): error TS2698: Spread appears unintentional because this value is not possibly an object.
+objectSpreadNegative.ts(54,19): error TS2698: Spread appears unintentional because this value is not possibly an object.
 objectSpreadNegative.ts(59,1): error TS2349: This expression is not callable.
   Type '{}' has no call signatures.
 objectSpreadNegative.ts(63,1): error TS2322: Type '12' is not assignable to type 'undefined'.
@@ -114,21 +114,21 @@ objectSpreadNegative.ts(74,11): error TS2339: Property 'a' does not exist on typ
     // primitives are not allowed, except for falsy ones
     let spreadNum = { ...12 };
                       ~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     let spreadSum = { ...1 + 1 };
                       ~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     let spreadZero = { ...0 };
                        ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     spreadZero.toFixed(); // error, no methods even from a falsy number
     let spreadBool = { ...true };
                        ~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     spreadBool.valueOf();
     let spreadStr = { ...'foo' };
                       ~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     spreadStr.length; // error, no 'length'
     spreadStr.charAt(1); // error, no methods either
     // functions are skipped

--- a/tests/baselines/reference/objectSpreadNegativeParse.errors.txt
+++ b/tests/baselines/reference/objectSpreadNegativeParse.errors.txt
@@ -1,6 +1,6 @@
 objectSpreadNegativeParse.ts(1,15): error TS2304: Cannot find name 'o'.
 objectSpreadNegativeParse.ts(1,18): error TS1109: Expression expected.
-objectSpreadNegativeParse.ts(2,12): error TS2698: Spread types may only be created from object types.
+objectSpreadNegativeParse.ts(2,12): error TS2698: Spread appears unintentional because this value is not possibly an object.
 objectSpreadNegativeParse.ts(2,15): error TS1109: Expression expected.
 objectSpreadNegativeParse.ts(2,16): error TS2304: Cannot find name 'o'.
 objectSpreadNegativeParse.ts(3,15): error TS2304: Cannot find name 'matchMedia'.
@@ -18,7 +18,7 @@ objectSpreadNegativeParse.ts(4,20): error TS1005: ',' expected.
 !!! error TS1109: Expression expected.
     let o8 = { ...*o };
                ~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
                   ~
 !!! error TS1109: Expression expected.
                    ~

--- a/tests/baselines/reference/spreadInvalidArgumentType.errors.txt
+++ b/tests/baselines/reference/spreadInvalidArgumentType.errors.txt
@@ -1,14 +1,14 @@
+spreadInvalidArgumentType.ts(32,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
 spreadInvalidArgumentType.ts(33,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(34,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(39,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(42,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(38,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(41,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(43,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
 spreadInvalidArgumentType.ts(44,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(45,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(46,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
 spreadInvalidArgumentType.ts(47,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(48,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(51,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
 spreadInvalidArgumentType.ts(52,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(53,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
-spreadInvalidArgumentType.ts(55,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(54,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== spreadInvalidArgumentType.ts (11 errors) ====
@@ -24,13 +24,13 @@ spreadInvalidArgumentType.ts(55,17): error TS2698: Spread appears unintentional 
         var mapped: {[P in "b"]: T[P]};
     
         var union_generic: T | { a: number };
-        var union_primitive: { a: number } | number;
+        var union_primitive: number | { a: number };
     
         var intersection_generic: T & { a: number };
-        var intersection_primitive: { a: number } | string;
+        var intersection_primitive: number & { a: number };
     
         var num: number;
-        var str: number;
+        var str: string;
         var literal_string: "string";
         var literal_number: 42;
     
@@ -38,12 +38,11 @@ spreadInvalidArgumentType.ts(55,17): error TS2698: Spread appears unintentional 
         var n: null;
         var a: any;
     
-    
         var e: E;
     
-        var o1 = { ...p1 };  // OK, generic type paramterre
+        var o1 = { ...p1 };  // OK, generic type parameter
         var o2 = { ...p2 };  // OK
-        var o3 = { ...t };   // OK, generic type paramter
+        var o3 = { ...t };   // OK, generic type parameter
         var o4 = { ...i };   // Error, index access
                    ~~~~
 !!! error TS2698: Spread appears unintentional because this value is not possibly an object.

--- a/tests/baselines/reference/spreadInvalidArgumentType.errors.txt
+++ b/tests/baselines/reference/spreadInvalidArgumentType.errors.txt
@@ -1,14 +1,14 @@
-spreadInvalidArgumentType.ts(33,16): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(34,16): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(39,16): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(42,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(44,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(45,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(47,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(48,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(52,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(53,17): error TS2698: Spread types may only be created from object types.
-spreadInvalidArgumentType.ts(55,17): error TS2698: Spread types may only be created from object types.
+spreadInvalidArgumentType.ts(33,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(34,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(39,16): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(42,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(44,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(45,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(47,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(48,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(52,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(53,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadInvalidArgumentType.ts(55,17): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== spreadInvalidArgumentType.ts (11 errors) ====
@@ -46,48 +46,48 @@ spreadInvalidArgumentType.ts(55,17): error TS2698: Spread types may only be crea
         var o3 = { ...t };   // OK, generic type paramter
         var o4 = { ...i };   // Error, index access
                    ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         var o5 = { ...k };   // Error, index
                    ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         var o6 = { ...mapped_generic }; // OK, generic mapped object type
         var o7 = { ...mapped };  // OK, non-generic mapped type
     
         var o8 = { ...union_generic };  // OK, union with generic type parameter
         var o9 = { ...union_primitive };  // Error, union with generic type parameter
                    ~~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
         var o10 = { ...intersection_generic };  // OK, intersection with generic type parameter
         var o11 = { ...intersection_primitive };  // Error, intersection with generic type parameter
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
         var o12 = { ...num };  // Error
                     ~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         var o13 = { ...str };  // Error
                     ~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
         var o14 = { ...u };  // error, undefined-only not allowed
                     ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         var o15 = { ...n };  // error, null-only not allowed
                     ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
         var o16 = { ...a };  // OK
     
         var o17 = { ...literal_string };  // Error
                     ~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         var o18 = { ...literal_number };  // Error
                     ~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     
         var o19 = { ...e };  // Error, enum
                     ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     

--- a/tests/baselines/reference/spreadInvalidArgumentType.js
+++ b/tests/baselines/reference/spreadInvalidArgumentType.js
@@ -13,13 +13,13 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
     var mapped: {[P in "b"]: T[P]};
 
     var union_generic: T | { a: number };
-    var union_primitive: { a: number } | number;
+    var union_primitive: number | { a: number };
 
     var intersection_generic: T & { a: number };
-    var intersection_primitive: { a: number } | string;
+    var intersection_primitive: number & { a: number };
 
     var num: number;
-    var str: number;
+    var str: string;
     var literal_string: "string";
     var literal_number: 42;
 
@@ -27,12 +27,11 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
     var n: null;
     var a: any;
 
-
     var e: E;
 
-    var o1 = { ...p1 };  // OK, generic type paramterre
+    var o1 = { ...p1 };  // OK, generic type parameter
     var o2 = { ...p2 };  // OK
-    var o3 = { ...t };   // OK, generic type paramter
+    var o3 = { ...t };   // OK, generic type parameter
     var o4 = { ...i };   // Error, index access
     var o5 = { ...k };   // Error, index
     var o6 = { ...mapped_generic }; // OK, generic mapped object type
@@ -95,9 +94,9 @@ function f(p1, p2) {
     var n;
     var a;
     var e;
-    var o1 = __assign({}, p1); // OK, generic type paramterre
+    var o1 = __assign({}, p1); // OK, generic type parameter
     var o2 = __assign({}, p2); // OK
-    var o3 = __assign({}, t); // OK, generic type paramter
+    var o3 = __assign({}, t); // OK, generic type parameter
     var o4 = __assign({}, i); // Error, index access
     var o5 = __assign({}, k); // Error, index
     var o6 = __assign({}, mapped_generic); // OK, generic mapped object type

--- a/tests/baselines/reference/spreadInvalidArgumentType.symbols
+++ b/tests/baselines/reference/spreadInvalidArgumentType.symbols
@@ -45,23 +45,23 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >T : Symbol(T, Decl(spreadInvalidArgumentType.ts, 2, 11))
 >a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 11, 28))
 
-    var union_primitive: { a: number } | number;
+    var union_primitive: number | { a: number };
 >union_primitive : Symbol(union_primitive, Decl(spreadInvalidArgumentType.ts, 12, 7))
->a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 12, 26))
+>a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 12, 35))
 
     var intersection_generic: T & { a: number };
 >intersection_generic : Symbol(intersection_generic, Decl(spreadInvalidArgumentType.ts, 14, 7))
 >T : Symbol(T, Decl(spreadInvalidArgumentType.ts, 2, 11))
 >a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 14, 35))
 
-    var intersection_primitive: { a: number } | string;
+    var intersection_primitive: number & { a: number };
 >intersection_primitive : Symbol(intersection_primitive, Decl(spreadInvalidArgumentType.ts, 15, 7))
->a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 15, 33))
+>a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 15, 42))
 
     var num: number;
 >num : Symbol(num, Decl(spreadInvalidArgumentType.ts, 17, 7))
 
-    var str: number;
+    var str: string;
 >str : Symbol(str, Decl(spreadInvalidArgumentType.ts, 18, 7))
 
     var literal_string: "string";
@@ -79,85 +79,84 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
     var a: any;
 >a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 24, 7))
 
-
     var e: E;
->e : Symbol(e, Decl(spreadInvalidArgumentType.ts, 27, 7))
+>e : Symbol(e, Decl(spreadInvalidArgumentType.ts, 26, 7))
 >E : Symbol(E, Decl(spreadInvalidArgumentType.ts, 0, 0))
 
-    var o1 = { ...p1 };  // OK, generic type paramterre
->o1 : Symbol(o1, Decl(spreadInvalidArgumentType.ts, 29, 7))
+    var o1 = { ...p1 };  // OK, generic type parameter
+>o1 : Symbol(o1, Decl(spreadInvalidArgumentType.ts, 28, 7))
 >p1 : Symbol(p1, Decl(spreadInvalidArgumentType.ts, 2, 36))
 
     var o2 = { ...p2 };  // OK
->o2 : Symbol(o2, Decl(spreadInvalidArgumentType.ts, 30, 7))
+>o2 : Symbol(o2, Decl(spreadInvalidArgumentType.ts, 29, 7))
 >p2 : Symbol(p2, Decl(spreadInvalidArgumentType.ts, 2, 42))
 
-    var o3 = { ...t };   // OK, generic type paramter
->o3 : Symbol(o3, Decl(spreadInvalidArgumentType.ts, 31, 7))
+    var o3 = { ...t };   // OK, generic type parameter
+>o3 : Symbol(o3, Decl(spreadInvalidArgumentType.ts, 30, 7))
 >t : Symbol(t, Decl(spreadInvalidArgumentType.ts, 3, 7))
 
     var o4 = { ...i };   // Error, index access
->o4 : Symbol(o4, Decl(spreadInvalidArgumentType.ts, 32, 7))
+>o4 : Symbol(o4, Decl(spreadInvalidArgumentType.ts, 31, 7))
 >i : Symbol(i, Decl(spreadInvalidArgumentType.ts, 5, 7))
 
     var o5 = { ...k };   // Error, index
->o5 : Symbol(o5, Decl(spreadInvalidArgumentType.ts, 33, 7))
+>o5 : Symbol(o5, Decl(spreadInvalidArgumentType.ts, 32, 7))
 >k : Symbol(k, Decl(spreadInvalidArgumentType.ts, 6, 7))
 
     var o6 = { ...mapped_generic }; // OK, generic mapped object type
->o6 : Symbol(o6, Decl(spreadInvalidArgumentType.ts, 34, 7))
+>o6 : Symbol(o6, Decl(spreadInvalidArgumentType.ts, 33, 7))
 >mapped_generic : Symbol(mapped_generic, Decl(spreadInvalidArgumentType.ts, 8, 7))
 
     var o7 = { ...mapped };  // OK, non-generic mapped type
->o7 : Symbol(o7, Decl(spreadInvalidArgumentType.ts, 35, 7))
+>o7 : Symbol(o7, Decl(spreadInvalidArgumentType.ts, 34, 7))
 >mapped : Symbol(mapped, Decl(spreadInvalidArgumentType.ts, 9, 7))
 
     var o8 = { ...union_generic };  // OK, union with generic type parameter
->o8 : Symbol(o8, Decl(spreadInvalidArgumentType.ts, 37, 7))
+>o8 : Symbol(o8, Decl(spreadInvalidArgumentType.ts, 36, 7))
 >union_generic : Symbol(union_generic, Decl(spreadInvalidArgumentType.ts, 11, 7))
 
     var o9 = { ...union_primitive };  // Error, union with generic type parameter
->o9 : Symbol(o9, Decl(spreadInvalidArgumentType.ts, 38, 7))
+>o9 : Symbol(o9, Decl(spreadInvalidArgumentType.ts, 37, 7))
 >union_primitive : Symbol(union_primitive, Decl(spreadInvalidArgumentType.ts, 12, 7))
 
     var o10 = { ...intersection_generic };  // OK, intersection with generic type parameter
->o10 : Symbol(o10, Decl(spreadInvalidArgumentType.ts, 40, 7))
+>o10 : Symbol(o10, Decl(spreadInvalidArgumentType.ts, 39, 7))
 >intersection_generic : Symbol(intersection_generic, Decl(spreadInvalidArgumentType.ts, 14, 7))
 
     var o11 = { ...intersection_primitive };  // Error, intersection with generic type parameter
->o11 : Symbol(o11, Decl(spreadInvalidArgumentType.ts, 41, 7))
+>o11 : Symbol(o11, Decl(spreadInvalidArgumentType.ts, 40, 7))
 >intersection_primitive : Symbol(intersection_primitive, Decl(spreadInvalidArgumentType.ts, 15, 7))
 
     var o12 = { ...num };  // Error
->o12 : Symbol(o12, Decl(spreadInvalidArgumentType.ts, 43, 7))
+>o12 : Symbol(o12, Decl(spreadInvalidArgumentType.ts, 42, 7))
 >num : Symbol(num, Decl(spreadInvalidArgumentType.ts, 17, 7))
 
     var o13 = { ...str };  // Error
->o13 : Symbol(o13, Decl(spreadInvalidArgumentType.ts, 44, 7))
+>o13 : Symbol(o13, Decl(spreadInvalidArgumentType.ts, 43, 7))
 >str : Symbol(str, Decl(spreadInvalidArgumentType.ts, 18, 7))
 
     var o14 = { ...u };  // error, undefined-only not allowed
->o14 : Symbol(o14, Decl(spreadInvalidArgumentType.ts, 46, 7))
+>o14 : Symbol(o14, Decl(spreadInvalidArgumentType.ts, 45, 7))
 >u : Symbol(u, Decl(spreadInvalidArgumentType.ts, 22, 7))
 
     var o15 = { ...n };  // error, null-only not allowed
->o15 : Symbol(o15, Decl(spreadInvalidArgumentType.ts, 47, 7))
+>o15 : Symbol(o15, Decl(spreadInvalidArgumentType.ts, 46, 7))
 >n : Symbol(n, Decl(spreadInvalidArgumentType.ts, 23, 7))
 
     var o16 = { ...a };  // OK
->o16 : Symbol(o16, Decl(spreadInvalidArgumentType.ts, 49, 7))
+>o16 : Symbol(o16, Decl(spreadInvalidArgumentType.ts, 48, 7))
 >a : Symbol(a, Decl(spreadInvalidArgumentType.ts, 24, 7))
 
     var o17 = { ...literal_string };  // Error
->o17 : Symbol(o17, Decl(spreadInvalidArgumentType.ts, 51, 7))
+>o17 : Symbol(o17, Decl(spreadInvalidArgumentType.ts, 50, 7))
 >literal_string : Symbol(literal_string, Decl(spreadInvalidArgumentType.ts, 19, 7))
 
     var o18 = { ...literal_number };  // Error
->o18 : Symbol(o18, Decl(spreadInvalidArgumentType.ts, 52, 7))
+>o18 : Symbol(o18, Decl(spreadInvalidArgumentType.ts, 51, 7))
 >literal_number : Symbol(literal_number, Decl(spreadInvalidArgumentType.ts, 20, 7))
 
     var o19 = { ...e };  // Error, enum
->o19 : Symbol(o19, Decl(spreadInvalidArgumentType.ts, 54, 7))
->e : Symbol(e, Decl(spreadInvalidArgumentType.ts, 27, 7))
+>o19 : Symbol(o19, Decl(spreadInvalidArgumentType.ts, 53, 7))
+>e : Symbol(e, Decl(spreadInvalidArgumentType.ts, 26, 7))
 }
 

--- a/tests/baselines/reference/spreadInvalidArgumentType.types
+++ b/tests/baselines/reference/spreadInvalidArgumentType.types
@@ -45,7 +45,7 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >a : number
 >  : ^^^^^^
 
-    var union_primitive: { a: number } | number;
+    var union_primitive: number | { a: number };
 >union_primitive : number | { a: number; }
 >                : ^^^^^^^^^^^^^^      ^^^
 >a : number
@@ -57,8 +57,8 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >a : number
 >  : ^^^^^^
 
-    var intersection_primitive: { a: number } | string;
->intersection_primitive : string | { a: number; }
+    var intersection_primitive: number & { a: number };
+>intersection_primitive : number & { a: number; }
 >                       : ^^^^^^^^^^^^^^      ^^^
 >a : number
 >  : ^^^^^^
@@ -67,8 +67,8 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >num : number
 >    : ^^^^^^
 
-    var str: number;
->str : number
+    var str: string;
+>str : string
 >    : ^^^^^^
 
     var literal_string: "string";
@@ -91,12 +91,11 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >a : any
 >  : ^^^
 
-
     var e: E;
 >e : E
 >  : ^
 
-    var o1 = { ...p1 };  // OK, generic type paramterre
+    var o1 = { ...p1 };  // OK, generic type parameter
 >o1 : T
 >   : ^
 >{ ...p1 } : T
@@ -112,7 +111,7 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >p2 : T[]
 >   : ^^^
 
-    var o3 = { ...t };   // OK, generic type paramter
+    var o3 = { ...t };   // OK, generic type parameter
 >o3 : T
 >   : ^
 >{ ...t } : T
@@ -181,7 +180,7 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >    : ^^^
 >{ ...intersection_primitive } : any
 >                              : ^^^
->intersection_primitive : string | { a: number; }
+>intersection_primitive : number & { a: number; }
 >                       : ^^^^^^^^^^^^^^^^^^^^^^^
 
     var o12 = { ...num };  // Error
@@ -197,7 +196,7 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
 >    : ^^^
 >{ ...str } : any
 >           : ^^^
->str : number
+>str : string
 >    : ^^^^^^
 
     var o14 = { ...u };  // error, undefined-only not allowed

--- a/tests/baselines/reference/spreadObjectOrFalsy.errors.txt
+++ b/tests/baselines/reference/spreadObjectOrFalsy.errors.txt
@@ -1,12 +1,12 @@
-spreadObjectOrFalsy.ts(2,14): error TS2698: Spread types may only be created from object types.
-spreadObjectOrFalsy.ts(10,14): error TS2698: Spread types may only be created from object types.
+spreadObjectOrFalsy.ts(2,14): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadObjectOrFalsy.ts(10,14): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== spreadObjectOrFalsy.ts (2 errors) ====
     function f1<T>(a: T & undefined) {
         return { ...a };  // Error
                  ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     
     function f2<T>(a: T | T & undefined) {
@@ -16,7 +16,7 @@ spreadObjectOrFalsy.ts(10,14): error TS2698: Spread types may only be created fr
     function f3<T extends undefined>(a: T) {
         return { ...a };  // Error
                  ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     
     function f4<T extends undefined>(a: object | T) {

--- a/tests/baselines/reference/spreadTypeVariable.errors.txt
+++ b/tests/baselines/reference/spreadTypeVariable.errors.txt
@@ -1,13 +1,13 @@
-spreadTypeVariable.ts(2,12): error TS2698: Spread types may only be created from object types.
-spreadTypeVariable.ts(10,12): error TS2698: Spread types may only be created from object types.
-spreadTypeVariable.ts(14,12): error TS2698: Spread types may only be created from object types.
+spreadTypeVariable.ts(2,12): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadTypeVariable.ts(10,12): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadTypeVariable.ts(14,12): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== spreadTypeVariable.ts (3 errors) ====
     function f1<T extends number>(arg: T) {
       return { ...arg };
                ~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     
     function f2<T extends string[]>(arg: T) {
@@ -17,13 +17,13 @@ spreadTypeVariable.ts(14,12): error TS2698: Spread types may only be created fro
     function f3<T extends number | string[]>(arg: T) {
       return { ...arg }
                ~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     
     function f4<T extends number | { [key: string]: any }>(arg: T) {
       return { ...arg }
                ~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     }
     
     function f5<T extends string[] | { [key: string]: any }>(arg: T) {

--- a/tests/baselines/reference/spreadUnion3.errors.txt
+++ b/tests/baselines/reference/spreadUnion3.errors.txt
@@ -1,9 +1,9 @@
 spreadUnion3.ts(2,14): error TS2322: Type 'number' is not assignable to type 'string'.
 spreadUnion3.ts(9,9): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
   Type 'undefined' is not assignable to type 'number'.
-spreadUnion3.ts(17,11): error TS2698: Spread types may only be created from object types.
-spreadUnion3.ts(17,37): error TS2698: Spread types may only be created from object types.
-spreadUnion3.ts(18,11): error TS2698: Spread types may only be created from object types.
+spreadUnion3.ts(17,11): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadUnion3.ts(17,37): error TS2698: Spread appears unintentional because this value is not possibly an object.
+spreadUnion3.ts(18,11): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== spreadUnion3.ts (5 errors) ====
@@ -31,10 +31,10 @@ spreadUnion3.ts(18,11): error TS2698: Spread types may only be created from obje
     declare const nullAndUndefinedUnion: null | undefined;
     var x = { ...nullAndUndefinedUnion, ...nullAndUndefinedUnion };
               ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
                                         ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     var y = { ...nullAndUndefinedUnion };
               ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     

--- a/tests/baselines/reference/tsxSpreadInvalidType.errors.txt
+++ b/tests/baselines/reference/tsxSpreadInvalidType.errors.txt
@@ -1,6 +1,6 @@
-a.tsx(9,21): error TS2698: Spread types may only be created from object types.
-a.tsx(10,21): error TS2698: Spread types may only be created from object types.
-a.tsx(11,21): error TS2698: Spread types may only be created from object types.
+a.tsx(9,21): error TS2698: Spread appears unintentional because this value is not possibly an object.
+a.tsx(10,21): error TS2698: Spread appears unintentional because this value is not possibly an object.
+a.tsx(11,21): error TS2698: Spread appears unintentional because this value is not possibly an object.
 
 
 ==== a.tsx (3 errors) ====
@@ -14,11 +14,11 @@ a.tsx(11,21): error TS2698: Spread types may only be created from object types.
     
     const d = <div { ...a } />
                         ~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     const e = <div { ...b } />
                         ~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     const f = <div { ...c } />
                         ~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
     

--- a/tests/baselines/reference/unknownType1.errors.txt
+++ b/tests/baselines/reference/unknownType1.errors.txt
@@ -18,8 +18,8 @@ unknownType1.ts(120,9): error TS2322: Type 'T' is not assignable to type 'object
 unknownType1.ts(128,5): error TS2322: Type 'number[]' is not assignable to type '{ [x: string]: unknown; }'.
   Index signature for type 'string' is missing in type 'number[]'.
 unknownType1.ts(129,5): error TS2322: Type 'number' is not assignable to type '{ [x: string]: unknown; }'.
-unknownType1.ts(143,29): error TS2698: Spread types may only be created from object types.
-unknownType1.ts(144,29): error TS2698: Spread types may only be created from object types.
+unknownType1.ts(143,29): error TS2698: Spread appears unintentional because this value is not possibly an object.
+unknownType1.ts(144,29): error TS2698: Spread appears unintentional because this value is not possibly an object.
 unknownType1.ts(150,17): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 unknownType1.ts(156,14): error TS2700: Rest types may only be created from object types.
 unknownType1.ts(162,5): error TS2564: Property 'a' has no initializer and is not definitely assigned in the constructor.
@@ -212,10 +212,10 @@ unknownType1.ts(181,5): error TS2322: Type 'T' is not assignable to type '{}'.
         let o1 = { a: 42, ...x };  // { a: number }
         let o2 = { a: 42, ...x, ...y };  // unknown
                                 ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         let o3 = { a: 42, ...x, ...y, ...z };  // any
                                 ~~~~
-!!! error TS2698: Spread types may only be created from object types.
+!!! error TS2698: Spread appears unintentional because this value is not possibly an object.
         let o4 = { a: 42, ...z }; // any
     }
     

--- a/tests/cases/compiler/spreadInvalidArgumentType.ts
+++ b/tests/cases/compiler/spreadInvalidArgumentType.ts
@@ -10,13 +10,13 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
     var mapped: {[P in "b"]: T[P]};
 
     var union_generic: T | { a: number };
-    var union_primitive: { a: number } | number;
+    var union_primitive: number | { a: number };
 
     var intersection_generic: T & { a: number };
-    var intersection_primitive: { a: number } | string;
+    var intersection_primitive: number & { a: number };
 
     var num: number;
-    var str: number;
+    var str: string;
     var literal_string: "string";
     var literal_number: 42;
 
@@ -24,12 +24,11 @@ function f<T extends { b: string }>(p1: T, p2: T[]) {
     var n: null;
     var a: any;
 
-
     var e: E;
 
-    var o1 = { ...p1 };  // OK, generic type paramterre
+    var o1 = { ...p1 };  // OK, generic type parameter
     var o2 = { ...p2 };  // OK
-    var o3 = { ...t };   // OK, generic type paramter
+    var o3 = { ...t };   // OK, generic type parameter
     var o4 = { ...i };   // Error, index access
     var o5 = { ...k };   // Error, index
     var o6 = { ...mapped_generic }; // OK, generic mapped object type


### PR DESCRIPTION
Update this error message

> error TS2698: Spread types may only be created from object types.

to this one

> error TS2698: Spread appears unintentional because this value is not possibly an object.

Fixes #57957 