### PR TITLE
Disable no-inferrable-types eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -127,6 +127,7 @@
                 "varsIgnorePattern": "^(_+$|_[^_])"
             }
         ],
+        "@typescript-eslint/no-inferrable-types": "off",
 
         // Pending https://github.com/typescript-eslint/typescript-eslint/issues/4820
         "@typescript-eslint/prefer-optional-chain": "off",

--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -3,7 +3,6 @@
 export const versionMajorMinor = "5.5";
 // The following is baselined as a literal template type without intervention
 /** The version of the TypeScript compiler release */
-// eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = `${versionMajorMinor}.0-dev`;
 
 /**


### PR DESCRIPTION
This should fix the `create release-X.Y` task.

This was a stylistic rule introduced when we switched to using ts-eslint's presets, but we explicitly annotate some stuff that's inferable on purpose. Since this is just style, it seems okay to just disable it.