### PR TITLE
Always set node-version for setup-node

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
 
       - name: Configure Git, Run Tests, Update Baselines, Apply Fixes
         run: |

--- a/.github/workflows/insiders.yaml
+++ b/.github/workflows/insiders.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm
@@ -43,6 +45,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
+          node-version: 'lts/*'
           # Use NODE_AUTH_TOKEN environment variable to authenticate to this registry.
           registry-url: https://registry.npmjs.org/
       - run: |

--- a/.github/workflows/lkg.yml
+++ b/.github/workflows/lkg.yml
@@ -32,6 +32,8 @@ jobs:
           ref: ${{ inputs.branch_name }}
           token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -56,6 +56,8 @@ jobs:
           fetch-depth: 0 # Default is 1; need to set to 0 to get the benefits of blob:none.
           token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm
@@ -43,6 +45,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
+          node-version: 'lts/*'
           # Use NODE_AUTH_TOKEN environment variable to authenticate to this registry.
           registry-url: https://registry.npmjs.org/
       - run: |

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -54,6 +54,8 @@ jobs:
           ref: ${{ inputs.branch_name }}
           token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - run: |
           npm --version
           # corepack enable npm

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ inputs.branch_name }}

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -56,6 +56,8 @@ jobs:
       - if: ${{ !github.event.inputs.bisect }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 'lts/*'
       - uses: microsoft/TypeScript-Twoslash-Repro-Action@8680b5b290d48a7badbc7ba65971d526c61b86b8 # master
         with:
           github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Not setting a node version here means you get the global install, and the global install does not always behave, e.g. https://github.com/actions/runner-images/issues/9644#issuecomment-2041554588

Ensure these are all set to something. This should fix nightly and other tasks.