### PR TITLE
Experiment: Infer type predicates for functions with multiple returns

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5336,7 +5336,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     /**
      * Generate the text for a generated identifier.
      */
-    function generateName(name: GeneratedIdentifier | GeneratedPrivateIdentifier) {
+    function generateName(name: GeneratedIdentifier | GeneratedPrivateIdentifier): string {
         const autoGenerate = name.emitNode.autoGenerate;
         if ((autoGenerate.flags & GeneratedIdentifierFlags.KindMask) === GeneratedIdentifierFlags.Node) {
             // Node names generate unique names based on their original node
@@ -5351,7 +5351,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         }
     }
 
-    function generateNameCached(node: Node, privateName: boolean, flags?: GeneratedIdentifierFlags, prefix?: string | GeneratedNamePart, suffix?: string) {
+    function generateNameCached(node: Node, privateName: boolean, flags?: GeneratedIdentifierFlags, prefix?: string | GeneratedNamePart, suffix?: string): string {
         const nodeId = getNodeId(node);
         const cache = privateName ? nodeIdToGeneratedPrivateName : nodeIdToGeneratedName;
         return cache[nodeId] || (cache[nodeId] = generateNameForNode(node, privateName, flags ?? GeneratedIdentifierFlags.None, formatGeneratedNamePart(prefix, generateName), formatGeneratedNamePart(suffix)));

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
@@ -130,4 +130,4 @@ type OptionalNullableString = string | null | undefined;
 declare function allowsNull(val?: OptionalNullableString): void;
 declare function removeUndefinedButNotFalse(x?: boolean): false | undefined;
 declare const cond: boolean;
-declare function removeNothing(y?: boolean | undefined): boolean;
+declare function removeNothing(y?: boolean | undefined): y is true | undefined;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
@@ -302,8 +302,8 @@ declare const cond: boolean;
 >     : ^^^^^^^
 
 function removeNothing(y = cond ? true : undefined) {
->removeNothing : (y?: boolean | undefined) => boolean
->              : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>removeNothing : (y?: boolean | undefined) => y is true | undefined
+>              : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >y : boolean | undefined
 >  : ^^^^^^^^^^^^^^^^^^^
 >cond ? true : undefined : true | undefined

--- a/tests/baselines/reference/inferTypePredicates.errors.txt
+++ b/tests/baselines/reference/inferTypePredicates.errors.txt
@@ -326,3 +326,31 @@ inferTypePredicates.ts(205,7): error TS2741: Property 'z' is missing in type 'C1
       foobar.foo;
     }
     
+    // Returning true can result in a predicate if the function throws earlier.
+    function assertReturnTrue(x: string | number | Date) {
+      if (x instanceof Date) {
+        throw new Error();
+      }
+      return true;
+    }
+    
+    function isStringForWhichWeHaveACaseHandler(anyString: string) {
+      switch (anyString) {
+        case 'a':
+        case 'b':
+        case 'c':
+          return true
+        default:
+          return false
+      }
+    }
+    
+    function ifElseIfPredicate(x: Date | string | number) {
+      if (x instanceof Date) {
+        return true;
+      } else if (typeof x === 'string') {
+        return true;
+      }
+      return false;
+    }
+    

--- a/tests/baselines/reference/inferTypePredicates.js
+++ b/tests/baselines/reference/inferTypePredicates.js
@@ -280,6 +280,34 @@ if (foobarPred(foobar)) {
   foobar.foo;
 }
 
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+  if (x instanceof Date) {
+    throw new Error();
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+  switch (anyString) {
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+  if (x instanceof Date) {
+    return true;
+  } else if (typeof x === 'string') {
+    return true;
+  }
+  return false;
+}
+
 
 //// [inferTypePredicates.js]
 // https://github.com/microsoft/TypeScript/issues/16069
@@ -538,6 +566,32 @@ var foobarPred = function (fb) { return fb.type === "foo"; };
 if (foobarPred(foobar)) {
     foobar.foo;
 }
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x) {
+    if (x instanceof Date) {
+        throw new Error();
+    }
+    return true;
+}
+function isStringForWhichWeHaveACaseHandler(anyString) {
+    switch (anyString) {
+        case 'a':
+        case 'b':
+        case 'c':
+            return true;
+        default:
+            return false;
+    }
+}
+function ifElseIfPredicate(x) {
+    if (x instanceof Date) {
+        return true;
+    }
+    else if (typeof x === 'string') {
+        return true;
+    }
+    return false;
+}
 
 
 //// [inferTypePredicates.d.ts]
@@ -583,7 +637,7 @@ declare let maybeDate: object;
 declare function irrelevantIsNumber(x: string | number): boolean;
 declare function irrelevantIsNumberDestructuring(x: string | number): boolean;
 declare function areBothNums(x: string | number, y: string | number): boolean;
-declare function doubleReturn(x: string | number): boolean;
+declare function doubleReturn(x: string | number): x is string;
 declare function guardsOneButNotOthers(a: string | number, b: string | number, c: string | number): b is string;
 declare function dunderguard(__x: number | string): __x is string;
 declare const booleanIdentity: (x: boolean) => boolean;
@@ -630,3 +684,6 @@ declare const foobarPred: (fb: typeof foobar) => fb is {
     type: "foo";
     foo: number;
 };
+declare function assertReturnTrue(x: string | number | Date): x is string | number;
+declare function isStringForWhichWeHaveACaseHandler(anyString: string): anyString is "a" | "b" | "c";
+declare function ifElseIfPredicate(x: Date | string | number): x is string | Date;

--- a/tests/baselines/reference/inferTypePredicates.symbols
+++ b/tests/baselines/reference/inferTypePredicates.symbols
@@ -777,3 +777,53 @@ if (foobarPred(foobar)) {
 >foo : Symbol(foo, Decl(inferTypePredicates.ts, 271, 18))
 }
 
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+>assertReturnTrue : Symbol(assertReturnTrue, Decl(inferTypePredicates.ts, 277, 1))
+>x : Symbol(x, Decl(inferTypePredicates.ts, 280, 26))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+  if (x instanceof Date) {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 280, 26))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+    throw new Error();
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+>isStringForWhichWeHaveACaseHandler : Symbol(isStringForWhichWeHaveACaseHandler, Decl(inferTypePredicates.ts, 285, 1))
+>anyString : Symbol(anyString, Decl(inferTypePredicates.ts, 287, 44))
+
+  switch (anyString) {
+>anyString : Symbol(anyString, Decl(inferTypePredicates.ts, 287, 44))
+
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+>ifElseIfPredicate : Symbol(ifElseIfPredicate, Decl(inferTypePredicates.ts, 296, 1))
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+  if (x instanceof Date) {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+    return true;
+  } else if (typeof x === 'string') {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+
+    return true;
+  }
+  return false;
+}
+

--- a/tests/baselines/reference/inferTypePredicates.types
+++ b/tests/baselines/reference/inferTypePredicates.types
@@ -1059,8 +1059,8 @@ function areBothNums(x: string|number, y: string|number) {
 
 // Could potentially infer a type guard here but it would require more bookkeeping.
 function doubleReturn(x: string|number) {
->doubleReturn : (x: string | number) => boolean
->             : ^ ^^               ^^^^^^^^^^^^
+>doubleReturn : (x: string | number) => x is string
+>             : ^ ^^               ^^^^^^^^^^^^^^^^
 >x : string | number
 >  : ^^^^^^^^^^^^^^^
 
@@ -1647,5 +1647,101 @@ if (foobarPred(foobar)) {
 >       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >foo : number
 >    : ^^^^^^
+}
+
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+>assertReturnTrue : (x: string | number | Date) => x is string | number
+>                 : ^ ^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+
+  if (x instanceof Date) {
+>x instanceof Date : boolean
+>                  : ^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>Date : DateConstructor
+>     : ^^^^^^^^^^^^^^^
+
+    throw new Error();
+>new Error() : Error
+>            : ^^^^^
+>Error : ErrorConstructor
+>      : ^^^^^^^^^^^^^^^^
+  }
+  return true;
+>true : true
+>     : ^^^^
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+>isStringForWhichWeHaveACaseHandler : (anyString: string) => anyString is "a" | "b" | "c"
+>                                   : ^         ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>anyString : string
+>          : ^^^^^^
+
+  switch (anyString) {
+>anyString : string
+>          : ^^^^^^
+
+    case 'a':
+>'a' : "a"
+>    : ^^^
+
+    case 'b':
+>'b' : "b"
+>    : ^^^
+
+    case 'c':
+>'c' : "c"
+>    : ^^^
+
+      return true
+>true : true
+>     : ^^^^
+
+    default:
+      return false
+>false : false
+>      : ^^^^^
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+>ifElseIfPredicate : (x: Date | string | number) => x is string | Date
+>                  : ^ ^^                      ^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+
+  if (x instanceof Date) {
+>x instanceof Date : boolean
+>                  : ^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>Date : DateConstructor
+>     : ^^^^^^^^^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+
+  } else if (typeof x === 'string') {
+>typeof x === 'string' : boolean
+>                      : ^^^^^^^
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number
+>  : ^^^^^^^^^^^^^^^
+>'string' : "string"
+>         : ^^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+  }
+  return false;
+>false : false
+>      : ^^^^^
 }
 

--- a/tests/baselines/reference/typeGuardsInIfStatement.types
+++ b/tests/baselines/reference/typeGuardsInIfStatement.types
@@ -320,8 +320,8 @@ function foo8(x: number | string | boolean) {
     }
 }
 function foo9(x: number | string) {
->foo9 : (x: number | string) => boolean
->     : ^ ^^               ^^^^^^^^^^^^
+>foo9 : (x: number | string) => x is 10 | "hello"
+>     : ^ ^^               ^^^^^^^^^^^^^^^^^^^^^^
 >x : string | number
 >  : ^^^^^^^^^^^^^^^
 

--- a/tests/cases/compiler/inferTypePredicates.ts
+++ b/tests/cases/compiler/inferTypePredicates.ts
@@ -279,3 +279,31 @@ const foobarPred = (fb: typeof foobar) => fb.type === "foo";
 if (foobarPred(foobar)) {
   foobar.foo;
 }
+
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+  if (x instanceof Date) {
+    throw new Error();
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+  switch (anyString) {
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+  if (x instanceof Date) {
+    return true;
+  } else if (typeof x === 'string') {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Follow-on to #57465

_⚠️ **Disclaimer**: I'm not sure this is a good idea, I'm posting this mostly to get a sense for perf impact and breakages._

The original PR restricted itself to functions with a single `return`. This PR lifts that restriction.

This allows us to infer predicates for constructs like this:

```ts
// infers x is string | Date
function ifElseIfPredicate(x: string | number | Date) {
  if (typeof x === 'string') {
    return true;
  } else if (x instanceof Date) {
    return true;
  }
  return false;
}
```

or

```ts
// infers str is "a" | "b" | "c"
function switchPredicate(str: string) {
  switch (str) {
    case 'a':
    case 'b':
    case 'c':
      return true
    default:
      return false
  }
}
```

## How this works

Type predicate inference works by rewriting `return` statements from:

```ts
function foo(p: InitType) {
  return expr_involving_p;
}
```

to:

```ts
function foo(p: InitType) {
  if (expr_involving_p) {
    p  // TrueType
  } else {
    p  // FalseType
  }
}
```

If `TrueType != InitType` then we have a candidate for a type predicate. To generalize this to multiple returns, we determine the TrueType at each return statement and union them. These are all the parameter types for which the function can return true.

To verify the "if and only if" semantics of type predicates, we feed the type predicate type back into the function and look at all the false cases. For a valid type predicate, these should all be `never`.

I've also special-cased `return true` and `return false`. These weren't especially relevant when `getTypePredicateFromBody` only allowed one `return`, but they're very relevant now.

## Why this might not be a good idea

There were only two functions in the existing baselines that became type predicates with this change. So this might not be a very common pattern.

Moreover, I got a new circularity error in `emitter.ts`. This would _also_ have been a new circularity error with #57465, but the type predicate inference code didn't run because one of the functions had two returns. This change increases the odds that this happens on existing code.

More generally, I imagine the perf impact of this will be non-trivial since it might run on many more functions.

But those are all just hunches. I'd be curious to see the numbers and breakages on test repos!