### PR TITLE
Improve diagnostics deduplication

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -808,7 +808,12 @@ export function createSortedArray<T>(): SortedArray<T> {
 }
 
 /** @internal */
-export function insertSorted<T>(array: SortedArray<T>, insert: T, compare: Comparer<T>, allowDuplicates?: boolean): boolean {
+export function insertSorted<T>(
+    array: SortedArray<T>,
+    insert: T,
+    compare: Comparer<T>,
+    equalityComparer?: EqualityComparer<T>,
+    allowDuplicates?: boolean): boolean {
     if (array.length === 0) {
         array.push(insert);
         return true;
@@ -816,6 +821,16 @@ export function insertSorted<T>(array: SortedArray<T>, insert: T, compare: Compa
 
     const insertIndex = binarySearch(array, insert, identity, compare);
     if (insertIndex < 0) {
+        if (equalityComparer && !allowDuplicates) {
+            const idx = ~insertIndex;
+            if (idx > 0 && equalityComparer(insert, array[idx - 1])) {
+                return false;
+            }
+            if (idx < array.length && equalityComparer(insert, array[idx])) {
+                array.splice(idx, 1, insert);
+                return true;
+            }
+        }
         array.splice(~insertIndex, 0, insert);
         return true;
     }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -813,7 +813,8 @@ export function insertSorted<T>(
     insert: T,
     compare: Comparer<T>,
     equalityComparer?: EqualityComparer<T>,
-    allowDuplicates?: boolean): boolean {
+    allowDuplicates?: boolean,
+): boolean {
     if (array.length === 0) {
         array.push(insert);
         return true;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8589,10 +8589,10 @@ function compareMessageChain(
         return Comparison.LessThan;
     }
 
-    return compareMessageElaborationSize(c1, c2) || compareMessageElaborationContent(c1, c2);
+    return compareMessageChainSize(c1, c2) || compareMessageChainContent(c1, c2);
 }
 
-function compareMessageElaborationSize(
+function compareMessageChainSize(
     c1: DiagnosticMessageChain[] | undefined,
     c2: DiagnosticMessageChain[] | undefined,
 ): Comparison {
@@ -8612,7 +8612,7 @@ function compareMessageElaborationSize(
     }
 
     for (let i = 0; i < c2.length; i++) {
-        res = compareMessageElaborationSize(c1[i].next, c2[i].next);
+        res = compareMessageChainSize(c1[i].next, c2[i].next);
         if (res) {
             return res;
         }
@@ -8622,7 +8622,7 @@ function compareMessageElaborationSize(
 }
 
 // Assumes the two chains have the same shape.
-function compareMessageElaborationContent(
+function compareMessageChainContent(
     c1: DiagnosticMessageChain[],
     c2: DiagnosticMessageChain[],
 ): Comparison {
@@ -8635,7 +8635,7 @@ function compareMessageElaborationContent(
         if (c1[i].next === undefined) {
             continue;
         }
-        res = compareMessageElaborationContent(c1[i].next!, c2[i].next!);
+        res = compareMessageChainContent(c1[i].next!, c2[i].next!);
         if (res) {
             return res;
         }

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -49,6 +49,7 @@ import {
     Decorator,
     Diagnostic,
     Diagnostics,
+    diagnosticsEqualityComparer,
     ElementAccessChain,
     ElementAccessExpression,
     emptyArray,
@@ -304,7 +305,7 @@ export function isExternalModuleNameRelative(moduleName: string): boolean {
 }
 
 export function sortAndDeduplicateDiagnostics<T extends Diagnostic>(diagnostics: readonly T[]): SortedReadonlyArray<T> {
-    return sortAndDeduplicate<T>(diagnostics, compareDiagnostics);
+    return sortAndDeduplicate<T>(diagnostics, compareDiagnostics, diagnosticsEqualityComparer);
 }
 
 export function getDefaultLibFileName(options: CompilerOptions): string {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1340,7 +1340,7 @@ function completionInfoFromData(
                 !uniqueNames.has(keywordEntry.name)
             ) {
                 uniqueNames.add(keywordEntry.name);
-                insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
+                insertSorted(entries, keywordEntry, compareCompletionEntries, /*equalityComparer*/ undefined, /*allowDuplicates*/ true);
             }
         }
     }
@@ -1348,14 +1348,14 @@ function completionInfoFromData(
     for (const keywordEntry of getContextualKeywords(contextToken, position)) {
         if (!uniqueNames.has(keywordEntry.name)) {
             uniqueNames.add(keywordEntry.name);
-            insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
+            insertSorted(entries, keywordEntry, compareCompletionEntries, /*equalityComparer*/ undefined, /*allowDuplicates*/ true);
         }
     }
 
     for (const literal of literals) {
         const literalEntry = createCompletionEntryForLiteral(sourceFile, preferences, literal);
         uniqueNames.add(literalEntry.name);
-        insertSorted(entries, literalEntry, compareCompletionEntries, /*allowDuplicates*/ true);
+        insertSorted(entries, literalEntry, compareCompletionEntries, /*equalityComparer*/ undefined, /*allowDuplicates*/ true);
     }
 
     if (!isChecked) {
@@ -2630,7 +2630,7 @@ export function getCompletionEntriesFromSymbols(
         /** True for locals; false for globals, module exports from other files, `this.` completions. */
         const shouldShadowLaterSymbols = (!origin || originIsTypeOnlyAlias(origin)) && !(symbol.parent === undefined && !some(symbol.declarations, d => d.getSourceFile() === location.getSourceFile()));
         uniques.set(name, shouldShadowLaterSymbols);
-        insertSorted(entries, entry, compareCompletionEntries, /*allowDuplicates*/ true);
+        insertSorted(entries, entry, compareCompletionEntries, /*equalityComparer*/ undefined, /*allowDuplicates*/ true);
     }
 
     log("getCompletionsAtPosition: getCompletionEntriesFromSymbols: " + (timestamp() - start));

--- a/src/testRunner/tests.ts
+++ b/src/testRunner/tests.ts
@@ -6,6 +6,7 @@ import "./unittests/comments";
 import "./unittests/compilerCore";
 import "./unittests/convertToBase64";
 import "./unittests/customTransforms";
+import "./unittests/diagnosticCollection";
 import "./unittests/factory";
 import "./unittests/incrementalParser";
 import "./unittests/jsDocParsing";

--- a/src/testRunner/unittests/diagnosticCollection.ts
+++ b/src/testRunner/unittests/diagnosticCollection.ts
@@ -1,0 +1,50 @@
+import * as ts from "../_namespaces/ts";
+
+describe("unittests:: internalApi:: diagnosticCollection", () => {
+    describe("add", () => {
+        it("correctly inserts equivalent diagnostic with more elaboration", () => {
+            const collection = ts.createDiagnosticCollection();
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, true);
+            const node = file.statements[0];
+
+            const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
+            const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
+            collection.add(dy);
+            collection.add(da);
+
+            const chain = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
+                ts.Diagnostics.Cannot_find_name_0, "y");
+            const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
+            
+            collection.add(dyBetter);
+            const result = collection.getDiagnostics();
+            assert.deepEqual(result, [da, dyBetter]);
+        });
+
+        it("correctly inserts equivalent diagnostic with less elaboration", () => {
+            const collection = ts.createDiagnosticCollection();
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, true);
+            const node = file.statements[0];
+
+            const chain = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
+                ts.Diagnostics.Cannot_find_name_0, "y");
+            const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
+            const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
+            collection.add(da);
+            collection.add(dyBetter);
+
+            
+            const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
+            collection.add(dy);
+            const result = collection.getDiagnostics();
+            assert.deepEqual(result, [da, dyBetter]);
+        })
+    });
+
+    describe("lookup", () => {
+        // TODO
+        assert.ok(false, "TODO");
+    })
+});

--- a/src/testRunner/unittests/diagnosticCollection.ts
+++ b/src/testRunner/unittests/diagnosticCollection.ts
@@ -2,9 +2,9 @@ import * as ts from "../_namespaces/ts";
 
 describe("unittests:: internalApi:: diagnosticCollection", () => {
     describe("add", () => {
-        it("correctly inserts equivalent diagnostic with more elaboration", () => {
+        it("keeps equivalent diagnostic with elaboration", () => {
             const collection = ts.createDiagnosticCollection();
-            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, true);
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
             const node = file.statements[0];
 
             const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
@@ -14,37 +14,107 @@ describe("unittests:: internalApi:: diagnosticCollection", () => {
 
             const chain = ts.chainDiagnosticMessages(
                 ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
-                ts.Diagnostics.Cannot_find_name_0, "y");
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
             const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
-            
+
             collection.add(dyBetter);
             const result = collection.getDiagnostics();
             assert.deepEqual(result, [da, dyBetter]);
         });
 
-        it("correctly inserts equivalent diagnostic with less elaboration", () => {
+        it("keeps equivalent diagnostic with deeper elaboration", () => {
             const collection = ts.createDiagnosticCollection();
-            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, true);
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+            const node = file.statements[0];
+
+            const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
+            collection.add(da);
+
+            const chain = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "a"),
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
+            const dy = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
+            collection.add(dy);
+
+            const chainBetter = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(
+                    ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
+                    ts.Diagnostics.Did_you_mean_0,
+                    "b",
+                ),
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
+            const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chainBetter);
+
+            collection.add(dyBetter);
+            const result = collection.getDiagnostics();
+            assert.deepEqual(result, [da, dyBetter]);
+        });
+
+        it("doesn't keep equivalent diagnostic with no elaboration", () => {
+            const collection = ts.createDiagnosticCollection();
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
             const node = file.statements[0];
 
             const chain = ts.chainDiagnosticMessages(
                 ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
-                ts.Diagnostics.Cannot_find_name_0, "y");
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
             const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
             const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
             collection.add(da);
             collection.add(dyBetter);
 
-            
             const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
             collection.add(dy);
             const result = collection.getDiagnostics();
             assert.deepEqual(result, [da, dyBetter]);
-        })
+        });
     });
 
     describe("lookup", () => {
-        // TODO
-        assert.ok(false, "TODO");
-    })
+        it("returns an equivalent diagnostic with more elaboration", () => {
+            const collection = ts.createDiagnosticCollection();
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+            const node = file.statements[0];
+
+            const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
+            collection.add(da);
+
+            const chain = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
+            const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
+            collection.add(dyBetter);
+
+            const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
+            assert.equal(collection.lookup(dy), dyBetter);
+        });
+        it("doesn't return an equivalent diagnostic with less elaboration", () => {
+            const collection = ts.createDiagnosticCollection();
+            const file = ts.createSourceFile("index.ts", "const x = 1", ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+            const node = file.statements[0];
+
+            const da = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "a");
+            collection.add(da);
+            const dy = ts.createDiagnosticForNode(node, ts.Diagnostics.Cannot_find_name_0, "y");
+            collection.add(dy);
+
+            const chain = ts.chainDiagnosticMessages(
+                ts.chainDiagnosticMessages(/*details*/ undefined, ts.Diagnostics.Did_you_mean_0, "x"),
+                ts.Diagnostics.Cannot_find_name_0,
+                "y",
+            );
+            const dyBetter = ts.createDiagnosticForNodeFromMessageChain(file, node, chain);
+            assert.equal(collection.lookup(dyBetter), undefined);
+        });
+    });
 });

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
@@ -1,6 +1,6 @@
-destructuringAssignmentWithDefault2.ts(11,4): error TS2322: Type 'undefined' is not assignable to type 'number'.
 destructuringAssignmentWithDefault2.ts(11,4): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
   Type 'undefined' is not assignable to type 'number'.
+destructuringAssignmentWithDefault2.ts(11,4): error TS2322: Type 'undefined' is not assignable to type 'number'.
 destructuringAssignmentWithDefault2.ts(12,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
 destructuringAssignmentWithDefault2.ts(13,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
 
@@ -18,10 +18,10 @@ destructuringAssignmentWithDefault2.ts(13,7): error TS2322: Type 'undefined' is 
     // Should be error
     ({ x = undefined } = a);
        ~
-!!! error TS2322: Type 'undefined' is not assignable to type 'number'.
-       ~
 !!! error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 !!! error TS2322:   Type 'undefined' is not assignable to type 'number'.
+       ~
+!!! error TS2322: Type 'undefined' is not assignable to type 'number'.
     ({ x: x = undefined } = a);
           ~
 !!! error TS2322: Type 'undefined' is not assignable to type 'number'.

--- a/tests/baselines/reference/duplicateErrorClassExpression.errors.txt
+++ b/tests/baselines/reference/duplicateErrorClassExpression.errors.txt
@@ -1,13 +1,11 @@
 duplicateErrorClassExpression.ts(17,5): error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
   Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
-duplicateErrorClassExpression.ts(17,5): error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
-  Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
     'string' index signatures are incompatible.
       Property 'a' is missing in type 'ADerived' but required in type 'ABase'.
 duplicateErrorClassExpression.ts(20,5): error TS2538: Type 'typeof Derived' cannot be used as an index type.
 
 
-==== duplicateErrorClassExpression.ts (3 errors) ====
+==== duplicateErrorClassExpression.ts (2 errors) ====
     interface ComplicatedTypeBase {
         [s: string]: ABase;
     }
@@ -25,9 +23,6 @@ duplicateErrorClassExpression.ts(20,5): error TS2538: Type 'typeof Derived' cann
     }
     const x = class Derived extends Base {
         foo!: ComplicatedTypeDerived;
-        ~~~
-!!! error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
-!!! error TS2416:   Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
         ~~~
 !!! error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.

--- a/tests/baselines/reference/duplicateErrorClassExpression.errors.txt
+++ b/tests/baselines/reference/duplicateErrorClassExpression.errors.txt
@@ -1,0 +1,41 @@
+duplicateErrorClassExpression.ts(17,5): error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
+  Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
+duplicateErrorClassExpression.ts(17,5): error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
+  Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
+    'string' index signatures are incompatible.
+      Property 'a' is missing in type 'ADerived' but required in type 'ABase'.
+duplicateErrorClassExpression.ts(20,5): error TS2538: Type 'typeof Derived' cannot be used as an index type.
+
+
+==== duplicateErrorClassExpression.ts (3 errors) ====
+    interface ComplicatedTypeBase {
+        [s: string]: ABase;
+    }
+    interface ComplicatedTypeDerived {
+        [s: string]: ADerived;
+    }
+    interface ABase {
+        a: string;
+    }
+    interface ADerived {
+        b: string;
+    }
+    class Base {
+        foo!: ComplicatedTypeBase;
+    }
+    const x = class Derived extends Base {
+        foo!: ComplicatedTypeDerived;
+        ~~~
+!!! error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
+        ~~~
+!!! error TS2416: Property 'foo' in type 'Derived' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'ComplicatedTypeDerived' is not assignable to type 'ComplicatedTypeBase'.
+!!! error TS2416:     'string' index signatures are incompatible.
+!!! error TS2416:       Property 'a' is missing in type 'ADerived' but required in type 'ABase'.
+!!! related TS2728 duplicateErrorClassExpression.ts:8:5: 'a' is declared here.
+    }
+    let obj: { 3: string } = { 3: "three" };
+    obj[x];
+        ~
+!!! error TS2538: Type 'typeof Derived' cannot be used as an index type.

--- a/tests/baselines/reference/duplicateErrorClassExpression.js
+++ b/tests/baselines/reference/duplicateErrorClassExpression.js
@@ -1,0 +1,55 @@
+//// [tests/cases/compiler/duplicateErrorClassExpression.ts] ////
+
+//// [duplicateErrorClassExpression.ts]
+interface ComplicatedTypeBase {
+    [s: string]: ABase;
+}
+interface ComplicatedTypeDerived {
+    [s: string]: ADerived;
+}
+interface ABase {
+    a: string;
+}
+interface ADerived {
+    b: string;
+}
+class Base {
+    foo!: ComplicatedTypeBase;
+}
+const x = class Derived extends Base {
+    foo!: ComplicatedTypeDerived;
+}
+let obj: { 3: string } = { 3: "three" };
+obj[x];
+
+//// [duplicateErrorClassExpression.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    return Base;
+}());
+var x = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Derived;
+}(Base));
+var obj = { 3: "three" };
+obj[x];

--- a/tests/baselines/reference/duplicateErrorClassExpression.symbols
+++ b/tests/baselines/reference/duplicateErrorClassExpression.symbols
@@ -1,0 +1,54 @@
+//// [tests/cases/compiler/duplicateErrorClassExpression.ts] ////
+
+=== duplicateErrorClassExpression.ts ===
+interface ComplicatedTypeBase {
+>ComplicatedTypeBase : Symbol(ComplicatedTypeBase, Decl(duplicateErrorClassExpression.ts, 0, 0))
+
+    [s: string]: ABase;
+>s : Symbol(s, Decl(duplicateErrorClassExpression.ts, 1, 5))
+>ABase : Symbol(ABase, Decl(duplicateErrorClassExpression.ts, 5, 1))
+}
+interface ComplicatedTypeDerived {
+>ComplicatedTypeDerived : Symbol(ComplicatedTypeDerived, Decl(duplicateErrorClassExpression.ts, 2, 1))
+
+    [s: string]: ADerived;
+>s : Symbol(s, Decl(duplicateErrorClassExpression.ts, 4, 5))
+>ADerived : Symbol(ADerived, Decl(duplicateErrorClassExpression.ts, 8, 1))
+}
+interface ABase {
+>ABase : Symbol(ABase, Decl(duplicateErrorClassExpression.ts, 5, 1))
+
+    a: string;
+>a : Symbol(ABase.a, Decl(duplicateErrorClassExpression.ts, 6, 17))
+}
+interface ADerived {
+>ADerived : Symbol(ADerived, Decl(duplicateErrorClassExpression.ts, 8, 1))
+
+    b: string;
+>b : Symbol(ADerived.b, Decl(duplicateErrorClassExpression.ts, 9, 20))
+}
+class Base {
+>Base : Symbol(Base, Decl(duplicateErrorClassExpression.ts, 11, 1))
+
+    foo!: ComplicatedTypeBase;
+>foo : Symbol(Base.foo, Decl(duplicateErrorClassExpression.ts, 12, 12))
+>ComplicatedTypeBase : Symbol(ComplicatedTypeBase, Decl(duplicateErrorClassExpression.ts, 0, 0))
+}
+const x = class Derived extends Base {
+>x : Symbol(x, Decl(duplicateErrorClassExpression.ts, 15, 5))
+>Derived : Symbol(Derived, Decl(duplicateErrorClassExpression.ts, 15, 9))
+>Base : Symbol(Base, Decl(duplicateErrorClassExpression.ts, 11, 1))
+
+    foo!: ComplicatedTypeDerived;
+>foo : Symbol(Derived.foo, Decl(duplicateErrorClassExpression.ts, 15, 38))
+>ComplicatedTypeDerived : Symbol(ComplicatedTypeDerived, Decl(duplicateErrorClassExpression.ts, 2, 1))
+}
+let obj: { 3: string } = { 3: "three" };
+>obj : Symbol(obj, Decl(duplicateErrorClassExpression.ts, 18, 3))
+>3 : Symbol(3, Decl(duplicateErrorClassExpression.ts, 18, 10))
+>3 : Symbol(3, Decl(duplicateErrorClassExpression.ts, 18, 26))
+
+obj[x];
+>obj : Symbol(obj, Decl(duplicateErrorClassExpression.ts, 18, 3))
+>x : Symbol(x, Decl(duplicateErrorClassExpression.ts, 15, 5))
+

--- a/tests/baselines/reference/duplicateErrorClassExpression.types
+++ b/tests/baselines/reference/duplicateErrorClassExpression.types
@@ -1,0 +1,65 @@
+//// [tests/cases/compiler/duplicateErrorClassExpression.ts] ////
+
+=== duplicateErrorClassExpression.ts ===
+interface ComplicatedTypeBase {
+    [s: string]: ABase;
+>s : string
+>  : ^^^^^^
+}
+interface ComplicatedTypeDerived {
+    [s: string]: ADerived;
+>s : string
+>  : ^^^^^^
+}
+interface ABase {
+    a: string;
+>a : string
+>  : ^^^^^^
+}
+interface ADerived {
+    b: string;
+>b : string
+>  : ^^^^^^
+}
+class Base {
+>Base : Base
+>     : ^^^^
+
+    foo!: ComplicatedTypeBase;
+>foo : ComplicatedTypeBase
+>    : ^^^^^^^^^^^^^^^^^^^
+}
+const x = class Derived extends Base {
+>x : typeof Derived
+>  : ^^^^^^^^^^^^^^
+>class Derived extends Base {    foo!: ComplicatedTypeDerived;} : typeof Derived
+>                                                               : ^^^^^^^^^^^^^^
+>Derived : typeof Derived
+>        : ^^^^^^^^^^^^^^
+>Base : Base
+>     : ^^^^
+
+    foo!: ComplicatedTypeDerived;
+>foo : ComplicatedTypeDerived
+>    : ^^^^^^^^^^^^^^^^^^^^^^
+}
+let obj: { 3: string } = { 3: "three" };
+>obj : { 3: string; }
+>    : ^^^^^      ^^^
+>3 : string
+>  : ^^^^^^
+>{ 3: "three" } : { 3: string; }
+>               : ^^^^^^^^^^^^^^
+>3 : string
+>  : ^^^^^^
+>"three" : "three"
+>        : ^^^^^^^
+
+obj[x];
+>obj[x] : any
+>       : ^^^
+>obj : { 3: string; }
+>    : ^^^^^^^^^^^^^^
+>x : typeof Derived
+>  : ^^^^^^^^^^^^^^
+

--- a/tests/baselines/reference/multipleDefaultExports05.errors.txt
+++ b/tests/baselines/reference/multipleDefaultExports05.errors.txt
@@ -1,17 +1,13 @@
 multipleDefaultExports05.ts(1,22): error TS2528: A module cannot have multiple default exports.
-multipleDefaultExports05.ts(1,22): error TS2528: A module cannot have multiple default exports.
 multipleDefaultExports05.ts(3,22): error TS2528: A module cannot have multiple default exports.
 multipleDefaultExports05.ts(5,22): error TS2528: A module cannot have multiple default exports.
 
 
-==== multipleDefaultExports05.ts (4 errors) ====
+==== multipleDefaultExports05.ts (3 errors) ====
     export default class AA1 {}
                          ~~~
 !!! error TS2528: A module cannot have multiple default exports.
 !!! related TS2753 multipleDefaultExports05.ts:3:22: Another export default is here.
-                         ~~~
-!!! error TS2528: A module cannot have multiple default exports.
-!!! related TS2753 multipleDefaultExports05.ts:5:22: Another export default is here.
     
     export default class BB1 {}
                          ~~~

--- a/tests/cases/compiler/duplicateErrorClassExpression.ts
+++ b/tests/cases/compiler/duplicateErrorClassExpression.ts
@@ -1,0 +1,22 @@
+// @strict: true
+
+interface ComplicatedTypeBase {
+    [s: string]: ABase;
+}
+interface ComplicatedTypeDerived {
+    [s: string]: ADerived;
+}
+interface ABase {
+    a: string;
+}
+interface ADerived {
+    b: string;
+}
+class Base {
+    foo!: ComplicatedTypeBase;
+}
+const x = class Derived extends Base {
+    foo!: ComplicatedTypeDerived;
+}
+let obj: { 3: string } = { 3: "three" };
+obj[x];


### PR DESCRIPTION
Fixes #58207.

Before, we only considered two diagnostics the same if everything about them was equal, including the message chain and related information. With this PR, we now consider diagnostics at the same location and *with the same head message* as being the same, regardless of the rest of the message chain and related information.
That is necessary because, as the new test shows, we can generate the "same" diagnostic at different moments in type checking, and they will have different elaboration (different message chains and related information).

This PR also makes it so deduplication keeps the diagnostic with more elaboration between two diagnostics considered to be equal.

Note that this doesn't completely solve the issue, because not all diagnostics that should be considered equal have the same code and head message.
Edit: follow-up PR #58318 fixes this.