### PR TITLE
Sort imports with dprint instead of eslint

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -23,11 +23,10 @@
         "constructorType.spaceAfterNewKeyword": true,
         "constructSignature.spaceAfterNewKeyword": true,
 
-        // Let eslint-plugin-simple-import-sort handle this.
-        "module.sortImportDeclarations": "maintain",
-        "module.sortExportDeclarations": "maintain",
-        "exportDeclaration.sortNamedExports": "maintain",
-        "importDeclaration.sortNamedImports": "maintain"
+        "module.sortImportDeclarations": "caseInsensitive",
+        "module.sortExportDeclarations": "caseInsensitive",
+        "exportDeclaration.sortNamedExports": "caseInsensitive",
+        "importDeclaration.sortNamedImports": "caseInsensitive"
     },
     "prettier": {
         "newLineKind": "lf",
@@ -53,7 +52,8 @@
         "tests/**",
         "internal/**",
         "**/*.generated.*",
-        "scripts/*.d.*"
+        "scripts/*.d.*",
+        "**/_namespaces/**"
     ],
     // Note: if adding new languages, make sure settings.template.json is updated too.
     "plugins": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,8 +18,7 @@
     "plugins": [
         "@typescript-eslint",
         "no-null",
-        "eslint-plugin-local",
-        "simple-import-sort"
+        "eslint-plugin-local"
     ],
     "ignorePatterns": [
         "**/node_modules/**",
@@ -136,11 +135,7 @@
         "local/jsdoc-format": "error",
 
         // eslint-plugin-no-null
-        "no-null/no-null": "error",
-
-        // eslint-plugin-simple-import-sort
-        "simple-import-sort/imports": "error",
-        "simple-import-sort/exports": "error"
+        "no-null/no-null": "error"
     },
     "overrides": [
         // By default, the ESLint CLI only looks at .js files. But, it will also look at
@@ -166,14 +161,6 @@
                     { "name": "module" },
                     { "name": "exports" }
                 ]
-            }
-        },
-        {
-            // These files contain imports in a specific order that are generally unsafe to modify.
-            "files": ["**/_namespaces/**"],
-            "rules": {
-                "simple-import-sort/imports": "off",
-                "simple-import-sort/exports": "off"
             }
         }
     ]

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -18,7 +18,7 @@
         ".git-blame-ignore-revs"
     ],
 
-    // Match eslint-plugin-simple-import-sort in organize/auto-imports.
+    // Match dprint in organize/auto-imports.
     "typescript.unstable": {
         "organizeImportsCollation": "unicode",
         "organizeImportsCaseFirst": "upper",

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -23,13 +23,15 @@
         "organizeImportsCollation": "unicode",
         "organizeImportsCaseFirst": "upper",
         "organizeImportsIgnoreCase": false,
-        "organizeImportsNumericCollation": true
+        "organizeImportsNumericCollation": true,
+        "organizeImportsTypeOrder": "inline"
     },
     "javascript.unstable": {
         "organizeImportsCollation": "unicode",
         "organizeImportsCaseFirst": "upper",
         "organizeImportsIgnoreCase": false,
-        "organizeImportsNumericCollation": true
+        "organizeImportsNumericCollation": true,
+        "organizeImportsTypeOrder": "inline"
     },
 
     // These options search the repo recursively and slow down

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
                 "eslint-formatter-autolinkable-stylish": "^1.3.0",
                 "eslint-plugin-local": "^4.2.1",
                 "eslint-plugin-no-null": "^1.0.2",
-                "eslint-plugin-simple-import-sort": "^12.0.0",
                 "fast-xml-parser": "^4.3.6",
                 "glob": "^10.3.10",
                 "hereby": "^1.8.9",
@@ -2098,15 +2097,6 @@
             },
             "peerDependencies": {
                 "eslint": ">=3.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-simple-import-sort": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
-            "integrity": "sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==",
-            "dev": true,
-            "peerDependencies": {
-                "eslint": ">=5.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -5902,13 +5892,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
             "integrity": "sha512-uRDiz88zCO/2rzGfgG15DBjNsgwWtWiSo4Ezy7zzajUgpnFIqd1TjepKeRmJZHEfBGu58o2a8S0D7vglvvhkVA==",
-            "dev": true,
-            "requires": {}
-        },
-        "eslint-plugin-simple-import-sort": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
-            "integrity": "sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "eslint-formatter-autolinkable-stylish": "^1.3.0",
         "eslint-plugin-local": "^4.2.1",
         "eslint-plugin-no-null": "^1.0.2",
-        "eslint-plugin-simple-import-sort": "^12.0.0",
         "fast-xml-parser": "^4.3.6",
         "glob": "^10.3.10",
         "hereby": "^1.8.9",


### PR DESCRIPTION
A few people have expressed that they'd prefer if the formatter did this rather than eslint. dprint can do this a lot faster without the linter errors; if you save on format it'll be extra good.

The downside is that we will lose automatic grouping, until maybe https://github.com/dprint/dprint-plugin-typescript/issues/493. That's something I was relying on in #51455 to ensure the namespace imports always came first, but that could be achieved another way.

I also discovered https://github.com/dprint/dprint-plugin-typescript/issues/620, but that's not a very bad bug.

I had to disable formatting in `_namespaces`, as those import orders matter and dprint does not have the ability to ignore regions: https://github.com/dprint/dprint-plugin-typescript/issues/411