### PR TITLE
RegExp syntax checking performance

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31360,7 +31360,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkGrammarRegularExpressionLiteral(node: RegularExpressionLiteral) {
         const sourceFile = getSourceFileOfNode(node);
-        if (!hasParseDiagnostics(sourceFile)) {
+        if (!hasParseDiagnostics(sourceFile) && !node.isUnterminated) {
             let lastError: DiagnosticWithLocation | undefined;
             scanner ??= createScanner(ScriptTarget.ESNext, /*skipTrivia*/ true);
             scanner.setScriptTarget(sourceFile.languageVersion);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1733,7 +1733,7 @@
         "category": "Error",
         "code": 1519
     },
-    "Expected a class set oprand.": {
+    "Expected a class set operand.": {
         "category": "Error",
         "code": 1520
     },

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2592,10 +2592,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     : '[' ClassSetExpression ']'
         function scanAlternative(isInGroup: boolean) {
             let isPreviousTermQuantifiable = false;
-            while (pos < end) {
+            while (true) {
                 const start = pos;
-                const ch = charCodeUnchecked(pos);
+                const ch = charCodeChecked(pos);
                 switch (ch) {
+                    case CharacterCodes.EOF:
+                        return;
                     case CharacterCodes.caret:
                     case CharacterCodes.$:
                         pos++;
@@ -2760,9 +2762,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         }
 
         function scanPatternModifiers(currFlags: RegularExpressionFlags): RegularExpressionFlags {
-            while (pos < end) {
-                const ch = charCodeUnchecked(pos);
-                if (!isIdentifierPart(ch, languageVersion)) {
+            while (true) {
+                const ch = charCodeChecked(pos);
+                if (ch === CharacterCodes.EOF || !isIdentifierPart(ch, languageVersion)) {
                     break;
                 }
                 const flag = characterToRegularExpressionFlag(String.fromCharCode(ch));
@@ -2921,8 +2923,8 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 // character complement
                 pos++;
             }
-            while (pos < end) {
-                const ch = charCodeUnchecked(pos);
+            while (true) {
+                const ch = charCodeChecked(pos);
                 if (isClassContentExit(ch)) {
                     return;
                 }
@@ -2988,7 +2990,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
             }
             let start = pos;
             let operand!: string;
-            switch (text.slice(pos, pos + 2)) {
+            switch (text.slice(pos, pos + 2)) { // TODO: don't use slice
                 case "--":
                 case "&&":
                     error(Diagnostics.Expected_a_class_set_operand);
@@ -3031,8 +3033,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     expressionMayContainStrings = mayContainStrings;
                     break;
             }
-            while (pos < end) {
-                ch = charCodeUnchecked(pos);
+            while (true) {
+                ch = charCodeChecked(pos);
+                if (ch === CharacterCodes.EOF) {
+                    break;
+                }
                 switch (ch) {
                     case CharacterCodes.minus:
                         pos++;
@@ -3097,7 +3102,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     break;
                 }
                 start = pos;
-                switch (text.slice(pos, pos + 2)) {
+                switch (text.slice(pos, pos + 2)) { // TODO: don't use slice
                     case "--":
                     case "&&":
                         error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos, 2);
@@ -3114,8 +3119,8 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
         function scanClassSetSubExpression(expressionType: ClassSetExpressionType) {
             let expressionMayContainStrings = mayContainStrings;
-            while (pos < end) {
-                let ch = charCodeUnchecked(pos);
+            while (true) {
+                let ch = charCodeChecked(pos);
                 if (isClassContentExit(ch)) {
                     break;
                 }
@@ -3182,6 +3187,8 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         function scanClassSetOperand(): string {
             mayContainStrings = false;
             switch (charCodeChecked(pos)) {
+                case CharacterCodes.EOF:
+                    return "";
                 case CharacterCodes.openBracket:
                     pos++;
                     scanClassSetExpression();
@@ -3216,9 +3223,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         function scanClassStringDisjunctionContents() {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.openBrace);
             let characterCount = 0;
-            while (pos < end) {
-                const ch = charCodeUnchecked(pos);
+            while (true) {
+                const ch = charCodeChecked(pos);
                 switch (ch) {
+                    case CharacterCodes.EOF:
+                        return;
                     case CharacterCodes.closeBrace:
                         if (characterCount !== 1) {
                             mayContainStrings = true;
@@ -3438,9 +3447,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
         function scanWordCharacters(): string {
             let value = "";
-            while (pos < end) {
-                const ch = charCodeUnchecked(pos);
-                if (!isWordCharacter(ch)) {
+            while (true) {
+                const ch = charCodeChecked(pos);
+                if (ch === CharacterCodes.EOF || !isWordCharacter(ch)) {
                     break;
                 }
                 value += String.fromCharCode(ch);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2546,7 +2546,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         /** A stack of scopes for named capturing groups. @see {scanGroupName} */
         var namedCapturingGroupsScopeStack: (Set<string> | undefined)[] = [];
         var topNamedCapturingGroupsScope: Set<string> | undefined;
-
+        /* eslint-enable no-var */
         // Disjunction ::= Alternative ('|' Alternative)*
         function scanDisjunction(isInGroup: boolean) {
             while (true) {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2463,19 +2463,19 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
                 p++;
             }
+            pos = p;
             if (reportErrors) {
-                pos = tokenStart + 1;
-                const saveTokenPos = tokenStart;
+                const saveTokenStart = tokenStart;
                 const saveTokenFlags = tokenFlags;
-                scanRegularExpressionWorker(text, endOfBody, regExpFlags, isUnterminated, /*annexB*/ true);
-                if (!isUnterminated) {
-                    pos = p;
-                }
-                tokenStart = saveTokenPos;
+                const savePos = pos;
+                const saveEnd = end;
+                pos = tokenStart + 1;
+                end = endOfBody;
+                scanRegularExpressionWorker(regExpFlags, isUnterminated, /*annexB*/ true);
+                tokenStart = saveTokenStart;
                 tokenFlags = saveTokenFlags;
-            }
-            else {
-                pos = p;
+                pos = savePos;
+                end = saveEnd;
             }
             tokenValue = text.substring(tokenStart, pos);
             token = SyntaxKind.RegularExpressionLiteral;
@@ -2483,7 +2483,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         return token;
     }
 
-    function scanRegularExpressionWorker(text: string, end: number, regExpFlags: RegularExpressionFlags, isUnterminated: boolean, annexB: boolean) {
+    function scanRegularExpressionWorker(regExpFlags: RegularExpressionFlags, isUnterminated: boolean, annexB: boolean) {
         // Why var? It avoids TDZ checks in the runtime which can be costly.
         // See: https://github.com/microsoft/TypeScript/issues/52924
         /* eslint-disable no-var */

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1109,13 +1109,13 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         return codePointAt(text, pos);
     }
 
-    // /**
-    //  * Returns the code point for the character at the given position within `text`. If
-    //  * `pos` is outside the bounds set for `text`, `CharacterCodes.EOF` is returned instead.
-    //  */
-    // function codePointChecked(pos: number) {
-    //     return pos >= 0 && pos < end ? codePointUnchecked(pos) : CharacterCodes.EOF;
-    // }
+    /**
+     * Returns the code point for the character at the given position within `text`. If
+     * `pos` is outside the bounds set for `text`, `CharacterCodes.EOF` is returned instead.
+     */
+    function codePointChecked(pos: number) {
+        return pos >= 0 && pos < end ? codePointUnchecked(pos) : CharacterCodes.EOF;
+    }
 
     /**
      * Returns the char code for the character at the given position within `text`. This
@@ -1126,13 +1126,13 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         return text.charCodeAt(pos);
     }
 
-    // /**
-    //  * Returns the char code for the character at the given position within `text`. If
-    //  * `pos` is outside the bounds set for `text`, `CharacterCodes.EOF` is returned instead.
-    //  */
-    // function charCodeChecked(pos: number) {
-    //     return pos >= 0 && pos < end ? charCodeUnchecked(pos) : CharacterCodes.EOF;
-    // }
+    /**
+     * Returns the char code for the character at the given position within `text`. If
+     * `pos` is outside the bounds set for `text`, `CharacterCodes.EOF` is returned instead.
+     */
+    function charCodeChecked(pos: number) {
+        return pos >= 0 && pos < end ? charCodeUnchecked(pos) : CharacterCodes.EOF;
+    }
 
     function error(message: DiagnosticMessage): void;
     function error(message: DiagnosticMessage, errPos: number, length: number, arg0?: any): void;
@@ -1325,7 +1325,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
     function scanDigits(): boolean {
         const start = pos;
         let isOctal = true;
-        while (isDigit(charCodeUnchecked(pos))) {
+        while (isDigit(charCodeChecked(pos))) {
             if (!isOctalDigit(charCodeUnchecked(pos))) {
                 isOctal = false;
             }
@@ -2554,7 +2554,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 topNamedCapturingGroupsScope = undefined;
                 scanAlternative(isInGroup);
                 topNamedCapturingGroupsScope = namedCapturingGroupsScopeStack.pop();
-                if (charCodeUnchecked(pos) !== CharacterCodes.bar) {
+                if (charCodeChecked(pos) !== CharacterCodes.bar) {
                     return;
                 }
                 pos++;
@@ -2603,7 +2603,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         break;
                     case CharacterCodes.backslash:
                         pos++;
-                        switch (charCodeUnchecked(pos)) {
+                        switch (charCodeChecked(pos)) {
                             case CharacterCodes.b:
                             case CharacterCodes.B:
                                 pos++;
@@ -2617,9 +2617,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         break;
                     case CharacterCodes.openParen:
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.question) {
+                        if (charCodeChecked(pos) === CharacterCodes.question) {
                             pos++;
-                            switch (charCodeUnchecked(pos)) {
+                            switch (charCodeChecked(pos)) {
                                 case CharacterCodes.equals:
                                 case CharacterCodes.exclamation:
                                     pos++;
@@ -2629,7 +2629,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                                 case CharacterCodes.lessThan:
                                     const groupNameStart = pos;
                                     pos++;
-                                    switch (charCodeUnchecked(pos)) {
+                                    switch (charCodeChecked(pos)) {
                                         case CharacterCodes.equals:
                                         case CharacterCodes.exclamation:
                                             pos++;
@@ -2649,7 +2649,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                                 default:
                                     const start = pos;
                                     const setFlags = scanPatternModifiers(RegularExpressionFlags.None);
-                                    if (charCodeUnchecked(pos) === CharacterCodes.minus) {
+                                    if (charCodeChecked(pos) === CharacterCodes.minus) {
                                         pos++;
                                         scanPatternModifiers(setFlags);
                                         if (pos === start + 1) {
@@ -2673,12 +2673,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         const digitsStart = pos;
                         scanDigits();
                         const min = tokenValue;
-                        if (charCodeUnchecked(pos) === CharacterCodes.comma) {
+                        if (charCodeChecked(pos) === CharacterCodes.comma) {
                             pos++;
                             scanDigits();
                             const max = tokenValue;
                             if (!min) {
-                                if (max || charCodeUnchecked(pos) === CharacterCodes.closeBrace) {
+                                if (max || charCodeChecked(pos) === CharacterCodes.closeBrace) {
                                     error(Diagnostics.Incomplete_quantifier_Digit_expected, digitsStart, 0);
                                 }
                                 else {
@@ -2707,7 +2707,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     case CharacterCodes.plus:
                     case CharacterCodes.question:
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.question) {
+                        if (charCodeChecked(pos) === CharacterCodes.question) {
                             // Non-greedy
                             pos++;
                         }
@@ -2791,10 +2791,10 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | 'k<' RegExpIdentifierName '>'
         function scanAtomEscape() {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.backslash);
-            switch (charCodeUnchecked(pos)) {
+            switch (charCodeChecked(pos)) {
                 case CharacterCodes.k:
                     pos++;
-                    if (charCodeUnchecked(pos) === CharacterCodes.lessThan) {
+                    if (charCodeChecked(pos) === CharacterCodes.lessThan) {
                         pos++;
                         scanGroupName(/*isReference*/ true);
                         scanExpectedChar(CharacterCodes.greaterThan);
@@ -2821,7 +2821,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         // DecimalEscape ::= [1-9] [0-9]*
         function scanDecimalEscape(): boolean {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.backslash);
-            const ch = charCodeUnchecked(pos);
+            const ch = charCodeChecked(pos);
             if (ch >= CharacterCodes._1 && ch <= CharacterCodes._9) {
                 const start = pos;
                 scanDigits();
@@ -2840,11 +2840,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | [~UnicodeMode] (any other non-identifier characters)
         function scanCharacterEscape(atomEscape: boolean): string {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.backslash);
-            let ch = charCodeUnchecked(pos);
+            let ch = charCodeChecked(pos);
             switch (ch) {
                 case CharacterCodes.c:
                     pos++;
-                    ch = charCodeUnchecked(pos);
+                    ch = charCodeChecked(pos);
                     if (isASCIILetter(ch)) {
                         pos++;
                         return String.fromCharCode(ch & 0x1f);
@@ -2881,7 +2881,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     return String.fromCharCode(ch);
                 default:
                     if (pos >= end) {
-                        error(Diagnostics.Undetermined_character_escape, pos - 1, 1, ch);
+                        error(Diagnostics.Undetermined_character_escape, pos - 1, 1);
                         return "\\";
                     }
                     pos--;
@@ -2892,7 +2892,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         function scanGroupName(isReference: boolean) {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.lessThan);
             tokenStart = pos;
-            scanIdentifier(codePointUnchecked(pos), languageVersion);
+            scanIdentifier(codePointChecked(pos), languageVersion);
             if (pos === tokenStart) {
                 error(Diagnostics.Expected_a_capturing_group_name);
             }
@@ -2911,13 +2911,13 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         }
 
         function isClassContentExit(ch: number) {
-            return ch === CharacterCodes.closeBracket || pos >= end;
+            return ch === CharacterCodes.closeBracket || ch === CharacterCodes.EOF || pos >= end;
         }
 
         // ClassRanges ::= '^'? (ClassAtom ('-' ClassAtom)?)*
         function scanClassRanges() {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.openBracket);
-            if (charCodeUnchecked(pos) === CharacterCodes.caret) {
+            if (charCodeChecked(pos) === CharacterCodes.caret) {
                 // character complement
                 pos++;
             }
@@ -2928,9 +2928,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
                 const minStart = pos;
                 const minCharacter = scanClassAtom();
-                if (charCodeUnchecked(pos) === CharacterCodes.minus) {
+                if (charCodeChecked(pos) === CharacterCodes.minus) {
                     pos++;
-                    const ch = charCodeUnchecked(pos);
+                    const ch = charCodeChecked(pos);
                     if (isClassContentExit(ch)) {
                         return;
                     }
@@ -2977,12 +2977,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         function scanClassSetExpression() {
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.openBracket);
             let isCharacterComplement = false;
-            if (charCodeUnchecked(pos) === CharacterCodes.caret) {
+            if (charCodeChecked(pos) === CharacterCodes.caret) {
                 pos++;
                 isCharacterComplement = true;
             }
             let expressionMayContainStrings = false;
-            let ch = charCodeUnchecked(pos);
+            let ch = charCodeChecked(pos);
             if (isClassContentExit(ch)) {
                 return;
             }
@@ -2998,9 +2998,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     operand = scanClassSetOperand();
                     break;
             }
-            switch (charCodeUnchecked(pos)) {
+            switch (charCodeChecked(pos)) {
                 case CharacterCodes.minus:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.minus) {
+                    if (charCodeChecked(pos + 1) === CharacterCodes.minus) {
                         if (isCharacterComplement && mayContainStrings) {
                             error(Diagnostics.Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class, start, pos - start);
                         }
@@ -3011,7 +3011,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     }
                     break;
                 case CharacterCodes.ampersand:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.ampersand) {
+                    if (charCodeChecked(pos + 1) === CharacterCodes.ampersand) {
                         scanClassSetSubExpression(ClassSetExpressionType.ClassIntersection);
                         if (isCharacterComplement && mayContainStrings) {
                             error(Diagnostics.Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class, start, pos - start);
@@ -3036,7 +3036,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 switch (ch) {
                     case CharacterCodes.minus:
                         pos++;
-                        ch = charCodeUnchecked(pos);
+                        ch = charCodeChecked(pos);
                         if (isClassContentExit(ch)) {
                             mayContainStrings = !isCharacterComplement && expressionMayContainStrings;
                             return;
@@ -3079,10 +3079,10 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     case CharacterCodes.ampersand:
                         start = pos;
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.ampersand) {
+                        if (charCodeChecked(pos) === CharacterCodes.ampersand) {
                             pos++;
                             error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos - 2, 2);
-                            if (charCodeUnchecked(pos) === CharacterCodes.ampersand) {
+                            if (charCodeChecked(pos) === CharacterCodes.ampersand) {
                                 error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos, 1, String.fromCharCode(ch));
                                 pos++;
                             }
@@ -3093,7 +3093,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         operand = text.slice(start, pos);
                         continue;
                 }
-                if (isClassContentExit(charCodeUnchecked(pos))) {
+                if (isClassContentExit(charCodeChecked(pos))) {
                     break;
                 }
                 start = pos;
@@ -3123,7 +3123,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 switch (ch) {
                     case CharacterCodes.minus:
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.minus) {
+                        if (charCodeChecked(pos) === CharacterCodes.minus) {
                             pos++;
                             if (expressionType !== ClassSetExpressionType.ClassSubtraction) {
                                 error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos - 2, 2);
@@ -3135,12 +3135,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         break;
                     case CharacterCodes.ampersand:
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.ampersand) {
+                        if (charCodeChecked(pos) === CharacterCodes.ampersand) {
                             pos++;
                             if (expressionType !== ClassSetExpressionType.ClassIntersection) {
                                 error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos - 2, 2);
                             }
-                            if (charCodeUnchecked(pos) === CharacterCodes.ampersand) {
+                            if (charCodeChecked(pos) === CharacterCodes.ampersand) {
                                 error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos, 1, String.fromCharCode(ch));
                                 pos++;
                             }
@@ -3162,7 +3162,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         }
                         break;
                 }
-                ch = charCodeUnchecked(pos);
+                ch = charCodeChecked(pos);
                 if (isClassContentExit(ch)) {
                     error(Diagnostics.Expected_a_class_set_operand);
                     break;
@@ -3181,7 +3181,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | ClassSetCharacter
         function scanClassSetOperand(): string {
             mayContainStrings = false;
-            switch (charCodeUnchecked(pos)) {
+            switch (charCodeChecked(pos)) {
                 case CharacterCodes.openBracket:
                     pos++;
                     scanClassSetExpression();
@@ -3192,9 +3192,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     if (scanCharacterClassEscape()) {
                         return "";
                     }
-                    else if (charCodeUnchecked(pos) === CharacterCodes.q) {
+                    else if (charCodeChecked(pos) === CharacterCodes.q) {
                         pos++;
-                        if (charCodeUnchecked(pos) === CharacterCodes.openBrace) {
+                        if (charCodeChecked(pos) === CharacterCodes.openBrace) {
                             pos++;
                             scanClassStringDisjunctionContents();
                             scanExpectedChar(CharacterCodes.closeBrace);
@@ -3244,10 +3244,14 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | SourceCharacter -- ClassSetSyntaxCharacter -- ClassSetReservedDoublePunctuator
         //     | '\' (CharacterEscape | ClassSetReservedPunctuator | 'b')
         function scanClassSetCharacter(): string {
-            const ch = charCodeUnchecked(pos);
+            const ch = charCodeChecked(pos);
+            if (ch === CharacterCodes.EOF) {
+                // no need to report an error, the initial scan will already have reported that the RegExp is unterminated.
+                return "";
+            }
             if (ch === CharacterCodes.backslash) {
                 pos++;
-                const ch = charCodeUnchecked(pos);
+                const ch = charCodeChecked(pos);
                 switch (ch) {
                     case CharacterCodes.b:
                         pos++;
@@ -3272,7 +3276,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         return scanCharacterEscape(/*atomEscape*/ false);
                 }
             }
-            else if (ch === charCodeUnchecked(pos + 1)) {
+            else if (ch === charCodeChecked(pos + 1)) {
                 switch (ch) {
                     case CharacterCodes.ampersand:
                     case CharacterCodes.exclamation:
@@ -3322,9 +3326,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | CharacterClassEscape
         //     | CharacterEscape
         function scanClassAtom(): string {
-            if (charCodeUnchecked(pos) === CharacterCodes.backslash) {
+            if (charCodeChecked(pos) === CharacterCodes.backslash) {
                 pos++;
-                const ch = charCodeUnchecked(pos);
+                const ch = charCodeChecked(pos);
                 switch (ch) {
                     case CharacterCodes.b:
                         pos++;
@@ -3351,7 +3355,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
             Debug.assertEqual(charCodeUnchecked(pos - 1), CharacterCodes.backslash);
             let isCharacterComplement = false;
             const start = pos - 1;
-            const ch = charCodeUnchecked(pos);
+            const ch = charCodeChecked(pos);
             switch (ch) {
                 case CharacterCodes.d:
                 case CharacterCodes.D:
@@ -3366,11 +3370,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 // falls through
                 case CharacterCodes.p:
                     pos++;
-                    if (charCodeUnchecked(pos) === CharacterCodes.openBrace) {
+                    if (charCodeChecked(pos) === CharacterCodes.openBrace) {
                         pos++;
                         const propertyNameOrValueStart = pos;
                         const propertyNameOrValue = scanWordCharacters();
-                        if (charCodeUnchecked(pos) === CharacterCodes.equals) {
+                        if (charCodeChecked(pos) === CharacterCodes.equals) {
                             const propertyName = nonBinaryUnicodeProperties.get(propertyNameOrValue);
                             if (pos === propertyNameOrValueStart) {
                                 error(Diagnostics.Expected_a_Unicode_property_name);
@@ -3446,13 +3450,13 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         }
 
         function scanSourceCharacter(): string {
-            const size = unicodeMode ? charSize(codePointUnchecked(pos)) : 1;
+            const size = unicodeMode ? charSize(charCodeChecked(pos)) : 1;
             pos += size;
-            return text.substring(pos - size, pos);
+            return size > 0 ? text.substring(pos - size, pos) : "";
         }
 
         function scanExpectedChar(ch: CharacterCodes) {
-            if (charCodeUnchecked(pos) === ch) {
+            if (charCodeChecked(pos) === ch) {
                 pos++;
             }
             else {
@@ -3788,7 +3792,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
         if (isIdentifierStart(ch, languageVersion)) {
             let char = ch;
-            while (pos < end && isIdentifierPart(char = codePointUnchecked(pos), languageVersion) || charCodeUnchecked(pos) === CharacterCodes.minus) pos += charSize(char);
+            while (pos < end && isIdentifierPart(char = codePointUnchecked(pos), languageVersion) || char === CharacterCodes.minus) pos += charSize(char);
             tokenValue = text.substring(tokenStart, pos);
             if (char === CharacterCodes.backslash) {
                 tokenValue += scanIdentifierParts();
@@ -3912,6 +3916,9 @@ function codePointAt(s: string, i: number): number {
 function charSize(ch: number) {
     if (ch >= 0x10000) {
         return 2;
+    }
+    if (ch === CharacterCodes.EOF) {
+        return 0;
     }
     return 1;
 }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2946,15 +2946,15 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 return;
             }
             let start = pos;
-            let oprand!: string;
+            let operand!: string;
             switch (text.slice(pos, pos + 2)) {
                 case "--":
                 case "&&":
-                    error(Diagnostics.Expected_a_class_set_oprand);
+                    error(Diagnostics.Expected_a_class_set_operand);
                     mayContainStrings = false;
                     break;
                 default:
-                    oprand = scanClassSetOprand();
+                    operand = scanClassSetOperand();
                     break;
             }
             switch (text.charCodeAt(pos)) {
@@ -3004,31 +3004,31 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                             pos++;
                             error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos - 2, 2);
                             start = pos - 2;
-                            oprand = text.slice(start, pos);
+                            operand = text.slice(start, pos);
                             continue;
                         }
                         else {
-                            if (!oprand) {
+                            if (!operand) {
                                 error(Diagnostics.A_character_class_range_must_not_be_bounded_by_another_character_class, start, pos - 1 - start);
                             }
                             const secondStart = pos;
-                            const secondOprand = scanClassSetOprand();
+                            const secondOperand = scanClassSetOperand();
                             if (isCharacterComplement && mayContainStrings) {
                                 error(Diagnostics.Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class, secondStart, pos - secondStart);
                             }
                             expressionMayContainStrings ||= mayContainStrings;
-                            if (!secondOprand) {
+                            if (!secondOperand) {
                                 error(Diagnostics.A_character_class_range_must_not_be_bounded_by_another_character_class, secondStart, pos - secondStart);
                                 break;
                             }
-                            if (!oprand) {
+                            if (!operand) {
                                 break;
                             }
-                            const minCharacterValue = codePointAt(oprand, 0);
-                            const maxCharacterValue = codePointAt(secondOprand, 0);
+                            const minCharacterValue = codePointAt(operand, 0);
+                            const maxCharacterValue = codePointAt(secondOperand, 0);
                             if (
-                                oprand.length === charSize(minCharacterValue) &&
-                                secondOprand.length === charSize(maxCharacterValue) &&
+                                operand.length === charSize(minCharacterValue) &&
+                                secondOperand.length === charSize(maxCharacterValue) &&
                                 minCharacterValue > maxCharacterValue
                             ) {
                                 error(Diagnostics.Range_out_of_order_in_character_class, start, pos - start);
@@ -3049,7 +3049,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         else {
                             error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos - 1, 1, String.fromCharCode(ch));
                         }
-                        oprand = text.slice(start, pos);
+                        operand = text.slice(start, pos);
                         continue;
                 }
                 if (isClassContentExit(text.charCodeAt(pos))) {
@@ -3061,10 +3061,10 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     case "&&":
                         error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos, 2);
                         pos += 2;
-                        oprand = text.slice(start, pos);
+                        operand = text.slice(start, pos);
                         break;
                     default:
-                        oprand = scanClassSetOprand();
+                        operand = scanClassSetOperand();
                         break;
                 }
             }
@@ -3123,10 +3123,10 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
                 ch = text.charCodeAt(pos);
                 if (isClassContentExit(ch)) {
-                    error(Diagnostics.Expected_a_class_set_oprand);
+                    error(Diagnostics.Expected_a_class_set_operand);
                     break;
                 }
-                scanClassSetOprand();
+                scanClassSetOperand();
                 // Used only if expressionType is Intersection
                 expressionMayContainStrings &&= mayContainStrings;
             }
@@ -3138,7 +3138,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         //     | '\' CharacterClassEscape
         //     | '\q{' ClassStringDisjunctionContents '}'
         //     | ClassSetCharacter
-        function scanClassSetOprand(): string {
+        function scanClassSetOperand(): string {
             mayContainStrings = false;
             switch (text.charCodeAt(pos)) {
                 case CharacterCodes.openBracket:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7612,6 +7612,7 @@ export type CommandLineOption = CommandLineOptionOfCustomType | CommandLineOptio
 // dprint-ignore
 /** @internal */
 export const enum CharacterCodes {
+    EOF = -1,
     nullCharacter = 0,
     maxAsciiCharacter = 0x7F,
 

--- a/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
@@ -157,8 +157,8 @@ regularExpressionScanning.ts(37,61): error TS1508: Unexpected '}'. Did you mean 
 regularExpressionScanning.ts(37,63): error TS1517: Range out of order in character class.
 regularExpressionScanning.ts(37,76): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(38,8): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,9): error TS1520: Expected a class set oprand.
-regularExpressionScanning.ts(38,11): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,9): error TS1520: Expected a class set operand.
+regularExpressionScanning.ts(38,11): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,12): error TS1005: '--' expected.
 regularExpressionScanning.ts(38,15): error TS1522: A character class must not contain a reserved double punctuator. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,20): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
@@ -166,15 +166,15 @@ regularExpressionScanning.ts(38,28): error TS1519: Operators must not be mixed w
 regularExpressionScanning.ts(38,40): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,47): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,49): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
-regularExpressionScanning.ts(38,50): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,50): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,55): error TS1511: '\q' is only available inside character class.
 regularExpressionScanning.ts(38,57): error TS1508: Unexpected '{'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,61): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,66): error TS1508: Unexpected '-'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,67): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,70): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,70): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,75): error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
-regularExpressionScanning.ts(38,85): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,85): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,87): error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
@@ -561,9 +561,9 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	      
 !!! error TS1005: '--' expected.
     	       
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	         
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	          
 !!! error TS1005: '--' expected.
     	             ~~
@@ -579,7 +579,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                               ~
 !!! error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
     	                                                
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                     ~~
 !!! error TS1511: '\q' is only available inside character class.
     	                                                       ~
@@ -591,11 +591,11 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                 
 !!! error TS1005: '--' expected.
     	                                                                    
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                                         ~
 !!! error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
     	                                                                                   
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                                                     ~
 !!! error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
     	/[[^\P{Decimal_Number}&&[0-9]]&&\p{L}&&\p{ID_Continue}--\p{ASCII}\p{CWCF}]/v,

--- a/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
@@ -164,8 +164,8 @@ regularExpressionScanning.ts(37,63): error TS1517: Range out of order in charact
 regularExpressionScanning.ts(37,76): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(37,87): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
 regularExpressionScanning.ts(38,8): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,9): error TS1520: Expected a class set oprand.
-regularExpressionScanning.ts(38,11): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,9): error TS1520: Expected a class set operand.
+regularExpressionScanning.ts(38,11): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,12): error TS1005: '--' expected.
 regularExpressionScanning.ts(38,15): error TS1522: A character class must not contain a reserved double punctuator. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,20): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
@@ -173,15 +173,15 @@ regularExpressionScanning.ts(38,28): error TS1519: Operators must not be mixed w
 regularExpressionScanning.ts(38,40): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,47): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,49): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
-regularExpressionScanning.ts(38,50): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,50): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,55): error TS1511: '\q' is only available inside character class.
 regularExpressionScanning.ts(38,57): error TS1508: Unexpected '{'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,61): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,66): error TS1508: Unexpected '-'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,67): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,70): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,70): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,75): error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
-regularExpressionScanning.ts(38,85): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,85): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,87): error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
@@ -582,9 +582,9 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	      
 !!! error TS1005: '--' expected.
     	       
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	         
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	          
 !!! error TS1005: '--' expected.
     	             ~~
@@ -600,7 +600,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                               ~
 !!! error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
     	                                                
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                     ~~
 !!! error TS1511: '\q' is only available inside character class.
     	                                                       ~
@@ -612,11 +612,11 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                 
 !!! error TS1005: '--' expected.
     	                                                                    
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                                         ~
 !!! error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
     	                                                                                   
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                                                     ~
 !!! error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
     	/[[^\P{Decimal_Number}&&[0-9]]&&\p{L}&&\p{ID_Continue}--\p{ASCII}\p{CWCF}]/v,

--- a/tests/baselines/reference/regularExpressionScanning(target=esnext).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=esnext).errors.txt
@@ -141,8 +141,8 @@ regularExpressionScanning.ts(37,61): error TS1508: Unexpected '}'. Did you mean 
 regularExpressionScanning.ts(37,63): error TS1517: Range out of order in character class.
 regularExpressionScanning.ts(37,76): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(38,8): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,9): error TS1520: Expected a class set oprand.
-regularExpressionScanning.ts(38,11): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,9): error TS1520: Expected a class set operand.
+regularExpressionScanning.ts(38,11): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,12): error TS1005: '--' expected.
 regularExpressionScanning.ts(38,15): error TS1522: A character class must not contain a reserved double punctuator. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,20): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
@@ -150,15 +150,15 @@ regularExpressionScanning.ts(38,28): error TS1519: Operators must not be mixed w
 regularExpressionScanning.ts(38,40): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,47): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(38,49): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
-regularExpressionScanning.ts(38,50): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,50): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,55): error TS1511: '\q' is only available inside character class.
 regularExpressionScanning.ts(38,57): error TS1508: Unexpected '{'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,61): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,66): error TS1508: Unexpected '-'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(38,67): error TS1005: '--' expected.
-regularExpressionScanning.ts(38,70): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,70): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,75): error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
-regularExpressionScanning.ts(38,85): error TS1520: Expected a class set oprand.
+regularExpressionScanning.ts(38,85): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
 regularExpressionScanning.ts(41,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -503,9 +503,9 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
     	      
 !!! error TS1005: '--' expected.
     	       
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	         
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	          
 !!! error TS1005: '--' expected.
     	             ~~
@@ -521,7 +521,7 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
     	                                               ~
 !!! error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
     	                                                
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                     ~~
 !!! error TS1511: '\q' is only available inside character class.
     	                                                       ~
@@ -533,11 +533,11 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
     	                                                                 
 !!! error TS1005: '--' expected.
     	                                                                    
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	                                                                         ~
 !!! error TS1508: Unexpected '&'. Did you mean to escape it with backslash?
     	                                                                                   
-!!! error TS1520: Expected a class set oprand.
+!!! error TS1520: Expected a class set operand.
     	/[[^\P{Decimal_Number}&&[0-9]]&&\p{L}&&\p{ID_Continue}--\p{ASCII}\p{CWCF}]/v,
     	                                                      ~~
 !!! error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.


### PR DESCRIPTION
This makes a few changes to the RegExp syntax checking algorithm for possible performance improvements. This also fixes a small typo in one of the RegExp diagnostic messages.

One of the changes is to ensure we perform proper bounds checks when `pos` might advance past `end`. To accomplish this, I added the `charCodeChecked` and `charCodeUnchecked` functions. `charCodeChecked` performs boundary tests which both improves reliability and avoids potential deoptimizations due to reading past the end of a string. `charCodeUnchecked` is simply a wrapper for `text.charCodeAt` and exists primarily to make it easier to readily identify unchecked vs checked reads from `text`. `charCodeUnchecked` should only be used when we've already performed a bounds check before reading a character, such as in a `while (pos < end)` loop. I've also done the same for code points with `codePointChecked` and `codePointUnchecked`. Each of these functions is small, so ideally will be inlined by an optimizing compiler like the one used by V8.

I've primarily focused on optimizing `scanRegularExpressionWorker` for now. If this seems effective, I will investigate adopting `charCodeChecked` in more places in the scanner in a later PR.

I've also made a few other small perf improvements:
- We now delay allocations for capture group tracking until they are necessary.
- `scanRegularExpressionWorker` has been moved out of `reScanSlashToken` and updated to use the existing `text` and `end` values from the outer scope.
- A few frequently referenced variables from the RegExp scanner have been switched to `var` to avoid TDZ check overhead.