### PR TITLE
fix(58151): JSDoc tags get lost when inheriting from a grandparent class

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -740,6 +740,7 @@ class SymbolObject implements Symbol {
 
     getJsDocTags(checker?: TypeChecker): JSDocTagInfo[] {
         if (this.tags === undefined) {
+            this.tags = emptyArray; // Set temporarily to avoid an infinite loop finding inherited tags
             this.tags = getJsDocTagsOfDeclarations(this.declarations, checker);
         }
 
@@ -988,7 +989,7 @@ function getJsDocTagsOfDeclarations(declarations: Declaration[] | undefined, che
                     if (declaration.kind === SyntaxKind.GetAccessor || declaration.kind === SyntaxKind.SetAccessor) {
                         return symbol.getContextualJsDocTags(declaration, checker);
                     }
-                    return symbol.declarations?.length === 1 ? symbol.getJsDocTags() : undefined;
+                    return symbol.declarations?.length === 1 ? symbol.getJsDocTags(checker) : undefined;
                 }
             });
             if (inheritedTags) {

--- a/tests/baselines/reference/quickInfoJsDocTags16.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags16.baseline
@@ -1,0 +1,185 @@
+// === QuickInfo ===
+=== /tests/cases/fourslash/quickInfoJsDocTags16.ts ===
+// class A {
+//     /**
+//      * Description text here.
+//      *
+//      * @virtual
+//      */
+//     foo() { }
+// }
+// 
+// class B extends A {
+//     override foo() { }
+//              ^^^
+// | ----------------------------------------------------------------------
+// | (method) B.foo(): void
+// | Description text here.
+// | @virtual 
+// | ----------------------------------------------------------------------
+// }
+// 
+// class C extends B {
+//     override foo() { }
+//              ^^^
+// | ----------------------------------------------------------------------
+// | (method) C.foo(): void
+// | Description text here.
+// | @virtual 
+// | ----------------------------------------------------------------------
+// }
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags16.ts",
+      "position": 129,
+      "name": "1"
+    },
+    "item": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 129,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "B",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "Description text here.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "virtual"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags16.ts",
+      "position": 175,
+      "name": "2"
+    },
+    "item": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 175,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "C",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "Description text here.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "virtual"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoJsDocTags16.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags16.ts
@@ -1,0 +1,20 @@
+///<reference path="fourslash.ts" />
+
+////class A {
+////    /**
+////     * Description text here.
+////     *
+////     * @virtual
+////     */
+////    foo() { }
+////}
+////
+////class B extends A {
+////    override /*1*/foo() { }
+////}
+////
+////class C extends B {
+////    override /*2*/foo() { }
+////}
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #58151