### PR TITLE
Validate the options passed in are numbers instead of strings for our custom commandline options 

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1639,6 +1639,12 @@ export const configDirTemplateSubstitutionWatchOptions: readonly CommandLineOpti
     option => option.allowConfigDirTemplateSubstitution || (!option.isCommandLineOnly && option.isFilePath),
 );
 
+/** @internal */
+export const commandLineOptionOfCustomType: readonly CommandLineOptionOfCustomType[] = optionDeclarations.filter(isCommandLineOptionOfCustomType);
+function isCommandLineOptionOfCustomType(option: CommandLineOption): option is CommandLineOptionOfCustomType {
+    return !isString(option.type);
+}
+
 // Build related options
 /** @internal */
 export const optionsForBuild: CommandLineOption[] = [

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1553,7 +1553,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     let { oldProgram } = createProgramOptions;
     for (const option of commandLineOptionOfCustomType) {
         if (hasProperty(options, option.name)) {
-            if (typeof options[option.name] === "string") throw new Error(`Found option: ${option.name} that is string and expected number/enum value.`);
+            if (typeof options[option.name] === "string") {
+                throw new Error(`${option.name} is a string value; tsconfig JSON must be parsed with parseJsonSourceFileConfigFileContent or getParsedCommandLineOfConfigFile before passing to createProgram`);
+            }
         }
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -15,6 +15,7 @@ import {
     changesAffectingProgramStructure,
     changesAffectModuleResolution,
     combinePaths,
+    commandLineOptionOfCustomType,
     CommentDirective,
     CommentDirectivesMap,
     compareDataObjects,
@@ -1550,6 +1551,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     const createProgramOptions = isArray(rootNamesOrOptions) ? createCreateProgramOptions(rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : rootNamesOrOptions; // TODO: GH#18217
     const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion } = createProgramOptions;
     let { oldProgram } = createProgramOptions;
+    for (const option of commandLineOptionOfCustomType) {
+        if (hasProperty(options, option.name)) {
+            if (typeof options[option.name] === "string") throw new Error(`Found option: ${option.name} that is string and expected number/enum value.`);
+        }
+    }
 
     const reportInvalidIgnoreDeprecations = memoize(() => createOptionValueDiagnostic("ignoreDeprecations", Diagnostics.Invalid_value_for_ignoreDeprecations));
 

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -317,7 +317,7 @@ describe("unittests:: Public APIs:: createProgram", () => {
             /*setParentNodes*/ undefined,
             sys,
         );
-        assert.doesNotThrow(() =>
+        (useJsonParsingApi ? assert.doesNotThrow : assert.throws)(() =>
             ts.createProgram({
                 rootNames: commandLine.fileNames,
                 options: useJsonParsingApi ? commandLine.options : config.compilerOptions,

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -3,6 +3,9 @@ import * as fakes from "../_namespaces/fakes";
 import * as Harness from "../_namespaces/Harness";
 import * as ts from "../_namespaces/ts";
 import * as vfs from "../_namespaces/vfs";
+import { jsonToReadableText } from "./helpers";
+import { libContent } from "./helpers/contents";
+import { loadProjectFromFiles } from "./helpers/vfs";
 
 describe("unittests:: Public APIs", () => {
     function verifyApi(fileName: string) {
@@ -260,5 +263,72 @@ class C {
         assert.equal(ts.ModifierFlags.None, ts.getSyntacticModifierFlags(propNode));
         assert.equal(ts.ModifierFlags.Private, ts.getEffectiveModifierFlags(propNode));
         assert.equal(ts.ModifierFlags.None, ts.getSyntacticModifierFlags(propNode));
+    });
+});
+
+describe("unittests:: Public APIs:: createProgram", () => {
+    function verifyAPI(useJsonParsingApi: boolean) {
+        const fs = loadProjectFromFiles({
+            "/src/projects/project/packages/a/index.js": `export const a = 'a';`,
+            "/src/projects/project/packages/a/test/index.js": `import 'a';`,
+            "/src/projects/project/packages/a/tsconfig.json": jsonToReadableText({
+                compilerOptions: {
+                    checkJs: true,
+                    composite: true,
+                    declaration: true,
+                    emitDeclarationOnly: true,
+                    module: "nodenext",
+                    outDir: "types",
+                },
+            }),
+            "/src/projects/project/packages/a/package.json": jsonToReadableText({
+                name: "a",
+                version: "0.0.0",
+                type: "module",
+                exports: {
+                    ".": {
+                        types: "./types/index.d.ts",
+                        default: "./index.js",
+                    },
+                },
+            }),
+            "/lib/lib.esnext.full.d.ts": libContent,
+        }, { cwd: "/src/projects/project", executingFilePath: "/lib/tsc.js" });
+        const sys = new fakes.System(fs, { executingFilePath: "/lib/tsc.js" });
+        const commandLine = ts.getParsedCommandLineOfConfigFile(
+            "/src/projects/project/packages/a/tsconfig.json",
+            /*optionsToExtend*/ undefined,
+            {
+                fileExists: sys.fileExists.bind(sys),
+                getCurrentDirectory: sys.getCurrentDirectory.bind(sys),
+                onUnRecoverableConfigFileDiagnostic: () => {},
+                readDirectory: sys.readDirectory.bind(sys),
+                readFile: sys.readFile.bind(sys),
+                useCaseSensitiveFileNames: sys.useCaseSensitiveFileNames,
+                directoryExists: sys.directoryExists.bind(sys),
+                getDirectories: sys.getDirectories.bind(sys),
+                realpath: sys.realpath.bind(sys),
+            },
+        )!;
+        const config = !useJsonParsingApi ? JSON.parse(fs.readFileSync("/src/projects/project/packages/a/tsconfig.json", "utf-8")) : undefined;
+        // This is really createCompilerHost but we want to use our own sys so simple usage
+        const host = ts.createCompilerHostWorker(
+            useJsonParsingApi ? commandLine.options : config.compilerOptions,
+            /*setParentNodes*/ undefined,
+            sys,
+        );
+        assert.doesNotThrow(() =>
+            ts.createProgram({
+                rootNames: commandLine.fileNames,
+                options: useJsonParsingApi ? commandLine.options : config.compilerOptions,
+                host,
+            })
+        );
+    }
+    it("when using correct config file API", () => {
+        verifyAPI(/*useJsonParsingApi*/ true);
+    });
+    it("when using direct json read", () => {
+        verifyAPI(/*useJsonParsingApi*/ false);
     });
 });


### PR DESCRIPTION
cc: @RyanCavanaugh 

There are only 7 options that need to be checked so i think should be ok to check that irrespective of setting some symbol or something on our parsed option and not verify it. 