### PR TITLE
Consistent CreateSourceFileOptions shape

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1327,9 +1327,32 @@ export interface CreateSourceFileOptions {
      * check specified by `isFileProbablyExternalModule` will be used to set the field.
      */
     setExternalModuleIndicator?: (file: SourceFile) => void;
+    jsDocParsingMode?: JSDocParsingMode;
     /** @internal */ packageJsonLocations?: readonly string[];
     /** @internal */ packageJsonScope?: PackageJsonInfo;
-    jsDocParsingMode?: JSDocParsingMode;
+}
+
+/**
+ * Creates a CreateSourceFileOptions with a consistent shape.
+ *
+ * @internal
+ */
+export function createCreateSourceFileOptions(
+    languageVersion: ScriptTarget,
+    impliedNodeFormat?: ResolutionMode,
+    setExternalModuleIndicator?: (file: SourceFile) => void,
+    jsDocParsingMode?: JSDocParsingMode,
+    packageJsonLocations?: readonly string[],
+    packageJsonScope?: PackageJsonInfo,
+): CreateSourceFileOptions {
+    return {
+        languageVersion,
+        impliedNodeFormat,
+        setExternalModuleIndicator,
+        jsDocParsingMode,
+        packageJsonLocations,
+        packageJsonScope,
+    };
 }
 
 function setExternalModuleIndicator(sourceFile: SourceFile) {
@@ -1347,7 +1370,7 @@ export function createSourceFile(fileName: string, sourceText: string, languageV
         setExternalModuleIndicator: overrideSetExternalModuleIndicator,
         impliedNodeFormat: format,
         jsDocParsingMode,
-    } = typeof languageVersionOrOptions === "object" ? languageVersionOrOptions : ({ languageVersion: languageVersionOrOptions } as CreateSourceFileOptions);
+    } = typeof languageVersionOrOptions === "object" ? languageVersionOrOptions : createCreateSourceFileOptions(languageVersionOrOptions);
     if (languageVersion === ScriptTarget.JSON) {
         result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON, noop, jsDocParsingMode);
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -32,6 +32,7 @@ import {
     createCommentDirectivesMap,
     createCompilerDiagnostic,
     createCompilerDiagnosticFromMessageChain,
+    createCreateSourceFileOptions,
     createDiagnosticCollection,
     createDiagnosticForNodeFromMessageChain,
     createDiagnosticForNodeInSourceFile,
@@ -3570,9 +3571,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const result = getImpliedNodeFormatForFileWorker(getNormalizedAbsolutePath(fileName, currentDirectory), moduleResolutionCache?.getPackageJsonInfoCache(), host, options);
         const languageVersion = getEmitScriptTarget(options);
         const setExternalModuleIndicator = getSetExternalModuleIndicator(options);
-        return typeof result === "object" ?
-            { ...result, languageVersion, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode } :
-            { languageVersion, impliedNodeFormat: result, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode };
+        if (typeof result === "object") {
+            return createCreateSourceFileOptions(languageVersion, result.impliedNodeFormat, setExternalModuleIndicator, host.jsDocParsingMode, result.packageJsonLocations, result.packageJsonScope);
+        }
+        return createCreateSourceFileOptions(languageVersion, result, setExternalModuleIndicator, host.jsDocParsingMode);
     }
 
     function findSourceFileWorker(fileName: string, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, reason: FileIncludeReason, packageId: PackageId | undefined): SourceFile | undefined {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2802,17 +2802,17 @@ export class TestState {
         // Check syntactic structure
         const content = this.getFileContent(this.activeFile.fileName);
 
-        const options: ts.CreateSourceFileOptions = {
-            languageVersion: ts.ScriptTarget.Latest,
-            impliedNodeFormat: ts.getImpliedNodeFormatForFile(
+        const options = ts.createCreateSourceFileOptions(
+            ts.ScriptTarget.Latest,
+            ts.getImpliedNodeFormatForFile(
                 ts.toPath(this.activeFile.fileName, this.languageServiceAdapterHost.sys.getCurrentDirectory(), ts.hostGetCanonicalFileName(this.languageServiceAdapterHost)),
                 /*packageJsonInfoCache*/ undefined,
                 this.languageServiceAdapterHost,
                 this.languageService.getProgram()?.getCompilerOptions() || {},
             ),
-            setExternalModuleIndicator: ts.getSetExternalModuleIndicator(this.languageService.getProgram()?.getCompilerOptions() || {}),
-            jsDocParsingMode: this.languageServiceAdapterHost.jsDocParsingMode,
-        };
+            ts.getSetExternalModuleIndicator(this.languageService.getProgram()?.getCompilerOptions() || {}),
+            this.languageServiceAdapterHost.jsDocParsingMode,
+        );
         const referenceSourceFile = ts.createLanguageServiceSourceFile(
             this.activeFile.fileName,
             createScriptSnapShot(content),

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -1,6 +1,7 @@
 import {
     arrayFrom,
     CompilerOptions,
+    createCreateSourceFileOptions,
     createGetCanonicalFileName,
     createLanguageServiceSourceFile,
     CreateSourceFileOptions,
@@ -267,13 +268,12 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
         const host: MinimalResolutionCacheHost | undefined = compilationSettingsOrHost === compilationSettings ? undefined : compilationSettingsOrHost as MinimalResolutionCacheHost;
         const scriptTarget = scriptKind === ScriptKind.JSON ? ScriptTarget.JSON : getEmitScriptTarget(compilationSettings);
         const sourceFileOptions: CreateSourceFileOptions = typeof languageVersionOrOptions === "object" ?
-            languageVersionOrOptions :
-            {
-                languageVersion: scriptTarget,
-                impliedNodeFormat: host && getImpliedNodeFormatForFile(path, host.getCompilerHost?.()?.getModuleResolutionCache?.()?.getPackageJsonInfoCache(), host, compilationSettings),
-                setExternalModuleIndicator: getSetExternalModuleIndicator(compilationSettings),
+            languageVersionOrOptions : createCreateSourceFileOptions(
+                scriptTarget,
+                host && getImpliedNodeFormatForFile(path, host.getCompilerHost?.()?.getModuleResolutionCache?.()?.getPackageJsonInfoCache(), host, compilationSettings),
+                getSetExternalModuleIndicator(compilationSettings),
                 jsDocParsingMode,
-            };
+            );
         sourceFileOptions.languageVersion = scriptTarget;
         Debug.assertEqual(jsDocParsingMode, sourceFileOptions.jsDocParsingMode);
         const oldBucketCount = buckets.size;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -33,6 +33,7 @@ import {
     computePositionOfLineAndCharacter,
     computeSuggestionDiagnostics,
     containsParseError,
+    createCreateSourceFileOptions,
     createDocumentRegistry,
     createGetCanonicalFileName,
     createMultiMap,
@@ -1350,18 +1351,18 @@ class SyntaxTreeCache {
 
         if (this.currentFileName !== fileName) {
             // This is a new file, just parse it
-            const options: CreateSourceFileOptions = {
-                languageVersion: ScriptTarget.Latest,
-                impliedNodeFormat: getImpliedNodeFormatForFile(
+            const options = createCreateSourceFileOptions(
+                ScriptTarget.Latest,
+                getImpliedNodeFormatForFile(
                     toPath(fileName, this.host.getCurrentDirectory(), this.host.getCompilerHost?.()?.getCanonicalFileName || hostGetCanonicalFileName(this.host)),
                     this.host.getCompilerHost?.()?.getModuleResolutionCache?.()?.getPackageJsonInfoCache(),
                     this.host,
                     this.host.getCompilationSettings(),
                 ),
-                setExternalModuleIndicator: getSetExternalModuleIndicator(this.host.getCompilationSettings()),
+                getSetExternalModuleIndicator(this.host.getCompilationSettings()),
                 // These files are used to produce syntax-based highlighting, which reads JSDoc, so we must use ParseAll.
-                jsDocParsingMode: JSDocParsingMode.ParseAll,
-            };
+                JSDocParsingMode.ParseAll,
+            );
             sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, options, version, /*setNodeParents*/ true, scriptKind);
         }
         else if (this.currentFileVersion !== version) {
@@ -1451,12 +1452,12 @@ export function updateLanguageServiceSourceFile(sourceFile: SourceFile, scriptSn
         }
     }
 
-    const options: CreateSourceFileOptions = {
-        languageVersion: sourceFile.languageVersion,
-        impliedNodeFormat: sourceFile.impliedNodeFormat,
-        setExternalModuleIndicator: sourceFile.setExternalModuleIndicator,
-        jsDocParsingMode: sourceFile.jsDocParsingMode,
-    };
+    const options = createCreateSourceFileOptions(
+        sourceFile.languageVersion,
+        sourceFile.impliedNodeFormat,
+        sourceFile.setExternalModuleIndicator,
+        sourceFile.jsDocParsingMode,
+    );
     // Otherwise, just create a new source file.
     return createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, options, version, /*setNodeParents*/ true, sourceFile.scriptKind);
 }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -10,6 +10,7 @@ import {
     concatenate,
     ConstructorDeclaration,
     contains,
+    createCreateSourceFileOptions,
     createMultiMap,
     createNodeFactory,
     createPrinter,
@@ -1296,7 +1297,7 @@ namespace changesToText {
     export function newFileChangesWorker(scriptKind: ScriptKind, insertions: readonly NewFileInsertion[], newLineCharacter: string, formatContext: formatting.FormatContext): string {
         // TODO: this emits the file, parses it back, then formats it that -- may be a less roundabout way to do this
         const nonFormattedText = flatMap(insertions, insertion => insertion.statements.map(s => s === SyntaxKind.NewLineTrivia ? "" : getNonformattedText(s, insertion.oldFile, newLineCharacter).text)).join(newLineCharacter);
-        const sourceFile = createSourceFile("any file name", nonFormattedText, { languageVersion: ScriptTarget.ESNext, jsDocParsingMode: JSDocParsingMode.ParseNone }, /*setParentNodes*/ true, scriptKind);
+        const sourceFile = createSourceFile("any file name", nonFormattedText, createCreateSourceFileOptions(ScriptTarget.ESNext, /*impliedNodeFormat*/ undefined, /*setExternalModuleIndicator*/ undefined, JSDocParsingMode.ParseNone), /*setParentNodes*/ true, scriptKind);
         const changes = formatting.formatDocument(sourceFile, formatContext);
         return applyChanges(nonFormattedText, changes) + newLineCharacter;
     }

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -5,6 +5,7 @@ import {
     CompilerHost,
     CompilerOptions,
     createCompilerDiagnosticForInvalidCustomType,
+    createCreateSourceFileOptions,
     createProgram,
     createSourceFile,
     CustomTransformers,
@@ -116,12 +117,12 @@ export function transpileModule(input: string, transpileOptions: TranspileOption
     const sourceFile = createSourceFile(
         inputFileName,
         input,
-        {
-            languageVersion: getEmitScriptTarget(options),
-            impliedNodeFormat: getImpliedNodeFormatForFile(toPath(inputFileName, "", compilerHost.getCanonicalFileName), /*packageJsonInfoCache*/ undefined, compilerHost, options),
-            setExternalModuleIndicator: getSetExternalModuleIndicator(options),
-            jsDocParsingMode: transpileOptions.jsDocParsingMode ?? JSDocParsingMode.ParseAll,
-        },
+        createCreateSourceFileOptions(
+            getEmitScriptTarget(options),
+            getImpliedNodeFormatForFile(toPath(inputFileName, "", compilerHost.getCanonicalFileName), /*packageJsonInfoCache*/ undefined, compilerHost, options),
+            getSetExternalModuleIndicator(options),
+            transpileOptions.jsDocParsingMode ?? JSDocParsingMode.ParseAll,
+        ),
     );
     if (transpileOptions.moduleName) {
         sourceFile.moduleName = transpileOptions.moduleName;

--- a/src/testRunner/unittests/skipJSDocParsing.ts
+++ b/src/testRunner/unittests/skipJSDocParsing.ts
@@ -21,9 +21,9 @@ describe("unittests:: skipJSDocParsing", () => {
             for (const filename of filenames) {
                 const testName = `${name}-${kindName}-${filename}`;
                 it(testName, () => {
-                    const sourceFile = ts.createSourceFile(filename, content, { languageVersion: ts.ScriptTarget.ESNext, jsDocParsingMode: undefined });
+                    const sourceFile = ts.createSourceFile(filename, content, ts.createCreateSourceFileOptions(ts.ScriptTarget.ESNext));
                     assert.isTrue(sourceFile && sourceFile.parseDiagnostics.length === 0, "no errors issued");
-                    const sourceFileSkipped = ts.createSourceFile(filename, content, { languageVersion: ts.ScriptTarget.ESNext, jsDocParsingMode });
+                    const sourceFileSkipped = ts.createSourceFile(filename, content, ts.createCreateSourceFileOptions(ts.ScriptTarget.ESNext, /*impliedNodeFormat*/ undefined, /*setExternalModuleIndicator*/ undefined, jsDocParsingMode));
                     assert.isTrue(sourceFileSkipped && sourceFileSkipped.parseDiagnostics.length === 0, "no errors issued");
 
                     const patch = Diff.createTwoFilesPatch("default", kindName, Utils.sourceFileToJSON(sourceFile), Utils.sourceFileToJSON(sourceFileSkipped));


### PR DESCRIPTION
With my rudimentary understanding of the deopt explorer, `getCreateSourceFileOptions` sure seemed like a hostspot. Try making CreateSourceFileOptions consistently created.