### PR TITLE
Clone questionMark and dotdotdot token

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6689,7 +6689,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (!nodeIsSynthesized(node) && getParseTreeNode(node) === node) {
                         return node;
                     }
-                    return setTextRange(context, factory.cloneNode(visitEachChild(node, deepCloneOrReuseNode, /*context*/ undefined, deepCloneOrReuseNodes)), node);
+                    return setTextRange(context, factory.cloneNode(visitEachChild(node, deepCloneOrReuseNode, /*context*/ undefined, deepCloneOrReuseNodes, deepCloneOrReuseNode)), node);
                 }
 
                 function deepCloneOrReuseNodes(

--- a/tests/cases/fourslash/completionCloneQuestionToken.ts
+++ b/tests/cases/fourslash/completionCloneQuestionToken.ts
@@ -1,0 +1,29 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /file2.ts
+//// type TCallback<T = any> = (options: T) => any;
+//// type InKeyOf<E> = { [K in keyof E]?: TCallback<E[K]>; };
+//// export class Bar<A> {
+////     baz(a: InKeyOf<A>): void { }
+//// }
+
+// @Filename: /file1.ts
+//// import { Bar } from './file2';
+//// type TwoKeys = Record<'a' | 'b', { thisFails?: any; }>
+//// class Foo extends Bar<TwoKeys> {
+////     /**/
+//// }
+
+verify.completions({
+    marker: "",
+    includes: {
+        name: "baz",
+        insertText: "baz(a: { a?: (options: { thisFails?: any; }) => any; b?: (options: { thisFails?: any; }) => any; }): void {\n}",
+        filterText: "baz",
+    },
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/57924#issuecomment-2016963508

`CompletionInfo` is failing due to a synthetic `propertySignature` using an incorrect `questionToken` position which cause the Assert to fail. 

The positions are incorrect due to the checker reusing the synthetic node for the `questionToken`. When assigning positions the value gets overwritten by the latest position update this generating a node that is "not contained" on the parent.

The PR fixes this by always cloning a synthetic `questionToken` instead of reusing it.