### PR TITLE
Ensure equal FileIncludeReasons are not duplicitively added

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -83,6 +83,7 @@ import {
     fileExtensionIsOneOf,
     FileIncludeKind,
     FileIncludeReason,
+    fileIncludeReasonIsEqual,
     fileIncludeReasonToDiagnostics,
     FilePreprocessingDiagnostics,
     FilePreprocessingDiagnosticsKind,
@@ -3797,7 +3798,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     }
 
     function addFileIncludeReason(file: SourceFile | undefined, reason: FileIncludeReason) {
-        if (file) fileReasons.add(file.path, reason);
+        if (file) {
+            const existing = fileReasons.get(file.path);
+            if (some(existing, r => fileIncludeReasonIsEqual(r, reason))) return;
+            fileReasons.add(file.path, reason);
+        }
     }
 
     function addFileToFilesByName(file: SourceFile | undefined, path: Path, fileName: string, redirectedPath: Path | undefined) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4598,6 +4598,8 @@ export interface AutomaticTypeDirectiveFile {
     packageId: PackageId | undefined;
 }
 
+// Note: if updating FileIncludeReason, ensure fileIncludeReasonIsEqual is also updated.
+
 /** @internal */
 export type FileIncludeReason =
     | RootFile

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -24,6 +24,7 @@ import {
     AssignmentDeclarationKind,
     AssignmentExpression,
     AssignmentOperatorToken,
+    AutomaticTypeDirectiveFile,
     BarBarEqualsToken,
     BinaryExpression,
     binarySearch,
@@ -136,6 +137,8 @@ import {
     FileExtensionInfo,
     fileExtensionIs,
     fileExtensionIsOneOf,
+    FileIncludeKind,
+    FileIncludeReason,
     FileWatcher,
     filter,
     find,
@@ -399,6 +402,7 @@ import {
     lastOrUndefined,
     LateVisibilityPaintedStatement,
     length,
+    LibFile,
     LiteralImportTypeNode,
     LiteralLikeElementAccessExpression,
     LiteralLikeNode,
@@ -466,6 +470,7 @@ import {
     PrintHandlers,
     PrivateIdentifier,
     ProjectReference,
+    ProjectReferenceFile,
     PrologueDirective,
     PropertyAccessEntityNameExpression,
     PropertyAccessExpression,
@@ -481,6 +486,7 @@ import {
     QuestionQuestionEqualsToken,
     ReadonlyCollection,
     ReadonlyTextRange,
+    ReferencedFile,
     removeTrailingDirectorySeparator,
     RequireOrImportCall,
     RequireVariableStatement,
@@ -492,6 +498,7 @@ import {
     returnFalse,
     ReturnStatement,
     returnUndefined,
+    RootFile,
     SatisfiesExpression,
     ScriptKind,
     ScriptTarget,
@@ -850,6 +857,36 @@ export function typeDirectiveIsEqualTo(oldResolution: ResolvedTypeReferenceDirec
             oldResolution.resolvedTypeReferenceDirective.resolvedFileName === newResolution.resolvedTypeReferenceDirective.resolvedFileName &&
             !!oldResolution.resolvedTypeReferenceDirective.primary === !!newResolution.resolvedTypeReferenceDirective.primary &&
             oldResolution.resolvedTypeReferenceDirective.originalPath === newResolution.resolvedTypeReferenceDirective.originalPath;
+}
+
+/** @internal */
+export function fileIncludeReasonIsEqual(a: FileIncludeReason, b: FileIncludeReason): boolean {
+    if (a === b) return true;
+    if (a.kind !== b.kind) return false;
+
+    switch (a.kind) {
+        case FileIncludeKind.RootFile:
+            Debug.type<RootFile>(b);
+            return a.index === b.index;
+        case FileIncludeKind.LibFile:
+            Debug.type<LibFile>(b);
+            return a.index === b.index;
+        case FileIncludeKind.SourceFromProjectReference:
+        case FileIncludeKind.OutputFromProjectReference:
+            Debug.type<ProjectReferenceFile>(b);
+            return a.index === b.index;
+        case FileIncludeKind.Import:
+        case FileIncludeKind.ReferenceFile:
+        case FileIncludeKind.TypeReferenceDirective:
+        case FileIncludeKind.LibReferenceDirective:
+            Debug.type<ReferencedFile>(b);
+            return a.file === b.file && a.index === b.index;
+        case FileIncludeKind.AutomaticTypeDirectiveFile:
+            Debug.type<AutomaticTypeDirectiveFile>(b);
+            return a.typeReference === b.typeReference && packageIdIsEqual(a.packageId, b.packageId);
+        default:
+            return Debug.assertNever(a);
+    }
 }
 
 /** @internal */

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-errors.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-errors.js
@@ -80,7 +80,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-in-host-configuration.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-in-host-configuration.js
@@ -107,7 +107,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options.js
@@ -78,7 +78,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'


### PR DESCRIPTION
When we add file include reasons, they're effectively just stored per file path in a big list (a MultiMap). When we reuse a program, we keep using that same list, but may rediscover the same files over and over again, pushing more and more into that mapping.

Whenever we call `createDiagnosticExplainingFile`, we search through the file include reasons and include them in the related info. In the case of `forceConsistentCasingInFileNames`, we'll build a potentially massive diagnostic that references these other files.

Now, imagine the intersection of the two; I'm in eslint with a watch program, `forceConsistentCasingInFileNames` is the new default, but its diagnostics are never given to anyone. Maybe a file with the wrong case is queried over and over as the user types, it keeps getting added to a reused fileReasons map, then the `forceConsistentCasingInFileNames` just keeps building bigger and bigger diagnostics.

If we ensure that `fileReason` doesn't duplicitively include reasons, we avoid the blowup. It's still not great that there are bigish diagnostics, or that clients may query using a different path, etc, but I think this may handle the OOM. And the baseline change shows that duplication removes some errors.

It's also worth noting that `DiagnosticCollection` doesn't seem to handle deduplicating these diagnostics at all, probably due to the duplication or differing orders. But, it may after this PR? (Hard to observe.)

Relatd:

- https://github.com/microsoft/TypeScript/issues/58011
- https://github.com/typescript-eslint/typescript-eslint/issues/1192
- https://github.com/microsoft/TypeScript/issues/58274