### PR TITLE
Add  test case related to invalid object spreads

### DIFF
--- a/tests/baselines/reference/spreadNonObject1.errors.txt
+++ b/tests/baselines/reference/spreadNonObject1.errors.txt
@@ -1,0 +1,15 @@
+spreadNonObject1.ts(6,17): error TS2698: Spread types may only be created from object types.
+
+
+==== spreadNonObject1.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/45493
+    
+    type S = `${number}`;
+    const b = {
+      c: (["4"] as S[]).map(function (s) {
+        const a = { ...s, y: 6 };
+                    ~~~~
+!!! error TS2698: Spread types may only be created from object types.
+      }),
+    };
+    

--- a/tests/baselines/reference/spreadNonObject1.symbols
+++ b/tests/baselines/reference/spreadNonObject1.symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/conformance/types/spread/spreadNonObject1.ts] ////
+
+=== spreadNonObject1.ts ===
+// https://github.com/microsoft/TypeScript/issues/45493
+
+type S = `${number}`;
+>S : Symbol(S, Decl(spreadNonObject1.ts, 0, 0))
+
+const b = {
+>b : Symbol(b, Decl(spreadNonObject1.ts, 3, 5))
+
+  c: (["4"] as S[]).map(function (s) {
+>c : Symbol(c, Decl(spreadNonObject1.ts, 3, 11))
+>(["4"] as S[]).map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>S : Symbol(S, Decl(spreadNonObject1.ts, 0, 0))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>s : Symbol(s, Decl(spreadNonObject1.ts, 4, 34))
+
+    const a = { ...s, y: 6 };
+>a : Symbol(a, Decl(spreadNonObject1.ts, 5, 9))
+>s : Symbol(s, Decl(spreadNonObject1.ts, 4, 34))
+>y : Symbol(y, Decl(spreadNonObject1.ts, 5, 21))
+
+  }),
+};
+

--- a/tests/baselines/reference/spreadNonObject1.types
+++ b/tests/baselines/reference/spreadNonObject1.types
@@ -1,0 +1,52 @@
+//// [tests/cases/conformance/types/spread/spreadNonObject1.ts] ////
+
+=== spreadNonObject1.ts ===
+// https://github.com/microsoft/TypeScript/issues/45493
+
+type S = `${number}`;
+>S : `${number}`
+>  : ^^^^^^^^^^^
+
+const b = {
+>b : { c: void[]; }
+>  : ^^^^^^^^^^^^^^
+>{  c: (["4"] as S[]).map(function (s) {    const a = { ...s, y: 6 };  }),} : { c: void[]; }
+>                                                                           : ^^^^^^^^^^^^^^
+
+  c: (["4"] as S[]).map(function (s) {
+>c : void[]
+>  : ^^^^^^
+>(["4"] as S[]).map(function (s) {    const a = { ...s, y: 6 };  }) : void[]
+>                                                                   : ^^^^^^
+>(["4"] as S[]).map : <U>(callbackfn: (value: `${number}`, index: number, array: `${number}`[]) => U, thisArg?: any) => U[]
+>                   : ^^^^          ^^^     ^^^^^^^^^^^^^^^     ^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^
+>(["4"] as S[]) : `${number}`[]
+>               : ^^^^^^^^^^^^^
+>["4"] as S[] : `${number}`[]
+>             : ^^^^^^^^^^^^^
+>["4"] : "4"[]
+>      : ^^^^^
+>"4" : "4"
+>    : ^^^
+>map : <U>(callbackfn: (value: `${number}`, index: number, array: `${number}`[]) => U, thisArg?: any) => U[]
+>    : ^^^^          ^^^     ^^^^^^^^^^^^^^^     ^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^
+>function (s) {    const a = { ...s, y: 6 };  } : (s: `${number}`) => void
+>                                               : ^ ^^^^^^^^^^^^^^^^^^^^^^
+>s : `${number}`
+>  : ^^^^^^^^^^^
+
+    const a = { ...s, y: 6 };
+>a : any
+>  : ^^^
+>{ ...s, y: 6 } : any
+>               : ^^^
+>s : `${number}`
+>  : ^^^^^^^^^^^
+>y : number
+>  : ^^^^^^
+>6 : 6
+>  : ^
+
+  }),
+};
+

--- a/tests/cases/conformance/types/spread/spreadNonObject1.ts
+++ b/tests/cases/conformance/types/spread/spreadNonObject1.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/45493
+
+type S = `${number}`;
+const b = {
+  c: (["4"] as S[]).map(function (s) {
+    const a = { ...s, y: 6 };
+  }),
+};


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/45493
this was fixed in 4.6.0-dev.20211204 (likely by https://github.com/microsoft/TypeScript/pull/47010 )