### PR TITLE
fix(58146): enum quick info can display non ascii strings

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1761,7 +1761,7 @@ function canUseOriginalText(node: LiteralLikeNode, flags: GetLiteralTextFlags): 
 
 /** @internal */
 export function getTextOfConstantValue(value: string | number) {
-    return isString(value) ? '"' + escapeNonAsciiString(value) + '"' : "" + value;
+    return isString(value) ? `"${escapeString(value)}"` : "" + value;
 }
 
 // Make an identifier from an external module name by extracting the string after the last "/" and replacing

--- a/tests/cases/fourslash/quickInfoEnumMembersAcceptNonAsciiStrings.ts
+++ b/tests/cases/fourslash/quickInfoEnumMembersAcceptNonAsciiStrings.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+//// enum Demo {
+////     /*Emoji*/Emoji = '🍎',
+////     /*Hebrew*/Hebrew = 'תפוח',
+////     /*Chinese*/Chinese = '苹果',
+////     /*Japanese*/Japanese = 'りんご',
+//// }
+
+verify.quickInfoAt("Emoji", '(enum member) Demo.Emoji = "🍎"');
+verify.quickInfoAt("Hebrew",'(enum member) Demo.Hebrew = "תפוח"');
+verify.quickInfoAt("Chinese", '(enum member) Demo.Chinese = "苹果"');
+verify.quickInfoAt("Japanese",'(enum member) Demo.Japanese = "りんご"');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #58146
