### PR TITLE
Move all js emit alias marking behavior behind a single entrypoint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29257,7 +29257,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isThisIdentifier(left) || !isIdentifier(left)) {
             return;
         }
-        const right = isPropertyAccessExpression(location) ? location.name : location.right;
         const leftType = parentType || checkExpressionCached(left);
         const parentSymbol = getNodeLinks(left).resolvedSymbol;
         if (!parentSymbol || parentSymbol === unknownSymbol) {
@@ -29283,6 +29282,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         let prop = propSymbol;
         if (!prop && !parentType) {
+            const right = isPropertyAccessExpression(location) ? location.name : location.right;
             const lexicallyScopedSymbol = isPrivateIdentifier(right) && lookupSymbolForPrivateIdentifierDeclaration(right.escapedText, right);
             const assignmentKind = getAssignmentTargetKind(location);
             const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(location) ? getWidenedType(leftType) : leftType);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1112,6 +1112,18 @@ import * as performance from "./_namespaces/ts.performance";
 const ambientModuleSymbolRegex = /^".+"$/;
 const anon = "(anonymous)" as __String & string;
 
+const enum ReferenceHint {
+    Unspecified,
+    Identifier,
+    Property,
+    ExportAssignment,
+    Jsx,
+    AsyncFunction,
+    ExportImportEquals,
+    ExportSpecifier,
+    Decorator,
+}
+
 let nextSymbolId = 1;
 let nextNodeId = 1;
 let nextMergeId = 1;
@@ -29137,18 +29149,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             return false;
         });
-    }
-
-    enum ReferenceHint {
-        Unspecified,
-        Identifier,
-        Property,
-        ExportAssignment,
-        Jsx,
-        AsyncFunction,
-        ExportImportEquals,
-        ExportSpecifier,
-        Decorator,
     }
 
     /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29379,7 +29379,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isInternalModuleImportEqualsDeclaration(node)) {
                 if (getSymbolFlags(resolveSymbol(symbol)) & SymbolFlags.Value) {
                     // import foo = <symbol>
-                    checkExpressionCached(node.moduleReference as Expression);
+                    const left = getFirstIdentifier(node.moduleReference as EntityNameExpression);
+                    markIdentifierAliasReferenced(left);
                 }
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29140,9 +29140,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     /**
+     * This function marks all the imports the given location refers to as `.referenced` in `NodeLinks` (transitively through local import aliases).
+     * (This corresponds to not getting elided in JS emit.)
+     * It can be called on *most* nodes in the AST and will filter its inputs, but care should be taken to avoid calling it on the RHS of an `import =` or specifiers in a `import {} from "..."`,
+     * unless you *really* want to *definitely* mark those as referenced.
+     * These shouldn't be directly marked, and should only get marked transitively by the internals of this function.
+     *
      * @param location The location to mark js import refernces for
      * @param propSymbol The optional symbol of the property we're looking up - this is used for property accesses when `const enum`s do not count as references (no `isolatedModules`, no `preserveConstEnums` + export). It will be calculated if not provided.
-     * @param parentType The optional type of the parent of the LHS of the property access - this will be recalculated if not provided.
+     * @param parentType The optional type of the parent of the LHS of the property access - this will be recalculated if not provided (but is costly).
      */
     function markLinkedReferences(location: Node, propSymbol?: Symbol, parentType?: Type) {
         if (!canCollectSymbolAliasAccessabilityData) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29259,7 +29259,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const right = isPropertyAccessExpression(location) ? location.name : location.right;
         const assignmentKind = getAssignmentTargetKind(location);
-        const leftType = parentType || checkExpression(left); // cannot use checkExpressionCached - causes stack overflow in control flow due to resetting the control flow state
+        const leftType = parentType || checkExpressionCached(left);
         const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(location) ? getWidenedType(leftType) : leftType);
         const parentSymbol = getNodeLinks(left).resolvedSymbol;
         if (!parentSymbol || parentSymbol === unknownSymbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29258,9 +29258,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return;
         }
         const right = isPropertyAccessExpression(location) ? location.name : location.right;
-        const assignmentKind = getAssignmentTargetKind(location);
         const leftType = parentType || checkExpressionCached(left);
-        const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(location) ? getWidenedType(leftType) : leftType);
         const parentSymbol = getNodeLinks(left).resolvedSymbol;
         if (!parentSymbol || parentSymbol === unknownSymbol) {
             return;
@@ -29286,6 +29284,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let prop = propSymbol;
         if (!prop && !parentType) {
             const lexicallyScopedSymbol = isPrivateIdentifier(right) && lookupSymbolForPrivateIdentifierDeclaration(right.escapedText, right);
+            const assignmentKind = getAssignmentTargetKind(location);
+            const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(location) ? getWidenedType(leftType) : leftType);
             prop = isPrivateIdentifier(right) ? lexicallyScopedSymbol && getPrivateIdentifierPropertyOfType(apparentType, lexicallyScopedSymbol) || undefined : getPropertyOfType(apparentType, right.escapedText);
         }
         if (

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29176,6 +29176,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!canCollectSymbolAliasAccessabilityData) {
             return;
         }
+        if (location.flags & NodeFlags.Ambient) {
+            return; // References within types and declaration files are never going to contribute to retaining a JS import
+        }
         switch (hint) {
             case ReferenceHint.Identifier:
                 return markIdentifierAliasReferenced(location as Identifier);

--- a/tests/baselines/reference/importDeclWithDeclareModifier.errors.txt
+++ b/tests/baselines/reference/importDeclWithDeclareModifier.errors.txt
@@ -1,9 +1,8 @@
 importDeclWithDeclareModifier.ts(5,9): error TS1029: 'export' modifier must precede 'declare' modifier.
-importDeclWithDeclareModifier.ts(5,27): error TS2708: Cannot use namespace 'x' as a value.
 importDeclWithDeclareModifier.ts(5,29): error TS2694: Namespace 'x' has no exported member 'c'.
 
 
-==== importDeclWithDeclareModifier.ts (3 errors) ====
+==== importDeclWithDeclareModifier.ts (2 errors) ====
     module x {
         interface c {
         }
@@ -11,8 +10,6 @@ importDeclWithDeclareModifier.ts(5,29): error TS2694: Namespace 'x' has no expor
     declare export import a = x.c;
             ~~~~~~
 !!! error TS1029: 'export' modifier must precede 'declare' modifier.
-                              ~
-!!! error TS2708: Cannot use namespace 'x' as a value.
                                 ~
 !!! error TS2694: Namespace 'x' has no exported member 'c'.
     var b: a;

--- a/tests/baselines/reference/moduleImport.errors.txt
+++ b/tests/baselines/reference/moduleImport.errors.txt
@@ -1,12 +1,9 @@
-moduleImport.ts(2,17): error TS2339: Property 'Y' does not exist on type 'typeof X'.
 moduleImport.ts(2,17): error TS2694: Namespace 'X' has no exported member 'Y'.
 
 
-==== moduleImport.ts (2 errors) ====
+==== moduleImport.ts (1 errors) ====
     module A.B.C {
     	import XYZ = X.Y.Z;
-    	               ~
-!!! error TS2339: Property 'Y' does not exist on type 'typeof X'.
     	               ~
 !!! error TS2694: Namespace 'X' has no exported member 'Y'.
     	export function ping(x: number) {

--- a/tests/baselines/reference/reexportedMissingAlias.errors.txt
+++ b/tests/baselines/reference/reexportedMissingAlias.errors.txt
@@ -1,11 +1,8 @@
-second.d.ts(1,27): error TS2304: Cannot find name 'CompletelyMissing'.
 second.d.ts(1,27): error TS2503: Cannot find namespace 'CompletelyMissing'.
 
 
-==== second.d.ts (2 errors) ====
+==== second.d.ts (1 errors) ====
     export import Component = CompletelyMissing;
-                              ~~~~~~~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'CompletelyMissing'.
                               ~~~~~~~~~~~~~~~~~
 !!! error TS2503: Cannot find namespace 'CompletelyMissing'.
 ==== first.d.ts (0 errors) ====


### PR DESCRIPTION
This is one of the two bigger checker refactors in #58364 - by validating its' perf separately, I can narrow down the perf regression there (and possibly simplify merging it by getting this merged separately).