### PR TITLE
[experiment] error on comparisons where the only comparable type is undefined

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38875,7 +38875,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         error(errorNode, Diagnostics.This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value, eqType ? "false" : "true");
                     }
                     checkNaNEquality(errorNode, operator, left, right);
-                    reportOperatorErrorUnless((left, right) => isTypeEqualityComparableTo(left, right) || isTypeEqualityComparableTo(right, left));
+                    const hasReported = reportOperatorErrorUnless((left, right) => isTypeEqualityComparableTo(left, right) || isTypeEqualityComparableTo(right, left));
+                    if (!hasReported && isNullableType(leftType) && isNullableType(rightType)) {
+                        reportOperatorErrorUnless((left, right) => {
+                            left = getNonNullableType(left);
+                            right = getNonNullableType(right);
+                            return isTypeEqualityComparableTo(left, right) || isTypeEqualityComparableTo(right, left)
+                        })
+                    }
                 }
                 return booleanType;
             case SyntaxKind.InstanceOfKeyword:

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).errors.txt
@@ -1,0 +1,9 @@
+comparisonOperatorWithUndefinedType.ts(3,1): error TS2367: This comparison appears to be unintentional because the types 'string' and 'number' have no overlap.
+
+
+==== comparisonOperatorWithUndefinedType.ts (1 errors) ====
+    declare let foo: string | undefined;
+    declare let bar: number | undefined;
+    foo === bar;
+    ~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'string' and 'number' have no overlap.

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).js
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).js
@@ -1,0 +1,9 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+//// [comparisonOperatorWithUndefinedType.ts]
+declare let foo: string | undefined;
+declare let bar: number | undefined;
+foo === bar;
+
+//// [comparisonOperatorWithUndefinedType.js]
+foo === bar;

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).symbols
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+=== comparisonOperatorWithUndefinedType.ts ===
+declare let foo: string | undefined;
+>foo : Symbol(foo, Decl(comparisonOperatorWithUndefinedType.ts, 0, 11))
+
+declare let bar: number | undefined;
+>bar : Symbol(bar, Decl(comparisonOperatorWithUndefinedType.ts, 1, 11))
+
+foo === bar;
+>foo : Symbol(foo, Decl(comparisonOperatorWithUndefinedType.ts, 0, 11))
+>bar : Symbol(bar, Decl(comparisonOperatorWithUndefinedType.ts, 1, 11))
+

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).types
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=false).types
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+=== comparisonOperatorWithUndefinedType.ts ===
+declare let foo: string | undefined;
+>foo : string
+
+declare let bar: number | undefined;
+>bar : number
+
+foo === bar;
+>foo === bar : boolean
+>foo : string
+>bar : number
+

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).errors.txt
@@ -1,0 +1,9 @@
+comparisonOperatorWithUndefinedType.ts(3,1): error TS2367: This comparison appears to be unintentional because the types 'string | undefined' and 'number | undefined' have no overlap.
+
+
+==== comparisonOperatorWithUndefinedType.ts (1 errors) ====
+    declare let foo: string | undefined;
+    declare let bar: number | undefined;
+    foo === bar;
+    ~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'string | undefined' and 'number | undefined' have no overlap.

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).js
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).js
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+//// [comparisonOperatorWithUndefinedType.ts]
+declare let foo: string | undefined;
+declare let bar: number | undefined;
+foo === bar;
+
+//// [comparisonOperatorWithUndefinedType.js]
+"use strict";
+foo === bar;

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).symbols
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+=== comparisonOperatorWithUndefinedType.ts ===
+declare let foo: string | undefined;
+>foo : Symbol(foo, Decl(comparisonOperatorWithUndefinedType.ts, 0, 11))
+
+declare let bar: number | undefined;
+>bar : Symbol(bar, Decl(comparisonOperatorWithUndefinedType.ts, 1, 11))
+
+foo === bar;
+>foo : Symbol(foo, Decl(comparisonOperatorWithUndefinedType.ts, 0, 11))
+>bar : Symbol(bar, Decl(comparisonOperatorWithUndefinedType.ts, 1, 11))
+

--- a/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).types
+++ b/tests/baselines/reference/comparisonOperatorWithUndefinedType(strict=true).types
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts] ////
+
+=== comparisonOperatorWithUndefinedType.ts ===
+declare let foo: string | undefined;
+>foo : string | undefined
+
+declare let bar: number | undefined;
+>bar : number | undefined
+
+foo === bar;
+>foo === bar : boolean
+>foo : string | undefined
+>bar : number | undefined
+

--- a/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithUndefinedType.ts
@@ -1,0 +1,4 @@
+//@strict: true, false
+declare let foo: string | undefined;
+declare let bar: number | undefined;
+foo === bar;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

For more detailed information, checkout https://github.com/typescript-eslint/typescript-eslint/issues/5602
As far as I know, there are no typescript issues related. I'm curious to witness how it performs on actual code in real-world scenarios. Would anyone be available to help me by executing the "top800" test suite?
