### PR TITLE
Treat the input file name from referenced project as "ts" rather than file extension it is when determining eliding file for program construction

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -4106,7 +4106,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 }
 
                 const isFromNodeModulesSearch = resolution.isExternalLibraryImport;
-                const isJsFile = !resolutionExtensionIsTSOrJson(resolution.extension);
+                // If this is js file source of project reference, dont treat it as js file but as d.ts
+                const isJsFile = !resolutionExtensionIsTSOrJson(resolution.extension) && !getProjectReferenceRedirectProject(resolution.resolvedFileName);
                 const isJsFileFromNodeModules = isFromNodeModulesSearch && isJsFile && (!resolution.originalPath || pathContainsNodeModules(resolution.resolvedFileName));
                 const resolvedFileName = resolution.resolvedFileName;
 

--- a/tests/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
+++ b/tests/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
@@ -1,0 +1,254 @@
+currentDirectory:: /src/projects/project useCaseSensitiveFileNames: false
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/lib/lib.esnext.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/src/projects/project/node_modules/a] symlink(/src/projects/project/packages/a)
+//// [/src/projects/project/packages/a/index.js]
+export const a = 'a';
+
+//// [/src/projects/project/packages/a/package.json]
+{
+  "name": "a",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}
+
+//// [/src/projects/project/packages/a/test/index.js]
+import 'a';
+
+//// [/src/projects/project/packages/a/tsconfig.json]
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "nodenext",
+    "outDir": "types"
+  }
+}
+
+//// [/src/projects/project/packages/b/index.js]
+export { a } from 'a';
+
+//// [/src/projects/project/packages/b/package.json]
+{
+  "name": "b",
+  "version": "0.0.0",
+  "type": "module"
+}
+
+//// [/src/projects/project/packages/b/tsconfig.json]
+{
+  "references": [
+    {
+      "path": "../a"
+    }
+  ],
+  "compilerOptions": {
+    "checkJs": true,
+    "module": "nodenext",
+    "noEmit": true,
+    "noImplicitAny": true
+  }
+}
+
+
+
+Output::
+/lib/tsc -b packages/b --verbose --traceResolution --explainFiles
+[[90m12:00:22 AM[0m] Projects in this build: 
+    * packages/a/tsconfig.json
+    * packages/b/tsconfig.json
+
+[[90m12:00:23 AM[0m] Project 'packages/a/tsconfig.json' is out of date because output file 'packages/a/types/tsconfig.tsbuildinfo' does not exist
+
+[[90m12:00:24 AM[0m] Building project '/src/projects/project/packages/a/tsconfig.json'...
+
+Found 'package.json' at '/src/projects/project/packages/a/package.json'.
+File '/src/projects/project/packages/a/test/package.json' does not exist.
+File '/src/projects/project/packages/a/package.json' exists according to earlier cached lookups.
+======== Resolving module 'a' from '/src/projects/project/packages/a/test/index.js'. ========
+Module resolution kind is not specified, using 'NodeNext'.
+Resolving in ESM mode with conditions 'import', 'types', 'node'.
+File '/src/projects/project/packages/a/test/package.json' does not exist according to earlier cached lookups.
+File '/src/projects/project/packages/a/package.json' exists according to earlier cached lookups.
+Entering conditional exports.
+Matched 'exports' condition 'types'.
+Using 'exports' subpath '.' with target './types/index.d.ts'.
+File name '/src/projects/project/packages/a/index.js' has a '.js' extension - stripping it.
+File '/src/projects/project/packages/a/index.ts' does not exist.
+File '/src/projects/project/packages/a/index.tsx' does not exist.
+File '/src/projects/project/packages/a/index.d.ts' does not exist.
+File '/src/projects/project/packages/a/index.js' exists - use it as a name resolution result.
+'package.json' does not have a 'peerDependencies' field.
+Resolved under condition 'types'.
+Exiting conditional exports.
+Resolving real path for '/src/projects/project/packages/a/index.js', result '/src/projects/project/packages/a/index.js'.
+======== Module name 'a' was successfully resolved to '/src/projects/project/packages/a/index.js' with Package ID 'a/index.js@0.0.0'. ========
+File '/lib/package.json' does not exist.
+File '/package.json' does not exist.
+../../../lib/lib.esnext.full.d.ts
+  Default library for target 'esnext'
+packages/a/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
+packages/a/test/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
+[[90m12:00:32 AM[0m] Project 'packages/b/tsconfig.json' is out of date because output 'packages/b/index.js' is older than input 'packages/a'
+
+[[90m12:00:33 AM[0m] Building project '/src/projects/project/packages/b/tsconfig.json'...
+
+Found 'package.json' at '/src/projects/project/packages/b/package.json'.
+======== Resolving module 'a' from '/src/projects/project/packages/b/index.js'. ========
+Module resolution kind is not specified, using 'NodeNext'.
+Resolving in ESM mode with conditions 'import', 'types', 'node'.
+File '/src/projects/project/packages/b/package.json' exists according to earlier cached lookups.
+Loading module 'a' from 'node_modules' folder, target file types: TypeScript, JavaScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/src/projects/project/packages/b/node_modules' does not exist, skipping all lookups in it.
+Resolution for module 'a' was found in cache from location '/src/projects/project/packages'.
+======== Module name 'a' was successfully resolved to '/src/projects/project/packages/a/index.js' with Package ID 'a/index.js@0.0.0'. ========
+File '/lib/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+[96mpackages/b/index.js[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module 'a'. '/src/projects/project/packages/a/index.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/a` if it exists or add a new declaration (.d.ts) file containing `declare module 'a';`
+
+[7m1[0m export { a } from 'a';
+[7m [0m [91m                  ~~~[0m
+
+../../../lib/lib.esnext.full.d.ts
+  Default library for target 'esnext'
+packages/b/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/b/package.json' has field "type" with value "module"
+
+Found 1 error.
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/projects/project/packages/a/types/index.d.ts]
+export const a: "a";
+
+
+//// [/src/projects/project/packages/a/types/test/index.d.ts]
+export {};
+
+
+//// [/src/projects/project/packages/a/types/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../../lib/lib.esnext.full.d.ts","../index.js","../test/index.js"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-15642581130-export const a = 'a';","signature":"-13259723213-export const a: \"a\";\n","impliedFormat":99},{"version":"-3920874422-import 'a';","signature":"-3531856636-export {};\n","impliedFormat":99}],"root":[2,3],"options":{"checkJs":true,"composite":true,"declaration":true,"emitDeclarationOnly":true,"module":199,"outDir":"./"},"fileIdsList":[[2]],"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./test/index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/projects/project/packages/a/types/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../../lib/lib.esnext.full.d.ts",
+      "../index.js",
+      "../test/index.js"
+    ],
+    "fileNamesList": [
+      [
+        "../index.js"
+      ]
+    ],
+    "fileInfos": {
+      "../../../../../../lib/lib.esnext.full.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../index.js": {
+        "original": {
+          "version": "-15642581130-export const a = 'a';",
+          "signature": "-13259723213-export const a: \"a\";\n",
+          "impliedFormat": 99
+        },
+        "version": "-15642581130-export const a = 'a';",
+        "signature": "-13259723213-export const a: \"a\";\n",
+        "impliedFormat": "esnext"
+      },
+      "../test/index.js": {
+        "original": {
+          "version": "-3920874422-import 'a';",
+          "signature": "-3531856636-export {};\n",
+          "impliedFormat": 99
+        },
+        "version": "-3920874422-import 'a';",
+        "signature": "-3531856636-export {};\n",
+        "impliedFormat": "esnext"
+      }
+    },
+    "root": [
+      [
+        2,
+        "../index.js"
+      ],
+      [
+        3,
+        "../test/index.js"
+      ]
+    ],
+    "options": {
+      "checkJs": true,
+      "composite": true,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 199,
+      "outDir": "./"
+    },
+    "referencedMap": {
+      "../test/index.js": [
+        "../index.js"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../../../lib/lib.esnext.full.d.ts",
+      "../index.js",
+      "../test/index.js"
+    ],
+    "latestChangedDtsFile": "./test/index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1032
+}
+

--- a/tests/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
+++ b/tests/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
@@ -142,23 +142,20 @@ Searching all ancestor node_modules directories for preferred extensions: TypeSc
 Directory '/src/projects/project/packages/b/node_modules' does not exist, skipping all lookups in it.
 Resolution for module 'a' was found in cache from location '/src/projects/project/packages'.
 ======== Module name 'a' was successfully resolved to '/src/projects/project/packages/a/index.js' with Package ID 'a/index.js@0.0.0'. ========
+File '/src/projects/project/packages/a/types/package.json' does not exist.
+File '/src/projects/project/packages/a/package.json' exists according to earlier cached lookups.
 File '/lib/package.json' does not exist according to earlier cached lookups.
 File '/package.json' does not exist according to earlier cached lookups.
-[96mpackages/b/index.js[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module 'a'. '/src/projects/project/packages/a/index.js' implicitly has an 'any' type.
-  Try `npm i --save-dev @types/a` if it exists or add a new declaration (.d.ts) file containing `declare module 'a';`
-
-[7m1[0m export { a } from 'a';
-[7m [0m [91m                  ~~~[0m
-
 ../../../lib/lib.esnext.full.d.ts
   Default library for target 'esnext'
+packages/a/types/index.d.ts
+  Imported via 'a' from file 'packages/b/index.js' with packageId 'a/index.js@0.0.0'
+  File is output of project reference source 'packages/a/index.js'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
 packages/b/index.js
   Matched by default include pattern '**/*'
   File is ECMAScript module because 'packages/b/package.json' has field "type" with value "module"
-
-Found 1 error.
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+exitCode:: ExitStatus.Success
 
 
 //// [/src/projects/project/packages/a/types/index.d.ts]

--- a/tests/baselines/reference/tsbuild/moduleResolution/when-resolution-is-not-shared.js
+++ b/tests/baselines/reference/tsbuild/moduleResolution/when-resolution-is-not-shared.js
@@ -1,0 +1,275 @@
+currentDirectory:: /src/projects/project useCaseSensitiveFileNames: false
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/lib/lib.esnext.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/src/projects/project/node_modules/a] symlink(/src/projects/project/packages/a)
+//// [/src/projects/project/packages/a/index.js]
+export const a = 'a';
+
+//// [/src/projects/project/packages/a/package.json]
+{
+  "name": "a",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}
+
+//// [/src/projects/project/packages/a/test/index.js]
+import 'a';
+
+//// [/src/projects/project/packages/a/tsconfig.json]
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "nodenext",
+    "outDir": "types"
+  }
+}
+
+//// [/src/projects/project/packages/b/index.js]
+export { a } from 'a';
+
+//// [/src/projects/project/packages/b/package.json]
+{
+  "name": "b",
+  "version": "0.0.0",
+  "type": "module"
+}
+
+//// [/src/projects/project/packages/b/tsconfig.json]
+{
+  "references": [
+    {
+      "path": "../a"
+    }
+  ],
+  "compilerOptions": {
+    "checkJs": true,
+    "module": "nodenext",
+    "noEmit": true,
+    "noImplicitAny": true
+  }
+}
+
+
+
+Output::
+/lib/tsc -b packages/a --verbose --traceResolution --explainFiles
+[[90m12:00:22 AM[0m] Projects in this build: 
+    * packages/a/tsconfig.json
+
+[[90m12:00:23 AM[0m] Project 'packages/a/tsconfig.json' is out of date because output file 'packages/a/types/tsconfig.tsbuildinfo' does not exist
+
+[[90m12:00:24 AM[0m] Building project '/src/projects/project/packages/a/tsconfig.json'...
+
+Found 'package.json' at '/src/projects/project/packages/a/package.json'.
+File '/src/projects/project/packages/a/test/package.json' does not exist.
+File '/src/projects/project/packages/a/package.json' exists according to earlier cached lookups.
+======== Resolving module 'a' from '/src/projects/project/packages/a/test/index.js'. ========
+Module resolution kind is not specified, using 'NodeNext'.
+Resolving in ESM mode with conditions 'import', 'types', 'node'.
+File '/src/projects/project/packages/a/test/package.json' does not exist according to earlier cached lookups.
+File '/src/projects/project/packages/a/package.json' exists according to earlier cached lookups.
+Entering conditional exports.
+Matched 'exports' condition 'types'.
+Using 'exports' subpath '.' with target './types/index.d.ts'.
+File name '/src/projects/project/packages/a/index.js' has a '.js' extension - stripping it.
+File '/src/projects/project/packages/a/index.ts' does not exist.
+File '/src/projects/project/packages/a/index.tsx' does not exist.
+File '/src/projects/project/packages/a/index.d.ts' does not exist.
+File '/src/projects/project/packages/a/index.js' exists - use it as a name resolution result.
+'package.json' does not have a 'peerDependencies' field.
+Resolved under condition 'types'.
+Exiting conditional exports.
+Resolving real path for '/src/projects/project/packages/a/index.js', result '/src/projects/project/packages/a/index.js'.
+======== Module name 'a' was successfully resolved to '/src/projects/project/packages/a/index.js' with Package ID 'a/index.js@0.0.0'. ========
+File '/lib/package.json' does not exist.
+File '/package.json' does not exist.
+../../../lib/lib.esnext.full.d.ts
+  Default library for target 'esnext'
+packages/a/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
+packages/a/test/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
+exitCode:: ExitStatus.Success
+
+
+//// [/src/projects/project/packages/a/types/index.d.ts]
+export const a: "a";
+
+
+//// [/src/projects/project/packages/a/types/test/index.d.ts]
+export {};
+
+
+//// [/src/projects/project/packages/a/types/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../../lib/lib.esnext.full.d.ts","../index.js","../test/index.js"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-15642581130-export const a = 'a';","signature":"-13259723213-export const a: \"a\";\n","impliedFormat":99},{"version":"-3920874422-import 'a';","signature":"-3531856636-export {};\n","impliedFormat":99}],"root":[2,3],"options":{"checkJs":true,"composite":true,"declaration":true,"emitDeclarationOnly":true,"module":199,"outDir":"./"},"fileIdsList":[[2]],"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./test/index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/projects/project/packages/a/types/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../../lib/lib.esnext.full.d.ts",
+      "../index.js",
+      "../test/index.js"
+    ],
+    "fileNamesList": [
+      [
+        "../index.js"
+      ]
+    ],
+    "fileInfos": {
+      "../../../../../../lib/lib.esnext.full.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../index.js": {
+        "original": {
+          "version": "-15642581130-export const a = 'a';",
+          "signature": "-13259723213-export const a: \"a\";\n",
+          "impliedFormat": 99
+        },
+        "version": "-15642581130-export const a = 'a';",
+        "signature": "-13259723213-export const a: \"a\";\n",
+        "impliedFormat": "esnext"
+      },
+      "../test/index.js": {
+        "original": {
+          "version": "-3920874422-import 'a';",
+          "signature": "-3531856636-export {};\n",
+          "impliedFormat": 99
+        },
+        "version": "-3920874422-import 'a';",
+        "signature": "-3531856636-export {};\n",
+        "impliedFormat": "esnext"
+      }
+    },
+    "root": [
+      [
+        2,
+        "../index.js"
+      ],
+      [
+        3,
+        "../test/index.js"
+      ]
+    ],
+    "options": {
+      "checkJs": true,
+      "composite": true,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 199,
+      "outDir": "./"
+    },
+    "referencedMap": {
+      "../test/index.js": [
+        "../index.js"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../../../lib/lib.esnext.full.d.ts",
+      "../index.js",
+      "../test/index.js"
+    ],
+    "latestChangedDtsFile": "./test/index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1032
+}
+
+
+
+Change:: build b
+Input::
+
+
+Output::
+/lib/tsc -b packages/b --verbose --traceResolution --explainFiles
+[[90m12:00:32 AM[0m] Projects in this build: 
+    * packages/a/tsconfig.json
+    * packages/b/tsconfig.json
+
+[[90m12:00:33 AM[0m] Project 'packages/a/tsconfig.json' is up to date because newest input 'packages/a/test/index.js' is older than output 'packages/a/types/tsconfig.tsbuildinfo'
+
+[[90m12:00:34 AM[0m] Project 'packages/b/tsconfig.json' is out of date because output 'packages/b/index.js' is older than input 'packages/b/tsconfig.json'
+
+[[90m12:00:35 AM[0m] Building project '/src/projects/project/packages/b/tsconfig.json'...
+
+Found 'package.json' at '/src/projects/project/packages/b/package.json'.
+======== Resolving module 'a' from '/src/projects/project/packages/b/index.js'. ========
+Module resolution kind is not specified, using 'NodeNext'.
+Resolving in ESM mode with conditions 'import', 'types', 'node'.
+File '/src/projects/project/packages/b/package.json' exists according to earlier cached lookups.
+Loading module 'a' from 'node_modules' folder, target file types: TypeScript, JavaScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/src/projects/project/packages/b/node_modules' does not exist, skipping all lookups in it.
+Directory '/src/projects/project/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/src/projects/project/node_modules/a/package.json'.
+Entering conditional exports.
+Matched 'exports' condition 'types'.
+Using 'exports' subpath '.' with target './types/index.d.ts'.
+File '/src/projects/project/node_modules/a/types/index.d.ts' exists - use it as a name resolution result.
+'package.json' does not have a 'peerDependencies' field.
+Resolved under condition 'types'.
+Exiting conditional exports.
+Resolving real path for '/src/projects/project/node_modules/a/types/index.d.ts', result '/src/projects/project/packages/a/types/index.d.ts'.
+======== Module name 'a' was successfully resolved to '/src/projects/project/packages/a/types/index.d.ts' with Package ID 'a/types/index.d.ts@0.0.0'. ========
+File '/src/projects/project/packages/a/types/package.json' does not exist.
+Found 'package.json' at '/src/projects/project/packages/a/package.json'.
+File '/lib/package.json' does not exist.
+File '/package.json' does not exist.
+../../../lib/lib.esnext.full.d.ts
+  Default library for target 'esnext'
+packages/a/types/index.d.ts
+  Imported via 'a' from file 'packages/b/index.js' with packageId 'a/types/index.d.ts@0.0.0'
+  File is ECMAScript module because 'packages/a/package.json' has field "type" with value "module"
+packages/b/index.js
+  Matched by default include pattern '**/*'
+  File is ECMAScript module because 'packages/b/package.json' has field "type" with value "module"
+exitCode:: ExitStatus.Success
+
+


### PR DESCRIPTION
During `tsc -b` the resolutions are shared across projects if the setting match. This means that if you resolved your own package name before building the project, you will get the "input" file as the resolution. And when we go to project that references this package and config, the input file will be used as resolution. This normally works out because we have rule to redirect to d.ts file and report error. But the issue is that if the input file is js file, it has rules for eliding imports. So if the file is input file name from referenced project, treat it as d.ts file for purpose of deciding eliding of imports and whether to include file or not.

Fixes https://github.com/microsoft/TypeScript/issues/57652