### PR TITLE
Special case check for this identifiers to skip exhaustive scope traversal

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8671,6 +8671,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return { introducesError, node };
             }
             const meaning = getMeaningOfEntityNameReference(node);
+            if (isThisIdentifier(leftmost)) {
+                if (isSymbolAccessible(getSymbolOfDeclaration(getThisContainer(leftmost, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false)), leftmost, meaning, /*shouldComputeAliasesToMakeVisible*/ false).accessibility !== SymbolAccessibility.Accessible) {
+                    introducesError = true;
+                    context.tracker.reportInaccessibleThisError();
+                }
+                return { introducesError, node };
+            }
             const sym = resolveEntityName(leftmost, meaning, /*ignoreErrors*/ true, /*dontResolveAlias*/ true);
             if (sym) {
                 // If a parameter is resolvable in the current context it is also visible, so no need to go to symbol accesibility


### PR DESCRIPTION
This PR adds a branch to `trackExistingEntityName` to handle `this`. `isEntityNameVisible` has a similar branch as a fallback when `resolveName` fails - `resolvename` will _always_ fail for a `this` identifier, since `this`, being a keyword, isn't a bindable name. By doing this check *first*, we can save on doing the exhaustive traversal of scopes trying to resolve the name.