### PR TITLE
fix(58265): JSDoc comment string with the keyword "@private" before import statement in JS file result in cryptic error TS1191 during compilation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46279,7 +46279,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // If we hit an import declaration in an illegal context, just bail out to avoid cascading errors.
             return;
         }
-        if (!checkGrammarModifiers(node) && hasEffectiveModifiers(node)) {
+        if (!checkGrammarModifiers(node) && node.modifiers) {
             grammarErrorOnFirstToken(node, Diagnostics.An_import_declaration_cannot_have_modifiers);
         }
         if (checkExternalImportOrExportDeclaration(node)) {

--- a/tests/baselines/reference/es6ImportWithJsDocTags.symbols
+++ b/tests/baselines/reference/es6ImportWithJsDocTags.symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/es6ImportWithJsDocTags.ts] ////
+
+=== ./a.js ===
+export const foo = 1;
+>foo : Symbol(foo, Decl(a.js, 0, 12))
+
+=== ./b.js ===
+'use strict';
+
+/** @private */
+
+import { foo } from './a.js';
+>foo : Symbol(foo, Decl(b.js, 4, 8))
+
+console.log(foo);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>foo : Symbol(foo, Decl(b.js, 4, 8))
+

--- a/tests/baselines/reference/es6ImportWithJsDocTags.types
+++ b/tests/baselines/reference/es6ImportWithJsDocTags.types
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/es6ImportWithJsDocTags.ts] ////
+
+=== ./a.js ===
+export const foo = 1;
+>foo : 1
+>    : ^
+>1 : 1
+>  : ^
+
+=== ./b.js ===
+'use strict';
+>'use strict' : "use strict"
+>             : ^^^^^^^^^^^^
+
+/** @private */
+
+import { foo } from './a.js';
+>foo : 1
+>    : ^
+
+console.log(foo);
+>console.log(foo) : void
+>                 : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^^^^^
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^^^^^
+>foo : 1
+>    : ^
+

--- a/tests/cases/compiler/es6ImportWithJsDocTags.ts
+++ b/tests/cases/compiler/es6ImportWithJsDocTags.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: ./a.js
+export const foo = 1;
+
+// @filename: ./b.js
+'use strict';
+
+/** @private */
+
+import { foo } from './a.js';
+
+console.log(foo);


### PR DESCRIPTION
Fixes #58265