### PR TITLE
Experiment: report functions with multiple returns that could be type predicates

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37874,7 +37874,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // We know it's all boolean returns. For each parameter, get the union of the true types.
         // Then feed that union back through to make sure that a false return value corresponds to never.
-        return forEach(func.parameters, (param, i) => {
+        const predicate = forEach(func.parameters, (param, i) => {
             const initType = getTypeOfSymbol(param.symbol);
             if (!initType || initType.flags & TypeFlags.Boolean || !isIdentifier(param.name) || isSymbolAssigned(param.symbol) || isRestParameter(param)) {
                 // Refining "x: boolean" to "x is true" or "x is false" isn't useful.
@@ -37932,6 +37932,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return createTypePredicate(TypePredicateKind.Identifier, unescapeLeadingUnderscores(param.name.escapedText), i, paramTrueType);
             }
         });
+        if (predicate && returns.length > 1) {
+            error(func.name ?? func, Diagnostics.Function_with_multiple_returns_is_implicitly_a_type_predicate);
+        }
+        return predicate;
     }
 
     /**

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1645,6 +1645,10 @@
         "category": "Error",
         "code": 1498
     },
+    "Function with multiple returns is implicitly a type predicate.": {
+        "category": "Error",
+        "code": 1499
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5336,7 +5336,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     /**
      * Generate the text for a generated identifier.
      */
-    function generateName(name: GeneratedIdentifier | GeneratedPrivateIdentifier) {
+    function generateName(name: GeneratedIdentifier | GeneratedPrivateIdentifier): string {
         const autoGenerate = name.emitNode.autoGenerate;
         if ((autoGenerate.flags & GeneratedIdentifierFlags.KindMask) === GeneratedIdentifierFlags.Node) {
             // Node names generate unique names based on their original node
@@ -5351,7 +5351,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         }
     }
 
-    function generateNameCached(node: Node, privateName: boolean, flags?: GeneratedIdentifierFlags, prefix?: string | GeneratedNamePart, suffix?: string) {
+    function generateNameCached(node: Node, privateName: boolean, flags?: GeneratedIdentifierFlags, prefix?: string | GeneratedNamePart, suffix?: string): string {
         const nodeId = getNodeId(node);
         const cache = privateName ? nodeIdToGeneratedPrivateName : nodeIdToGeneratedName;
         return cache[nodeId] || (cache[nodeId] = generateNameForNode(node, privateName, flags ?? GeneratedIdentifierFlags.None, formatGeneratedNamePart(prefix, generateName), formatGeneratedNamePart(suffix)));

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6518,7 +6518,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         return createGlobalMethodCall("Reflect", "set", receiver ? [target, propertyKey, value, receiver] : [target, propertyKey, value]);
     }
 
-    function tryAddPropertyAssignment(properties: PropertyAssignment[], propertyName: string, expression: Expression | undefined) {
+    function tryAddPropertyAssignment(properties: PropertyAssignment[], propertyName: string, expression: Expression | undefined): boolean {
         if (expression) {
             properties.push(createPropertyAssignment(propertyName, expression));
             return true;

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -528,7 +528,7 @@ function breakIntoSpans(identifier: string, word: boolean): TextSpan[] {
     return result;
 }
 
-function charIsPunctuation(ch: number) {
+function charIsPunctuation(ch: number): boolean {
     switch (ch) {
         case CharacterCodes.exclamation:
         case CharacterCodes.doubleQuote:

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2600,7 +2600,7 @@ export function createLanguageService(
         }
         else {
             // determines if the cursor is in an element tag
-            const tag = findAncestor(token.parent, n => {
+            const tag = findAncestor(token.parent, (n): boolean => {
                 if (isJsxOpeningElement(n) || isJsxClosingElement(n)) {
                     return true;
                 }

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.errors.txt
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.errors.txt
@@ -1,0 +1,66 @@
+error TS-1: Pre-emit (0) and post-emit (1) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+
+
+!!! error TS-1: Pre-emit (0) and post-emit (1) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+!!! related TS-1: The excess diagnostics are:
+!!! related TS1499 defaultParameterAddsUndefinedWithStrictNullChecks.ts:51:10: Function with multiple returns is implicitly a type predicate.
+==== defaultParameterAddsUndefinedWithStrictNullChecks.ts (0 errors) ====
+    function f(addUndefined1 = "J", addUndefined2?: number) {
+        return addUndefined1.length + (addUndefined2 || 0);
+    }
+    function g(addUndefined = "J", addDefined: number) {
+        return addUndefined.length + addDefined;
+    }
+    let total = f() + f('a', 1) + f('b') + f(undefined, 2);
+    total = g('c', 3) + g(undefined, 4);
+    
+    function foo1(x: string = "string", b: number) {
+        x.length;
+    }
+    
+    function foo2(x = "string", b: number) {
+        x.length; // ok, should be string
+    }
+    
+    function foo3(x: string | undefined = "string", b: number) {
+        x.length; // ok, should be string
+        x = undefined;
+    }
+    
+    function foo4(x: string | undefined = undefined, b: number) {
+        x; // should be string | undefined
+        x = undefined;
+    }
+    
+    type OptionalNullableString = string | null | undefined;
+    function allowsNull(val: OptionalNullableString = "") {
+        val = null;
+        val = 'string and null are both ok';
+    }
+    allowsNull(null); // still allows passing null
+    
+    
+    
+    // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
+    foo1(undefined, 1);
+    foo2(undefined, 1);
+    foo3(undefined, 1);
+    foo4(undefined, 1);
+    
+    
+    function removeUndefinedButNotFalse(x = true) {
+        if (x === false) {
+            return x;
+        }
+    }
+    
+    declare const cond: boolean;
+    function removeNothing(y = cond ? true : undefined) {
+        if (y !== undefined) {
+            if (y === false) {
+                return y;
+            }
+        }
+        return true;
+    }
+    

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
@@ -130,4 +130,4 @@ type OptionalNullableString = string | null | undefined;
 declare function allowsNull(val?: OptionalNullableString): void;
 declare function removeUndefinedButNotFalse(x?: boolean): false | undefined;
 declare const cond: boolean;
-declare function removeNothing(y?: boolean | undefined): boolean;
+declare function removeNothing(y?: boolean | undefined): y is true | undefined;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
@@ -302,8 +302,8 @@ declare const cond: boolean;
 >     : ^^^^^^^
 
 function removeNothing(y = cond ? true : undefined) {
->removeNothing : (y?: boolean | undefined) => boolean
->              : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>removeNothing : (y?: boolean | undefined) => y is true | undefined
+>              : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >y : boolean | undefined
 >  : ^^^^^^^^^^^^^^^^^^^
 >cond ? true : undefined : true | undefined

--- a/tests/baselines/reference/inferTypePredicates.errors.txt
+++ b/tests/baselines/reference/inferTypePredicates.errors.txt
@@ -1,3 +1,4 @@
+error TS-1: Pre-emit (11) and post-emit (14) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
 inferTypePredicates.ts(4,7): error TS2322: Type '(number | null)[]' is not assignable to type 'number[]'.
   Type 'number | null' is not assignable to type 'number'.
     Type 'null' is not assignable to type 'number'.
@@ -17,6 +18,11 @@ inferTypePredicates.ts(133,7): error TS2740: Type '{}' is missing the following 
 inferTypePredicates.ts(205,7): error TS2741: Property 'z' is missing in type 'C1' but required in type 'C2'.
 
 
+!!! error TS-1: Pre-emit (11) and post-emit (14) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+!!! related TS-1: The excess diagnostics are:
+!!! related TS1499 inferTypePredicates.ts:155:10: Function with multiple returns is implicitly a type predicate.
+!!! related TS1499 inferTypePredicates.ts:288:10: Function with multiple returns is implicitly a type predicate.
+!!! related TS1499 inferTypePredicates.ts:299:10: Function with multiple returns is implicitly a type predicate.
 ==== inferTypePredicates.ts (11 errors) ====
     // https://github.com/microsoft/TypeScript/issues/16069
     

--- a/tests/baselines/reference/inferTypePredicates.errors.txt
+++ b/tests/baselines/reference/inferTypePredicates.errors.txt
@@ -326,3 +326,31 @@ inferTypePredicates.ts(205,7): error TS2741: Property 'z' is missing in type 'C1
       foobar.foo;
     }
     
+    // Returning true can result in a predicate if the function throws earlier.
+    function assertReturnTrue(x: string | number | Date) {
+      if (x instanceof Date) {
+        throw new Error();
+      }
+      return true;
+    }
+    
+    function isStringForWhichWeHaveACaseHandler(anyString: string) {
+      switch (anyString) {
+        case 'a':
+        case 'b':
+        case 'c':
+          return true
+        default:
+          return false
+      }
+    }
+    
+    function ifElseIfPredicate(x: Date | string | number) {
+      if (x instanceof Date) {
+        return true;
+      } else if (typeof x === 'string') {
+        return true;
+      }
+      return false;
+    }
+    

--- a/tests/baselines/reference/inferTypePredicates.js
+++ b/tests/baselines/reference/inferTypePredicates.js
@@ -280,6 +280,34 @@ if (foobarPred(foobar)) {
   foobar.foo;
 }
 
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+  if (x instanceof Date) {
+    throw new Error();
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+  switch (anyString) {
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+  if (x instanceof Date) {
+    return true;
+  } else if (typeof x === 'string') {
+    return true;
+  }
+  return false;
+}
+
 
 //// [inferTypePredicates.js]
 // https://github.com/microsoft/TypeScript/issues/16069
@@ -538,6 +566,32 @@ var foobarPred = function (fb) { return fb.type === "foo"; };
 if (foobarPred(foobar)) {
     foobar.foo;
 }
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x) {
+    if (x instanceof Date) {
+        throw new Error();
+    }
+    return true;
+}
+function isStringForWhichWeHaveACaseHandler(anyString) {
+    switch (anyString) {
+        case 'a':
+        case 'b':
+        case 'c':
+            return true;
+        default:
+            return false;
+    }
+}
+function ifElseIfPredicate(x) {
+    if (x instanceof Date) {
+        return true;
+    }
+    else if (typeof x === 'string') {
+        return true;
+    }
+    return false;
+}
 
 
 //// [inferTypePredicates.d.ts]
@@ -583,7 +637,7 @@ declare let maybeDate: object;
 declare function irrelevantIsNumber(x: string | number): boolean;
 declare function irrelevantIsNumberDestructuring(x: string | number): boolean;
 declare function areBothNums(x: string | number, y: string | number): boolean;
-declare function doubleReturn(x: string | number): boolean;
+declare function doubleReturn(x: string | number): x is string;
 declare function guardsOneButNotOthers(a: string | number, b: string | number, c: string | number): b is string;
 declare function dunderguard(__x: number | string): __x is string;
 declare const booleanIdentity: (x: boolean) => boolean;
@@ -630,3 +684,6 @@ declare const foobarPred: (fb: typeof foobar) => fb is {
     type: "foo";
     foo: number;
 };
+declare function assertReturnTrue(x: string | number | Date): x is string | number;
+declare function isStringForWhichWeHaveACaseHandler(anyString: string): anyString is "a" | "b" | "c";
+declare function ifElseIfPredicate(x: Date | string | number): x is string | Date;

--- a/tests/baselines/reference/inferTypePredicates.symbols
+++ b/tests/baselines/reference/inferTypePredicates.symbols
@@ -777,3 +777,53 @@ if (foobarPred(foobar)) {
 >foo : Symbol(foo, Decl(inferTypePredicates.ts, 271, 18))
 }
 
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+>assertReturnTrue : Symbol(assertReturnTrue, Decl(inferTypePredicates.ts, 277, 1))
+>x : Symbol(x, Decl(inferTypePredicates.ts, 280, 26))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+  if (x instanceof Date) {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 280, 26))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+    throw new Error();
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+>isStringForWhichWeHaveACaseHandler : Symbol(isStringForWhichWeHaveACaseHandler, Decl(inferTypePredicates.ts, 285, 1))
+>anyString : Symbol(anyString, Decl(inferTypePredicates.ts, 287, 44))
+
+  switch (anyString) {
+>anyString : Symbol(anyString, Decl(inferTypePredicates.ts, 287, 44))
+
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+>ifElseIfPredicate : Symbol(ifElseIfPredicate, Decl(inferTypePredicates.ts, 296, 1))
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+  if (x instanceof Date) {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+    return true;
+  } else if (typeof x === 'string') {
+>x : Symbol(x, Decl(inferTypePredicates.ts, 298, 27))
+
+    return true;
+  }
+  return false;
+}
+

--- a/tests/baselines/reference/inferTypePredicates.types
+++ b/tests/baselines/reference/inferTypePredicates.types
@@ -1059,8 +1059,8 @@ function areBothNums(x: string|number, y: string|number) {
 
 // Could potentially infer a type guard here but it would require more bookkeeping.
 function doubleReturn(x: string|number) {
->doubleReturn : (x: string | number) => boolean
->             : ^ ^^               ^^^^^^^^^^^^
+>doubleReturn : (x: string | number) => x is string
+>             : ^ ^^               ^^^^^^^^^^^^^^^^
 >x : string | number
 >  : ^^^^^^^^^^^^^^^
 
@@ -1647,5 +1647,101 @@ if (foobarPred(foobar)) {
 >       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >foo : number
 >    : ^^^^^^
+}
+
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+>assertReturnTrue : (x: string | number | Date) => x is string | number
+>                 : ^ ^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+
+  if (x instanceof Date) {
+>x instanceof Date : boolean
+>                  : ^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>Date : DateConstructor
+>     : ^^^^^^^^^^^^^^^
+
+    throw new Error();
+>new Error() : Error
+>            : ^^^^^
+>Error : ErrorConstructor
+>      : ^^^^^^^^^^^^^^^^
+  }
+  return true;
+>true : true
+>     : ^^^^
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+>isStringForWhichWeHaveACaseHandler : (anyString: string) => anyString is "a" | "b" | "c"
+>                                   : ^         ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>anyString : string
+>          : ^^^^^^
+
+  switch (anyString) {
+>anyString : string
+>          : ^^^^^^
+
+    case 'a':
+>'a' : "a"
+>    : ^^^
+
+    case 'b':
+>'b' : "b"
+>    : ^^^
+
+    case 'c':
+>'c' : "c"
+>    : ^^^
+
+      return true
+>true : true
+>     : ^^^^
+
+    default:
+      return false
+>false : false
+>      : ^^^^^
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+>ifElseIfPredicate : (x: Date | string | number) => x is string | Date
+>                  : ^ ^^                      ^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+
+  if (x instanceof Date) {
+>x instanceof Date : boolean
+>                  : ^^^^^^^
+>x : string | number | Date
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>Date : DateConstructor
+>     : ^^^^^^^^^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+
+  } else if (typeof x === 'string') {
+>typeof x === 'string' : boolean
+>                      : ^^^^^^^
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>x : string | number
+>  : ^^^^^^^^^^^^^^^
+>'string' : "string"
+>         : ^^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+  }
+  return false;
+>false : false
+>      : ^^^^^
 }
 

--- a/tests/baselines/reference/typeGuardsInIfStatement.types
+++ b/tests/baselines/reference/typeGuardsInIfStatement.types
@@ -320,8 +320,8 @@ function foo8(x: number | string | boolean) {
     }
 }
 function foo9(x: number | string) {
->foo9 : (x: number | string) => boolean
->     : ^ ^^               ^^^^^^^^^^^^
+>foo9 : (x: number | string) => x is 10 | "hello"
+>     : ^ ^^               ^^^^^^^^^^^^^^^^^^^^^^
 >x : string | number
 >  : ^^^^^^^^^^^^^^^
 

--- a/tests/cases/compiler/inferTypePredicates.ts
+++ b/tests/cases/compiler/inferTypePredicates.ts
@@ -279,3 +279,31 @@ const foobarPred = (fb: typeof foobar) => fb.type === "foo";
 if (foobarPred(foobar)) {
   foobar.foo;
 }
+
+// Returning true can result in a predicate if the function throws earlier.
+function assertReturnTrue(x: string | number | Date) {
+  if (x instanceof Date) {
+    throw new Error();
+  }
+  return true;
+}
+
+function isStringForWhichWeHaveACaseHandler(anyString: string) {
+  switch (anyString) {
+    case 'a':
+    case 'b':
+    case 'c':
+      return true
+    default:
+      return false
+  }
+}
+
+function ifElseIfPredicate(x: Date | string | number) {
+  if (x instanceof Date) {
+    return true;
+  } else if (typeof x === 'string') {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
This is a side experiment for #58154. That PR extends type predicate inference to functions with multiple `return`s. It seems to have minimal perf impact and also minimal breakages. This makes you wonder… _are_ there any such functions?

This fork of the PR should answer that question by reporting errors on all functions with 2+ `return` statements where it can infer a type predicate. To be clear, these aren't real errors! They're just identifying multi-return predicates in the wild.

There are three such function in TypeScript itself:

1. `tryAddPropertyAssignment` in `nodeFactory.ts`:

```ts
function tryAddPropertyAssignment(properties: PropertyAssignment[], propertyName: string, expression: Expression | undefined) {
    if (expression) {
        properties.push(createPropertyAssignment(propertyName, expression));
        return true;
    }
    return false;
}
```

This gets an inferred return type of `expression is Expression`. This is accurate, though not consequential for any of the code that calls this function.

2. `charIsPunctuation` in `patternMatcher.ts`:

```ts
function charIsPunctuation(ch: number) {
    switch (ch) {
        case CharacterCodes.exclamation:
        case CharacterCodes.doubleQuote:
        // ...
        case CharacterCodes._:
        case CharacterCodes.openBrace:
        case CharacterCodes.closeBrace:
            return true;
    }

    return false;
}
```

This gets an inferred return type of `ch is CharacterCodes._ | CharacterCodes.ampersand | CharacterCodes.asterisk | ... | CharacterCodes.slash`. Again, this is accurate but not consequential for any of the calling code.

3. An anonymous function in `getLinkedEditingRangeAtPosition` in `services.ts`:

```ts
const tag = findAncestor(token.parent, n => {
    if (isJsxOpeningElement(n) || isJsxClosingElement(n)) {
        return true;
    }
    return false;
});
if (!tag) return undefined;
Debug.assert(isJsxOpeningElement(tag) || isJsxClosingElement(tag), "tag should be opening or closing element");
```

The arrow function becomes a type predicate with #58154 which changes the type of `tag`. This is a positive change that eliminates the need for the `Debug.assert` statement.

Of course, the function could have been written more succinctly as `n => isJsxOpeningElement(n) || isJsxClosingElement(n)` and the existing code would infer a type predicate.

I'm curious what other errors this reports on the user/top/etc suites. This will characterize whether this is a common pattern in the wild.