### PR TITLE
Add synthetic TypeScriptSettings interface that exposes some compiler options to type system

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -583,6 +583,27 @@ export const moduleOptionDeclaration: CommandLineOptionOfCustomType = {
     defaultValueDescription: undefined,
 };
 
+/** @internal */
+export const moduleResolutionOptionDeclaration: CommandLineOptionOfCustomType = {
+    name: "moduleResolution",
+    type: new Map(Object.entries({
+        // N.B. The first entry specifies the value shown in `tsc --init`
+        node10: ModuleResolutionKind.Node10,
+        node: ModuleResolutionKind.Node10,
+        classic: ModuleResolutionKind.Classic,
+        node16: ModuleResolutionKind.Node16,
+        nodenext: ModuleResolutionKind.NodeNext,
+        bundler: ModuleResolutionKind.Bundler,
+    })),
+    deprecatedKeys: new Set(["node"]),
+    affectsSourceFile: true,
+    affectsModuleResolution: true,
+    paramType: Diagnostics.STRATEGY,
+    category: Diagnostics.Modules,
+    description: Diagnostics.Specify_how_TypeScript_looks_up_a_file_from_a_given_module_specifier,
+    defaultValueDescription: Diagnostics.module_AMD_or_UMD_or_System_or_ES6_then_Classic_Otherwise_Node,
+};
+
 const commandOptionsWithoutBuild: CommandLineOption[] = [
     // CommandLine only options
     {
@@ -1028,25 +1049,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     },
 
     // Module Resolution
-    {
-        name: "moduleResolution",
-        type: new Map(Object.entries({
-            // N.B. The first entry specifies the value shown in `tsc --init`
-            node10: ModuleResolutionKind.Node10,
-            node: ModuleResolutionKind.Node10,
-            classic: ModuleResolutionKind.Classic,
-            node16: ModuleResolutionKind.Node16,
-            nodenext: ModuleResolutionKind.NodeNext,
-            bundler: ModuleResolutionKind.Bundler,
-        })),
-        deprecatedKeys: new Set(["node"]),
-        affectsSourceFile: true,
-        affectsModuleResolution: true,
-        paramType: Diagnostics.STRATEGY,
-        category: Diagnostics.Modules,
-        description: Diagnostics.Specify_how_TypeScript_looks_up_a_file_from_a_given_module_specifier,
-        defaultValueDescription: Diagnostics.module_AMD_or_UMD_or_System_or_ES6_then_Classic_Otherwise_Node,
-    },
+    moduleResolutionOptionDeclaration,
     {
         name: "baseUrl",
         type: "string",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -4790,8 +4790,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     message = Diagnostics.File_is_library_specified_here;
                     break;
                 }
-                const target = getNameOfScriptTarget(getEmitScriptTarget(options));
-                configFileNode = target ? getOptionsSyntaxByValue("target", target) : undefined;
+                const target = getEmitScriptTarget(options);
+                const targetText = getNameOfScriptTarget(target);
+                configFileNode = target === ScriptTarget.ES2015 ? getOptionsSyntaxByValue("target", "es2015") ?? getOptionsSyntaxByValue("target", "es6") :
+                    targetText ? getOptionsSyntaxByValue("target", targetText) :
+                    undefined;
                 message = Diagnostics.File_is_default_library_for_target_specified_here;
                 break;
             default:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5981,7 +5981,8 @@ export const enum CheckFlags {
     Mapped            = 1 << 18,        // Property of mapped type
     StripOptional     = 1 << 19,        // Strip optionality in mapped property
     Unresolved        = 1 << 20,        // Unresolved type alias symbol
-    Synthetic = SyntheticProperty | SyntheticMethod,
+    SyntheticInterface = 1 << 21,       // Synthetic interface
+    SyntheticMember = SyntheticProperty | SyntheticMethod,
     Discriminant = HasNonUniformType | HasLiteralType,
     Partial = ReadPartial | WritePartial,
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -421,7 +421,9 @@ import {
     ModuleDeclaration,
     ModuleDetectionKind,
     ModuleKind,
+    moduleOptionDeclaration,
     ModuleResolutionKind,
+    moduleResolutionOptionDeclaration,
     moduleResolutionOptionDeclarations,
     MultiMap,
     NamedDeclaration,
@@ -7808,7 +7810,7 @@ export function getDeclarationModifierFlagsFromSymbol(s: Symbol, isWrite = false
         const flags = getCombinedModifierFlags(declaration);
         return s.parent && s.parent.flags & SymbolFlags.Class ? flags : flags & ~ModifierFlags.AccessibilityModifier;
     }
-    if (getCheckFlags(s) & CheckFlags.Synthetic) {
+    if (getCheckFlags(s) & CheckFlags.SyntheticMember) {
         // NOTE: potentially unchecked cast to TransientSymbol
         const checkFlags = (s as TransientSymbol).links.checkFlags;
         const accessModifier = checkFlags & CheckFlags.ContainsPrivate ? ModifierFlags.Private :
@@ -9101,7 +9103,23 @@ export function getStrictOptionValue(compilerOptions: CompilerOptions, flag: Str
 
 /** @internal */
 export function getNameOfScriptTarget(scriptTarget: ScriptTarget): string | undefined {
-    return forEachEntry(targetOptionDeclaration.type, (value, key) => value === scriptTarget ? key : undefined);
+    const entries = [...targetOptionDeclaration.type].reverse();
+    return forEach(entries, ([key, value]) => value === scriptTarget ? key : undefined);
+}
+
+/** @internal */
+export function getNameOfModuleKind(moduleKind: ModuleKind): string | undefined {
+    const entries = [...moduleOptionDeclaration.type].reverse();
+    return forEach(entries, ([key, value]) => value === moduleKind ? key : undefined);
+}
+
+/** @internal */
+export function getNameOfModuleResolutionKind(moduleResolution: ModuleResolutionKind): string | undefined {
+    if (moduleResolution === ModuleResolutionKind.Node10) {
+        return "node10";
+    }
+    const entries = [...moduleResolutionOptionDeclaration.type].reverse();
+    return forEach(entries, ([key, value]) => value === moduleResolution ? key : undefined);
 }
 
 /** @internal */

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1240,7 +1240,7 @@ export namespace Completion {
         kind: "module",
         sortText: SortText.GlobalsOrKeywords,
     };
-    
+
     export const globalTypes = globalTypesPlus([]);
     export const globalTypesNoLib = globalTypesPlus([], { noLib: true });
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1111,6 +1111,8 @@ export namespace Completion {
         return combineExpectedCompletionEntries("typeKeywordsPlus", typeKeywords, plus);
     }
 
+    const typeScriptSettingsEntry = interfaceEntry("TypeScriptSettings");
+
     const globalTypeDecls: readonly ExpectedCompletionEntryObject[] = [
         interfaceEntry("Symbol"),
         typeEntry("PropertyKey"),
@@ -1238,11 +1240,19 @@ export namespace Completion {
         kind: "module",
         sortText: SortText.GlobalsOrKeywords,
     };
+    
     export const globalTypes = globalTypesPlus([]);
-    export function globalTypesPlus(plus: readonly ExpectedCompletionEntry[]) {
+    export const globalTypesNoLib = globalTypesPlus([], { noLib: true });
+
+    export function globalTypesPlus(plus: readonly ExpectedCompletionEntry[], options?: { noLib?: boolean; }) {
         return combineExpectedCompletionEntries(
             "globalTypesPlus",
-            [globalThisEntry, ...globalTypeDecls, ...typeKeywords],
+            [
+                globalThisEntry,
+                typeScriptSettingsEntry,
+                ...typeKeywords,
+                ...options?.noLib ? [] : globalTypeDecls,
+            ],
             plus,
         );
     }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -2706,7 +2706,7 @@ export namespace Core {
             }
             return search.includes(baseSymbol || rootSymbol || sym)
                 // For a base type, use the symbol for the derived type. For a synthetic (e.g. union) property, use the union symbol.
-                ? { symbol: rootSymbol && !(getCheckFlags(sym) & CheckFlags.Synthetic) ? rootSymbol : sym, kind }
+                ? { symbol: rootSymbol && !(getCheckFlags(sym) & CheckFlags.SyntheticMember) ? rootSymbol : sym, kind }
                 : undefined;
         }, /*allowBaseTypes*/ rootSymbol => !(search.parents && !search.parents.some(parent => explicitlyInheritsFrom(rootSymbol.parent!, parent, state.inheritsFromCache, checker))));
     }

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -331,7 +331,7 @@ function getSymbolForContextualType(node: Node, checker: TypeChecker): Symbol | 
     if (element) {
         const contextualType = checker.getContextualTypeForObjectLiteralElement(element as ObjectLiteralElementLike);
         const symbol = contextualType?.getSymbol();
-        if (symbol && !(getCheckFlags(symbol) & CheckFlags.Synthetic)) {
+        if (symbol && !(getCheckFlags(symbol) & CheckFlags.SyntheticMember)) {
             return symbol;
         }
     }

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -186,7 +186,7 @@ function getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeCheck
     if (flags & SymbolFlags.Signature) return ScriptElementKind.indexSignatureElement;
 
     if (flags & SymbolFlags.Property) {
-        if (flags & SymbolFlags.Transient && (symbol as TransientSymbol).links.checkFlags & CheckFlags.Synthetic) {
+        if (flags & SymbolFlags.Transient && (symbol as TransientSymbol).links.checkFlags & CheckFlags.SyntheticMember) {
             // If union property is result of union of non method (property/accessors/variables), it is labeled as property
             const unionPropertyKind = forEach(typeChecker.getRootSymbols(symbol), rootSymbol => {
                 const rootSymbolFlags = rootSymbol.getFlags();
@@ -223,6 +223,10 @@ function getNormalizedSymbolModifiers(symbol: Symbol) {
         if (modifiers) {
             return modifiers.split(",");
         }
+    }
+    else if (symbol.flags & SymbolFlags.Interface) {
+        // Synthetic interface produced by checker, such as 'TypeScriptSettings'
+        return [ScriptElementKindModifier.ambientModifier];
     }
     return [];
 }

--- a/tests/baselines/reference/jsxChildrenArrayWrongType.types
+++ b/tests/baselines/reference/jsxChildrenArrayWrongType.types
@@ -1,5 +1,8 @@
 //// [tests/cases/compiler/jsxChildrenArrayWrongType.tsx] ////
 
+=== Performance Stats ===
+Type Count: 1,000
+
 === index.tsx ===
 /// <reference path="react18/react18.d.ts" />
 /// <reference path="react18/global.d.ts" />

--- a/tests/baselines/reference/regExpWithOpenBracketInCharClass(target=es5).errors.txt
+++ b/tests/baselines/reference/regExpWithOpenBracketInCharClass(target=es5).errors.txt
@@ -1,4 +1,4 @@
-regExpWithOpenBracketInCharClass.ts(3,8): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regExpWithOpenBracketInCharClass.ts(3,8): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regExpWithOpenBracketInCharClass.ts(4,7): error TS1005: ']' expected.
 regExpWithOpenBracketInCharClass.ts(4,8): error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
 
@@ -8,7 +8,7 @@ regExpWithOpenBracketInCharClass.ts(4,8): error TS1501: This regular expression 
       /[[]/,  // Valid
       /[[]/u, // Valid
            ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
       /[[]/v, // Well-terminated regex with an incomplete character class
           
 !!! error TS1005: ']' expected.

--- a/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
@@ -24,7 +24,7 @@ regularExpressionScanning.ts(13,29): error TS1487: Octal escape sequences are no
 regularExpressionScanning.ts(13,37): error TS1487: Octal escape sequences are not allowed. Use the syntax '\x03'.
 regularExpressionScanning.ts(13,42): error TS1533: This backreference refers to a group that does not exist. There are only 4 capturing groups in this regular expression.
 regularExpressionScanning.ts(13,43): error TS1487: Octal escape sequences are not allowed. Use the syntax '\x05'.
-regularExpressionScanning.ts(13,48): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(13,48): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(14,5): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,14): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,29): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
@@ -55,7 +55,7 @@ regularExpressionScanning.ts(20,59): error TS1530: Unicode property value expres
 regularExpressionScanning.ts(20,62): error TS1529: Unknown Unicode property name or value.
 regularExpressionScanning.ts(21,28): error TS1529: Unknown Unicode property name or value.
 regularExpressionScanning.ts(21,62): error TS1529: Unknown Unicode property name or value.
-regularExpressionScanning.ts(21,72): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(21,72): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(22,28): error TS1529: Unknown Unicode property name or value.
 regularExpressionScanning.ts(22,62): error TS1529: Unknown Unicode property name or value.
 regularExpressionScanning.ts(22,72): error TS1501: This regular expression flag is only available when targeting 'esnext' or later.
@@ -84,7 +84,7 @@ regularExpressionScanning.ts(24,53): error TS1531: '\p' must be followed by a Un
 regularExpressionScanning.ts(24,57): error TS1531: '\P' must be followed by a Unicode property value expression enclosed in braces.
 regularExpressionScanning.ts(24,62): error TS1527: Expected a Unicode property name or value.
 regularExpressionScanning.ts(24,66): error TS1527: Expected a Unicode property name or value.
-regularExpressionScanning.ts(24,67): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(24,67): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(25,6): error TS1524: Unknown Unicode property name.
 regularExpressionScanning.ts(25,31): error TS1523: Expected a Unicode property name.
 regularExpressionScanning.ts(25,32): error TS1525: Expected a Unicode property value.
@@ -108,7 +108,7 @@ regularExpressionScanning.ts(27,6): error TS1528: Any Unicode property that woul
 regularExpressionScanning.ts(27,19): error TS1528: Any Unicode property that would possibly match more than a single character is only available when the Unicode Sets (v) flag is set.
 regularExpressionScanning.ts(27,34): error TS1528: Any Unicode property that would possibly match more than a single character is only available when the Unicode Sets (v) flag is set.
 regularExpressionScanning.ts(27,47): error TS1528: Any Unicode property that would possibly match more than a single character is only available when the Unicode Sets (v) flag is set.
-regularExpressionScanning.ts(27,59): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(27,59): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(28,19): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(28,31): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(28,47): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -119,7 +119,7 @@ regularExpressionScanning.ts(31,15): error TS1512: '\c' must be followed by an A
 regularExpressionScanning.ts(31,17): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(31,20): error TS1512: '\c' must be followed by an ASCII letter.
 regularExpressionScanning.ts(31,23): error TS1535: This character cannot be escaped in a regular expression.
-regularExpressionScanning.ts(31,26): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(31,26): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(33,3): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(33,7): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(33,10): error TS1535: This character cannot be escaped in a regular expression.
@@ -132,7 +132,7 @@ regularExpressionScanning.ts(33,41): error TS1508: Unexpected '{'. Did you mean 
 regularExpressionScanning.ts(33,42): error TS1508: Unexpected ']'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(33,43): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(33,45): error TS1508: Unexpected '{'. Did you mean to escape it with backslash?
-regularExpressionScanning.ts(33,47): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(33,47): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(34,3): error TS1511: '\q' is only available inside character class.
 regularExpressionScanning.ts(34,7): error TS1535: This character cannot be escaped in a regular expression.
 regularExpressionScanning.ts(34,10): error TS1521: '\q' must be followed by string alternatives enclosed in braces.
@@ -162,7 +162,7 @@ regularExpressionScanning.ts(37,57): error TS1508: Unexpected '{'. Did you mean 
 regularExpressionScanning.ts(37,61): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
 regularExpressionScanning.ts(37,63): error TS1517: Range out of order in character class.
 regularExpressionScanning.ts(37,76): error TS1535: This character cannot be escaped in a regular expression.
-regularExpressionScanning.ts(37,87): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionScanning.ts(37,87): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 regularExpressionScanning.ts(38,8): error TS1005: '--' expected.
 regularExpressionScanning.ts(38,9): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(38,11): error TS1520: Expected a class set operand.
@@ -277,7 +277,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                         ~~~~
 !!! error TS1487: Octal escape sequences are not allowed. Use the syntax '\x05'.
     	                                              ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/(?<foo>)((?<bar>bar)bar)(?<baz>baz)|(foo(?<foo>foo))(?<baz>)/,
     	   ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
@@ -347,7 +347,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                            ~~~~~~~
 !!! error TS1529: Unknown Unicode property name or value.
     	                                                                      ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/\p{L}\p{gc=L}\p{ASCII}\p{Invalid}[\p{L}\p{gc=L}\P{ASCII}\p{Invalid}]/v,
     	                          ~~~~~~~
 !!! error TS1529: Unknown Unicode property name or value.
@@ -408,7 +408,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                
 !!! error TS1527: Expected a Unicode property name or value.
     	                                                                 ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/\p{InvalidProperty=Value}\p{=}\p{sc=}\P{=foo}[\p{}\p\\\P\P{]\p{/v,
     	    ~~~~~~~~~~~~~~~
 !!! error TS1524: Unknown Unicode property name.
@@ -459,7 +459,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                             ~~~~~~~~~
 !!! error TS1528: Any Unicode property that would possibly match more than a single character is only available when the Unicode Sets (v) flag is set.
     	                                                         ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/\p{RGI_Emoji}\P{RGI_Emoji}[^\p{RGI_Emoji}\P{RGI_Emoji}]/v,
     	                 ~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -485,7 +485,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                     ~~
 !!! error TS1535: This character cannot be escaped in a regular expression.
     	                        ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/\q\\\`[\q\\\`[\Q\\\Q{\q{foo|bar|baz]\q{]\q{/,
     	/\q\\\`[\q\\\`[\Q\\\Q{\q{foo|bar|baz]\q{]\q{/u,
     	 ~~
@@ -513,7 +513,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                           ~
 !!! error TS1508: Unexpected '{'. Did you mean to escape it with backslash?
     	                                             ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/\q\\\`[\q\\\`[\Q\\\Q{\q{foo|bar|baz]\q{]\q{/v,
     	 ~~
 !!! error TS1511: '\q' is only available inside character class.
@@ -577,7 +577,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                          ~~
 !!! error TS1535: This character cannot be escaped in a regular expression.
     	                                                                                     ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     	/[a--b[--][\d++[]]&&[[&0-9--]&&[\p{L}]--\P{L}-_-]]&&&\q{foo}[0---9][&&q&&&\q{bar}&&]/v,
     	      
 !!! error TS1005: '--' expected.

--- a/tests/baselines/reference/regularExpressionUnicodePropertyValueExpressionSuggestions.errors.txt
+++ b/tests/baselines/reference/regularExpressionUnicodePropertyValueExpressionSuggestions.errors.txt
@@ -1,7 +1,7 @@
 regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,19): error TS1529: Unknown Unicode property name or value.
 regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,28): error TS1524: Unknown Unicode property name.
 regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,45): error TS1526: Unknown Unicode property value.
-regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,55): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,55): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== regularExpressionUnicodePropertyValueExpressionSuggestions.ts (4 errors) ====
@@ -16,5 +16,5 @@ regularExpressionUnicodePropertyValueExpressionSuggestions.ts(1,55): error TS150
 !!! error TS1526: Unknown Unicode property value.
 !!! related TS1369: Did you mean 'Unknown'?
                                                           ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/tsserver/cachingFileSystemInformation/when-calling-goto-definition-of-module.js
+++ b/tests/baselines/reference/tsserver/cachingFileSystemInformation/when-calling-goto-definition-of-module.js
@@ -174,7 +174,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/tsserver/configuredProjects/should-keep-the-configured-project-when-the-opened-file-is-referenced-by-the-project-but-not-its-root.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-keep-the-configured-project-when-the-opened-file-is-referenced-by-the-project-but-not-its-root.js
@@ -127,7 +127,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/tsserver/configuredProjects/should-not-close-configured-project-after-closing-last-open-file,-but-should-be-closed-on-next-file-open-if-its-not-the-file-from-same-project.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-not-close-configured-project-after-closing-last-open-file,-but-should-be-closed-on-next-file-open-if-its-not-the-file-from-same-project.js
@@ -133,7 +133,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/tsserver/configuredProjects/should-reuse-same-project-if-file-is-opened-from-the-configured-project-that-has-no-open-files.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-reuse-same-project-if-file-is-opened-from-the-configured-project-that-has-no-open-files.js
@@ -142,7 +142,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/tsserver/configuredProjects/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
@@ -142,7 +142,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_namespaceSameNameAsIntrinsic.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_namespaceSameNameAsIntrinsic.js
@@ -1095,6 +1095,12 @@ Info seq  [hh:mm:ss:mss] response:
             "sortText": "15"
           },
           {
+            "name": "TypeScriptSettings",
+            "kind": "interface",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
             "name": "Uint8Array",
             "kind": "var",
             "kindModifiers": "declare",

--- a/tests/baselines/reference/tsserver/inferredProjects/should-use-only-one-inferred-project-if-useOneInferredProject-is-set.js
+++ b/tests/baselines/reference/tsserver/inferredProjects/should-use-only-one-inferred-project-if-useOneInferredProject-is-set.js
@@ -458,7 +458,7 @@ Info seq  [hh:mm:ss:mss] event:
         "configFile": "/user/username/projects/myproject/a/b/tsconfig.json",
         "diagnostics": [
           {
-            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es6'",
+            "text": "File '/a/lib/lib.es6.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es2015'",
             "code": 6053,
             "category": "error",
             "relatedInformation": [

--- a/tests/baselines/reference/typeScriptSettings.customConditions.0.symbols
+++ b/tests/baselines/reference/typeScriptSettings.customConditions.0.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.0.ts] ////
+
+=== typeScriptSettings.customConditions.0.ts ===
+type customConditions = TypeScriptSettings["customConditions"];
+>customConditions : Symbol(customConditions, Decl(typeScriptSettings.customConditions.0.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.customConditions.0.types
+++ b/tests/baselines/reference/typeScriptSettings.customConditions.0.types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.0.ts] ////
+
+=== typeScriptSettings.customConditions.0.ts ===
+type customConditions = TypeScriptSettings["customConditions"];
+>customConditions : readonly []
+>                 : ^^^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.customConditions.1.symbols
+++ b/tests/baselines/reference/typeScriptSettings.customConditions.1.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.1.ts] ////
+
+=== typeScriptSettings.customConditions.1.ts ===
+type customConditions = TypeScriptSettings["customConditions"];
+>customConditions : Symbol(customConditions, Decl(typeScriptSettings.customConditions.1.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.customConditions.1.types
+++ b/tests/baselines/reference/typeScriptSettings.customConditions.1.types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.1.ts] ////
+
+=== typeScriptSettings.customConditions.1.ts ===
+type customConditions = TypeScriptSettings["customConditions"];
+>customConditions : readonly ["cond1", "cond2"]
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts] ////
+
+=== typeScriptSettings.esModuleInterop.ts ===
+type esModuleInterop = TypeScriptSettings["esModuleInterop"];
+>esModuleInterop : Symbol(esModuleInterop, Decl(typeScriptSettings.esModuleInterop.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=false).types
+++ b/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts] ////
+
+=== typeScriptSettings.esModuleInterop.ts ===
+type esModuleInterop = TypeScriptSettings["esModuleInterop"];
+>esModuleInterop : false
+>                : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts] ////
+
+=== typeScriptSettings.esModuleInterop.ts ===
+type esModuleInterop = TypeScriptSettings["esModuleInterop"];
+>esModuleInterop : Symbol(esModuleInterop, Decl(typeScriptSettings.esModuleInterop.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=true).types
+++ b/tests/baselines/reference/typeScriptSettings.esModuleInterop(esmoduleinterop=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts] ////
+
+=== typeScriptSettings.esModuleInterop.ts ===
+type esModuleInterop = TypeScriptSettings["esModuleInterop"];
+>esModuleInterop : true
+>                : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts] ////
+
+=== typeScriptSettings.exactOptionalPropertyTypes.ts ===
+type exactOptionalPropertyTypes = TypeScriptSettings["exactOptionalPropertyTypes"];
+>exactOptionalPropertyTypes : Symbol(exactOptionalPropertyTypes, Decl(typeScriptSettings.exactOptionalPropertyTypes.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts] ////
+
+=== typeScriptSettings.exactOptionalPropertyTypes.ts ===
+type exactOptionalPropertyTypes = TypeScriptSettings["exactOptionalPropertyTypes"];
+>exactOptionalPropertyTypes : false
+>                           : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts] ////
+
+=== typeScriptSettings.exactOptionalPropertyTypes.ts ===
+type exactOptionalPropertyTypes = TypeScriptSettings["exactOptionalPropertyTypes"];
+>exactOptionalPropertyTypes : Symbol(exactOptionalPropertyTypes, Decl(typeScriptSettings.exactOptionalPropertyTypes.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/typeScriptSettings.exactOptionalPropertyTypes(exactoptionalpropertytypes=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts] ////
+
+=== typeScriptSettings.exactOptionalPropertyTypes.ts ===
+type exactOptionalPropertyTypes = TypeScriptSettings["exactOptionalPropertyTypes"];
+>exactOptionalPropertyTypes : true
+>                           : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.locale.0.symbols
+++ b/tests/baselines/reference/typeScriptSettings.locale.0.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.0.ts] ////
+
+=== typeScriptSettings.locale.0.ts ===
+type locale = TypeScriptSettings["locale"];
+>locale : Symbol(locale, Decl(typeScriptSettings.locale.0.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.locale.0.types
+++ b/tests/baselines/reference/typeScriptSettings.locale.0.types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.0.ts] ////
+
+=== typeScriptSettings.locale.0.ts ===
+type locale = TypeScriptSettings["locale"];
+>locale : undefined
+>       : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.locale.1.symbols
+++ b/tests/baselines/reference/typeScriptSettings.locale.1.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.1.ts] ////
+
+=== typeScriptSettings.locale.1.ts ===
+type locale = TypeScriptSettings["locale"];
+>locale : Symbol(locale, Decl(typeScriptSettings.locale.1.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.locale.1.types
+++ b/tests/baselines/reference/typeScriptSettings.locale.1.types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.1.ts] ////
+
+=== typeScriptSettings.locale.1.ts ===
+type locale = TypeScriptSettings["locale"];
+>locale : "en-US"
+>       : ^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=amd).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=amd).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=amd).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=amd).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "amd"
+>       : ^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=commonjs).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=commonjs).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=commonjs).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=commonjs).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "commonjs"
+>       : ^^^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es2020).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es2020).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es2020).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es2020).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "es2020"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es2022).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es2022).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es2022).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es2022).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "es2022"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es6).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es6).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=es6).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=es6).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "es2015"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=esnext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=esnext).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=esnext).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=esnext).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "esnext"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=node16).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=node16).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=node16).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=node16).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "node16"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node16"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=nodenext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=nodenext).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=nodenext).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=nodenext).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "nodenext"
+>       : ^^^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "nodenext"
+>                 : ^^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=none).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=none).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=none).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=none).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "none"
+>       : ^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=preserve).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=preserve).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=preserve).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=preserve).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "preserve"
+>       : ^^^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "bundler"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=system).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=system).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=system).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=system).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "system"
+>       : ^^^^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=umd).symbols
+++ b/tests/baselines/reference/typeScriptSettings.module(module=umd).symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : Symbol(module, Decl(typeScriptSettings.module.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.module.ts, 0, 43))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.module(module=umd).types
+++ b/tests/baselines/reference/typeScriptSettings.module(module=umd).types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts] ////
+
+=== typeScriptSettings.module.ts ===
+type module = TypeScriptSettings["module"];
+>module : "umd"
+>       : ^^^^^
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "classic"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2015).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2015).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.bundler.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2015).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2015).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "bundler"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2020).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2020).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.bundler.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2020).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=es2020).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "bundler"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=esnext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=esnext).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.bundler.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=esnext).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=esnext).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "bundler"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=preserve).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=preserve).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.bundler.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=preserve).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.bundler(module=preserve).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts] ////
+
+=== typeScriptSettings.moduleResolution.bundler.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "bundler"
+>                 : ^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=amd).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=amd).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=amd).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=amd).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=commonjs).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=commonjs).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=commonjs).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=commonjs).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2020).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2020).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2020).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2020).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2022).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2022).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2022).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es2022).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es6).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es6).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es6).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=es6).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=esnext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=esnext).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=esnext).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=esnext).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=none).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=none).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=none).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=none).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=preserve).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=preserve).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=preserve).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=preserve).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=system).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=system).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=system).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=system).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=umd).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=umd).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node10.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=umd).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node10(module=umd).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts] ////
+
+=== typeScriptSettings.moduleResolution.node10.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node10"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=node16).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=node16).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts] ////
+
+=== typeScriptSettings.moduleResolution.node16.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node16.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=node16).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=node16).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts] ////
+
+=== typeScriptSettings.moduleResolution.node16.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node16"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=nodenext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=nodenext).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts] ////
+
+=== typeScriptSettings.moduleResolution.node16.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.node16.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=nodenext).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.node16(module=nodenext).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts] ////
+
+=== typeScriptSettings.moduleResolution.node16.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "node16"
+>                 : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=node16).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=node16).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts] ////
+
+=== typeScriptSettings.moduleResolution.nodenext.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.nodenext.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=node16).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=node16).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts] ////
+
+=== typeScriptSettings.moduleResolution.nodenext.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "nodenext"
+>                 : ^^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=nodenext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=nodenext).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts] ////
+
+=== typeScriptSettings.moduleResolution.nodenext.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : Symbol(moduleResolution, Decl(typeScriptSettings.moduleResolution.nodenext.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=nodenext).types
+++ b/tests/baselines/reference/typeScriptSettings.moduleResolution.nodenext(module=nodenext).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts] ////
+
+=== typeScriptSettings.moduleResolution.nodenext.ts ===
+type moduleResolution = TypeScriptSettings["moduleResolution"];
+>moduleResolution : "nodenext"
+>                 : ^^^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts] ////
+
+=== typeScriptSettings.noImplicitAny.ts ===
+type noImplicitAny = TypeScriptSettings["noImplicitAny"];
+>noImplicitAny : Symbol(noImplicitAny, Decl(typeScriptSettings.noImplicitAny.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=false).types
+++ b/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts] ////
+
+=== typeScriptSettings.noImplicitAny.ts ===
+type noImplicitAny = TypeScriptSettings["noImplicitAny"];
+>noImplicitAny : false
+>              : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts] ////
+
+=== typeScriptSettings.noImplicitAny.ts ===
+type noImplicitAny = TypeScriptSettings["noImplicitAny"];
+>noImplicitAny : Symbol(noImplicitAny, Decl(typeScriptSettings.noImplicitAny.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=true).types
+++ b/tests/baselines/reference/typeScriptSettings.noImplicitAny(noimplicitany=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts] ////
+
+=== typeScriptSettings.noImplicitAny.ts ===
+type noImplicitAny = TypeScriptSettings["noImplicitAny"];
+>noImplicitAny : true
+>              : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts] ////
+
+=== typeScriptSettings.noUncheckedIndexedAccess.ts ===
+type noUncheckedIndexedAccess = TypeScriptSettings["noUncheckedIndexedAccess"];
+>noUncheckedIndexedAccess : Symbol(noUncheckedIndexedAccess, Decl(typeScriptSettings.noUncheckedIndexedAccess.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=false).types
+++ b/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts] ////
+
+=== typeScriptSettings.noUncheckedIndexedAccess.ts ===
+type noUncheckedIndexedAccess = TypeScriptSettings["noUncheckedIndexedAccess"];
+>noUncheckedIndexedAccess : false
+>                         : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts] ////
+
+=== typeScriptSettings.noUncheckedIndexedAccess.ts ===
+type noUncheckedIndexedAccess = TypeScriptSettings["noUncheckedIndexedAccess"];
+>noUncheckedIndexedAccess : Symbol(noUncheckedIndexedAccess, Decl(typeScriptSettings.noUncheckedIndexedAccess.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=true).types
+++ b/tests/baselines/reference/typeScriptSettings.noUncheckedIndexedAccess(nouncheckedindexedaccess=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts] ////
+
+=== typeScriptSettings.noUncheckedIndexedAccess.ts ===
+type noUncheckedIndexedAccess = TypeScriptSettings["noUncheckedIndexedAccess"];
+>noUncheckedIndexedAccess : true
+>                         : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts] ////
+
+=== typeScriptSettings.strictBindCallApply.ts ===
+type strictBindCallApply = TypeScriptSettings["strictBindCallApply"];
+>strictBindCallApply : Symbol(strictBindCallApply, Decl(typeScriptSettings.strictBindCallApply.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=false).types
+++ b/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts] ////
+
+=== typeScriptSettings.strictBindCallApply.ts ===
+type strictBindCallApply = TypeScriptSettings["strictBindCallApply"];
+>strictBindCallApply : false
+>                    : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts] ////
+
+=== typeScriptSettings.strictBindCallApply.ts ===
+type strictBindCallApply = TypeScriptSettings["strictBindCallApply"];
+>strictBindCallApply : Symbol(strictBindCallApply, Decl(typeScriptSettings.strictBindCallApply.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=true).types
+++ b/tests/baselines/reference/typeScriptSettings.strictBindCallApply(strictbindcallapply=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts] ////
+
+=== typeScriptSettings.strictBindCallApply.ts ===
+type strictBindCallApply = TypeScriptSettings["strictBindCallApply"];
+>strictBindCallApply : true
+>                    : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts] ////
+
+=== typeScriptSettings.strictFunctionTypes.ts ===
+type strictFunctionTypes = TypeScriptSettings["strictFunctionTypes"];
+>strictFunctionTypes : Symbol(strictFunctionTypes, Decl(typeScriptSettings.strictFunctionTypes.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=false).types
+++ b/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts] ////
+
+=== typeScriptSettings.strictFunctionTypes.ts ===
+type strictFunctionTypes = TypeScriptSettings["strictFunctionTypes"];
+>strictFunctionTypes : false
+>                    : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts] ////
+
+=== typeScriptSettings.strictFunctionTypes.ts ===
+type strictFunctionTypes = TypeScriptSettings["strictFunctionTypes"];
+>strictFunctionTypes : Symbol(strictFunctionTypes, Decl(typeScriptSettings.strictFunctionTypes.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=true).types
+++ b/tests/baselines/reference/typeScriptSettings.strictFunctionTypes(strictfunctiontypes=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts] ////
+
+=== typeScriptSettings.strictFunctionTypes.ts ===
+type strictFunctionTypes = TypeScriptSettings["strictFunctionTypes"];
+>strictFunctionTypes : true
+>                    : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts] ////
+
+=== typeScriptSettings.strictNullChecks.ts ===
+type strictNullChecks = TypeScriptSettings["strictNullChecks"];
+>strictNullChecks : Symbol(strictNullChecks, Decl(typeScriptSettings.strictNullChecks.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=false).types
+++ b/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts] ////
+
+=== typeScriptSettings.strictNullChecks.ts ===
+type strictNullChecks = TypeScriptSettings["strictNullChecks"];
+>strictNullChecks : false
+>                 : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts] ////
+
+=== typeScriptSettings.strictNullChecks.ts ===
+type strictNullChecks = TypeScriptSettings["strictNullChecks"];
+>strictNullChecks : Symbol(strictNullChecks, Decl(typeScriptSettings.strictNullChecks.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=true).types
+++ b/tests/baselines/reference/typeScriptSettings.strictNullChecks(strictnullchecks=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts] ////
+
+=== typeScriptSettings.strictNullChecks.ts ===
+type strictNullChecks = TypeScriptSettings["strictNullChecks"];
+>strictNullChecks : true
+>                 : ^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2016).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2016).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2016).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2016).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2016"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2017).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2017).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2017).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2017).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2017"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2018).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2018).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2018).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2018).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2018"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2019).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2019).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2019).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2019).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2019"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2020).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2020).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2020).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2020).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2020"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2021).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2021).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2021).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2021).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2021"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2022).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2022).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2022).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2022).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2022"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2023).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2023).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es2023).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es2023).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2023"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es5).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es5).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es5).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es5).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es5"
+>       : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es6).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es6).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=es6).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=es6).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "es2015"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=esnext).symbols
+++ b/tests/baselines/reference/typeScriptSettings.target(target=esnext).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : Symbol(target, Decl(typeScriptSettings.target.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.target(target=esnext).types
+++ b/tests/baselines/reference/typeScriptSettings.target(target=esnext).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts] ////
+
+=== typeScriptSettings.target.ts ===
+type target = TypeScriptSettings["target"];
+>target : "esnext"
+>       : ^^^^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=false).symbols
+++ b/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=false).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts] ////
+
+=== typeScriptSettings.useDefineForClassFields.ts ===
+type useDefineForClassFields = TypeScriptSettings["useDefineForClassFields"];
+>useDefineForClassFields : Symbol(useDefineForClassFields, Decl(typeScriptSettings.useDefineForClassFields.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=false).types
+++ b/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=false).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts] ////
+
+=== typeScriptSettings.useDefineForClassFields.ts ===
+type useDefineForClassFields = TypeScriptSettings["useDefineForClassFields"];
+>useDefineForClassFields : false
+>                        : ^^^^^
+

--- a/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=true).symbols
+++ b/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=true).symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts] ////
+
+=== typeScriptSettings.useDefineForClassFields.ts ===
+type useDefineForClassFields = TypeScriptSettings["useDefineForClassFields"];
+>useDefineForClassFields : Symbol(useDefineForClassFields, Decl(typeScriptSettings.useDefineForClassFields.ts, 0, 0))
+>TypeScriptSettings : Symbol(TypeScriptSettings)
+

--- a/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=true).types
+++ b/tests/baselines/reference/typeScriptSettings.useDefineForClassFields(usedefineforclassfields=true).types
@@ -1,0 +1,7 @@
+//// [tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts] ////
+
+=== typeScriptSettings.useDefineForClassFields.ts ===
+type useDefineForClassFields = TypeScriptSettings["useDefineForClassFields"];
+>useDefineForClassFields : true
+>                        : ^^^^
+

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions01(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions01(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions01.ts(1,17): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions01.ts(1,17): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions01.ts (1 errors) ====
     var x = /\u{0}/gu;
                     ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions02(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions02(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions02.ts(1,18): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions02.ts(1,18): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions02.ts (1 errors) ====
     var x = /\u{00}/gu;
                      ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions03(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions03(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions03.ts(1,20): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions03.ts(1,20): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions03.ts (1 errors) ====
     var x = /\u{0000}/gu;
                        ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions04(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions04(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions04.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions04.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions04.ts (1 errors) ====
     var x = /\u{00000000}/gu;
                            ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions05(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions05(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions05.ts(1,78): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions05.ts(1,78): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions05.ts (1 errors) ====
     var x = /\u{48}\u{65}\u{6c}\u{6c}\u{6f}\u{20}\u{77}\u{6f}\u{72}\u{6c}\u{64}/gu;
                                                                                  ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions06(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions06(target=es5).errors.txt
@@ -1,4 +1,4 @@
-unicodeExtendedEscapesInRegularExpressions06.ts(3,22): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions06.ts(3,22): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions06.ts (1 errors) ====
@@ -6,5 +6,5 @@ unicodeExtendedEscapesInRegularExpressions06.ts(3,22): error TS1501: This regula
     //  1. Assert: 0 ≤ cp ≤ 0x10FFFF.
     var x = /\u{10FFFF}/gu;
                          ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions07(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions07(target=es5).errors.txt
@@ -1,5 +1,5 @@
 unicodeExtendedEscapesInRegularExpressions07.ts(3,13): error TS1198: An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.
-unicodeExtendedEscapesInRegularExpressions07.ts(3,22): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions07.ts(3,22): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions07.ts (2 errors) ====
@@ -9,5 +9,5 @@ unicodeExtendedEscapesInRegularExpressions07.ts(3,22): error TS1501: This regula
                 ~~~~~~
 !!! error TS1198: An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.
                          ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions08(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions08(target=es5).errors.txt
@@ -1,4 +1,4 @@
-unicodeExtendedEscapesInRegularExpressions08.ts(4,20): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions08.ts(4,20): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions08.ts (1 errors) ====
@@ -7,5 +7,5 @@ unicodeExtendedEscapesInRegularExpressions08.ts(4,20): error TS1501: This regula
     // (FFFF == 65535)
     var x = /\u{FFFF}/gu;
                        ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions09(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions09(target=es5).errors.txt
@@ -1,4 +1,4 @@
-unicodeExtendedEscapesInRegularExpressions09.ts(4,21): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions09.ts(4,21): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions09.ts (1 errors) ====
@@ -7,5 +7,5 @@ unicodeExtendedEscapesInRegularExpressions09.ts(4,21): error TS1501: This regula
     // (10000 == 65536)
     var x = /\u{10000}/gu;
                         ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions10(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions10(target=es5).errors.txt
@@ -1,4 +1,4 @@
-unicodeExtendedEscapesInRegularExpressions10.ts(5,20): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions10.ts(5,20): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions10.ts (1 errors) ====
@@ -8,5 +8,5 @@ unicodeExtendedEscapesInRegularExpressions10.ts(5,20): error TS1501: This regula
     // this is a useful edge-case test.
     var x = /\u{D800}/gu;
                        ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions11(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions11(target=es5).errors.txt
@@ -1,4 +1,4 @@
-unicodeExtendedEscapesInRegularExpressions11.ts(5,20): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions11.ts(5,20): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions11.ts (1 errors) ====
@@ -8,5 +8,5 @@ unicodeExtendedEscapesInRegularExpressions11.ts(5,20): error TS1501: This regula
     // this is a useful edge-case test.
     var x = /\u{DC00}/gu;
                        ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions12(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions12(target=es5).errors.txt
@@ -1,5 +1,5 @@
 unicodeExtendedEscapesInRegularExpressions12.ts(1,13): error TS1198: An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.
-unicodeExtendedEscapesInRegularExpressions12.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions12.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions12.ts (2 errors) ====
@@ -7,5 +7,5 @@ unicodeExtendedEscapesInRegularExpressions12.ts(1,24): error TS1501: This regula
                 ~~~~~~~~
 !!! error TS1198: An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.
                            ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions13(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions13(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions13.ts(1,21): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions13.ts(1,21): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions13.ts (1 errors) ====
     var x = /\u{DDDDD}/gu;
                         ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions14(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions14(target=es5).errors.txt
@@ -1,6 +1,6 @@
 unicodeExtendedEscapesInRegularExpressions14.ts(2,13): error TS1125: Hexadecimal digit expected.
 unicodeExtendedEscapesInRegularExpressions14.ts(2,18): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
-unicodeExtendedEscapesInRegularExpressions14.ts(2,21): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions14.ts(2,21): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions14.ts (3 errors) ====
@@ -11,5 +11,5 @@ unicodeExtendedEscapesInRegularExpressions14.ts(2,21): error TS1501: This regula
                      ~
 !!! error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
                         ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions15(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions15(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions15.ts(1,44): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions15.ts(1,44): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions15.ts (1 errors) ====
     var x = /\u{abcd}\u{ef12}\u{3456}\u{7890}/gu;
                                                ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions16(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions16(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions16.ts(1,44): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions16.ts(1,44): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions16.ts (1 errors) ====
     var x = /\u{ABCD}\u{EF12}\u{3456}\u{7890}/gu;
                                                ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions17(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions17(target=es5).errors.txt
@@ -4,7 +4,7 @@ unicodeExtendedEscapesInRegularExpressions17.ts(1,18): error TS1125: Hexadecimal
 unicodeExtendedEscapesInRegularExpressions17.ts(1,19): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
 unicodeExtendedEscapesInRegularExpressions17.ts(1,23): error TS1125: Hexadecimal digit expected.
 unicodeExtendedEscapesInRegularExpressions17.ts(1,24): error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
-unicodeExtendedEscapesInRegularExpressions17.ts(1,27): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions17.ts(1,27): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions17.ts (7 errors) ====
@@ -22,5 +22,5 @@ unicodeExtendedEscapesInRegularExpressions17.ts(1,27): error TS1501: This regula
                            ~
 !!! error TS1508: Unexpected '}'. Did you mean to escape it with backslash?
                               ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions18(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions18(target=es5).errors.txt
@@ -1,8 +1,8 @@
-unicodeExtendedEscapesInRegularExpressions18.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions18.ts(1,24): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions18.ts (1 errors) ====
     var x = /\u{65}\u{65}/gu;
                            ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions19(target=es5).errors.txt
+++ b/tests/baselines/reference/unicodeExtendedEscapesInRegularExpressions19(target=es5).errors.txt
@@ -1,5 +1,5 @@
 unicodeExtendedEscapesInRegularExpressions19.ts(1,13): error TS1125: Hexadecimal digit expected.
-unicodeExtendedEscapesInRegularExpressions19.ts(1,16): error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+unicodeExtendedEscapesInRegularExpressions19.ts(1,16): error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
 
 
 ==== unicodeExtendedEscapesInRegularExpressions19.ts (2 errors) ====
@@ -7,5 +7,5 @@ unicodeExtendedEscapesInRegularExpressions19.ts(1,16): error TS1501: This regula
                 
 !!! error TS1125: Hexadecimal digit expected.
                    ~
-!!! error TS1501: This regular expression flag is only available when targeting 'es6' or later.
+!!! error TS1501: This regular expression flag is only available when targeting 'es2015' or later.
     

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.0.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.0.ts
@@ -1,0 +1,5 @@
+// @target: esnext
+// @module: nodenext
+// @noEmit: true
+
+type customConditions = TypeScriptSettings["customConditions"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.1.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.customConditions.1.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: nodenext
+// @customConditions: cond1,cond2
+// @noEmit: true
+
+type customConditions = TypeScriptSettings["customConditions"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.esModuleInterop.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @esModuleInterop: *
+// @noEmit: true
+
+type esModuleInterop = TypeScriptSettings["esModuleInterop"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.exactOptionalPropertyTypes.ts
@@ -1,0 +1,7 @@
+// @target: esnext
+// @module: esnext
+// @strictNullChecks: true
+// @exactOptionalPropertyTypes: *
+// @noEmit: true
+
+type exactOptionalPropertyTypes = TypeScriptSettings["exactOptionalPropertyTypes"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.0.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.0.ts
@@ -1,0 +1,4 @@
+// @target: esnext
+// @noEmit: true
+
+type locale = TypeScriptSettings["locale"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.1.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.locale.1.ts
@@ -1,0 +1,5 @@
+// @target: esnext
+// @noEmit: true
+// @locale: en-US
+
+type locale = TypeScriptSettings["locale"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.module.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: *
+// @noEmit: true
+
+type module = TypeScriptSettings["module"];
+type moduleResolution = TypeScriptSettings["moduleResolution"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.bundler.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: es2015,es2020,esnext,preserve
+// @moduleResolution: bundler
+// @noEmit: true
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node10.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: *,-node16,-nodenext
+// @moduleResolution: node10
+// @noEmit: true
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.node16.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: node16,nodenext
+// @moduleResolution: node16
+// @noEmit: true
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.moduleResolution.nodenext.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: node16,nodenext
+// @moduleResolution: nodenext
+// @noEmit: true
+
+type moduleResolution = TypeScriptSettings["moduleResolution"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noImplicitAny.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @noImplicitAny: *
+// @noEmit: true
+
+type noImplicitAny = TypeScriptSettings["noImplicitAny"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.noUncheckedIndexedAccess.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @noUncheckedIndexedAccess: *
+// @noEmit: true
+
+type noUncheckedIndexedAccess = TypeScriptSettings["noUncheckedIndexedAccess"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictBindCallApply.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @strictBindCallApply: *
+// @noEmit: true
+
+type strictBindCallApply = TypeScriptSettings["strictBindCallApply"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictFunctionTypes.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @strictFunctionTypes: *
+// @noEmit: true
+
+type strictFunctionTypes = TypeScriptSettings["strictFunctionTypes"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.strictNullChecks.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @strictNullChecks: *
+// @noEmit: true
+
+type strictNullChecks = TypeScriptSettings["strictNullChecks"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.target.ts
@@ -1,0 +1,4 @@
+// @target: *,-es3
+// @noEmit: true
+
+type target = TypeScriptSettings["target"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.useDefineForClassFields.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+// @module: esnext
+// @useDefineForClassFields: *
+// @noEmit: true
+
+type useDefineForClassFields = TypeScriptSettings["useDefineForClassFields"];

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.version.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.version.ts
@@ -1,0 +1,7 @@
+// @target: esnext
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// NOTE: Cannot use type tests here as there would be a diff every time the version changes
+type CheckVersion<T extends `${bigint}.${bigint}.${bigint}` | `${bigint}.${bigint}.${bigint}-${string}`> = T;
+type version = CheckVersion<TypeScriptSettings["version"]>;

--- a/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.versionMajorMinor.ts
+++ b/tests/cases/conformance/types/typeScriptSettings/typeScriptSettings.versionMajorMinor.ts
@@ -1,0 +1,7 @@
+// @target: esnext
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// NOTE: Cannot use type tests here as there would be a diff every time the version changes
+type CheckVersion<T extends `${bigint}.${bigint}`> = T;
+type versionMajorMinor = CheckVersion<TypeScriptSettings["versionMajorMinor"]>;

--- a/tests/cases/fourslash/completionListNewIdentifierFunctionDeclaration.ts
+++ b/tests/cases/fourslash/completionListNewIdentifierFunctionDeclaration.ts
@@ -6,6 +6,6 @@
 
 verify.completions({
     marker: "1",
-    exact: completion.typeKeywords,
+    exact: completion.globalTypesNoLib,
     isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionListWithMeanings.ts
+++ b/tests/cases/fourslash/completionListWithMeanings.ts
@@ -26,11 +26,10 @@ const values: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry> = comple
 ], { noLib: true });
 
 const types: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry> = completion.sorted([
-    completion.globalThisEntry,
+    ...completion.globalTypesNoLib,
     { name: "m", text: "namespace m" },
     { name: "m3", text: "namespace m3" },
     { name: "point", text: "interface point" },
-    ...completion.typeKeywords,
 ]);
 
 const filterValuesByName = (name: string) => {

--- a/tests/cases/fourslash/completionListWithModulesFromModule.ts
+++ b/tests/cases/fourslash/completionListWithModulesFromModule.ts
@@ -267,12 +267,11 @@ verify.completions(
         ], { noLib: true }),
     }, {
         marker: ["shadowNamespaceWithNoExportType", "shadowNamespaceWithExportType"],
-        unsorted: completion.typeKeywordsPlus([
-            completion.globalThisEntry,
+        unsorted: completion.globalTypesPlus([
             { name: "shwcls", text: "class shwcls" },
             { name: "shwint", text: "interface shwint" },
             ...commonTypes,
-        ]),
+        ], { noLib: true }),
     },
     {
         marker: "namespaceWithImport",
@@ -288,13 +287,12 @@ verify.completions(
     },
     {
         marker: "namespaceWithImportType",
-        unsorted: completion.typeKeywordsPlus([
-            completion.globalThisEntry,
+        unsorted: completion.globalTypesPlus([
             "Mod1",
             "iMod1",
             ...commonTypes,
             { name: "shwcls", text: "class shwcls" },
             { name: "shwint", text: "interface shwint" },
-        ]),
+        ], { noLib: true }),
     }
 );

--- a/tests/cases/fourslash/completionsIsTypeOnlyCompletion.ts
+++ b/tests/cases/fourslash/completionsIsTypeOnlyCompletion.ts
@@ -12,7 +12,7 @@
 verify.completions({
     marker: "",
     // Should not have an import completion for 'Abc', should use the local one
-    exact: completion.typeKeywordsPlus(["Abc"]),
+    exact: completion.globalTypesPlus(["Abc"], { noLib: true }),
     preferences: {
         includeCompletionsForModuleExports: true,
     },

--- a/tests/cases/fourslash/completionsTypeKeywords.ts
+++ b/tests/cases/fourslash/completionsTypeKeywords.ts
@@ -6,5 +6,5 @@
 
 verify.completions({
     marker: "",
-    exact: completion.typeKeywordsPlus(["T", completion.globalThisEntry]),
+    exact: completion.globalTypesPlus(["T"], { noLib: true }),
 });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -914,7 +914,8 @@ declare namespace completion {
     export const typeKeywords: ReadonlyArray<Entry>;
     export function typeKeywordsPlus(plus: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry>): ReadonlyArray<Entry>;
     export const globalTypes: ReadonlyArray<Entry>;
-    export function globalTypesPlus(plus: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry>): ReadonlyArray<Entry>;
+    export const globalTypesNoLib: ReadonlyArray<Entry>;
+    export function globalTypesPlus(plus: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry>, options?: GlobalsPlusOptions): ReadonlyArray<Entry>;
     export const typeAssertionKeywords: ReadonlyArray<Entry>;
     export const classElementKeywords: ReadonlyArray<Entry>;
     export const classElementInJsKeywords: ReadonlyArray<Entry>;


### PR DESCRIPTION
This adds a synthetic `TypeScriptSettings` interface to the global scope that reflects the state of _current compilation_'s compiler options. The synthetic interface looks something like the following:

```ts
interface TypeScriptSettings {
  version: string; // e.g., "5.5.0-dev", etc.
  versionMajorMinor: string; // e.g., "5.5", etc.
  locale: string | undefined; // e.g., "en-US", etc.
  target: string; // e.g., "es2023", etc.
  module: string; // e.g., "node16", etc.
  moduleResolution: string; // e.g., "node16", etc.
  customConditions: readonly string[] | undefined;
  exactOptionalPropertyTypes: boolean;
  noImplicitAny: boolean;
  noUncheckedIndexedAccess: boolean;
  strictBindCallApply: boolean;
  strictFunctionTypes: boolean;
  strictNullChecks: boolean;
  useDefineForClassFields: boolean;
}
```

Some compiler options can already be detected by the type system, such as `--strictNullChecks` or `--exactOptionalPropertyTypes`:

```ts
type StrictNullChecks = (1 | undefined extends 1 ? false : true);
type ExactOptionalPropertyTypes = { _?: true | undefined } extends { _?: true } ? false : true;
```
[TypeScript playground](https://www.typescriptlang.org/play/?exactOptionalPropertyTypes=true&ts=5.5.0-pr-58243-49#code/PTAEAEGcBcCcEsDG0ByBXANhgwgCwKaIDWkAXKHGvgLABQIE+AHgIbIDyADtPAPYB2LDAAVYvTvljQAngBVpEshVhU6dGRNABlOElSYcBYpFABeUAAoA2gEZQAH1Bp+AE3wAzeP3wuAuqGZofFcTW38AflB3IUh8UHJKfABKAG46BlBQAD1wtVoNOIBRVg5uPkERMQkpOQV8E3MAb1AAfXCElTjHZzdPbxdQAF8ApiCQ0Ga2jqoh0EjojFj45So0+jBMnKA)

But most compiler options are not so easily derived.

## Supporting stricter `Iterable`/`IterableIterator`

One of the key benefits of this approach is that types can be tailored for specific compiler options without the need to introduce new syntax or new `intrinsic` types. For example, we found that the changes in #58243, which introduces new type parameters for a stricter definition of `Iterable`, caused far too many breaks were we to ship those changes unflagged. When we shipped `--strictBindCallApply`, we were able to control strictness by swapping out the base type of a function or constructor type with something stricter than `Function`. Doing the same for all of the different JS built-ins that are iterable becomes far tricker, and is more likely to run afoul of users writing custom iterators, or would cause complications with the new `Iterator` constructor introduced by #58222.

Instead, we can leverage `TypeScriptSettings` to handle this case:

```ts
type BuiltinIteratorReturnType = TypeScriptSettings extends { noUncheckedIndexedAccess: true } ? undefined : any;

...

interface Array<T> {
  value(): IterableIterator<T, BuiltinIteratorReturnType>;
}
```

Here, we can use the existing `--noUncheckedIndexedAccess` flag to control the strictness of the `TReturn` type passed to `IterableIterator`. When the flag is unset, we fallback to the current behavior for `IterableIterator` (where `TReturn` is `any`). When the flag is set, we instead pass `undefined` for `TReturn`.

## Why use an interface and not an `intrinsic` type alias?

Rather than use `intrinsic`, the new `TypeScriptSettings` type is introduced as an `interface` to allow for declaration merging when a library needs to target both newer and older versions of TypeScript:

```ts
type __StrictNullAwareType<T> = ...;
type __NonStrictNullAwareType<T> = ...;
type __LegacyType<T> = ...;

export type NullAwareType<T> = 
  TypeScriptSettings extends { strictNullChecks: true } ? __StrictNullAwareType<T> :
  TypeScriptSettings extends { strictNullChecks: false} ? __NonStrictNullAwareType<T> :
  __LegacyType<T>;
  
// stub TypeScriptSettings to support older compilers:
declare global { interface TypeScriptSettings {} }
```

## TODO

While this PR is fully functional, we must still discuss which flags to include/exclude, as well as whether to continue with `TypeScriptSetings` or use a different name. I've only included options that could have an impact on types. Some options like `customConditions` have some interesting potential, but may end up being cut as they could be abused.

Fixes #50196
Related #58243