### PR TITLE
Fix ghost errors resulting from out-of-order type checking

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11741,7 +11741,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 type = anyType;
             }
-            links.type = type;
+            links.type ??= type;
         }
         return links.type;
     }
@@ -11763,7 +11763,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 writeType = anyType;
             }
             // Absent an explicit setter type annotation we use the read type of the accessor.
-            links.writeType = writeType || getTypeOfAccessors(symbol);
+            links.writeType ??= writeType || getTypeOfAccessors(symbol);
         }
         return links.writeType;
     }
@@ -11849,7 +11849,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // type symbol, call getDeclaredTypeOfSymbol.
             // This check is important because without it, a call to getTypeOfSymbol could end
             // up recursively calling getTypeOfAlias, causing a stack overflow.
-            links.type = exportSymbol?.declarations && isDuplicatedCommonJSExport(exportSymbol.declarations) && symbol.declarations!.length ? getFlowTypeFromCommonJSExport(exportSymbol)
+            links.type ??= exportSymbol?.declarations && isDuplicatedCommonJSExport(exportSymbol.declarations) && symbol.declarations!.length ? getFlowTypeFromCommonJSExport(exportSymbol)
                 : isDuplicatedCommonJSExport(symbol.declarations) ? autoType
                 : declaredType ? declaredType
                 : getSymbolFlags(targetSymbol) & SymbolFlags.Value ? getTypeOfSymbol(targetSymbol)
@@ -11857,7 +11857,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (!popTypeResolution()) {
                 reportCircularityError(exportSymbol ?? symbol);
-                return links.type = errorType;
+                return links.type ??= errorType;
             }
         }
         return links.type;
@@ -12199,7 +12199,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             if (!popTypeResolution()) {
                 error(type.symbol.valueDeclaration, Diagnostics._0_is_referenced_directly_or_indirectly_in_its_own_base_expression, symbolToString(type.symbol));
-                return type.resolvedBaseConstructorType = errorType;
+                return type.resolvedBaseConstructorType ??= errorType;
             }
             if (!(baseConstructorType.flags & TypeFlags.Any) && baseConstructorType !== nullWideningType && !isConstructorType(baseConstructorType)) {
                 const err = error(baseTypeNode.expression, Diagnostics.Type_0_is_not_a_constructor_function_type, typeToString(baseConstructorType));
@@ -12216,9 +12216,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         addRelatedInfo(err, createDiagnosticForNode(baseConstructorType.symbol.declarations[0], Diagnostics.Did_you_mean_for_0_to_be_constrained_to_type_new_args_Colon_any_1, symbolToString(baseConstructorType.symbol), typeToString(ctorReturn)));
                     }
                 }
-                return type.resolvedBaseConstructorType = errorType;
+                return type.resolvedBaseConstructorType ??= errorType;
             }
-            type.resolvedBaseConstructorType = baseConstructorType;
+            type.resolvedBaseConstructorType ??= baseConstructorType;
         }
         return type.resolvedBaseConstructorType;
     }
@@ -12500,7 +12500,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     error(isNamedDeclaration(declaration) ? declaration.name || declaration : declaration, Diagnostics.Type_alias_0_circularly_references_itself, symbolToString(symbol));
                 }
             }
-            links.declaredType = type;
+            links.declaredType ??= type;
         }
         return links.declaredType;
     }
@@ -13814,7 +13814,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 error(currentNode, Diagnostics.Type_of_property_0_circularly_references_itself_in_mapped_type_1, symbolToString(symbol), typeToString(mappedType));
                 type = errorType;
             }
-            symbol.links.type = type;
+            symbol.links.type ??= type;
         }
         return symbol.links.type;
     }
@@ -14266,7 +14266,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     result = circularConstraintType;
                 }
-                t.immediateBaseConstraint = result || noConstraintType;
+                t.immediateBaseConstraint ??= result || noConstraintType;
             }
             return t.immediateBaseConstraint;
         }
@@ -15824,10 +15824,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
                 map(node.elements, getTypeFromTypeNode);
             if (popTypeResolution()) {
-                type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
+                type.resolvedTypeArguments ??= type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }
             else {
-                type.resolvedTypeArguments = type.target.localTypeParameters?.map(() => errorType) || emptyArray;
+                type.resolvedTypeArguments ??= type.target.localTypeParameters?.map(() => errorType) || emptyArray;
                 error(
                     type.node || currentNode,
                     type.target.symbol ? Diagnostics.Type_arguments_for_0_circularly_reference_themselves : Diagnostics.Tuple_type_arguments_circularly_reference_themselves,
@@ -29080,7 +29080,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return true;
             }
 
-            links.parameterInitializerContainsUndefined = containsUndefined;
+            links.parameterInitializerContainsUndefined ??= containsUndefined;
         }
 
         return links.parameterInitializerContainsUndefined;
@@ -35749,7 +35749,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return cached;
         }
         const saveResolutionStart = resolutionStart;
-        if (saveResolutionStart === 0) {
+        if (!cached) {
             // If we haven't already done so, temporarily reset the resolution stack. This allows us to
             // handle "inverted" situations where, for example, an API client asks for the type of a symbol
             // containined in a function call argument whose contextual type depends on the symbol itself

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23761,6 +23761,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!links.variances) {
             tracing?.push(tracing.Phase.CheckTypes, "getVariancesWorker", { arity: typeParameters.length, id: getTypeId(getDeclaredTypeOfSymbol(symbol)) });
             const oldVarianceComputation = inVarianceComputation;
+            const saveResolutionStart = resolutionStart;
             if (!inVarianceComputation) {
                 inVarianceComputation = true;
                 resolutionStart = resolutionTargets.length;
@@ -23805,7 +23806,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             if (!oldVarianceComputation) {
                 inVarianceComputation = false;
-                resolutionStart = 0;
+                resolutionStart = saveResolutionStart;
             }
             links.variances = variances;
             tracing?.pop({ variances: variances.map(Debug.formatVariance) });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15392,7 +15392,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 type = anyType;
             }
-            signature.resolvedReturnType = type;
+            signature.resolvedReturnType ??= type;
         }
         return signature.resolvedReturnType;
     }

--- a/tests/baselines/reference/circularReferenceInReturnType.errors.txt
+++ b/tests/baselines/reference/circularReferenceInReturnType.errors.txt
@@ -1,13 +1,17 @@
 circularReferenceInReturnType.ts(3,7): error TS7022: 'res1' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+circularReferenceInReturnType.ts(3,18): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 circularReferenceInReturnType.ts(9,7): error TS7022: 'res3' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+circularReferenceInReturnType.ts(9,20): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 
 
-==== circularReferenceInReturnType.ts (2 errors) ====
+==== circularReferenceInReturnType.ts (4 errors) ====
     // inference fails for res1 and res2, but ideally should not
     declare function fn1<T>(cb: () => T): string;
     const res1 = fn1(() => res1);
           ~~~~
 !!! error TS7022: 'res1' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+                     ~~~~~~~~~~
+!!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
     
     declare function fn2<T>(): (cb: () => any) => (a: T) => void;
     const res2 = fn2()(() => res2);
@@ -16,4 +20,6 @@ circularReferenceInReturnType.ts(9,7): error TS7022: 'res3' implicitly has type 
     const res3 = fn3()(() => res3);
           ~~~~
 !!! error TS7022: 'res3' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+                       ~~~~~~~~~~
+!!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
     

--- a/tests/baselines/reference/circularReferenceInReturnType2.errors.txt
+++ b/tests/baselines/reference/circularReferenceInReturnType2.errors.txt
@@ -1,7 +1,8 @@
 circularReferenceInReturnType2.ts(39,7): error TS7022: 'A' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+circularReferenceInReturnType2.ts(41,3): error TS7023: 'fields' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 
 
-==== circularReferenceInReturnType2.ts (1 errors) ====
+==== circularReferenceInReturnType2.ts (2 errors) ====
     type ObjectType<Source> = {
       kind: "object";
       __source: (source: Source) => void;
@@ -45,6 +46,8 @@ circularReferenceInReturnType2.ts(39,7): error TS7022: 'A' implicitly has type '
 !!! error TS7022: 'A' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
       name: "A",
       fields: () => ({
+      ~~~~~~
+!!! error TS7023: 'fields' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
         a: field({
           type: A,
           resolve() {

--- a/tests/baselines/reference/circularReferenceInReturnType2.types
+++ b/tests/baselines/reference/circularReferenceInReturnType2.types
@@ -104,16 +104,16 @@ type Something = { foo: number };
 
 // inference fails here, but ideally should not
 const A = object<Something>()({
->A : any
->  : ^^^
+>A : ObjectType<Something>
+>  : ^^^^^^^^^^^^^^^^^^^^^
 >object<Something>()({  name: "A",  fields: () => ({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }),}) : ObjectType<Something>
 >                                                                                                                                                                    : ^^^^^^^^^^^^^^^^^^^^^
 >object<Something>() : <Fields extends { [Key in keyof Fields]: Field<Something, Key & string>; }>(config: { name: string; fields: Fields | (() => Fields); }) => ObjectType<Something>
 >                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >object : <Source>() => <Fields extends { [Key in keyof Fields]: Field<Source, Key & string>; }>(config: { name: string; fields: Fields | (() => Fields); }) => ObjectType<Source>
 >       : ^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^                                                  ^^^^^^^^^^^^^^^^^^^^^^^
->{  name: "A",  fields: () => ({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }),} : { name: string; fields: () => { a: Field<Something, "a">; }; }
->                                                                                                                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{  name: "A",  fields: () => ({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }),} : { name: string; fields: () => any; }
+>                                                                                                                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   name: "A",
 >name : string
@@ -122,10 +122,10 @@ const A = object<Something>()({
 >    : ^^^
 
   fields: () => ({
->fields : () => { a: Field<Something, "a">; }
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->() => ({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }) : () => { a: Field<Something, "a">; }
->                                                                                                                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fields : () => any
+>       : ^^^^^^^^^
+>() => ({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }) : () => any
+>                                                                                                                      : ^^^^^^^^^
 >({    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  }) : { a: Field<Something, "a">; }
 >                                                                                                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{    a: field({      type: A,      resolve() {        return {          foo: 100,        };      },    }),  } : { a: Field<Something, "a">; }
@@ -138,14 +138,14 @@ const A = object<Something>()({
 >                                                                                                  : ^^^^^^^^^^^^^^^^^^^^^
 >field : <Source, Type extends ObjectType<any>, Key extends string>(field: FieldFuncArgs<Source, Type>) => Field<Source, Key>
 >      : ^      ^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^                           ^^^^^^^^^^^^^^^^^^^^^^^
->{      type: A,      resolve() {        return {          foo: 100,        };      },    } : { type: any; resolve(): { foo: number; }; }
->                                                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{      type: A,      resolve() {        return {          foo: 100,        };      },    } : { type: ObjectType<Something>; resolve(): { foo: number; }; }
+>                                                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
       type: A,
->type : any
->     : ^^^
->A : any
->  : ^^^
+>type : ObjectType<Something>
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>A : ObjectType<Something>
+>  : ^^^^^^^^^^^^^^^^^^^^^
 
       resolve() {
 >resolve : () => { foo: number; }

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
@@ -20,7 +20,7 @@ import self = require("recursiveExportAssignmentAndFindAliasedType7_moduleD");
 
 var selfVar = self;
 >selfVar : any
->self : error
+>self : any
 
 export = selfVar;
 >selfVar : any

--- a/tests/cases/fourslash/issue57429.ts
+++ b/tests/cases/fourslash/issue57429.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+
+//// function Builder<I>(def: I) {
+////   return def;
+//// }
+////
+//// interface IThing {
+////   doThing: (args: { value: object }) => string
+////   doAnotherThing: () => void
+//// }
+////
+//// Builder<IThing>({
+////   doThing(args: { value: object }) {
+////     const { v/*1*/alue } = this.[|args|]
+////     return `${value}`
+////   },
+////   doAnotherThing() { },
+//// })
+
+verify.quickInfoAt("1", "const value: any");
+verify.getSemanticDiagnostics([{
+  message: "Property 'args' does not exist on type 'IThing'.",
+  code: 2339,
+}]);

--- a/tests/cases/fourslash/issue57585-2.ts
+++ b/tests/cases/fourslash/issue57585-2.ts
@@ -1,0 +1,76 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// declare const EffectTypeId: unique symbol;
+////
+//// type Covariant<A> = (_: never) => A;
+////
+//// interface VarianceStruct<out A, out E, out R> {
+////   readonly _V: string;
+////   readonly _A: Covariant<A>;
+////   readonly _E: Covariant<E>;
+////   readonly _R: Covariant<R>;
+//// }
+////
+//// interface Variance<out A, out E, out R> {
+////   readonly [EffectTypeId]: VarianceStruct<A, E, R>;
+//// }
+////
+//// type Success<T extends Effect<any, any, any>> = [T] extends [
+////   Effect<infer _A, infer _E, infer _R>,
+//// ]
+////   ? _A
+////   : never;
+////
+//// declare const YieldWrapTypeId: unique symbol;
+////
+//// class YieldWrap<T> {
+////   readonly #value: T;
+////   constructor(value: T) {
+////     this.#value = value;
+////   }
+////   [YieldWrapTypeId](): T {
+////     return this.#value;
+////   }
+//// }
+////
+//// interface EffectGenerator<T extends Effect<any, any, any>> {
+////   next(...args: ReadonlyArray<any>): IteratorResult<YieldWrap<T>, Success<T>>;
+//// }
+////
+//// interface Effect<out A, out E = never, out R = never>
+////   extends Variance<A, E, R> {
+////   [Symbol.iterator](): EffectGenerator<Effect<A, E, R>>;
+//// }
+////
+//// declare const gen: {
+////   <Eff extends YieldWrap<Effect<any, any, any>>, AEff>(
+////     f: () => Generator<Eff, AEff, never>,
+////   ): Effect<
+////     AEff,
+////     [Eff] extends [never]
+////       ? never
+////       : [Eff] extends [YieldWrap<Effect<infer _A, infer E, infer _R>>]
+////       ? E
+////       : never,
+////     [Eff] extends [never]
+////       ? never
+////       : [Eff] extends [YieldWrap<Effect<infer _A, infer _E, infer R>>]
+////       ? R
+////       : never
+////   >;
+//// };
+////
+//// declare const succeed: <A>(value: A) => Effect<A>;
+////
+//// gen(function* () {
+////   const a = yield* succeed(1);
+////   const b/*1*/ = yield* succeed(2);
+////   return a + b;
+//// });
+
+verify.quickInfoAt("1", "const b: number");
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/issue57585.ts
+++ b/tests/cases/fourslash/issue57585.ts
@@ -1,0 +1,29 @@
+/// <reference path='fourslash.ts'/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// export interface Result<T, E> {
+////   mapErr<F>(fn: (error: E) => F): Result<T, F>;
+////   [Symbol.iterator](): Generator<E, T>;
+//// }
+////
+//// declare const okIfObject: (
+////   value: unknown,
+//// ) => Result<Record<string, unknown>, "ERR_NOT_AN_OBJECT">;
+////
+//// declare const okIfInt: (value: unknown) => Result<number, "ERR_NOT_AN_INT">;
+////
+//// export declare function Do2<T, E>(job: () => Generator<E, T>): void;
+////
+//// declare let value: unknown;
+////
+//// Do2(function* () {
+////   const object = yield* okIfObject(value).mapErr((error) => 0);
+////   const age = yield* okIfInt(object.age).mapErr((error) => 0);
+////   return { age };
+//// });
+
+verify.encodedSemanticClassificationsLength('2020', 132);
+verify.getSemanticDiagnostics([]);


### PR DESCRIPTION
This PR introduces logic that suppresses ghost errors resulting from "inverted" type checking situations where, for example, an API client asks for the type of a symbol in the middle of a section of code, causing type resolution to occur in a different order than when the code is checked from top to bottom in a regular compilation.

Some context on the fix in this PR. In this example

```ts
function builder(def: IThing) {
  return def;
}

interface IThing {
  doThing: (args: { value: object }) => string
  args: { value: number }
}

builder({
  doThing(args: { value: object }) {
    const { value } = this.args;  // Ghost circularity error on "value"
    return `${value}`
  },
  args: { value: 42 }
});
```

a circularity error is reported in the VS Code IDE, but no error is reported with the command-line compiler. The issue is that the IDE language service requests type information on identifiers in the code (likely for semantic classification, but doesn't really matter) _before_ it requests the full list of diagnostics for the code. Specifically, a request is initially made for `getTypeOfSymbol` for the symbol of the `value` identifier. This causes resolution of `this.args`, and to resolve the type of `this`, a request is made for the contextual type of the object literal passed as an argument in the `builder({...})` call. That in turn means we need to resolve the signature for the call, which in turn means resolving the type of the arguments, which in turn means obtaining the type of the `{...}` object literal argument, which further requires resolving the return type of `doThing`, which gets us back to a second `getTypeOfSymbol` call for `value`. And we have a circularity.

However, in the regular top-to-bottom sweep to produce diagnostics, we request resolving the signature of the `builder({...})` call first, which eventually gets us to a `getTypeOfSymbol` for `value`, which in turn requests the contextual type for the object literal. We then see that we're in the process of resolving the signature of the containing `builder({...})` call, and therefore we simply report that there is no contextual type. And thus no circularity.

With the fix in this PR, we temporarily reset the resolution stack during `getResolvedSignature` calls. In the IDE scenario this means that the first call to `getTypeOfSymbol` is no longer reflected on the resolution stack, so resolution can proceed in the same manner as the regular case. Following that, the outer `getTypeOfSymbol` call notices that a resolved type has already been recorded, so it simply proceeds with that. No circularity, and all is well.

Fixes #57429.
Fixes #57585.
