### PR TITLE
Make unused variable rule a warning, error on warnings for CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,7 @@
             }
         ],
         "@typescript-eslint/no-unused-vars": [
-            "error",
+            "warn",
             {
                 // Ignore: (solely underscores | starting with exactly one underscore)
                 "argsIgnorePattern": "^(_+$|_[^_])",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -538,6 +538,8 @@ export const lint = task({
             "--format",
             formatter,
             "--report-unused-disable-directives",
+            "--max-warnings",
+            "0",
         ];
 
         if (cmdLineOptions.fix) {

--- a/src/testRunner/unittests/evaluation/esDecorators.ts
+++ b/src/testRunner/unittests/evaluation/esDecorators.ts
@@ -1,6 +1,6 @@
 import * as evaluator from "../../_namespaces/evaluator";
 import * as ts from "../../_namespaces/ts";
-import { ScriptTarget, SyntaxKind } from "../../_namespaces/ts";
+import { ScriptTarget} from "../../_namespaces/ts";
 
 describe("unittests:: evaluation:: esDecorators", () => {
     const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES2021 };

--- a/src/testRunner/unittests/evaluation/esDecorators.ts
+++ b/src/testRunner/unittests/evaluation/esDecorators.ts
@@ -1,6 +1,6 @@
 import * as evaluator from "../../_namespaces/evaluator";
 import * as ts from "../../_namespaces/ts";
-import { ScriptTarget } from "../../_namespaces/ts";
+import { ScriptTarget, SyntaxKind } from "../../_namespaces/ts";
 
 describe("unittests:: evaluation:: esDecorators", () => {
     const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES2021 };

--- a/src/testRunner/unittests/evaluation/esDecorators.ts
+++ b/src/testRunner/unittests/evaluation/esDecorators.ts
@@ -1,6 +1,6 @@
 import * as evaluator from "../../_namespaces/evaluator";
 import * as ts from "../../_namespaces/ts";
-import { ScriptTarget} from "../../_namespaces/ts";
+import { ScriptTarget } from "../../_namespaces/ts";
 
 describe("unittests:: evaluation:: esDecorators", () => {
     const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES2021 };


### PR DESCRIPTION
Some have expressed that an error is a bit too strong, and that a warning would be preferred; this PR makes an unused var a warning, but still ensures `hereby lint` errors on warnings.