### PR TITLE
Make diagnostics public on EmitOutput

### DIFF
--- a/src/compiler/builderStatePublic.ts
+++ b/src/compiler/builderStatePublic.ts
@@ -6,7 +6,7 @@ import {
 export interface EmitOutput {
     outputFiles: OutputFile[];
     emitSkipped: boolean;
-    /** @internal */ diagnostics: readonly Diagnostic[];
+    diagnostics: readonly Diagnostic[];
 }
 
 export interface OutputFile {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -9456,6 +9456,7 @@ declare namespace ts {
     interface EmitOutput {
         outputFiles: OutputFile[];
         emitSkipped: boolean;
+        diagnostics: readonly Diagnostic[];
     }
     interface OutputFile {
         name: string;


### PR DESCRIPTION
This EmitOutput is uses by monaco and the playground, but neither can see emit diags, which is a problem as they need to know that they need to process the diagnostics to remove non-serializable things.