### PR TITLE
Error on references to literal enum members in conditions

### DIFF
--- a/tests/baselines/reference/errorOnEnumReferenceInCondition.errors.txt
+++ b/tests/baselines/reference/errorOnEnumReferenceInCondition.errors.txt
@@ -1,0 +1,73 @@
+errorOnEnumReferenceInCondition.ts(6,11): error TS2845: This condition will always return 'false'.
+errorOnEnumReferenceInCondition.ts(7,11): error TS2845: This condition will always return 'true'.
+errorOnEnumReferenceInCondition.ts(9,5): error TS2845: This condition will always return 'false'.
+errorOnEnumReferenceInCondition.ts(17,5): error TS2845: This condition will always return 'true'.
+errorOnEnumReferenceInCondition.ts(30,11): error TS2845: This condition will always return 'false'.
+errorOnEnumReferenceInCondition.ts(31,11): error TS2845: This condition will always return 'true'.
+errorOnEnumReferenceInCondition.ts(33,5): error TS2845: This condition will always return 'false'.
+errorOnEnumReferenceInCondition.ts(41,5): error TS2845: This condition will always return 'true'.
+
+
+==== errorOnEnumReferenceInCondition.ts (8 errors) ====
+    enum Nums {
+        Zero = 0,
+        One = 1,
+    }
+    
+    const a = Nums.Zero ? "a" : "b";
+              ~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+    const b = Nums.One ? "a" : "b";
+              ~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    if (Nums.Zero) {
+        ~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+        Nums;
+    }
+    else {
+        Nums;
+    }
+    
+    
+    if (Nums.One) {
+        ~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        Nums;
+    }
+    else {
+        Nums;
+    }
+    
+    
+    enum Strs {
+        Empty = "",
+        A = "A",
+    }
+    
+    const c = Strs.Empty ? "a" : "b";
+              ~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+    const d = Strs.A ? "a" : "b";
+              ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    if (Strs.Empty) {
+        ~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+        Strs;
+    }
+    else {
+        Strs;
+    }
+    
+    
+    if (Strs.A) {
+        ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        Strs;
+    }
+    else {
+        Strs;
+    }

--- a/tests/baselines/reference/errorOnEnumReferenceInCondition.js
+++ b/tests/baselines/reference/errorOnEnumReferenceInCondition.js
@@ -1,0 +1,90 @@
+//// [tests/cases/compiler/errorOnEnumReferenceInCondition.ts] ////
+
+//// [errorOnEnumReferenceInCondition.ts]
+enum Nums {
+    Zero = 0,
+    One = 1,
+}
+
+const a = Nums.Zero ? "a" : "b";
+const b = Nums.One ? "a" : "b";
+
+if (Nums.Zero) {
+    Nums;
+}
+else {
+    Nums;
+}
+
+
+if (Nums.One) {
+    Nums;
+}
+else {
+    Nums;
+}
+
+
+enum Strs {
+    Empty = "",
+    A = "A",
+}
+
+const c = Strs.Empty ? "a" : "b";
+const d = Strs.A ? "a" : "b";
+
+if (Strs.Empty) {
+    Strs;
+}
+else {
+    Strs;
+}
+
+
+if (Strs.A) {
+    Strs;
+}
+else {
+    Strs;
+}
+
+//// [errorOnEnumReferenceInCondition.js]
+"use strict";
+var Nums;
+(function (Nums) {
+    Nums[Nums["Zero"] = 0] = "Zero";
+    Nums[Nums["One"] = 1] = "One";
+})(Nums || (Nums = {}));
+var a = Nums.Zero ? "a" : "b";
+var b = Nums.One ? "a" : "b";
+if (Nums.Zero) {
+    Nums;
+}
+else {
+    Nums;
+}
+if (Nums.One) {
+    Nums;
+}
+else {
+    Nums;
+}
+var Strs;
+(function (Strs) {
+    Strs["Empty"] = "";
+    Strs["A"] = "A";
+})(Strs || (Strs = {}));
+var c = Strs.Empty ? "a" : "b";
+var d = Strs.A ? "a" : "b";
+if (Strs.Empty) {
+    Strs;
+}
+else {
+    Strs;
+}
+if (Strs.A) {
+    Strs;
+}
+else {
+    Strs;
+}

--- a/tests/baselines/reference/errorOnEnumReferenceInCondition.symbols
+++ b/tests/baselines/reference/errorOnEnumReferenceInCondition.symbols
@@ -1,0 +1,101 @@
+//// [tests/cases/compiler/errorOnEnumReferenceInCondition.ts] ////
+
+=== errorOnEnumReferenceInCondition.ts ===
+enum Nums {
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+
+    Zero = 0,
+>Zero : Symbol(Nums.Zero, Decl(errorOnEnumReferenceInCondition.ts, 0, 11))
+
+    One = 1,
+>One : Symbol(Nums.One, Decl(errorOnEnumReferenceInCondition.ts, 1, 13))
+}
+
+const a = Nums.Zero ? "a" : "b";
+>a : Symbol(a, Decl(errorOnEnumReferenceInCondition.ts, 5, 5))
+>Nums.Zero : Symbol(Nums.Zero, Decl(errorOnEnumReferenceInCondition.ts, 0, 11))
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+>Zero : Symbol(Nums.Zero, Decl(errorOnEnumReferenceInCondition.ts, 0, 11))
+
+const b = Nums.One ? "a" : "b";
+>b : Symbol(b, Decl(errorOnEnumReferenceInCondition.ts, 6, 5))
+>Nums.One : Symbol(Nums.One, Decl(errorOnEnumReferenceInCondition.ts, 1, 13))
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+>One : Symbol(Nums.One, Decl(errorOnEnumReferenceInCondition.ts, 1, 13))
+
+if (Nums.Zero) {
+>Nums.Zero : Symbol(Nums.Zero, Decl(errorOnEnumReferenceInCondition.ts, 0, 11))
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+>Zero : Symbol(Nums.Zero, Decl(errorOnEnumReferenceInCondition.ts, 0, 11))
+
+    Nums;
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+}
+else {
+    Nums;
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+}
+
+
+if (Nums.One) {
+>Nums.One : Symbol(Nums.One, Decl(errorOnEnumReferenceInCondition.ts, 1, 13))
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+>One : Symbol(Nums.One, Decl(errorOnEnumReferenceInCondition.ts, 1, 13))
+
+    Nums;
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+}
+else {
+    Nums;
+>Nums : Symbol(Nums, Decl(errorOnEnumReferenceInCondition.ts, 0, 0))
+}
+
+
+enum Strs {
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+
+    Empty = "",
+>Empty : Symbol(Strs.Empty, Decl(errorOnEnumReferenceInCondition.ts, 24, 11))
+
+    A = "A",
+>A : Symbol(Strs.A, Decl(errorOnEnumReferenceInCondition.ts, 25, 15))
+}
+
+const c = Strs.Empty ? "a" : "b";
+>c : Symbol(c, Decl(errorOnEnumReferenceInCondition.ts, 29, 5))
+>Strs.Empty : Symbol(Strs.Empty, Decl(errorOnEnumReferenceInCondition.ts, 24, 11))
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+>Empty : Symbol(Strs.Empty, Decl(errorOnEnumReferenceInCondition.ts, 24, 11))
+
+const d = Strs.A ? "a" : "b";
+>d : Symbol(d, Decl(errorOnEnumReferenceInCondition.ts, 30, 5))
+>Strs.A : Symbol(Strs.A, Decl(errorOnEnumReferenceInCondition.ts, 25, 15))
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+>A : Symbol(Strs.A, Decl(errorOnEnumReferenceInCondition.ts, 25, 15))
+
+if (Strs.Empty) {
+>Strs.Empty : Symbol(Strs.Empty, Decl(errorOnEnumReferenceInCondition.ts, 24, 11))
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+>Empty : Symbol(Strs.Empty, Decl(errorOnEnumReferenceInCondition.ts, 24, 11))
+
+    Strs;
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+}
+else {
+    Strs;
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+}
+
+
+if (Strs.A) {
+>Strs.A : Symbol(Strs.A, Decl(errorOnEnumReferenceInCondition.ts, 25, 15))
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+>A : Symbol(Strs.A, Decl(errorOnEnumReferenceInCondition.ts, 25, 15))
+
+    Strs;
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+}
+else {
+    Strs;
+>Strs : Symbol(Strs, Decl(errorOnEnumReferenceInCondition.ts, 21, 1))
+}

--- a/tests/baselines/reference/errorOnEnumReferenceInCondition.types
+++ b/tests/baselines/reference/errorOnEnumReferenceInCondition.types
@@ -1,0 +1,175 @@
+//// [tests/cases/compiler/errorOnEnumReferenceInCondition.ts] ////
+
+=== errorOnEnumReferenceInCondition.ts ===
+enum Nums {
+>Nums : Nums
+>     : ^^^^
+
+    Zero = 0,
+>Zero : Nums.Zero
+>     : ^^^^^^^^^
+>0 : 0
+>  : ^
+
+    One = 1,
+>One : Nums.One
+>    : ^^^^^^^^
+>1 : 1
+>  : ^
+}
+
+const a = Nums.Zero ? "a" : "b";
+>a : "a" | "b"
+>  : ^^^^^^^^^
+>Nums.Zero ? "a" : "b" : "a" | "b"
+>                      : ^^^^^^^^^
+>Nums.Zero : Nums.Zero
+>          : ^^^^^^^^^
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+>Zero : Nums.Zero
+>     : ^^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+
+const b = Nums.One ? "a" : "b";
+>b : "a" | "b"
+>  : ^^^^^^^^^
+>Nums.One ? "a" : "b" : "a" | "b"
+>                     : ^^^^^^^^^
+>Nums.One : Nums.One
+>         : ^^^^^^^^
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+>One : Nums.One
+>    : ^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+
+if (Nums.Zero) {
+>Nums.Zero : Nums.Zero
+>          : ^^^^^^^^^
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+>Zero : Nums.Zero
+>     : ^^^^^^^^^
+
+    Nums;
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+}
+else {
+    Nums;
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+}
+
+
+if (Nums.One) {
+>Nums.One : Nums.One
+>         : ^^^^^^^^
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+>One : Nums.One
+>    : ^^^^^^^^
+
+    Nums;
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+}
+else {
+    Nums;
+>Nums : typeof Nums
+>     : ^^^^^^^^^^^
+}
+
+
+enum Strs {
+>Strs : Strs
+>     : ^^^^
+
+    Empty = "",
+>Empty : Strs.Empty
+>      : ^^^^^^^^^^
+>"" : ""
+>   : ^^
+
+    A = "A",
+>A : Strs.A
+>  : ^^^^^^
+>"A" : "A"
+>    : ^^^
+}
+
+const c = Strs.Empty ? "a" : "b";
+>c : "a" | "b"
+>  : ^^^^^^^^^
+>Strs.Empty ? "a" : "b" : "a" | "b"
+>                       : ^^^^^^^^^
+>Strs.Empty : Strs.Empty
+>           : ^^^^^^^^^^
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+>Empty : Strs.Empty
+>      : ^^^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+
+const d = Strs.A ? "a" : "b";
+>d : "a" | "b"
+>  : ^^^^^^^^^
+>Strs.A ? "a" : "b" : "a" | "b"
+>                   : ^^^^^^^^^
+>Strs.A : Strs.A
+>       : ^^^^^^
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+>A : Strs.A
+>  : ^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+
+if (Strs.Empty) {
+>Strs.Empty : Strs.Empty
+>           : ^^^^^^^^^^
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+>Empty : Strs.Empty
+>      : ^^^^^^^^^^
+
+    Strs;
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+}
+else {
+    Strs;
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+}
+
+
+if (Strs.A) {
+>Strs.A : Strs.A
+>       : ^^^^^^
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+>A : Strs.A
+>  : ^^^^^^
+
+    Strs;
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+}
+else {
+    Strs;
+>Strs : typeof Strs
+>     : ^^^^^^^^^^^
+}

--- a/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
+++ b/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
@@ -1,0 +1,47 @@
+// @strict: true
+enum Nums {
+    Zero = 0,
+    One = 1,
+}
+
+const a = Nums.Zero ? "a" : "b";
+const b = Nums.One ? "a" : "b";
+
+if (Nums.Zero) {
+    Nums;
+}
+else {
+    Nums;
+}
+
+
+if (Nums.One) {
+    Nums;
+}
+else {
+    Nums;
+}
+
+
+enum Strs {
+    Empty = "",
+    A = "A",
+}
+
+const c = Strs.Empty ? "a" : "b";
+const d = Strs.A ? "a" : "b";
+
+if (Strs.Empty) {
+    Strs;
+}
+else {
+    Strs;
+}
+
+
+if (Strs.A) {
+    Strs;
+}
+else {
+    Strs;
+}


### PR DESCRIPTION
So when you write
```ts
enum NodeKind {
    FunctionDeclaration = 0,
    VariableDeclaration = 1,
    ExpressionStatement = 2,
}

function kindToString(kind: NodeKind) {
    Debug.assert(!isExpressionStatementKind(kind));
    return NodeKind.FunctionDeclaration ? "func" : "var";
}
```
we inform you in advance that you've failed to actually write `kind ===`.