### PR TITLE
Add an extra test case for an error on async function typed using `@type`

### DIFF
--- a/tests/baselines/reference/asyncArrowFunction_allowJs.errors.txt
+++ b/tests/baselines/reference/asyncArrowFunction_allowJs.errors.txt
@@ -3,11 +3,12 @@ file.js(6,24): error TS1064: The return type of an async function or method must
 file.js(7,23): error TS2322: Type 'number' is not assignable to type 'string'.
 file.js(10,24): error TS1064: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
 file.js(12,2): error TS2322: Type 'number' is not assignable to type 'string'.
-file.js(19,3): error TS2345: Argument of type '() => Promise<number>' is not assignable to parameter of type '() => string'.
+file.js(16,24): error TS1064: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
+file.js(25,3): error TS2345: Argument of type '() => Promise<number>' is not assignable to parameter of type '() => string'.
   Type 'Promise<number>' is not assignable to type 'string'.
 
 
-==== file.js (6 errors) ====
+==== file.js (7 errors) ====
     // Error (good)
     /** @type {function(): string} */
     const a = () => 0
@@ -30,6 +31,14 @@ file.js(19,3): error TS2345: Argument of type '() => Promise<number>' is not ass
     	return 0
     	~~~~~~
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
+    }
+    
+    // Error (good)
+    /** @type {function(): string} */
+                           ~~~~~~
+!!! error TS1064: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
+    const d = async () => {
+    	return ""
     }
     
     /** @type {function(function(): string): void} */

--- a/tests/baselines/reference/asyncArrowFunction_allowJs.symbols
+++ b/tests/baselines/reference/asyncArrowFunction_allowJs.symbols
@@ -19,14 +19,22 @@ const c = async () => {
 	return 0
 }
 
+// Error (good)
+/** @type {function(): string} */
+const d = async () => {
+>d : Symbol(d, Decl(file.js, 16, 5))
+
+	return ""
+}
+
 /** @type {function(function(): string): void} */
 const f = (p) => {}
->f : Symbol(f, Decl(file.js, 15, 5))
->p : Symbol(p, Decl(file.js, 15, 11))
+>f : Symbol(f, Decl(file.js, 21, 5))
+>p : Symbol(p, Decl(file.js, 21, 11))
 
 // Error (good)
 f(async () => {
->f : Symbol(f, Decl(file.js, 15, 5))
+>f : Symbol(f, Decl(file.js, 21, 5))
 
 	return 0
 })

--- a/tests/baselines/reference/asyncArrowFunction_allowJs.types
+++ b/tests/baselines/reference/asyncArrowFunction_allowJs.types
@@ -34,6 +34,19 @@ const c = async () => {
 >  : ^
 }
 
+// Error (good)
+/** @type {function(): string} */
+const d = async () => {
+>d : () => string
+>  : ^^^^^^^^^^^^
+>async () => {	return ""} : () => string
+>                         : ^^^^^^^^^^^^
+
+	return ""
+>"" : ""
+>   : ^^
+}
+
 /** @type {function(function(): string): void} */
 const f = (p) => {}
 >f : (arg0: () => string) => void

--- a/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction_allowJs.ts
+++ b/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction_allowJs.ts
@@ -18,6 +18,12 @@ const c = async () => {
 	return 0
 }
 
+// Error (good)
+/** @type {function(): string} */
+const d = async () => {
+	return ""
+}
+
 /** @type {function(function(): string): void} */
 const f = (p) => {}
 


### PR DESCRIPTION
I broke this [here](https://github.com/microsoft/TypeScript/issues/58215#issuecomment-2059930788) so I'm somewhat sure that there is no other test case like this right now 