### PR TITLE
Report relation cache sizes in --diagnostics too

### DIFF
--- a/src/compiler/executeCommandLine.ts
+++ b/src/compiler/executeCommandLine.ts
@@ -1178,6 +1178,11 @@ function reportStatistics(sys: System, program: Program, solutionPerformance: So
         if (memoryUsed >= 0) {
             reportStatisticalValue({ name: "Memory used", value: memoryUsed, type: StatisticType.memory }, /*aggregate*/ true);
         }
+        const caches = program.getRelationCacheSizes();
+        reportCountStatistic("Assignability cache size", caches.assignable);
+        reportCountStatistic("Identity cache size", caches.identity);
+        reportCountStatistic("Subtype cache size", caches.subtype);
+        reportCountStatistic("Strict subtype cache size", caches.strictSubtype);
 
         const isPerformanceEnabled = performance.isEnabled();
         const programTime = isPerformanceEnabled ? performance.getDuration("Program") : 0;
@@ -1185,11 +1190,6 @@ function reportStatistics(sys: System, program: Program, solutionPerformance: So
         const checkTime = isPerformanceEnabled ? performance.getDuration("Check") : 0;
         const emitTime = isPerformanceEnabled ? performance.getDuration("Emit") : 0;
         if (compilerOptions.extendedDiagnostics) {
-            const caches = program.getRelationCacheSizes();
-            reportCountStatistic("Assignability cache size", caches.assignable);
-            reportCountStatistic("Identity cache size", caches.identity);
-            reportCountStatistic("Subtype cache size", caches.subtype);
-            reportCountStatistic("Strict subtype cache size", caches.strictSubtype);
             if (isPerformanceEnabled) {
                 performance.forEachMeasure((name, duration) => {
                     if (!isSolutionMarkOrMeasure(name)) reportTimeStatistic(`${name} time`, duration, /*aggregate*/ true);


### PR DESCRIPTION
This would be helpful for https://github.com/microsoft/typescript-benchmarking/pull/58, as passing `--extendedDiagnostics` turns on tracing which slows down the compiler (not great for benchmarking).

But, maybe this is too much info for the more generic `--diagnostics` printout.