### PR TITLE
[experiment] playing around with Node/Token/Identifier allocators

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8206,6 +8206,7 @@ function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) 
     this.modifierFlagsCache = ModifierFlags.None;
     this.transformFlags = TransformFlags.None;
     this.parent = undefined!;
+    this.original = undefined;
     this.emitNode = undefined;
 }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8197,32 +8197,6 @@ function Node(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
     this.emitNode = undefined;
 }
 
-function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
-    this.pos = pos;
-    this.end = end;
-    this.kind = kind;
-    this.id = 0;
-    this.flags = NodeFlags.None;
-    this.modifierFlagsCache = ModifierFlags.None;
-    this.transformFlags = TransformFlags.None;
-    this.parent = undefined!;
-    this.original = undefined;
-    this.emitNode = undefined;
-}
-
-function Identifier(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
-    this.pos = pos;
-    this.end = end;
-    this.kind = kind;
-    this.id = 0;
-    this.flags = NodeFlags.None;
-    this.modifierFlagsCache = ModifierFlags.None;
-    this.transformFlags = TransformFlags.None;
-    this.parent = undefined!;
-    this.original = undefined;
-    this.emitNode = undefined;
-}
-
 function SourceMapSource(this: SourceMapSource, fileName: string, text: string, skipTrivia?: (pos: number) => number) {
     this.fileName = fileName;
     this.text = text;
@@ -8232,8 +8206,8 @@ function SourceMapSource(this: SourceMapSource, fileName: string, text: string, 
 /** @internal */
 export const objectAllocator: ObjectAllocator = {
     getNodeConstructor: () => Node as any,
-    getTokenConstructor: () => Token as any,
-    getIdentifierConstructor: () => Identifier as any,
+    getTokenConstructor: () => Node as any,
+    getIdentifierConstructor: () => Node as any,
     getPrivateIdentifierConstructor: () => Node as any,
     getSourceFileConstructor: () => Node as any,
     getSymbolConstructor: () => Symbol as any,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8197,6 +8197,32 @@ function Node(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
     this.emitNode = undefined;
 }
 
+function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
+    this.pos = pos;
+    this.end = end;
+    this.kind = kind;
+    this.id = 0;
+    this.flags = NodeFlags.None;
+    this.modifierFlagsCache = ModifierFlags.None;
+    this.transformFlags = TransformFlags.None;
+    this.parent = undefined!;
+    this.original = undefined;
+    this.emitNode = undefined;
+}
+
+function Identifier(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
+    this.pos = pos;
+    this.end = end;
+    this.kind = kind;
+    this.id = 0;
+    this.flags = NodeFlags.None;
+    this.modifierFlagsCache = ModifierFlags.None;
+    this.transformFlags = TransformFlags.None;
+    this.parent = undefined!;
+    this.original = undefined;
+    this.emitNode = undefined;
+}
+
 function SourceMapSource(this: SourceMapSource, fileName: string, text: string, skipTrivia?: (pos: number) => number) {
     this.fileName = fileName;
     this.text = text;
@@ -8206,8 +8232,8 @@ function SourceMapSource(this: SourceMapSource, fileName: string, text: string, 
 /** @internal */
 export const objectAllocator: ObjectAllocator = {
     getNodeConstructor: () => Node as any,
-    getTokenConstructor: () => Node as any,
-    getIdentifierConstructor: () => Node as any,
+    getTokenConstructor: () => Token as any,
+    getIdentifierConstructor: () => Identifier as any,
     getPrivateIdentifierConstructor: () => Node as any,
     getSourceFileConstructor: () => Node as any,
     getSymbolConstructor: () => Symbol as any,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8203,6 +8203,7 @@ function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) 
     this.kind = kind;
     this.id = 0;
     this.flags = NodeFlags.None;
+    this.modifierFlagsCache = ModifierFlags.None;
     this.transformFlags = TransformFlags.None;
     this.parent = undefined!;
     this.emitNode = undefined;
@@ -8214,6 +8215,7 @@ function Identifier(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: num
     this.kind = kind;
     this.id = 0;
     this.flags = NodeFlags.None;
+    this.modifierFlagsCache = ModifierFlags.None;
     this.transformFlags = TransformFlags.None;
     this.parent = undefined!;
     this.original = undefined;


### PR DESCRIPTION
Something I noticed on #58045. I have no proof having not yet tested it, but it sure feels weird that `Node` gets `modifierFlagsCache` and `original` props but `Token`/`Identifier` do not. I would have expected those two to have differing shapes such that we stop being monomorphic on some paths.

Technically I can add the props to the others, but, trying out just using Node anyway?