### PR TITLE
Don't reuse program structure if we errored on filenames differing by case

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4888,6 +4888,7 @@ export interface Program extends ScriptReferenceHost {
      * @internal
      */
     writeFile: WriteFileCallback;
+    /** @internal */ hasFileNamesDifferOnlyInCasingError(): boolean;
 }
 
 /** @internal */

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -303,7 +303,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/xY/a.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
@@ -256,7 +256,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/XY.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -303,7 +303,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/Xy/a.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
@@ -256,7 +256,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/XY.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -303,7 +303,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/Xy/a.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
@@ -256,7 +256,7 @@ Program options: {
   "extendedDiagnostics": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/XY.ts

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-relative-information-file-location-changes.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-relative-information-file-location-changes.js
@@ -230,7 +230,7 @@ Program options: {
   "explainFiles": true,
   "configFilePath": "/user/username/projects/myproject/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/ModuleC.ts

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-link-open.js
@@ -474,7 +474,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -501,7 +501,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
@@ -551,7 +551,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -578,7 +578,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-open.js
@@ -476,7 +476,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -503,7 +503,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -404,7 +404,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -431,7 +431,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-link-open.js
@@ -465,7 +465,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -492,7 +492,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
@@ -540,7 +540,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -567,7 +567,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-open.js
@@ -467,7 +467,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -494,7 +494,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
@@ -397,7 +397,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -424,7 +424,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-link-open.js
@@ -474,7 +474,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -501,7 +501,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
@@ -551,7 +551,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -578,7 +578,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-open.js
@@ -476,7 +476,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -503,7 +503,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -404,7 +404,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -431,7 +431,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-link-open.js
@@ -465,7 +465,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -492,7 +492,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
@@ -540,7 +540,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -567,7 +567,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-open.js
@@ -467,7 +467,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -494,7 +494,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
@@ -397,7 +397,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -424,7 +424,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-link-open.js
@@ -474,7 +474,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -501,7 +501,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-and-link-open.js
@@ -551,7 +551,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -578,7 +578,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-open.js
@@ -476,7 +476,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -503,7 +503,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -404,7 +404,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -431,7 +431,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-link-open.js
@@ -465,7 +465,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 4:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -492,7 +492,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-and-link-open.js
@@ -540,7 +540,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -567,7 +567,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-open.js
@@ -467,7 +467,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -494,7 +494,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 Before running Immedidate callback:: count: 1

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
@@ -397,7 +397,7 @@ Before running Timeout callback:: count: 3
 
 Invoking Timeout callback:: timeoutId:: 6:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -424,7 +424,7 @@ Immedidate callback:: count: 1
 Projects::
 /user/username/projects/myproject/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
@@ -599,7 +599,7 @@ Before running Timeout callback:: count: 1
 2: checkOne
 
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"

--- a/tests/baselines/reference/tsserver/typeReferenceDirectives/when-typeReferenceDirective-contains-UpperCasePackage.js
+++ b/tests/baselines/reference/tsserver/typeReferenceDirectives/when-typeReferenceDirective-contains-UpperCasePackage.js
@@ -292,7 +292,7 @@ ScriptInfos::
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/test/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/test/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/test/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/test/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/test/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
@@ -335,7 +335,7 @@ After running Timeout callback:: count: 0
 Projects::
 /user/username/projects/myproject/test/tsconfig.json (Configured) *changed*
     projectStateVersion: 2
-    projectProgramVersion: 1
+    projectProgramVersion: 2 *changed*
     dirty: false *changed*
 
 ScriptInfos::


### PR DESCRIPTION
This is speculation based on https://github.com/microsoft/TypeScript/issues/58011 and https://github.com/typescript-eslint/typescript-eslint/issues/1192. Not 100% certain it'll help, and can't test without a repro...