### PR TITLE
fix(58259): getTextOfJSDocComment is stripping # from JSDoc comment

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2122,7 +2122,7 @@ export function entityNameToString(name: EntityNameOrEntityNameExpression | JSDo
                 return Debug.assertNever(name.name);
             }
         case SyntaxKind.JSDocMemberName:
-            return entityNameToString(name.left) + entityNameToString(name.right);
+            return entityNameToString(name.left) + "#" + entityNameToString(name.right);
         case SyntaxKind.JsxNamespacedName:
             return entityNameToString(name.namespace) + ":" + entityNameToString(name.name);
         default:

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -543,4 +543,21 @@ oh.no
             assert.equal((doc?.jsDoc.tags?.[0] as ts.JSDocTemplateTag).typeParameters.length, 0);
         });
     });
+    describe("getTextOfJSDocComment", () => {
+        it("should preserve hash in string representation of JsDocMemberName", () => {
+            const sourceText = `
+/**
+ *
+ * @see {@link foo#bar label}
+ */
+class Foo  {};
+`;
+
+            const root = ts.createSourceFile("foo.ts", sourceText, ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+            const [classDecl] = root.statements;
+            const [seeTag] = ts.getJSDocTags(classDecl);
+
+            assert.equal(ts.getTextOfJSDocComment(seeTag.comment), "{@link foo#bar label}");
+        });
+    });
 });


### PR DESCRIPTION
Fixes #58259