### PR TITLE
Don't exempt late bound symbols from EPC in presence of string index signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32414,13 +32414,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function isKnownProperty(targetType: Type, name: __String, isComparingJsxAttributes: boolean): boolean {
         if (targetType.flags & TypeFlags.Object) {
-            // For backwards compatibility a symbol-named property is satisfied by a string index signature. This
-            // is incorrect and inconsistent with element access expressions, where it is an error, so eventually
-            // we should remove this exception.
             if (
                 getPropertyOfObjectType(targetType, name) ||
                 getApplicableIndexInfoForName(targetType, name) ||
-                isLateBoundName(name) && getIndexInfoOfType(targetType, stringType) ||
                 isComparingJsxAttributes && isHyphenatedJsxName(name)
             ) {
                 // For JSXAttributes, if the attribute has a hyphenated name, consider that the attribute to be known.

--- a/tests/baselines/reference/indexSignatures1.errors.txt
+++ b/tests/baselines/reference/indexSignatures1.errors.txt
@@ -68,10 +68,11 @@ indexSignatures1.ts(277,7): error TS2322: Type '"&"' is not assignable to type '
 indexSignatures1.ts(281,35): error TS2353: Object literal may only specify known properties, and ''someKey'' does not exist in type 'PseudoDeclaration'.
 indexSignatures1.ts(286,7): error TS2322: Type '"two"' is not assignable to type '`/${string}`'.
 indexSignatures1.ts(289,7): error TS2322: Type 'number' is not assignable to type 'PathsObject'.
+indexSignatures1.ts(311,43): error TS2353: Object literal may only specify known properties, and '[sym]' does not exist in type '{ [key: string]: string; }'.
 indexSignatures1.ts(312,43): error TS2353: Object literal may only specify known properties, and '[sym]' does not exist in type '{ [key: number]: string; }'.
 
 
-==== indexSignatures1.ts (52 errors) ====
+==== indexSignatures1.ts (53 errors) ====
     // Symbol index signature checking
     
     const sym = Symbol();
@@ -503,7 +504,9 @@ indexSignatures1.ts(312,43): error TS2353: Object literal may only specify known
     const aa: AA = { [sym]: '123' };
     
     const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
-    const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
+    const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Error
+                                              ~~~~~
+!!! error TS2353: Object literal may only specify known properties, and '[sym]' does not exist in type '{ [key: string]: string; }'.
     const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
                                               ~~~~~
 !!! error TS2353: Object literal may only specify known properties, and '[sym]' does not exist in type '{ [key: number]: string; }'.

--- a/tests/baselines/reference/indexSignatures1.js
+++ b/tests/baselines/reference/indexSignatures1.js
@@ -311,7 +311,7 @@ interface AA {
 const aa: AA = { [sym]: '123' };
 
 const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
-const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
+const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Error
 const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
 
 // Repro from #45772
@@ -484,7 +484,7 @@ const a = { [id]: 'test' };
 let aid = a[id];
 const aa = { [sym]: '123' };
 const obj1 = { [sym]: 'hello ' };
-const obj2 = { [sym]: 'hello ' }; // Permitted for backwards compatibility
+const obj2 = { [sym]: 'hello ' }; // Error
 const obj3 = { [sym]: 'hello ' }; // Error
 
 

--- a/tests/baselines/reference/indexSignatures1.symbols
+++ b/tests/baselines/reference/indexSignatures1.symbols
@@ -903,7 +903,7 @@ const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
 >[sym] : Symbol([sym], Decl(indexSignatures1.ts, 309, 41))
 >sym : Symbol(sym, Decl(indexSignatures1.ts, 2, 5))
 
-const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
+const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Error
 >obj2 : Symbol(obj2, Decl(indexSignatures1.ts, 310, 5))
 >key : Symbol(key, Decl(indexSignatures1.ts, 310, 15))
 >[sym] : Symbol([sym], Decl(indexSignatures1.ts, 310, 41))

--- a/tests/baselines/reference/indexSignatures1.types
+++ b/tests/baselines/reference/indexSignatures1.types
@@ -1625,7 +1625,7 @@ const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
 >'hello ' : "hello "
 >         : ^^^^^^^^
 
-const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
+const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Error
 >obj2 : { [key: string]: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key : string

--- a/tests/cases/conformance/types/members/indexSignatures1.ts
+++ b/tests/cases/conformance/types/members/indexSignatures1.ts
@@ -312,7 +312,7 @@ interface AA {
 const aa: AA = { [sym]: '123' };
 
 const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
-const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
+const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Error
 const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
 
 // Repro from #45772


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/44794