### PR TITLE
Skip visits to child nodes of entity names in visitExistingNodeTreeSymbols

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8873,7 +8873,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     const { introducesError, node: result } = trackExistingEntityName(node, context);
                     hadError = hadError || introducesError;
-                    // We should not go to child nodes of the entity name, they will not be acesible
+                    // We should not go to child nodes of the entity name, they will not be accessible
                     return result;
                 }
 


### PR DESCRIPTION
This just skips visiting some children of entity names where we'd just repeat the same symbol resolution repeatedly (if we lookup `A` in `A.B`, we don't need to also visit `A` and `B`, so long as we attach symbol info for `A` during that first lookup), or would never actually resolve (because it's the name of the declaration).

I'm not sure if this'd actually show up on any perf tests (but it should definitely be good for perf - we're just doing less repeated work), but what it does do is make any future users of `trackSymbol` (eg, `isolatedDeclarations` resolver/checker) need to handle fewer cases.