### PR TITLE
Add gitHead to package.json in all release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
 
       - run: npx hereby lkg
       - run: |
+          node ./scripts/addPackageJsonGitHead.mjs package.json
           npm pack
           mv typescript*.tgz typescript.tgz
           echo "package=$PWD/typescript.tgz" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/insiders.yaml
+++ b/.github/workflows/insiders.yaml
@@ -59,6 +59,7 @@ jobs:
           npm ci
           npx hereby configure-insiders
           npx hereby LKG
+          node ./scripts/addPackageJsonGitHead.mjs package.json
           npm publish --tag insiders
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -59,6 +59,7 @@ jobs:
           npm ci
           npx hereby configure-nightly
           npx hereby LKG
+          node ./scripts/addPackageJsonGitHead.mjs package.json
           npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           npx hereby LKG
           npx hereby clean
+          node ./scripts/addPackageJsonGitHead.mjs package.json
           npm pack ./
           mv typescript-*.tgz typescript.tgz
       - name: Upload built tarfile

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -77,6 +77,7 @@ extends:
               - script: |
                   npx hereby LKG
                   npx hereby clean
+                  node ./scripts/addPackageJsonGitHead.mjs package.json
                   npm pack
                 displayName: 'LKG, clean, pack'
 

--- a/scripts/addPackageJsonGitHead.mjs
+++ b/scripts/addPackageJsonGitHead.mjs
@@ -1,0 +1,24 @@
+import { execFileSync } from "child_process";
+import {
+    readFileSync,
+    writeFileSync,
+} from "fs";
+import {
+    dirname,
+    resolve,
+} from "path";
+
+const packageJsonFilePath = process.argv[2];
+if (!packageJsonFilePath) {
+    console.error("Usage: node addPackageJsonGitHead.mjs <package.json location>");
+    process.exit(1);
+}
+
+const packageJsonValue = JSON.parse(readFileSync(packageJsonFilePath, "utf8"));
+
+const cwd = dirname(resolve(packageJsonFilePath));
+const gitHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+
+packageJsonValue.gitHead = gitHead;
+
+writeFileSync(packageJsonFilePath, JSON.stringify(packageJsonValue, undefined, 4) + "\n");

--- a/scripts/configurePrerelease.mjs
+++ b/scripts/configurePrerelease.mjs
@@ -1,5 +1,4 @@
 import assert from "assert";
-import { execFileSync } from "child_process";
 import {
     readFileSync,
     writeFileSync,
@@ -18,7 +17,6 @@ const __filename = url.fileURLToPath(new URL(import.meta.url));
     name: string;
     version: string;
     keywords: string[];
-    gitHead?: string;
 }} PackageJson
  */
 
@@ -59,7 +57,6 @@ function main() {
     // Finally write the changes to disk.
     // Modify the package.json structure
     packageJsonValue.version = `${majorMinor}.${prereleasePatch}`;
-    packageJsonValue.gitHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
     writeFileSync(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4));
     writeFileSync(tsFilePath, modifiedTsFileContents);
 }


### PR DESCRIPTION
This pulls @Andarist's code from #47932 out and uses it before we publish anything. This is actually reasonable to do everywhere now that our releases come from a checked-in pipeline (whereas before they weren't).

We do not do this in the LKG task because we currently check that in, and it'd be very annoying locally anyway even if we stop checking in the changes. (The checked in LKG on release branches is pointless anyway (beyond referring to directly outside of npm), as the release pipelines have always re-built and published that instead.)

Fixes #36960