### PR TITLE
Exclude outDir and declarationDir even if they come from extended config

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2976,12 +2976,12 @@ function parseJsonConfigFileContentWorker(
         const excludeOfRaw = getSpecsFromRaw("exclude");
         let isDefaultIncludeSpec = false;
         let excludeSpecs = toPropValue(excludeOfRaw);
-        if (excludeOfRaw === "no-prop" && raw.compilerOptions) {
-            const outDir = raw.compilerOptions.outDir;
-            const declarationDir = raw.compilerOptions.declarationDir;
+        if (excludeOfRaw === "no-prop") {
+            const outDir = options.outDir;
+            const declarationDir = options.declarationDir;
 
             if (outDir || declarationDir) {
-                excludeSpecs = [outDir, declarationDir].filter(d => !!d);
+                excludeSpecs = filter([outDir, declarationDir], d => !!d) as string[];
             }
         }
 

--- a/src/testRunner/unittests/config/tsconfigParsing.ts
+++ b/src/testRunner/unittests/config/tsconfigParsing.ts
@@ -241,7 +241,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
                 "files": []
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -251,7 +251,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
                 "references": []
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -261,7 +261,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
                 "references": [{ "path": "/apath" }]
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -269,7 +269,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
         jsonText: `{
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.js"],
     }]);
 
@@ -280,7 +280,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
                 }
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: [],
     }]);
 
@@ -301,7 +301,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
                 "include": ["**/*"]
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -314,7 +314,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
               }
             }`,
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }], /*skipJson*/ true);
 
@@ -328,7 +328,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
             }],
         }),
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -339,7 +339,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
             ],
         }),
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -350,7 +350,7 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
             },
         }),
         configFileName: "/apath/tsconfig.json",
-        basePath: "tests/cases/unittests",
+        basePath: "/apath",
         allFileList: ["/apath/a.ts"],
     }]);
 
@@ -392,6 +392,6 @@ describe("unittests:: config:: tsconfigParsing:: parseConfigFileTextToJson", () 
         jsonText: jsonToReadableText({
             include: ["./", "./**/*.json"],
         }),
-        basePath: "/foo",
+        basePath: "/foo.bar",
     }]);
 });

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with paths and more/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with paths and more/tsconfig.json
@@ -32,6 +32,6 @@
         "./src/**/*"
     ],
     "exclude": [
-        "./lib"
+        "/Show TSConfig with paths and more/lib"
     ]
 }

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors for empty files list when no references are provided with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors for empty files list when no references are provided with jsonSourceFile api.js
@@ -13,7 +13,7 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[96m/apath/tsconfig.json[0m:[93m2[0m:[93m26[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/apath/tsconfig.json' is empty.
+[96mtsconfig.json[0m:[93m2[0m:[93m26[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/apath/tsconfig.json' is empty.
 
 [7m2[0m                 "files": [],
 [7m [0m [91m                         ~~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors for empty files list with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors for empty files list with jsonSourceFile api.js
@@ -12,7 +12,7 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[96m/apath/tsconfig.json[0m:[93m2[0m:[93m26[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/apath/tsconfig.json' is empty.
+[96mtsconfig.json[0m:[93m2[0m:[93m26[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/apath/tsconfig.json' is empty.
 
 [7m2[0m                 "files": []
 [7m [0m [91m                         ~~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors for includes with outDir with json api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors for includes with outDir with json api.js
@@ -15,5 +15,5 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[91merror[0m[90m TS18003: [0mNo inputs were found in config file '/apath/tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["./"]'.
+[91merror[0m[90m TS18003: [0mNo inputs were found in config file '/apath/tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["/apath"]'.
 

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors for includes with outDir with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors for includes with outDir with jsonSourceFile api.js
@@ -15,5 +15,5 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[91merror[0m[90m TS18003: [0mNo inputs were found in config file '/apath/tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["./"]'.
+[91merror[0m[90m TS18003: [0mNo inputs were found in config file '/apath/tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["/apath"]'.
 

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors for when invalid comment type present in tsconfig with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors for when invalid comment type present in tsconfig with jsonSourceFile api.js
@@ -16,39 +16,39 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 /apath/a.ts
 Errors::
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS1327: [0mString literal with double quotes expected.
+[96mtsconfig.json[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS1327: [0mString literal with double quotes expected.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                ~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m18[0m - [91merror[0m[90m TS1328: [0mProperty value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal.
+[96mtsconfig.json[0m:[93m3[0m:[93m18[0m - [91merror[0m[90m TS1328: [0mProperty value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                 ~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option '#'.
+[96mtsconfig.json[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option '#'.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                ~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m20[0m - [91merror[0m[90m TS1327: [0mString literal with double quotes expected.
+[96mtsconfig.json[0m:[93m3[0m:[93m20[0m - [91merror[0m[90m TS1327: [0mString literal with double quotes expected.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                   ~~~~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m25[0m - [91merror[0m[90m TS1328: [0mProperty value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal.
+[96mtsconfig.json[0m:[93m3[0m:[93m25[0m - [91merror[0m[90m TS1328: [0mProperty value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                        ~~~~~~~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m20[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option 'this'.
+[96mtsconfig.json[0m:[93m3[0m:[93m20[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option 'this'.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                   ~~~~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m33[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
+[96mtsconfig.json[0m:[93m3[0m:[93m33[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                                ~~~~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m38[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
+[96mtsconfig.json[0m:[93m3[0m:[93m38[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                                     ~~~~~[0m
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m44[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
+[96mtsconfig.json[0m:[93m3[0m:[93m44[0m - [91merror[0m[90m TS1136: [0mProperty assignment expected.
 
 [7m3[0m                 ## this comment does cause issues
 [7m [0m [91m                                           ~~~~~~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors when commandline option is in tsconfig with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors when commandline option is in tsconfig with jsonSourceFile api.js
@@ -14,7 +14,7 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 /apath/a.ts
 Errors::
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS6266: [0mOption 'help' can only be specified on command line.
+[96mtsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS6266: [0mOption 'help' can only be specified on command line.
 
 [7m3[0m     "help": true
 [7m [0m [91m    ~~~~~~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors when files is not string with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors when files is not string with jsonSourceFile api.js
@@ -19,7 +19,7 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5024: [0mCompiler option 'files' requires a value of type string.
+[96mtsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5024: [0mCompiler option 'files' requires a value of type string.
 
 [7m  3[0m     {
 [7m   [0m [91m    ~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/generates errors when include is not string with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/generates errors when include is not string with jsonSourceFile api.js
@@ -16,7 +16,7 @@ configFileName:: /apath/tsconfig.json
 FileNames::
 
 Errors::
-[96m/apath/tsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5024: [0mCompiler option 'include' requires a value of type string.
+[96mtsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5024: [0mCompiler option 'include' requires a value of type string.
 
 [7m3[0m     [
 [7m [0m [91m    ~[0m

--- a/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with json api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with json api.js
@@ -20,7 +20,7 @@ Fs::
 
 configFileName:: tsconfig.json
 FileNames::
-/b.ts,/bin/a.ts
+/b.ts
 Errors::
 
 
@@ -46,6 +46,6 @@ Fs::
 
 configFileName:: tsconfig.json
 FileNames::
-/b.ts,/bin/a.ts
+/b.ts
 Errors::
 

--- a/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with json api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with json api.js
@@ -1,0 +1,51 @@
+Fs::
+//// [/b.ts]
+
+
+//// [/bin/a.ts]
+
+
+//// [/tsconfig.json]
+{
+  "extends": "./tsconfigWithoutConfigDir.json"
+}
+
+//// [/tsconfigWithoutConfigDir.json]
+{
+  "compilerOptions": {
+    "outDir": "bin"
+  }
+}
+
+
+configFileName:: tsconfig.json
+FileNames::
+/b.ts,/bin/a.ts
+Errors::
+
+
+Fs::
+//// [/b.ts]
+
+
+//// [/bin/a.ts]
+
+
+//// [/tsconfig.json]
+{
+  "extends": "./tsconfigWithConfigDir.json"
+}
+
+//// [/tsconfigWithConfigDir.json]
+{
+  "compilerOptions": {
+    "outDir": "${configDir}/bin"
+  }
+}
+
+
+configFileName:: tsconfig.json
+FileNames::
+/b.ts,/bin/a.ts
+Errors::
+

--- a/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with jsonSourceFile api.js
@@ -20,7 +20,7 @@ Fs::
 
 configFileName:: tsconfig.json
 FileNames::
-/b.ts,/bin/a.ts
+/b.ts
 Errors::
 
 
@@ -46,6 +46,6 @@ Fs::
 
 configFileName:: tsconfig.json
 FileNames::
-/b.ts,/bin/a.ts
+/b.ts
 Errors::
 

--- a/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/tsconfigParsing/with outDir from base tsconfig with jsonSourceFile api.js
@@ -1,0 +1,51 @@
+Fs::
+//// [/b.ts]
+
+
+//// [/bin/a.ts]
+
+
+//// [/tsconfig.json]
+{
+  "extends": "./tsconfigWithoutConfigDir.json"
+}
+
+//// [/tsconfigWithoutConfigDir.json]
+{
+  "compilerOptions": {
+    "outDir": "bin"
+  }
+}
+
+
+configFileName:: tsconfig.json
+FileNames::
+/b.ts,/bin/a.ts
+Errors::
+
+
+Fs::
+//// [/b.ts]
+
+
+//// [/bin/a.ts]
+
+
+//// [/tsconfig.json]
+{
+  "extends": "./tsconfigWithConfigDir.json"
+}
+
+//// [/tsconfigWithConfigDir.json]
+{
+  "compilerOptions": {
+    "outDir": "${configDir}/bin"
+  }
+}
+
+
+configFileName:: tsconfig.json
+FileNames::
+/b.ts,/bin/a.ts
+Errors::
+

--- a/tests/baselines/reference/tsc/extends/configDir-template-showConfig.js
+++ b/tests/baselines/reference/tsc/extends/configDir-template-showConfig.js
@@ -136,7 +136,8 @@ Output::
         "/home/src/projects/myproject/src"
     ],
     "exclude": [
-        "outDir"
+        "/home/src/projects/myproject/outDir",
+        "/home/src/projects/myproject/decls"
     ]
 }
 exitCode:: ExitStatus.Success


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/58327