### PR TITLE
Lazy calculation of expensive file explaining diagnsotics and some caching to be used to share the diagnostic data

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -88,7 +88,7 @@ import {
     fileIncludeReasonToDiagnostics,
     FilePreprocessingDiagnostics,
     FilePreprocessingDiagnosticsKind,
-    FilePreprocessingLibreferenceDiagnostic,
+    FilePreprocessingLibReferenceDiagnostic,
     FileReference,
     filter,
     find,
@@ -2067,7 +2067,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                                 diagnostic.args || emptyArray,
                             ),
                         );
-                    case FilePreprocessingDiagnosticsKind.FilePreprocessingLibreferenceDiagnostic:
+                    case FilePreprocessingDiagnosticsKind.FilePreprocessingLibReferenceDiagnostic:
                         return programDiagnostics.add(filePreprocessingLibreferenceDiagnostic(diagnostic));
                     case FilePreprocessingDiagnosticsKind.ResolutionDiagnostics:
                         return diagnostic.diagnostics.forEach(d => programDiagnostics.add(d));
@@ -2087,7 +2087,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         return programDiagnostics;
     }
 
-    function filePreprocessingLibreferenceDiagnostic({ reason }: FilePreprocessingLibreferenceDiagnostic) {
+    function filePreprocessingLibreferenceDiagnostic({ reason }: FilePreprocessingLibReferenceDiagnostic) {
         const { file, pos, end } = getReferencedFileLocation(program, reason) as ReferenceFileLocation;
         const libReference = file.libReferenceDirectives[reason.index];
         const libName = getLibNameFromLibReference(libReference);
@@ -4164,7 +4164,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             }
             else {
                 (fileProcessingDiagnostics ||= []).push({
-                    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingLibreferenceDiagnostic,
+                    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingLibReferenceDiagnostic,
                     reason: { kind: FileIncludeKind.LibReferenceDirective, file: file.path, index },
                 });
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4622,10 +4622,10 @@ export interface FilePreprocessingLibreferenceDiagnostic {
 /** @internal */
 export interface FilePreprocessingFileExplainingDiagnostic {
     kind: FilePreprocessingDiagnosticsKind.FilePreprocessingFileExplainingDiagnostic;
-    file?: Path;
+    file: Path | undefined;
     fileProcessingReason: FileIncludeReason;
     diagnostic: DiagnosticMessage;
-    args?: DiagnosticArguments;
+    args: DiagnosticArguments;
 }
 
 /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4608,17 +4608,15 @@ export type FileIncludeReason =
 
 /** @internal */
 export const enum FilePreprocessingDiagnosticsKind {
-    FilePreprocessingReferencedDiagnostic,
+    FilePreprocessingLibreferenceDiagnostic,
     FilePreprocessingFileExplainingDiagnostic,
     ResolutionDiagnostics,
 }
 
 /** @internal */
-export interface FilePreprocessingReferencedDiagnostic {
-    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingReferencedDiagnostic;
-    reason: ReferencedFile;
-    diagnostic: DiagnosticMessage;
-    args?: DiagnosticArguments;
+export interface FilePreprocessingLibreferenceDiagnostic {
+    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingLibreferenceDiagnostic;
+    reason: ReferencedFile & { kind: FileIncludeKind.LibReferenceDirective; };
 }
 
 /** @internal */
@@ -4637,7 +4635,7 @@ export interface ResolutionDiagnostics {
 }
 
 /** @internal */
-export type FilePreprocessingDiagnostics = FilePreprocessingReferencedDiagnostic | FilePreprocessingFileExplainingDiagnostic | ResolutionDiagnostics;
+export type FilePreprocessingDiagnostics = FilePreprocessingLibreferenceDiagnostic | FilePreprocessingFileExplainingDiagnostic | ResolutionDiagnostics;
 
 /** @internal */
 export const enum EmitOnly {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4608,14 +4608,14 @@ export type FileIncludeReason =
 
 /** @internal */
 export const enum FilePreprocessingDiagnosticsKind {
-    FilePreprocessingLibreferenceDiagnostic,
+    FilePreprocessingLibReferenceDiagnostic,
     FilePreprocessingFileExplainingDiagnostic,
     ResolutionDiagnostics,
 }
 
 /** @internal */
-export interface FilePreprocessingLibreferenceDiagnostic {
-    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingLibreferenceDiagnostic;
+export interface FilePreprocessingLibReferenceDiagnostic {
+    kind: FilePreprocessingDiagnosticsKind.FilePreprocessingLibReferenceDiagnostic;
     reason: ReferencedFile & { kind: FileIncludeKind.LibReferenceDirective; };
 }
 
@@ -4635,7 +4635,7 @@ export interface ResolutionDiagnostics {
 }
 
 /** @internal */
-export type FilePreprocessingDiagnostics = FilePreprocessingLibreferenceDiagnostic | FilePreprocessingFileExplainingDiagnostic | ResolutionDiagnostics;
+export type FilePreprocessingDiagnostics = FilePreprocessingLibReferenceDiagnostic | FilePreprocessingFileExplainingDiagnostic | ResolutionDiagnostics;
 
 /** @internal */
 export const enum EmitOnly {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -828,7 +828,8 @@ export function createModuleNotFoundChain(sourceFile: SourceFile, host: TypeChec
     return result;
 }
 
-function packageIdIsEqual(a: PackageId | undefined, b: PackageId | undefined): boolean {
+/** @internal */
+export function packageIdIsEqual(a: PackageId | undefined, b: PackageId | undefined): boolean {
     return a === b || !!a && !!b && a.name === b.name && a.subModuleName === b.subModuleName && a.version === b.version && a.peerDependencies === b.peerDependencies;
 }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -828,8 +828,7 @@ export function createModuleNotFoundChain(sourceFile: SourceFile, host: TypeChec
     return result;
 }
 
-/** @internal */
-export function packageIdIsEqual(a: PackageId | undefined, b: PackageId | undefined): boolean {
+function packageIdIsEqual(a: PackageId | undefined, b: PackageId | undefined): boolean {
     return a === b || !!a && !!b && a.name === b.name && a.subModuleName === b.subModuleName && a.version === b.version && a.peerDependencies === b.peerDependencies;
 }
 

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -594,6 +594,7 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
             });
             parsedConfigs = undefined;
         }
+        builderProgram = undefined!;
     }
 
     function getResolutionCache() {

--- a/src/testRunner/unittests/helpers.ts
+++ b/src/testRunner/unittests/helpers.ts
@@ -21,6 +21,7 @@ export interface NamedSourceText {
 export interface ProgramWithSourceTexts extends ts.Program {
     sourceTexts?: readonly NamedSourceText[];
     host: TestCompilerHost;
+    version: number;
 }
 
 export interface TestCompilerHost extends ts.CompilerHost {
@@ -102,7 +103,7 @@ function createSourceFileWithText(fileName: string, sourceText: SourceText, targ
     return file;
 }
 
-export function createTestCompilerHost(texts: readonly NamedSourceText[], target: ts.ScriptTarget, oldProgram?: ProgramWithSourceTexts, useGetSourceFileByPath?: boolean) {
+export function createTestCompilerHost(texts: readonly NamedSourceText[], target: ts.ScriptTarget, oldProgram?: ProgramWithSourceTexts, useGetSourceFileByPath?: boolean, useCaseSensitiveFileNames?: boolean) {
     const files = ts.arrayToMap(texts, t => t.name, t => {
         if (oldProgram) {
             let oldFile = oldProgram.getSourceFile(t.name) as SourceFileWithText;
@@ -115,14 +116,15 @@ export function createTestCompilerHost(texts: readonly NamedSourceText[], target
         }
         return createSourceFileWithText(t.name, t.text, target);
     });
-    const useCaseSensitiveFileNames = ts.sys && ts.sys.useCaseSensitiveFileNames;
+    if (useCaseSensitiveFileNames === undefined) useCaseSensitiveFileNames = ts.sys && ts.sys.useCaseSensitiveFileNames;
     const getCanonicalFileName = ts.createGetCanonicalFileName(useCaseSensitiveFileNames);
+    const filesByPath = ts.mapEntries(files, (fileName, file) => [ts.toPath(fileName, "", getCanonicalFileName), file]);
     const trace: string[] = [];
     const result: TestCompilerHost = {
         trace: s => trace.push(s),
         getTrace: () => trace,
         clearTrace: () => trace.length = 0,
-        getSourceFile: fileName => files.get(fileName),
+        getSourceFile: fileName => filesByPath.get(ts.toPath(fileName, "", getCanonicalFileName)),
         getDefaultLibFileName: () => "lib.d.ts",
         writeFile: ts.notImplemented,
         getCurrentDirectory: () => "",
@@ -130,37 +132,48 @@ export function createTestCompilerHost(texts: readonly NamedSourceText[], target
         getCanonicalFileName,
         useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
         getNewLine: () => ts.sys ? ts.sys.newLine : newLine,
-        fileExists: fileName => files.has(fileName),
+        fileExists: fileName => filesByPath.has(ts.toPath(fileName, "", getCanonicalFileName)),
         readFile: fileName => {
-            const file = files.get(fileName);
+            const file = filesByPath.get(ts.toPath(fileName, "", getCanonicalFileName));
             return file && file.text;
         },
     };
     if (useGetSourceFileByPath) {
-        const filesByPath = ts.mapEntries(files, (fileName, file) => [ts.toPath(fileName, "", getCanonicalFileName), file]);
         result.getSourceFileByPath = (_fileName, path) => filesByPath.get(path);
     }
     return result;
 }
 
-export function newProgram(texts: NamedSourceText[], rootNames: string[], options: ts.CompilerOptions, useGetSourceFileByPath?: boolean): ProgramWithSourceTexts {
-    const host = createTestCompilerHost(texts, options.target!, /*oldProgram*/ undefined, useGetSourceFileByPath);
-    const program = ts.createProgram(rootNames, options, host) as ProgramWithSourceTexts;
-    program.sourceTexts = texts;
-    program.host = host;
-    return program;
+export function newProgram(texts: NamedSourceText[], rootNames: string[], options: ts.CompilerOptions, useGetSourceFileByPath?: boolean, useCaseSensitiveFileNames?: boolean): ProgramWithSourceTexts {
+    const host = createTestCompilerHost(texts, options.target!, /*oldProgram*/ undefined, useGetSourceFileByPath, useCaseSensitiveFileNames);
+    return programToProgramWithSourceTexts(
+        ts.createProgram(rootNames, options, host),
+        texts,
+        host,
+        1,
+    );
 }
 
-export function updateProgram(oldProgram: ProgramWithSourceTexts, rootNames: readonly string[], options: ts.CompilerOptions, updater: (files: NamedSourceText[]) => void, newTexts?: NamedSourceText[], useGetSourceFileByPath?: boolean) {
+function programToProgramWithSourceTexts(program: ts.Program, texts: NamedSourceText[], host: TestCompilerHost, version: number): ProgramWithSourceTexts {
+    const result = program as ProgramWithSourceTexts;
+    result.sourceTexts = texts;
+    result.host = host;
+    result.version = version;
+    return result;
+}
+
+export function updateProgram(oldProgram: ProgramWithSourceTexts, rootNames: readonly string[], options: ts.CompilerOptions, updater: (files: NamedSourceText[]) => void, newTexts?: NamedSourceText[], useGetSourceFileByPath?: boolean, useCaseSensitiveFileNames?: boolean) {
     if (!newTexts) {
         newTexts = oldProgram.sourceTexts!.slice(0);
     }
     updater(newTexts);
-    const host = createTestCompilerHost(newTexts, options.target!, oldProgram, useGetSourceFileByPath);
-    const program = ts.createProgram(rootNames, options, host, oldProgram) as ProgramWithSourceTexts;
-    program.sourceTexts = newTexts;
-    program.host = host;
-    return program;
+    const host = createTestCompilerHost(newTexts, options.target!, oldProgram, useGetSourceFileByPath, useCaseSensitiveFileNames);
+    return programToProgramWithSourceTexts(
+        ts.createProgram(rootNames, options, host, oldProgram),
+        newTexts,
+        host,
+        oldProgram.version + 1,
+    );
 }
 
 export function updateProgramText(files: readonly NamedSourceText[], fileName: string, newProgramText: string) {

--- a/src/testRunner/unittests/helpers/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/helpers/forceConsistentCasingInFileNames.ts
@@ -1,0 +1,33 @@
+import { dedent } from "../../_namespaces/Utils";
+import { jsonToReadableText } from "../helpers";
+import {
+    FsContents,
+    libContent,
+} from "./contents";
+import { libFile } from "./virtualFileSystemWithWatch";
+
+export function getFsContentsForMultipleErrorsForceConsistentCasingInFileNames(): FsContents {
+    return {
+        "/home/src/projects/project/src/struct.d.ts": dedent`
+            import * as xs1 from "fp-ts/lib/Struct";
+            import * as xs2 from "fp-ts/lib/struct";
+            import * as xs3 from "./Struct";
+            import * as xs4 from "./struct";
+        `,
+        "/home/src/projects/project/src/anotherFile.ts": dedent`
+            import * as xs1 from "fp-ts/lib/Struct";
+            import * as xs2 from "fp-ts/lib/struct";
+            import * as xs3 from "./Struct";
+            import * as xs4 from "./struct";
+        `,
+        "/home/src/projects/project/src/oneMore.ts": dedent`
+            import * as xs1 from "fp-ts/lib/Struct";
+            import * as xs2 from "fp-ts/lib/struct";
+            import * as xs3 from "./Struct";
+            import * as xs4 from "./struct";
+        `,
+        "/home/src/projects/project/tsconfig.json": jsonToReadableText({}),
+        "/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts": `export function foo(): void`,
+        [libFile.path]: libContent,
+    };
+}

--- a/src/testRunner/unittests/helpers/libraryResolution.ts
+++ b/src/testRunner/unittests/helpers/libraryResolution.ts
@@ -91,3 +91,46 @@ export function getCommandLineArgsForLibResolution(withoutConfig: true | undefin
         ["project1/core.d.ts", "project1/utils.d.ts", "project1/file.ts", "project1/index.ts", "project1/file2.ts", "--lib", "es5,dom", "--traceResolution", "--explainFiles"] :
         ["-p", "project1", "--explainFiles"];
 }
+
+function getFsContentsForLibResolutionUnknown(): FsContents {
+    return {
+        "/home/src/projects/project1/utils.d.ts": `export const y = 10;`,
+        "/home/src/projects/project1/file.ts": `export const file = 10;`,
+        "/home/src/projects/project1/core.d.ts": `export const core = 10;`,
+        "/home/src/projects/project1/index.ts": `export const x = "type1";`,
+        "/home/src/projects/project1/file2.ts": dedent`
+            /// <reference lib="webworker2"/>
+            /// <reference lib="unknownlib"/>
+            /// <reference lib="scripthost"/>
+        `,
+        "/home/src/projects/project1/tsconfig.json": jsonToReadableText({
+            compilerOptions: {
+                composite: true,
+                traceResolution: true,
+            },
+        }),
+        "/home/src/lib/lib.d.ts": libContent,
+        "/home/src/lib/lib.webworker.d.ts": "interface WebWorkerInterface { }",
+        "/home/src/lib/lib.scripthost.d.ts": "interface ScriptHostInterface { }",
+    };
+}
+
+export function getFsForLibResolutionUnknown() {
+    return loadProjectFromFiles(
+        getFsContentsForLibResolutionUnknown(),
+        {
+            cwd: "/home/src/projects",
+            executingFilePath: "/home/src/lib/tsc.js",
+        },
+    );
+}
+
+export function getSysForLibResolutionUnknown() {
+    return createWatchedSystem(
+        getFsContentsForLibResolutionUnknown(),
+        {
+            currentDirectory: "/home/src/projects",
+            executingFilePath: "/home/src/lib/tsc.js",
+        },
+    );
+}

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -19,7 +19,8 @@ import {
     libFile,
 } from "./helpers/virtualFileSystemWithWatch";
 
-describe("unittests:: Reuse program structure:: General", () => {
+describe("unittests:: reuseProgramStructure:: General", () => {
+    type ProgramToBaseline = ts.Program & Pick<ProgramWithSourceTexts, "version">;
     function baselineCache<File, T>(
         baselines: string[],
         cacheType: string,
@@ -40,8 +41,21 @@ describe("unittests:: Reuse program structure:: General", () => {
             baselines.push(`${key}: ${mode ? ts.getNameOfCompilerOptionValue(mode, ts.moduleOptionDeclaration.type) + ": " : ""}${jsonToReadableText(resolved)}`);
         }
     }
-    function baselineProgram(baselines: string[], program: ts.Program, host?: TestCompilerHost) {
-        baselines.push(`Program Reused:: ${(ts as any).StructureIsReused[program.structureIsReused]}`);
+
+    function baselineDiagnostics(baselines: string[], program: ProgramToBaseline, skipHeader?: boolean) {
+        if (!skipHeader) {
+            baselines.push(`Program ${program.version} Reused:: ${(ts as any).StructureIsReused[program.structureIsReused]}`);
+            baselines.push(`Diagnostics:`);
+        }
+        baselines.push(ts.formatDiagnostics(program.getSemanticDiagnostics(), {
+            getCurrentDirectory: () => program.getCurrentDirectory(),
+            getNewLine: () => "\n",
+            getCanonicalFileName: ts.createGetCanonicalFileName(program.useCaseSensitiveFileNames()),
+        }));
+        baselines.push("", "");
+    }
+    function baselineProgram(baselines: string[], program: ProgramToBaseline, host?: TestCompilerHost, skipDiagnostics?: boolean) {
+        baselines.push(`Program ${program.version} Reused:: ${(ts as any).StructureIsReused[program.structureIsReused]}`);
         program.getSourceFiles().forEach(f => {
             baselines.push(`File: ${f.fileName}`, f.text);
             baselineCache(baselines, "resolvedModules", f, program.forEachResolvedModule);
@@ -55,12 +69,12 @@ describe("unittests:: Reuse program structure:: General", () => {
         baselines.push("");
         baselines.push(`MissingPaths:: ${jsonToReadableText(ts.arrayFrom(program.getMissingFilePaths().values()))}`);
         baselines.push("");
-        baselines.push(ts.formatDiagnostics(program.getSemanticDiagnostics(), {
-            getCurrentDirectory: () => program.getCurrentDirectory(),
-            getNewLine: () => "\n",
-            getCanonicalFileName: ts.createGetCanonicalFileName(program.useCaseSensitiveFileNames()),
-        }));
-        baselines.push("", "");
+        if (!skipDiagnostics) {
+            baselineDiagnostics(baselines, program, /*skipHeader*/ true);
+        }
+        else {
+            baselines.push("Skipped diagnostics", "", "");
+        }
     }
 
     function runBaseline(scenario: string, baselines: readonly string[]) {
@@ -281,7 +295,8 @@ describe("unittests:: Reuse program structure:: General", () => {
         ];
         const host = createTestCompilerHost(files, target);
         const options: ts.CompilerOptions = { target, typeRoots: ["/types"] };
-        const program1 = ts.createProgram(["/a.ts"], options, host);
+        const program1 = ts.createProgram(["/a.ts"], options, host) as ProgramToBaseline;
+        program1.version = 1;
         let sourceFile = program1.getSourceFile("/a.ts")!;
         const baselines: string[] = [];
         baselineProgram(baselines, program1, host);
@@ -293,7 +308,8 @@ describe("unittests:: Reuse program structure:: General", () => {
                 return fileName === sourceFile.fileName ? sourceFile : program1.getSourceFile(fileName);
             },
         };
-        const program2 = ts.createProgram(["/a.ts"], options, updateHost, program1);
+        const program2 = ts.createProgram(["/a.ts"], options, updateHost, program1) as ProgramToBaseline;
+        program2.version = 2;
         baselineProgram(baselines, program2, updateHost);
         baselines.push(`parent pointers are not altered: ${sourceFile.statements[2].getSourceFile() === sourceFile}`);
         runBaseline("works with updated SourceFiles", baselines);
@@ -554,15 +570,217 @@ describe("unittests:: Reuse program structure:: General", () => {
             verifyRedirects(/*useGetSourceFileByPath*/ true);
         });
     });
+
+    it("forceConsistentCasingInFileNames:: handles file preprocessing dignostics", () => {
+        const files = [
+            {
+                name: "/src/project/src/struct.d.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/src/anotherFile.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/src/oneMore.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+                text: SourceText.New("", "", `export function foo(): void`),
+            },
+        ];
+
+        const options: ts.CompilerOptions = { target, moduleResolution: ts.ModuleResolutionKind.Node10 };
+        const rootNames = files.map(f => f.name);
+        const program1 = newProgram(files, rootNames, options, /*useGetSourceFileByPath*/ undefined, /*useCaseSensitiveFileNames*/ false);
+        const baselines: string[] = [];
+        baselineProgram(baselines, program1);
+
+        const program2 = updateProgram(
+            program1,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(files[0].text.getFullText() + "export const y = 10;");
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program2);
+
+        const program3 = updateProgram(
+            program2,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                    `);
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program3);
+        runBaseline("handles file preprocessing dignostics", baselines);
+    });
+
+    it("forceConsistentCasingInFileNames:: handles file preprocessing dignostics when diagnostics are not queried", () => {
+        const files = [
+            {
+                name: "/src/project/src/struct.d.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/src/anotherFile.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/src/oneMore.ts",
+                text: SourceText.New(
+                    "",
+                    "",
+                    Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                        import * as xs4 from "./struct";
+                    `,
+                ),
+            },
+            {
+                name: "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+                text: SourceText.New("", "", `export function foo(): void`),
+            },
+        ];
+
+        const options: ts.CompilerOptions = { target, moduleResolution: ts.ModuleResolutionKind.Node10 };
+        const rootNames = files.map(f => f.name);
+        const program1 = newProgram(files, rootNames, options, /*useGetSourceFileByPath*/ undefined, /*useCaseSensitiveFileNames*/ false);
+        const baselines: string[] = [];
+        baselineProgram(baselines, program1, /*host*/ undefined, /*skipDiagnostics*/ true);
+
+        const program2 = updateProgram(
+            program1,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(files[0].text.getFullText() + "export const y = 10;");
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program2, /*host*/ undefined, /*skipDiagnostics*/ true);
+        baselineDiagnostics(baselines, program1);
+
+        const program3 = updateProgram(
+            program2,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(files[0].text.getFullText() + "export const z = 10;");
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program3);
+        baselineDiagnostics(baselines, program2);
+
+        const program4 = updateProgram(
+            program3,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs2 from "fp-ts/lib/struct";
+                        import * as xs3 from "./Struct";
+                    `);
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program4, /*host*/ undefined, /*skipDiagnostics*/ true);
+
+        const program5 = updateProgram(
+            program4,
+            rootNames,
+            options,
+            files => {
+                files[0].text = files[0].text.updateProgram(Utils.dedent`
+                        import * as xs1 from "fp-ts/lib/Struct";
+                        import * as xs3 from "./Struct";
+                    `);
+            },
+            /*newTexts*/ undefined,
+            /*useGetSourceFileByPath*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+        );
+        baselineProgram(baselines, program5);
+        baselineDiagnostics(baselines, program4);
+        runBaseline("handles file preprocessing dignostics when diagnostics are not queried", baselines);
+    });
 });
 
-describe("unittests:: Reuse program structure:: host is optional", () => {
+describe("unittests:: reuseProgramStructure:: host is optional", () => {
     it("should work if host is not provided", () => {
         ts.createProgram([], {});
     });
 });
 
-describe("unittests:: Reuse program structure:: isProgramUptoDate", () => {
+describe("unittests:: reuseProgramStructure:: isProgramUptoDate::", () => {
     function getWhetherProgramIsUptoDate(
         program: ts.Program,
         newRootFileNames: string[],

--- a/src/testRunner/unittests/tsc/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tsc/forceConsistentCasingInFileNames.ts
@@ -1,4 +1,5 @@
-import * as Utils from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
+import { getFsContentsForMultipleErrorsForceConsistentCasingInFileNames } from "../helpers/forceConsistentCasingInFileNames";
 import { verifyTsc } from "../helpers/tsc";
 import { loadProjectFromFiles } from "../helpers/vfs";
 
@@ -9,7 +10,7 @@ describe("unittests:: tsc:: forceConsistentCasingInFileNames::", () => {
         commandLineArgs: ["/src/project/src/struct.d.ts", "--forceConsistentCasingInFileNames", "--explainFiles"],
         fs: () =>
             loadProjectFromFiles({
-                "/src/project/src/struct.d.ts": Utils.dedent`
+                "/src/project/src/struct.d.ts": dedent`
                     import * as xs1 from "fp-ts/lib/Struct";
                     import * as xs2 from "fp-ts/lib/struct";
                     import * as xs3 from "./Struct";
@@ -17,5 +18,12 @@ describe("unittests:: tsc:: forceConsistentCasingInFileNames::", () => {
                 `,
                 "/src/project/node_modules/fp-ts/lib/struct.d.ts": `export function foo(): void`,
             }),
+    });
+
+    verifyTsc({
+        scenario: "forceConsistentCasingInFileNames",
+        subScenario: "when file is included from multiple places with different casing",
+        commandLineArgs: ["-p", "/home/src/projects/project/tsconfig.json", "--explainFiles"],
+        fs: () => loadProjectFromFiles(getFsContentsForMultipleErrorsForceConsistentCasingInFileNames()),
     });
 });

--- a/src/testRunner/unittests/tsc/libraryResolution.ts
+++ b/src/testRunner/unittests/tsc/libraryResolution.ts
@@ -1,6 +1,7 @@
 import {
     getCommandLineArgsForLibResolution,
     getFsForLibResolution,
+    getFsForLibResolutionUnknown,
 } from "../helpers/libraryResolution";
 import { verifyTsc } from "../helpers/tsc";
 
@@ -18,4 +19,12 @@ describe("unittests:: tsc:: libraryResolution:: library file resolution", () => 
     verify(/*libRedirection*/ true);
     verify(/*libRedirection*/ undefined, /*withoutConfig*/ true);
     verify(/*libRedirection*/ true, /*withoutConfig*/ true);
+
+    verifyTsc({
+        scenario: "libraryResolution",
+        subScenario: "unknown lib",
+        fs: () => getFsForLibResolutionUnknown(),
+        commandLineArgs: getCommandLineArgsForLibResolution(/*withoutConfig*/ undefined),
+        baselinePrograms: true,
+    });
 });

--- a/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
@@ -1,5 +1,6 @@
-import * as Utils from "../../_namespaces/Utils";
+import { dedent } from "../../_namespaces/Utils";
 import { jsonToReadableText } from "../helpers";
+import { getFsContentsForMultipleErrorsForceConsistentCasingInFileNames } from "../helpers/forceConsistentCasingInFileNames";
 import {
     TscWatchCompileChange,
     verifyTscWatch,
@@ -11,7 +12,7 @@ import {
     SymLink,
 } from "../helpers/virtualFileSystemWithWatch";
 
-describe("unittests:: tsc-watch:: forceConsistentCasingInFileNames", () => {
+describe("unittests:: tsc-watch:: forceConsistentCasingInFileNames::", () => {
     const loggerFile: File = {
         path: `/user/username/projects/myproject/logger.ts`,
         content: `export class logger { }`,
@@ -334,7 +335,7 @@ a;b;
                         ".": "./dist/index.js",
                     },
                 }),
-                "/Users/name/projects/web/index.ts": Utils.dedent`
+                "/Users/name/projects/web/index.ts": dedent`
                     import * as me from "@this/package";
                     me.thing();
                     export function thing(): void {}
@@ -365,10 +366,10 @@ a;b;
                     type: "module",
                     exports: "./src/index.ts",
                 }),
-                "/Users/name/projects/lib-boilerplate/src/index.ts": Utils.dedent`
+                "/Users/name/projects/lib-boilerplate/src/index.ts": dedent`
                     export function thing(): void {}
                 `,
-                "/Users/name/projects/lib-boilerplate/test/basic.spec.ts": Utils.dedent`
+                "/Users/name/projects/lib-boilerplate/test/basic.spec.ts": dedent`
                     import { thing } from 'lib-boilerplate'
                 `,
                 "/Users/name/projects/lib-boilerplate/tsconfig.json": jsonToReadableText({
@@ -381,5 +382,36 @@ a;b;
                 }),
                 "/a/lib/lib.es2021.full.d.ts": libFile.content,
             }, { currentDirectory: "/Users/name/projects/lib-boilerplate" }),
+    });
+
+    verifyTscWatch({
+        scenario: "forceConsistentCasingInFileNames",
+        subScenario: "when file is included from multiple places with different casing",
+        commandLineArgs: ["-w", "--explainFiles"],
+        sys: () =>
+            createWatchedSystem(
+                getFsContentsForMultipleErrorsForceConsistentCasingInFileNames(),
+                { currentDirectory: "/home/src/projects/project" },
+            ),
+        edits: [
+            {
+                caption: "change to reuse imports",
+                edit: sys => sys.appendFile("/home/src/projects/project/src/struct.d.ts", "export const y = 10;"),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+            {
+                caption: "change to update imports",
+                edit: sys =>
+                    sys.writeFile(
+                        "/home/src/projects/project/src/struct.d.ts",
+                        dedent`
+                            import * as xs1 from "fp-ts/lib/Struct";
+                            import * as xs2 from "fp-ts/lib/struct";
+                            import * as xs3 from "./Struct";
+                        `,
+                    ),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+        ],
     });
 });

--- a/src/testRunner/unittests/tscWatch/libraryResolution.ts
+++ b/src/testRunner/unittests/tscWatch/libraryResolution.ts
@@ -1,7 +1,9 @@
+import { dedent } from "../../_namespaces/Utils";
 import { jsonToReadableText } from "../helpers";
 import {
     getCommandLineArgsForLibResolution,
     getSysForLibResolution,
+    getSysForLibResolutionUnknown,
 } from "../helpers/libraryResolution";
 import {
     TscWatchCompileChange,
@@ -9,7 +11,7 @@ import {
     verifyTscWatch,
 } from "../helpers/tscWatch";
 
-describe("unittests:: tsc-watch:: libraryResolution", () => {
+describe("unittests:: tsc-watch:: libraryResolution::", () => {
     function commandLineArgs(withoutConfig: true | undefined) {
         return ["-w", ...getCommandLineArgsForLibResolution(withoutConfig), "--extendedDiagnostics"];
     }
@@ -147,4 +149,47 @@ describe("unittests:: tsc-watch:: libraryResolution", () => {
     }
     verify();
     verify(/*withoutConfig*/ true);
+
+    verifyTscWatch({
+        scenario: "libraryResolution",
+        subScenario: "unknwon lib",
+        sys: () => getSysForLibResolutionUnknown(),
+        commandLineArgs: commandLineArgs(/*withoutConfig*/ undefined),
+        edits: [
+            {
+                caption: "edit index",
+                edit: sys => sys.appendFile("/home/src/projects/project1/index.ts", "export const xyz = 10;"),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+            {
+                caption: "delete core",
+                edit: sys => sys.deleteFile("/home/src/projects/project1/core.d.ts"),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+            {
+                caption: "remove unknown lib",
+                edit: sys =>
+                    sys.writeFile(
+                        "/home/src/projects/project1/file2.ts",
+                        dedent`
+                            /// <reference lib="webworker2"/>
+                            /// <reference lib="scripthost"/>
+                        `,
+                    ),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+            {
+                caption: "correct webworker lib",
+                edit: sys =>
+                    sys.writeFile(
+                        "/home/src/projects/project1/file2.ts",
+                        dedent`
+                            /// <reference lib="webworker"/>
+                            /// <reference lib="scripthost"/>
+                        `,
+                    ),
+                timeouts: sys => sys.runQueuedTimeoutCallbacks(),
+            },
+        ],
+    });
 });

--- a/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
@@ -1,10 +1,12 @@
 import * as ts from "../../_namespaces/ts";
 import { dedent } from "../../_namespaces/Utils";
 import { jsonToReadableText } from "../helpers";
+import { getFsContentsForMultipleErrorsForceConsistentCasingInFileNames } from "../helpers/forceConsistentCasingInFileNames";
 import {
     baselineTsserverLogs,
     closeFilesForSession,
     openFilesForSession,
+    protocolFileLocationFromSubstring,
     protocolTextSpanFromSubstring,
     TestSession,
     verifyGetErrRequest,
@@ -16,7 +18,7 @@ import {
     SymLink,
 } from "../helpers/virtualFileSystemWithWatch";
 
-describe("unittests:: tsserver:: forceConsistentCasingInFileNames", () => {
+describe("unittests:: tsserver:: forceConsistentCasingInFileNames::", () => {
     it("works when extends is specified with a case insensitive file system", () => {
         const rootPath = "/Users/username/dev/project";
         const file1: File = {
@@ -327,5 +329,64 @@ describe("unittests:: tsserver:: forceConsistentCasingInFileNames", () => {
         verifyDirSymlink("when import matches disk but directory symlink target does not", `/user/username/projects/myproject/XY`, `/user/username/projects/myproject/XY`, `./Xy`);
         verifyDirSymlink("when import and directory symlink target agree but do not match disk", `/user/username/projects/myproject/XY`, `/user/username/projects/myproject/Xy`, `./Xy`);
         verifyDirSymlink("when import, directory symlink target, and disk are all different", `/user/username/projects/myproject/XY`, `/user/username/projects/myproject/Xy`, `./xY`);
+    });
+
+    it("when file is included from multiple places with different casing", () => {
+        const host = createServerHost(getFsContentsForMultipleErrorsForceConsistentCasingInFileNames());
+        const session = new TestSession(host);
+        const file = "/home/src/projects/project/src/struct.d.ts";
+        let fileText = host.readFile(file)!;
+        openFilesForSession([{ file, projectRootPath: "/home/src/projects/project" }], session);
+        verifyGetErrRequest({ session, files: [file] });
+
+        // Update file without import but dont get errors:
+        updateFile(fileText + "\nexport const y = 10;");
+        goToDef();
+
+        // Update file without import and get errors:
+        updateFile(fileText + "\nexport const yy = 10;");
+        verifyGetErrRequest({ session, files: [file] });
+
+        // Remove one import, dont get errors
+        updateFile(dedent`
+            import * as xs1 from "fp-ts/lib/Struct";
+            import * as xs2 from "fp-ts/lib/struct";
+            import * as xs3 from "./Struct";
+        `);
+        goToDef();
+
+        // Remove import, get errors
+        updateFile(dedent`
+            import * as xs1 from "fp-ts/lib/Struct";
+            import * as xs3 from "./struct";
+        `);
+        verifyGetErrRequest({ session, files: [file] });
+        baselineTsserverLogs("forceConsistentCasingInFileNames", "when file is included from multiple places with different casing", session);
+
+        function updateFile(newText: string) {
+            session.executeCommandSeq<ts.server.protocol.UpdateOpenRequest>({
+                command: ts.server.protocol.CommandTypes.UpdateOpen,
+                arguments: {
+                    changedFiles: [{
+                        fileName: file,
+                        textChanges: [{
+                            newText,
+                            ...protocolTextSpanFromSubstring(
+                                fileText,
+                                fileText,
+                            ),
+                        }],
+                    }],
+                },
+            });
+            fileText = newText;
+        }
+
+        function goToDef() {
+            session.executeCommandSeq<ts.server.protocol.DefinitionRequest>({
+                command: ts.server.protocol.CommandTypes.Definition,
+                arguments: protocolFileLocationFromSubstring({ path: file, content: fileText }, `"fp-ts/lib/Struct"`),
+            });
+        }
     });
 });

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /a/b/app.ts
 
 import * as fs from 'fs'
@@ -81,7 +81,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /a/b/app.ts
 
 import * as fs from 'fs'
@@ -136,7 +136,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 3 Reused:: Completely
 File: /a/b/app.ts
 
 import * as fs from 'fs'

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: a1.ts
 
 
@@ -138,7 +138,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: a1.ts
 
 
@@ -284,7 +284,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: SafeModules
+Program 3 Reused:: SafeModules
 File: a1.ts
 
 
@@ -413,7 +413,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: SafeModules
+Program 4 Reused:: SafeModules
 File: a1.ts
 
 
@@ -542,7 +542,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: Completely
+Program 5 Reused:: Completely
 File: a1.ts
 
 
@@ -653,7 +653,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: SafeModules
+Program 6 Reused:: SafeModules
 File: a1.ts
 
 
@@ -782,7 +782,7 @@ node_modules/@types/typerefs2/index.d.ts(3,13): error TS2451: Cannot redeclare b
 
 
 
-Program Reused:: SafeModules
+Program 7 Reused:: SafeModules
 File: a1.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/b/internal.d.ts
 
 
@@ -67,7 +67,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /node_modules/b/internal.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -42,7 +42,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: c.ts
 
 import x from 'b'

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -42,7 +42,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -42,7 +42,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -55,7 +55,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -42,7 +42,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -55,7 +55,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -46,7 +46,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
+++ b/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: file1.ts
 
 import * as a from "a";
@@ -63,7 +63,7 @@ file1.ts(2,20): error TS2307: Cannot find module 'a' or its corresponding type d
 
 
 
-Program Reused:: SafeModules
+Program 2 Reused:: SafeModules
 File: node_modules/a/index.d.ts
 
 export declare let x: number;

--- a/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics-when-diagnostics-are-not-queried.js
+++ b/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics-when-diagnostics-are-not-queried.js
@@ -1,0 +1,1624 @@
+Program 1 Reused:: Not
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+Skipped diagnostics
+
+
+Program 2 Reused:: Completely
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+export const y = 10;
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+Skipped diagnostics
+
+
+Program 1 Reused:: Not
+Diagnostics:
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 3 Reused:: Completely
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+
+
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+export const y = 10;export const z = 10;
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(7,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(8,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(9,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 2 Reused:: Completely
+Diagnostics:
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 4 Reused:: SafeModules
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+Skipped diagnostics
+
+
+Program 5 Reused:: SafeModules
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs3 from "./Struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 4 Reused:: SafeModules
+Diagnostics:
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+

--- a/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics.js
+++ b/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics.js
@@ -1,0 +1,990 @@
+Program 1 Reused:: Not
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 2 Reused:: Completely
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+export const y = 10;
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+
+
+Program 3 Reused:: SafeModules
+File: /src/project/node_modules/fp-ts/lib/Struct.d.ts
+
+
+export function foo(): void
+
+File: /src/project/src/struct.d.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+
+File: /src/project/src/anotherFile.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+File: /src/project/src/oneMore.ts
+
+
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+resolvedModules:
+fp-ts/lib/Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/Struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/Struct.ts",
+    "/src/project/node_modules/fp-ts/lib/Struct.tsx"
+  ]
+}
+fp-ts/lib/struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/node_modules/fp-ts/lib/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": true,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/fp-ts/package.json",
+    "/src/project/src/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.ts",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.tsx",
+    "/src/project/src/node_modules/fp-ts/lib/struct/index.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/package.json",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct.d.ts",
+    "/src/project/src/node_modules/@types/fp-ts/lib/struct/index.d.ts",
+    "/src/project/node_modules/fp-ts/lib/struct/package.json",
+    "/src/project/node_modules/fp-ts/package.json",
+    "/src/project/node_modules/fp-ts/lib/struct.ts",
+    "/src/project/node_modules/fp-ts/lib/struct.tsx"
+  ]
+}
+./Struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/Struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/Struct.ts",
+    "/src/project/src/Struct.tsx"
+  ]
+}
+./struct: {
+  "resolvedModule": {
+    "resolvedFileName": "/src/project/src/struct.d.ts",
+    "extension": ".d.ts",
+    "isExternalLibraryImport": false,
+    "resolvedUsingTsExtension": false
+  },
+  "failedLookupLocations": [
+    "/src/project/src/struct.ts",
+    "/src/project/src/struct.tsx"
+  ]
+}
+
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
+    Root file specified for compilation
+/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Root file specified for compilation
+    Imported via "./Struct" from file '/src/project/src/struct.d.ts'
+    Imported via "./Struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./struct" from file '/src/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/src/project/src/oneMore.ts'
+    Imported via "./struct" from file '/src/project/src/oneMore.ts'
+
+

--- a/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -41,7 +41,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -41,7 +41,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -42,7 +42,7 @@ a.ts(4,23): error TS2688: Cannot find type definition file for 'typerefs'.
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -115,7 +115,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -115,7 +115,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 
@@ -113,7 +113,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Not
+Program 2 Reused:: Not
 File: /node_modules/a/node_modules/x/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: b.ts
 
 
@@ -27,7 +27,7 @@ a.ts(2,17): error TS2306: File 'b.ts' is not a module.
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: b.ts
 
 
@@ -56,7 +56,7 @@ a.ts(2,17): error TS2306: File 'b.ts' is not a module.
 
 
 
-Program Reused:: SafeModules
+Program 3 Reused:: SafeModules
 File: a.ts
 
 
@@ -70,7 +70,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: SafeModules
+Program 4 Reused:: SafeModules
 File: b.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /types/typedefs/index.d.ts
 
 
@@ -29,7 +29,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /types/typedefs/index.d.ts
 
 
@@ -60,7 +60,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: SafeModules
+Program 3 Reused:: SafeModules
 File: /a.ts
 
 
@@ -74,7 +74,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: SafeModules
+Program 4 Reused:: SafeModules
 File: /types/typedefs/index.d.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /a.ts
 
 
@@ -21,7 +21,7 @@ MissingPaths:: [
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /a.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: c.ts
 
 
@@ -44,7 +44,7 @@ b.ts(1,22): error TS6059: File 'c.ts' is not under 'rootDir' '/a/b'. 'rootDir' i
 
 
 
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: c.ts
 
 

--- a/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
+++ b/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
@@ -1,4 +1,4 @@
-Program Reused:: Not
+Program 1 Reused:: Not
 File: /a.ts
 
 
@@ -22,7 +22,7 @@ MissingPaths:: [
 
 
 parent pointers are updated: true
-Program Reused:: Completely
+Program 2 Reused:: Completely
 File: /a.ts
 'use strict';
 

--- a/tests/baselines/reference/tsc/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
+++ b/tests/baselines/reference/tsc/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
@@ -1,0 +1,339 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts]
+export function foo(): void
+
+//// [/home/src/projects/project/src/anotherFile.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/oneMore.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/struct.d.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/tsconfig.json]
+{}
+
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+
+Output::
+/lib/tsc -p /home/src/projects/project/tsconfig.json --explainFiles
+[96mhome/src/projects/project/src/anotherFile.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/anotherFile.ts[0m:[93m3[0m:[93m22[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/home/src/projects/project/src/Struct.d.ts' differs from file name '/home/src/projects/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m3[0m import * as xs3 from "./Struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/anotherFile.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/oneMore.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/oneMore.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/Struct.d.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96mhome/src/projects/project/src/Struct.d.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96mhome/src/projects/project/src/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+lib/lib.d.ts
+  Default library for target 'es5'
+home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+  Imported via "fp-ts/lib/Struct" from file 'home/src/projects/project/src/anotherFile.ts'
+  Imported via "fp-ts/lib/struct" from file 'home/src/projects/project/src/anotherFile.ts'
+  Imported via "fp-ts/lib/Struct" from file 'home/src/projects/project/src/Struct.d.ts'
+  Imported via "fp-ts/lib/struct" from file 'home/src/projects/project/src/Struct.d.ts'
+  Imported via "fp-ts/lib/Struct" from file 'home/src/projects/project/src/oneMore.ts'
+  Imported via "fp-ts/lib/struct" from file 'home/src/projects/project/src/oneMore.ts'
+home/src/projects/project/src/Struct.d.ts
+  Imported via "./Struct" from file 'home/src/projects/project/src/anotherFile.ts'
+  Imported via "./Struct" from file 'home/src/projects/project/src/Struct.d.ts'
+  Imported via "./struct" from file 'home/src/projects/project/src/Struct.d.ts'
+  Imported via "./struct" from file 'home/src/projects/project/src/anotherFile.ts'
+  Imported via "./Struct" from file 'home/src/projects/project/src/oneMore.ts'
+  Imported via "./struct" from file 'home/src/projects/project/src/oneMore.ts'
+  Matched by default include pattern '**/*'
+home/src/projects/project/src/anotherFile.ts
+  Matched by default include pattern '**/*'
+home/src/projects/project/src/oneMore.ts
+  Matched by default include pattern '**/*'
+
+Found 7 errors in 3 files.
+
+Errors  Files
+     3  home/src/projects/project/src/anotherFile.ts[90m:2[0m
+     2  home/src/projects/project/src/oneMore.ts[90m:2[0m
+     2  home/src/projects/project/src/Struct.d.ts[90m:2[0m
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/home/src/projects/project/src/anotherFile.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+//// [/home/src/projects/project/src/oneMore.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+

--- a/tests/baselines/reference/tsc/libraryResolution/unknown-lib.js
+++ b/tests/baselines/reference/tsc/libraryResolution/unknown-lib.js
@@ -1,0 +1,331 @@
+currentDirectory:: /home/src/projects useCaseSensitiveFileNames: false
+Input::
+//// [/home/src/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/home/src/lib/lib.scripthost.d.ts]
+interface ScriptHostInterface { }
+
+//// [/home/src/lib/lib.webworker.d.ts]
+interface WebWorkerInterface { }
+
+//// [/home/src/projects/project1/core.d.ts]
+export const core = 10;
+
+//// [/home/src/projects/project1/file.ts]
+export const file = 10;
+
+//// [/home/src/projects/project1/file2.ts]
+/// <reference lib="webworker2"/>
+/// <reference lib="unknownlib"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/index.ts]
+export const x = "type1";
+
+//// [/home/src/projects/project1/tsconfig.json]
+{
+  "compilerOptions": {
+    "composite": true,
+    "traceResolution": true
+  }
+}
+
+//// [/home/src/projects/project1/utils.d.ts]
+export const y = 10;
+
+
+
+Output::
+/home/src/lib/tsc -p project1 --explainFiles
+File '/home/src/projects/project1/package.json' does not exist.
+File '/home/src/projects/package.json' does not exist.
+File '/home/src/package.json' does not exist.
+File '/home/package.json' does not exist.
+File '/package.json' does not exist.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+======== Resolving module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts'. ========
+Explicitly specified module resolution kind: 'Node10'.
+Loading module '@typescript/lib-scripthost' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Loading module '@typescript/lib-scripthost' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+======== Module name '@typescript/lib-scripthost' was not resolved. ========
+File '/home/src/lib/package.json' does not exist.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+[96mproject1/file2.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2727: [0mCannot find lib definition for 'webworker2'. Did you mean 'webworker'?
+
+[7m1[0m /// <reference lib="webworker2"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+[96mproject1/file2.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2726: [0mCannot find lib definition for 'unknownlib'.
+
+[7m2[0m /// <reference lib="unknownlib"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/core.d.ts
+  Matched by default include pattern '**/*'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+
+Found 2 errors in the same file, starting at: project1/file2.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+Program root files: [
+  "/home/src/projects/project1/core.d.ts",
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/core.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/core.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Shape signatures in builder refreshed for::
+/home/src/lib/lib.d.ts (used version)
+/home/src/lib/lib.scripthost.d.ts (used version)
+/home/src/projects/project1/core.d.ts (used version)
+/home/src/projects/project1/file.ts (computed .d.ts during emit)
+/home/src/projects/project1/file2.ts (computed .d.ts during emit)
+/home/src/projects/project1/index.ts (computed .d.ts during emit)
+/home/src/projects/project1/utils.d.ts (used version)
+
+
+//// [/home/src/projects/project1/file.d.ts]
+export declare const file = 10;
+
+
+//// [/home/src/projects/project1/file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.file = void 0;
+exports.file = 10;
+
+
+//// [/home/src/projects/project1/file2.d.ts]
+
+
+//// [/home/src/projects/project1/file2.js]
+/// <reference lib="webworker2"/>
+/// <reference lib="unknownlib"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/index.d.ts]
+export declare const x = "type1";
+
+
+//// [/home/src/projects/project1/index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = void 0;
+exports.x = "type1";
+
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-15683237936-export const core = 10;","impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-11532698187-export const x = \"type1\";","signature":"-5899226897-export declare const x = \"type1\";\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[3,7]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,2,3,4,5,6,7],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./core.d.ts": {
+        "original": {
+          "version": "-15683237936-export const core = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-15683237936-export const core = 10;",
+        "signature": "-15683237936-export const core = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-11532698187-export const x = \"type1\";",
+          "signature": "-5899226897-export declare const x = \"type1\";\n",
+          "impliedFormat": 1
+        },
+        "version": "-11532698187-export const x = \"type1\";",
+        "signature": "-5899226897-export declare const x = \"type1\";\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          7
+        ],
+        [
+          "./core.d.ts",
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1512
+}
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
@@ -1,0 +1,975 @@
+currentDirectory:: /home/src/projects/project useCaseSensitiveFileNames: false
+Input::
+//// [/home/src/projects/project/src/struct.d.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/anotherFile.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/oneMore.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/tsconfig.json]
+{}
+
+//// [/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts]
+export function foo(): void
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+/a/lib/tsc.js -w --explainFiles
+Output::
+>> Screen clear
+[[90mHH:MM:SS AM[0m] Starting compilation in watch mode...
+
+[96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/home/src/projects/project/src/Struct.d.ts' differs from file name '/home/src/projects/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m3[0m import * as xs3 from "./Struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+../../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+node_modules/fp-ts/lib/Struct.d.ts
+  Imported via "fp-ts/lib/Struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/oneMore.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/oneMore.ts'
+src/Struct.d.ts
+  Imported via "./Struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/Struct.d.ts'
+  Imported via "./struct" from file 'src/Struct.d.ts'
+  Imported via "./struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/oneMore.ts'
+  Imported via "./struct" from file 'src/oneMore.ts'
+  Matched by default include pattern '**/*'
+src/anotherFile.ts
+  Matched by default include pattern '**/*'
+src/oneMore.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 7 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project/src/anotherFile.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+//// [/home/src/projects/project/src/oneMore.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+PolledWatches::
+/home/src/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/project/node_modules/fp-ts/lib/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/fp-ts/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/src/package.json: *new*
+  {"pollingInterval":2000}
+
+FsWatches::
+/a/lib/lib.d.ts: *new*
+  {}
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts: *new*
+  {}
+/home/src/projects/project/src/Struct.d.ts: *new*
+  {}
+/home/src/projects/project/src/anotherFile.ts: *new*
+  {}
+/home/src/projects/project/src/oneMore.ts: *new*
+  {}
+/home/src/projects/project/tsconfig.json: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/project: *new*
+  {}
+/home/src/projects/project/node_modules: *new*
+  {}
+/home/src/projects/project/src: *new*
+  {}
+
+Program root files: [
+  "/home/src/projects/project/src/anotherFile.ts",
+  "/home/src/projects/project/src/oneMore.ts",
+  "/home/src/projects/project/src/struct.d.ts"
+]
+Program options: {
+  "watch": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/project/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts (used version)
+/home/src/projects/project/src/struct.d.ts (used version)
+/home/src/projects/project/src/anotherfile.ts (used version)
+/home/src/projects/project/src/onemore.ts (used version)
+
+exitCode:: ExitStatus.undefined
+
+Change:: change to reuse imports
+
+Input::
+//// [/home/src/projects/project/src/struct.d.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+export const y = 10;
+
+
+Timeout callback:: count: 1
+1: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+1: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+>> Screen clear
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+[96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/home/src/projects/project/src/Struct.d.ts' differs from file name '/home/src/projects/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m3[0m import * as xs3 from "./Struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/Struct.d.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+../../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+node_modules/fp-ts/lib/Struct.d.ts
+  Imported via "fp-ts/lib/Struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/oneMore.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/oneMore.ts'
+src/Struct.d.ts
+  Imported via "./Struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/Struct.d.ts'
+  Imported via "./struct" from file 'src/Struct.d.ts'
+  Imported via "./struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/oneMore.ts'
+  Imported via "./struct" from file 'src/oneMore.ts'
+  Matched by default include pattern '**/*'
+src/anotherFile.ts
+  Matched by default include pattern '**/*'
+src/oneMore.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 7 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project/src/anotherFile.js] file written with same contents
+//// [/home/src/projects/project/src/oneMore.js] file written with same contents
+
+
+Program root files: [
+  "/home/src/projects/project/src/anotherFile.ts",
+  "/home/src/projects/project/src/oneMore.ts",
+  "/home/src/projects/project/src/struct.d.ts"
+]
+Program options: {
+  "watch": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/project/tsconfig.json"
+}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Shape signatures in builder refreshed for::
+/home/src/projects/project/src/struct.d.ts (used version)
+/home/src/projects/project/src/onemore.ts (computed .d.ts)
+/home/src/projects/project/src/anotherfile.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined
+
+Change:: change to update imports
+
+Input::
+//// [/home/src/projects/project/src/struct.d.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+
+
+
+Timeout callback:: count: 1
+2: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+2: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+>> Screen clear
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+[96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/home/src/projects/project/src/Struct.d.ts' differs from file name '/home/src/projects/project/src/struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m3[0m import * as xs3 from "./Struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/oneMore.ts[0m:[93m4[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "./Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "./struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Matched by default include pattern '**/*'
+
+[7m4[0m import * as xs4 from "./struct";
+[7m [0m [91m                     ~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m4[0m:[93m22[0m
+    [7m4[0m import * as xs4 from "./struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m3[0m:[93m22[0m
+    [7m3[0m import * as xs3 from "./Struct";
+    [7m [0m [96m                     ~~~~~~~~~~[0m
+    File is included via import here.
+
+[96msrc/Struct.d.ts[0m:[93m2[0m:[93m22[0m - [91merror[0m[90m TS1149: [0mFile name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+  The file is in the program because:
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/anotherFile.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/Struct.d.ts'
+    Imported via "fp-ts/lib/Struct" from file '/home/src/projects/project/src/oneMore.ts'
+    Imported via "fp-ts/lib/struct" from file '/home/src/projects/project/src/oneMore.ts'
+
+[7m2[0m import * as xs2 from "fp-ts/lib/struct";
+[7m [0m [91m                     ~~~~~~~~~~~~~~~~~~[0m
+
+  [96msrc/anotherFile.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/anotherFile.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/Struct.d.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m1[0m:[93m22[0m
+    [7m1[0m import * as xs1 from "fp-ts/lib/Struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+  [96msrc/oneMore.ts[0m:[93m2[0m:[93m22[0m
+    [7m2[0m import * as xs2 from "fp-ts/lib/struct";
+    [7m [0m [96m                     ~~~~~~~~~~~~~~~~~~[0m
+    File is included via import here.
+
+../../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+node_modules/fp-ts/lib/Struct.d.ts
+  Imported via "fp-ts/lib/Struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/anotherFile.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/Struct.d.ts'
+  Imported via "fp-ts/lib/Struct" from file 'src/oneMore.ts'
+  Imported via "fp-ts/lib/struct" from file 'src/oneMore.ts'
+src/Struct.d.ts
+  Imported via "./Struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/Struct.d.ts'
+  Imported via "./struct" from file 'src/anotherFile.ts'
+  Imported via "./Struct" from file 'src/oneMore.ts'
+  Imported via "./struct" from file 'src/oneMore.ts'
+  Matched by default include pattern '**/*'
+src/anotherFile.ts
+  Matched by default include pattern '**/*'
+src/oneMore.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 6 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project/src/anotherFile.js] file written with same contents
+//// [/home/src/projects/project/src/oneMore.js] file written with same contents
+
+
+Program root files: [
+  "/home/src/projects/project/src/anotherFile.ts",
+  "/home/src/projects/project/src/oneMore.ts",
+  "/home/src/projects/project/src/struct.d.ts"
+]
+Program options: {
+  "watch": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/project/tsconfig.json"
+}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/projects/project/src/Struct.d.ts
+/home/src/projects/project/src/anotherFile.ts
+/home/src/projects/project/src/oneMore.ts
+
+Shape signatures in builder refreshed for::
+/home/src/projects/project/src/struct.d.ts (used version)
+/home/src/projects/project/src/onemore.ts (computed .d.ts)
+/home/src/projects/project/src/anotherfile.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/libraryResolution/unknwon-lib.js
+++ b/tests/baselines/reference/tscWatch/libraryResolution/unknwon-lib.js
@@ -1,0 +1,1516 @@
+currentDirectory:: /home/src/projects useCaseSensitiveFileNames: false
+Input::
+//// [/home/src/projects/project1/utils.d.ts]
+export const y = 10;
+
+//// [/home/src/projects/project1/file.ts]
+export const file = 10;
+
+//// [/home/src/projects/project1/core.d.ts]
+export const core = 10;
+
+//// [/home/src/projects/project1/index.ts]
+export const x = "type1";
+
+//// [/home/src/projects/project1/file2.ts]
+/// <reference lib="webworker2"/>
+/// <reference lib="unknownlib"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/tsconfig.json]
+{
+  "compilerOptions": {
+    "composite": true,
+    "traceResolution": true
+  }
+}
+
+//// [/home/src/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/home/src/lib/lib.webworker.d.ts]
+interface WebWorkerInterface { }
+
+//// [/home/src/lib/lib.scripthost.d.ts]
+interface ScriptHostInterface { }
+
+
+/home/src/lib/tsc.js -w -p project1 --explainFiles --extendedDiagnostics
+Output::
+[[90mHH:MM:SS AM[0m] Starting compilation in watch mode...
+
+Current directory: /home/src/projects CaseSensitiveFileNames: false
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/tsconfig.json 2000 undefined Config file
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/home/src/projects/project1/core.d.ts","/home/src/projects/project1/file.ts","/home/src/projects/project1/file2.ts","/home/src/projects/project1/index.ts","/home/src/projects/project1/utils.d.ts"]
+  options: {"composite":true,"traceResolution":true,"watch":true,"project":"/home/src/projects/project1","explainFiles":true,"extendedDiagnostics":true,"configFilePath":"/home/src/projects/project1/tsconfig.json"}
+File '/home/src/projects/project1/package.json' does not exist.
+File '/home/src/projects/package.json' does not exist.
+File '/home/src/package.json' does not exist.
+File '/home/package.json' does not exist.
+File '/package.json' does not exist.
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/core.d.ts 250 undefined Source file
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/file.ts 250 undefined Source file
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/file2.ts 250 undefined Source file
+======== Resolving module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts'. ========
+Explicitly specified module resolution kind: 'Node10'.
+Loading module '@typescript/lib-scripthost' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-scripthost'
+Loading module '@typescript/lib-scripthost' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+======== Module name '@typescript/lib-scripthost' was not resolved. ========
+DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules 1 undefined Failed Lookup Locations
+File '/home/src/lib/package.json' does not exist.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/lib/lib.scripthost.d.ts 250 undefined Source file
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/index.ts 250 undefined Source file
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/utils.d.ts 250 undefined Source file
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/lib/lib.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /home/src/projects/project1/package.json 2000 undefined File location affecting resolution
+FileWatcher:: Added:: WatchInfo: /home/src/projects/package.json 2000 undefined File location affecting resolution
+DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1/node_modules/@types 1 undefined Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Type roots
+[96mproject1/file2.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2727: [0mCannot find lib definition for 'webworker2'. Did you mean 'webworker'?
+
+[7m1[0m /// <reference lib="webworker2"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+[96mproject1/file2.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2726: [0mCannot find lib definition for 'unknownlib'.
+
+[7m2[0m /// <reference lib="unknownlib"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/core.d.ts
+  Matched by default include pattern '**/*'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+
+DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1 1 undefined Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project1 1 undefined Wild card directory
+
+
+//// [/home/src/projects/project1/file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.file = void 0;
+exports.file = 10;
+
+
+//// [/home/src/projects/project1/file.d.ts]
+export declare const file = 10;
+
+
+//// [/home/src/projects/project1/file2.js]
+/// <reference lib="webworker2"/>
+/// <reference lib="unknownlib"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/file2.d.ts]
+
+
+//// [/home/src/projects/project1/index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = void 0;
+exports.x = "type1";
+
+
+//// [/home/src/projects/project1/index.d.ts]
+export declare const x = "type1";
+
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-15683237936-export const core = 10;","impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-11532698187-export const x = \"type1\";","signature":"-5899226897-export declare const x = \"type1\";\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[3,7]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,2,3,4,5,6,7],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./core.d.ts": {
+        "original": {
+          "version": "-15683237936-export const core = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-15683237936-export const core = 10;",
+        "signature": "-15683237936-export const core = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-11532698187-export const x = \"type1\";",
+          "signature": "-5899226897-export declare const x = \"type1\";\n",
+          "impliedFormat": 1
+        },
+        "version": "-11532698187-export const x = \"type1\";",
+        "signature": "-5899226897-export declare const x = \"type1\";\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          7
+        ],
+        [
+          "./core.d.ts",
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1512
+}
+
+
+PolledWatches::
+/home/src/projects/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project1/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/projects/project1/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/project1/package.json: *new*
+  {"pollingInterval":2000}
+
+FsWatches::
+/home/src/lib/lib.d.ts: *new*
+  {}
+/home/src/lib/lib.scripthost.d.ts: *new*
+  {}
+/home/src/projects/project1/core.d.ts: *new*
+  {}
+/home/src/projects/project1/file.ts: *new*
+  {}
+/home/src/projects/project1/file2.ts: *new*
+  {}
+/home/src/projects/project1/index.ts: *new*
+  {}
+/home/src/projects/project1/tsconfig.json: *new*
+  {}
+/home/src/projects/project1/utils.d.ts: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/project1: *new*
+  {}
+
+Program root files: [
+  "/home/src/projects/project1/core.d.ts",
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "watch": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/core.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/core.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Shape signatures in builder refreshed for::
+/home/src/lib/lib.d.ts (used version)
+/home/src/lib/lib.scripthost.d.ts (used version)
+/home/src/projects/project1/core.d.ts (used version)
+/home/src/projects/project1/file.ts (computed .d.ts during emit)
+/home/src/projects/project1/file2.ts (computed .d.ts during emit)
+/home/src/projects/project1/index.ts (computed .d.ts during emit)
+/home/src/projects/project1/utils.d.ts (used version)
+
+exitCode:: ExitStatus.undefined
+
+Change:: edit index
+
+Input::
+//// [/home/src/projects/project1/index.ts]
+export const x = "type1";export const xyz = 10;
+
+
+Output::
+FileWatcher:: Triggered with /home/src/projects/project1/index.ts 1:: WatchInfo: /home/src/projects/project1/index.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/projects/project1/index.ts 1:: WatchInfo: /home/src/projects/project1/index.ts 250 undefined Source file
+
+
+Timeout callback:: count: 1
+1: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+1: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/projects/project1/core.d.ts","/home/src/projects/project1/file.ts","/home/src/projects/project1/file2.ts","/home/src/projects/project1/index.ts","/home/src/projects/project1/utils.d.ts"]
+  options: {"composite":true,"traceResolution":true,"watch":true,"project":"/home/src/projects/project1","explainFiles":true,"extendedDiagnostics":true,"configFilePath":"/home/src/projects/project1/tsconfig.json"}
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+Reusing resolution of module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts' of old program, it was not resolved.
+[96mproject1/file2.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2727: [0mCannot find lib definition for 'webworker2'. Did you mean 'webworker'?
+
+[7m1[0m /// <reference lib="webworker2"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+[96mproject1/file2.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2726: [0mCannot find lib definition for 'unknownlib'.
+
+[7m2[0m /// <reference lib="unknownlib"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/core.d.ts
+  Matched by default include pattern '**/*'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project1/index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.xyz = exports.x = void 0;
+exports.x = "type1";
+exports.xyz = 10;
+
+
+//// [/home/src/projects/project1/index.d.ts]
+export declare const x = "type1";
+export declare const xyz = 10;
+
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-15683237936-export const core = 10;","impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-6136895998-export const x = \"type1\";export const xyz = 10;","signature":"-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[3,7]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,2,3,4,5,6,7],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./core.d.ts": {
+        "original": {
+          "version": "-15683237936-export const core = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-15683237936-export const core = 10;",
+        "signature": "-15683237936-export const core = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+          "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+        "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          7
+        ],
+        [
+          "./core.d.ts",
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./core.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1565
+}
+
+
+
+Program root files: [
+  "/home/src/projects/project1/core.d.ts",
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "watch": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: Completely
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/core.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/projects/project1/index.ts
+
+Shape signatures in builder refreshed for::
+/home/src/projects/project1/index.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined
+
+Change:: delete core
+
+Input::
+//// [/home/src/projects/project1/core.d.ts] deleted
+
+Output::
+FileWatcher:: Triggered with /home/src/projects/project1/core.d.ts 2:: WatchInfo: /home/src/projects/project1/core.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/projects/project1/core.d.ts 2:: WatchInfo: /home/src/projects/project1/core.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /home/src/projects/project1/core.d.ts :: WatchInfo: /home/src/projects/project1 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/projects/project1/core.d.ts :: WatchInfo: /home/src/projects/project1 1 undefined Wild card directory
+
+
+Timeout callback:: count: 1
+3: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+3: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Reloading new file names and options
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/projects/project1/file.ts","/home/src/projects/project1/file2.ts","/home/src/projects/project1/index.ts","/home/src/projects/project1/utils.d.ts"]
+  options: {"composite":true,"traceResolution":true,"watch":true,"project":"/home/src/projects/project1","explainFiles":true,"extendedDiagnostics":true,"configFilePath":"/home/src/projects/project1/tsconfig.json"}
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+Reusing resolution of module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts' of old program, it was not resolved.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Close:: WatchInfo: /home/src/projects/project1/core.d.ts 250 undefined Source file
+[96mproject1/file2.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2727: [0mCannot find lib definition for 'webworker2'. Did you mean 'webworker'?
+
+[7m1[0m /// <reference lib="webworker2"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+[96mproject1/file2.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2726: [0mCannot find lib definition for 'unknownlib'.
+
+[7m2[0m /// <reference lib="unknownlib"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.scripthost.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-6136895998-export const x = \"type1\";export const xyz = 10;","signature":"-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[3,6]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,2,3,4,5,6],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-15920922626-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+          "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+        "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          6
+        ],
+        [
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1480
+}
+
+
+PolledWatches::
+/home/src/projects/node_modules:
+  {"pollingInterval":500}
+/home/src/projects/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/projects/package.json:
+  {"pollingInterval":2000}
+/home/src/projects/project1/node_modules:
+  {"pollingInterval":500}
+/home/src/projects/project1/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/projects/project1/package.json:
+  {"pollingInterval":2000}
+
+FsWatches::
+/home/src/lib/lib.d.ts:
+  {}
+/home/src/lib/lib.scripthost.d.ts:
+  {}
+/home/src/projects/project1/file.ts:
+  {}
+/home/src/projects/project1/file2.ts:
+  {}
+/home/src/projects/project1/index.ts:
+  {}
+/home/src/projects/project1/tsconfig.json:
+  {}
+/home/src/projects/project1/utils.d.ts:
+  {}
+
+FsWatches *deleted*::
+/home/src/projects/project1/core.d.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/project1:
+  {}
+
+
+Program root files: [
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "watch": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+
+No shapes updated in the builder::
+
+exitCode:: ExitStatus.undefined
+
+Change:: remove unknown lib
+
+Input::
+//// [/home/src/projects/project1/file2.ts]
+/// <reference lib="webworker2"/>
+/// <reference lib="scripthost"/>
+
+
+
+Output::
+FileWatcher:: Triggered with /home/src/projects/project1/file2.ts 1:: WatchInfo: /home/src/projects/project1/file2.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/projects/project1/file2.ts 1:: WatchInfo: /home/src/projects/project1/file2.ts 250 undefined Source file
+
+
+Timeout callback:: count: 1
+4: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+4: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/projects/project1/file.ts","/home/src/projects/project1/file2.ts","/home/src/projects/project1/index.ts","/home/src/projects/project1/utils.d.ts"]
+  options: {"composite":true,"traceResolution":true,"watch":true,"project":"/home/src/projects/project1","explainFiles":true,"extendedDiagnostics":true,"configFilePath":"/home/src/projects/project1/tsconfig.json"}
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+Reusing resolution of module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts' of old program, it was not resolved.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+[96mproject1/file2.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2727: [0mCannot find lib definition for 'webworker2'. Did you mean 'webworker'?
+
+[7m1[0m /// <reference lib="webworker2"/>
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+
+
+
+//// [/home/src/projects/project1/file2.js]
+/// <reference lib="webworker2"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.scripthost.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-13885971376-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-6136895998-export const x = \"type1\";export const xyz = 10;","signature":"-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[3,6]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,2,3,4,5,6],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-13885971376-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-13885971376-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+          "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+        "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          6
+        ],
+        [
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1443
+}
+
+
+
+Program root files: [
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "watch": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: SafeModules
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/projects/project1/file2.ts
+
+Shape signatures in builder refreshed for::
+/home/src/projects/project1/file2.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined
+
+Change:: correct webworker lib
+
+Input::
+//// [/home/src/projects/project1/file2.ts]
+/// <reference lib="webworker"/>
+/// <reference lib="scripthost"/>
+
+
+
+Output::
+FileWatcher:: Triggered with /home/src/projects/project1/file2.ts 1:: WatchInfo: /home/src/projects/project1/file2.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/projects/project1/file2.ts 1:: WatchInfo: /home/src/projects/project1/file2.ts 250 undefined Source file
+
+
+Timeout callback:: count: 1
+5: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+5: timerToUpdateProgram
+
+After running Timeout callback:: count: 0
+Output::
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/projects/project1/file.ts","/home/src/projects/project1/file2.ts","/home/src/projects/project1/index.ts","/home/src/projects/project1/utils.d.ts"]
+  options: {"composite":true,"traceResolution":true,"watch":true,"project":"/home/src/projects/project1","explainFiles":true,"extendedDiagnostics":true,"configFilePath":"/home/src/projects/project1/tsconfig.json"}
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+======== Resolving module '@typescript/lib-webworker' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.webworker.d.ts__.ts'. ========
+Explicitly specified module resolution kind: 'Node10'.
+Loading module '@typescript/lib-webworker' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-webworker'
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-webworker'
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-webworker'
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-webworker'
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'typescript__lib-webworker'
+Loading module '@typescript/lib-webworker' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+Directory '/home/src/projects/project1/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+======== Module name '@typescript/lib-webworker' was not resolved. ========
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+FileWatcher:: Added:: WatchInfo: /home/src/lib/lib.webworker.d.ts 250 undefined Source file
+Reusing resolution of module '@typescript/lib-scripthost' from '/home/src/projects/project1/__lib_node_modules_lookup_lib.scripthost.d.ts__.ts' of old program, it was not resolved.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/project1/package.json' does not exist according to earlier cached lookups.
+File '/home/src/projects/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+File '/home/src/lib/package.json' does not exist according to earlier cached lookups.
+File '/home/src/package.json' does not exist according to earlier cached lookups.
+File '/home/package.json' does not exist according to earlier cached lookups.
+File '/package.json' does not exist according to earlier cached lookups.
+../lib/lib.d.ts
+  Default library for target 'es5'
+../lib/lib.webworker.d.ts
+  Library referenced via 'webworker' from file 'project1/file2.ts'
+../lib/lib.scripthost.d.ts
+  Library referenced via 'scripthost' from file 'project1/file2.ts'
+project1/file.ts
+  Matched by default include pattern '**/*'
+project1/file2.ts
+  Matched by default include pattern '**/*'
+project1/index.ts
+  Matched by default include pattern '**/*'
+project1/utils.d.ts
+  Matched by default include pattern '**/*'
+[[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+//// [/home/src/projects/project1/file.js] file written with same contents
+//// [/home/src/projects/project1/file2.js]
+/// <reference lib="webworker"/>
+/// <reference lib="scripthost"/>
+
+
+//// [/home/src/projects/project1/index.js] file written with same contents
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../../lib/lib.webworker.d.ts","../../lib/lib.scripthost.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedFormat":1},{"version":"-3990185033-interface WebWorkerInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-5403980302-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedFormat":1},{"version":"-16628394009-export const file = 10;","signature":"-9025507999-export declare const file = 10;\n","impliedFormat":1},{"version":"-17945718466-/// <reference lib=\"webworker\"/>\n/// <reference lib=\"scripthost\"/>\n","signature":"5381-","impliedFormat":1},{"version":"-6136895998-export const x = \"type1\";export const xyz = 10;","signature":"-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[[4,7]],"options":{"composite":true},"referencedMap":[],"semanticDiagnosticsPerFile":[1,3,2,4,5,6,7],"latestChangedDtsFile":"./index.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.webworker.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.webworker.d.ts": {
+        "original": {
+          "version": "-3990185033-interface WebWorkerInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-3990185033-interface WebWorkerInterface { }",
+        "signature": "-3990185033-interface WebWorkerInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "../../lib/lib.scripthost.d.ts": {
+        "original": {
+          "version": "-5403980302-interface ScriptHostInterface { }",
+          "affectsGlobalScope": true,
+          "impliedFormat": 1
+        },
+        "version": "-5403980302-interface ScriptHostInterface { }",
+        "signature": "-5403980302-interface ScriptHostInterface { }",
+        "affectsGlobalScope": true,
+        "impliedFormat": "commonjs"
+      },
+      "./file.ts": {
+        "original": {
+          "version": "-16628394009-export const file = 10;",
+          "signature": "-9025507999-export declare const file = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-16628394009-export const file = 10;",
+        "signature": "-9025507999-export declare const file = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file2.ts": {
+        "original": {
+          "version": "-17945718466-/// <reference lib=\"webworker\"/>\n/// <reference lib=\"scripthost\"/>\n",
+          "signature": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "-17945718466-/// <reference lib=\"webworker\"/>\n/// <reference lib=\"scripthost\"/>\n",
+        "signature": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./index.ts": {
+        "original": {
+          "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+          "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "-6136895998-export const x = \"type1\";export const xyz = 10;",
+        "signature": "-9988949802-export declare const x = \"type1\";\nexport declare const xyz = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./utils.d.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "signature": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          4,
+          7
+        ],
+        [
+          "./file.ts",
+          "./file2.ts",
+          "./index.ts",
+          "./utils.d.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../../lib/lib.scripthost.d.ts",
+      "../../lib/lib.webworker.d.ts",
+      "./file.ts",
+      "./file2.ts",
+      "./index.ts",
+      "./utils.d.ts"
+    ],
+    "latestChangedDtsFile": "./index.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1578
+}
+
+
+PolledWatches::
+/home/src/projects/node_modules:
+  {"pollingInterval":500}
+/home/src/projects/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/projects/package.json:
+  {"pollingInterval":2000}
+/home/src/projects/project1/node_modules:
+  {"pollingInterval":500}
+/home/src/projects/project1/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/projects/project1/package.json:
+  {"pollingInterval":2000}
+
+FsWatches::
+/home/src/lib/lib.d.ts:
+  {}
+/home/src/lib/lib.scripthost.d.ts:
+  {}
+/home/src/lib/lib.webworker.d.ts: *new*
+  {}
+/home/src/projects/project1/file.ts:
+  {}
+/home/src/projects/project1/file2.ts:
+  {}
+/home/src/projects/project1/index.ts:
+  {}
+/home/src/projects/project1/tsconfig.json:
+  {}
+/home/src/projects/project1/utils.d.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/project1:
+  {}
+
+
+Program root files: [
+  "/home/src/projects/project1/file.ts",
+  "/home/src/projects/project1/file2.ts",
+  "/home/src/projects/project1/index.ts",
+  "/home/src/projects/project1/utils.d.ts"
+]
+Program options: {
+  "composite": true,
+  "traceResolution": true,
+  "watch": true,
+  "project": "/home/src/projects/project1",
+  "explainFiles": true,
+  "extendedDiagnostics": true,
+  "configFilePath": "/home/src/projects/project1/tsconfig.json"
+}
+Program structureReused: SafeModules
+Program files::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.webworker.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/lib/lib.d.ts
+/home/src/lib/lib.webworker.d.ts
+/home/src/lib/lib.scripthost.d.ts
+/home/src/projects/project1/file.ts
+/home/src/projects/project1/file2.ts
+/home/src/projects/project1/index.ts
+/home/src/projects/project1/utils.d.ts
+
+Shape signatures in builder refreshed for::
+/home/src/lib/lib.webworker.d.ts (used version)
+/home/src/lib/lib.scripthost.d.ts (used version)
+/home/src/projects/project1/file.ts (computed .d.ts)
+/home/src/projects/project1/file2.ts (computed .d.ts)
+/home/src/projects/project1/index.ts (computed .d.ts)
+/home/src/projects/project1/utils.d.ts (used version)
+
+exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
@@ -1,0 +1,1542 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+Before request
+//// [/home/src/projects/project/src/struct.d.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/anotherFile.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/src/oneMore.ts]
+import * as xs1 from "fp-ts/lib/Struct";
+import * as xs2 from "fp-ts/lib/struct";
+import * as xs3 from "./Struct";
+import * as xs4 from "./struct";
+
+
+//// [/home/src/projects/project/tsconfig.json]
+{}
+
+//// [/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts]
+export function foo(): void
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "projectRootPath": "/home/src/projects/project"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/projects/project/src/struct.d.ts ProjectRootPath: /home/src/projects/project:: Result: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/tsconfig.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/home/src/projects/project/tsconfig.json",
+        "reason": "Creating possible configured project for /home/src/projects/project/src/struct.d.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /home/src/projects/project/tsconfig.json : {
+ "rootNames": [
+  "/home/src/projects/project/src/anotherFile.ts",
+  "/home/src/projects/project/src/oneMore.ts",
+  "/home/src/projects/project/src/struct.d.ts"
+ ],
+ "options": {
+  "configFilePath": "/home/src/projects/project/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project 1 undefined Config: /home/src/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project 1 undefined Config: /home/src/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/src/anotherFile.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/src/oneMore.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/src 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/src 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules/fp-ts/lib/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules/fp-ts/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/project/src/package.json 2000 undefined Project: /home/src/projects/project/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules/@types 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/node_modules/@types 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Project: /home/src/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/project/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts Text-1 "export function foo(): void"
+	/home/src/projects/project/src/Struct.d.ts SVC-1-0 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/anotherFile.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/oneMore.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	node_modules/fp-ts/lib/Struct.d.ts
+	  Imported via "fp-ts/lib/Struct" from file 'src/anotherFile.ts'
+	  Imported via "fp-ts/lib/struct" from file 'src/anotherFile.ts'
+	  Imported via "fp-ts/lib/Struct" from file 'src/Struct.d.ts'
+	  Imported via "fp-ts/lib/struct" from file 'src/Struct.d.ts'
+	  Imported via "fp-ts/lib/Struct" from file 'src/oneMore.ts'
+	  Imported via "fp-ts/lib/struct" from file 'src/oneMore.ts'
+	src/Struct.d.ts
+	  Imported via "./Struct" from file 'src/anotherFile.ts'
+	  Imported via "./Struct" from file 'src/Struct.d.ts'
+	  Imported via "./struct" from file 'src/Struct.d.ts'
+	  Imported via "./struct" from file 'src/anotherFile.ts'
+	  Imported via "./Struct" from file 'src/oneMore.ts'
+	  Imported via "./struct" from file 'src/oneMore.ts'
+	  Matched by default include pattern '**/*'
+	src/anotherFile.ts
+	  Matched by default include pattern '**/*'
+	src/oneMore.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/home/src/projects/project/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "telemetry",
+      "body": {
+        "telemetryEventName": "projectInfo",
+        "payload": {
+          "projectId": "1097a5f82e8323ba7aba7567ec06402f7ad4ea74abce44ec5efd223ac77ff169",
+          "fileStats": {
+            "js": 0,
+            "jsSize": 0,
+            "jsx": 0,
+            "jsxSize": 0,
+            "ts": 2,
+            "tsSize": 296,
+            "tsx": 0,
+            "tsxSize": 0,
+            "dts": 3,
+            "dtsSize": 588,
+            "deferred": 0,
+            "deferredSize": 0
+          },
+          "compilerOptions": {},
+          "typeAcquisition": {
+            "enable": false,
+            "include": false,
+            "exclude": false
+          },
+          "extends": false,
+          "files": false,
+          "include": false,
+          "exclude": false,
+          "compileOnSave": false,
+          "configFileName": "tsconfig.json",
+          "projectType": "configured",
+          "languageServiceEnabled": true,
+          "version": "FakeVersion"
+        }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/projects/project/src/struct.d.ts",
+        "configFile": "/home/src/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/projects/project/src/struct.d.ts ProjectRootPath: /home/src/projects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/home/src/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/project/node_modules/fp-ts/lib/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/fp-ts/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/node_modules/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/package.json: *new*
+  {"pollingInterval":2000}
+/home/src/projects/project/src/package.json: *new*
+  {"pollingInterval":2000}
+
+FsWatches::
+/a/lib/lib.d.ts: *new*
+  {}
+/home/src/projects/project/src/anotherFile.ts: *new*
+  {}
+/home/src/projects/project/src/oneMore.ts: *new*
+  {}
+/home/src/projects/project/tsconfig.json: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/project: *new*
+  {}
+/home/src/projects/project/node_modules: *new*
+  {}
+/home/src/projects/project/src: *new*
+  {}
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+
+ScriptInfos::
+/a/lib/lib.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "geterr",
+      "arguments": {
+        "delay": 0,
+        "files": [
+          "/home/src/projects/project/src/struct.d.ts"
+        ]
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Timeout callback:: count: 1
+1: checkOne *new*
+
+Before running Timeout callback:: count: 1
+1: checkOne
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "syntaxDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": []
+      }
+    }
+After running Timeout callback:: count: 0
+
+Immedidate callback:: count: 1
+1: semanticCheck *new*
+
+Before running Immedidate callback:: count: 1
+1: semanticCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "semanticDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 2,
+              "offset": 22
+            },
+            "end": {
+              "line": 2,
+              "offset": 40
+            },
+            "text": "File name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.\n  The file is in the program because:\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/oneMore.ts'",
+            "code": 1149,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 2,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/Struct.d.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 2,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              }
+            ]
+          },
+          {
+            "start": {
+              "line": 4,
+              "offset": 22
+            },
+            "end": {
+              "line": 4,
+              "offset": 32
+            },
+            "text": "File name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.\n  The file is in the program because:\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Matched by default include pattern '**/*'",
+            "code": 1149,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/Struct.d.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              }
+            ]
+          }
+        ]
+      }
+    }
+After running Immedidate callback:: count: 1
+
+Immedidate callback:: count: 1
+2: suggestionCheck *new*
+
+Before running Immedidate callback:: count: 1
+2: suggestionCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "suggestionDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 1,
+              "offset": 1
+            },
+            "end": {
+              "line": 1,
+              "offset": 41
+            },
+            "text": "'xs1' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 2,
+              "offset": 1
+            },
+            "end": {
+              "line": 2,
+              "offset": 41
+            },
+            "text": "'xs2' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 3,
+              "offset": 1
+            },
+            "end": {
+              "line": 3,
+              "offset": 33
+            },
+            "text": "'xs3' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 4,
+              "offset": 1
+            },
+            "end": {
+              "line": 4,
+              "offset": 33
+            },
+            "text": "'xs4' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "requestCompleted",
+      "body": {
+        "request_seq": 2
+      }
+    }
+After running Immedidate callback:: count: 0
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/projects/project/src/struct.d.ts",
+            "textChanges": [
+              {
+                "newText": "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n\nexport const y = 10;",
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 5,
+                  "offset": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open) *changed*
+    version: SVC-1-1 *changed*
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "definition",
+      "arguments": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "line": 1,
+        "offset": 22
+      },
+      "seq": 4,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/project/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts Text-1 "export function foo(): void"
+	/home/src/projects/project/src/Struct.d.ts SVC-1-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n\nexport const y = 10;"
+	/home/src/projects/project/src/anotherFile.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/oneMore.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [
+        {
+          "file": "/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts",
+          "start": {
+            "line": 1,
+            "offset": 1
+          },
+          "end": {
+            "line": 1,
+            "offset": 28
+          }
+        }
+      ],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2
+    projectProgramVersion: 1
+    dirty: false *changed*
+    documentPositionMappers: 1 *changed*
+        /home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts: identitySourceMapConsumer *new*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts *changed*
+    version: Text-1
+    sourceMapFilePath: false *changed*
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/projects/project/src/struct.d.ts",
+            "textChanges": [
+              {
+                "newText": "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n\nexport const y = 10;\nexport const yy = 10;",
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 6,
+                  "offset": 21
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 5,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open) *changed*
+    version: SVC-1-2 *changed*
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "geterr",
+      "arguments": {
+        "delay": 0,
+        "files": [
+          "/home/src/projects/project/src/struct.d.ts"
+        ]
+      },
+      "seq": 6,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Timeout callback:: count: 1
+2: checkOne *new*
+
+Before running Timeout callback:: count: 1
+2: checkOne
+
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts Text-1 "export function foo(): void"
+	/home/src/projects/project/src/Struct.d.ts SVC-1-2 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n\nexport const y = 10;\nexport const yy = 10;"
+	/home/src/projects/project/src/anotherFile.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/oneMore.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "syntaxDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": []
+      }
+    }
+After running Timeout callback:: count: 0
+
+Immedidate callback:: count: 1
+3: semanticCheck *new*
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3
+    projectProgramVersion: 1
+    dirty: false *changed*
+    documentPositionMappers: 0 *changed*
+        /home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts: identitySourceMapConsumer *deleted*
+
+Before running Immedidate callback:: count: 1
+3: semanticCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "semanticDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 2,
+              "offset": 22
+            },
+            "end": {
+              "line": 2,
+              "offset": 40
+            },
+            "text": "File name '/home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.\n  The file is in the program because:\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"fp-ts/lib/Struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Imported via \"fp-ts/lib/struct\" from file '/home/src/projects/project/src/oneMore.ts'",
+            "code": 1149,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 2,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/Struct.d.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 2,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "offset": 40
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              }
+            ]
+          },
+          {
+            "start": {
+              "line": 4,
+              "offset": 22
+            },
+            "end": {
+              "line": 4,
+              "offset": 32
+            },
+            "text": "File name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.\n  The file is in the program because:\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Matched by default include pattern '**/*'",
+            "code": 1149,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/Struct.d.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              }
+            ]
+          }
+        ]
+      }
+    }
+After running Immedidate callback:: count: 1
+
+Immedidate callback:: count: 1
+4: suggestionCheck *new*
+
+Before running Immedidate callback:: count: 1
+4: suggestionCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "suggestionDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 1,
+              "offset": 1
+            },
+            "end": {
+              "line": 1,
+              "offset": 41
+            },
+            "text": "'xs1' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 2,
+              "offset": 1
+            },
+            "end": {
+              "line": 2,
+              "offset": 41
+            },
+            "text": "'xs2' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 3,
+              "offset": 1
+            },
+            "end": {
+              "line": 3,
+              "offset": 33
+            },
+            "text": "'xs3' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 4,
+              "offset": 1
+            },
+            "end": {
+              "line": 4,
+              "offset": 33
+            },
+            "text": "'xs4' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "requestCompleted",
+      "body": {
+        "request_seq": 6
+      }
+    }
+After running Immedidate callback:: count: 0
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/projects/project/src/struct.d.ts",
+            "textChanges": [
+              {
+                "newText": "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\n",
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 7,
+                  "offset": 22
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 7,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open) *changed*
+    version: SVC-1-3 *changed*
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "definition",
+      "arguments": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "line": 1,
+        "offset": 22
+      },
+      "seq": 8,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 1 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts Text-1 "export function foo(): void"
+	/home/src/projects/project/src/Struct.d.ts SVC-1-3 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\n"
+	/home/src/projects/project/src/anotherFile.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/oneMore.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [
+        {
+          "file": "/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts",
+          "start": {
+            "line": 1,
+            "offset": 1
+          },
+          "end": {
+            "line": 1,
+            "offset": 28
+          }
+        }
+      ],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4
+    projectProgramVersion: 2 *changed*
+    dirty: false *changed*
+    documentPositionMappers: 1 *changed*
+        /home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts: identitySourceMapConsumer *new*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/projects/project/src/struct.d.ts",
+            "textChanges": [
+              {
+                "newText": "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs3 from \"./struct\";\n",
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 4,
+                  "offset": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 9,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 5 *changed*
+    projectProgramVersion: 2
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/anotherFile.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/oneMore.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json
+/home/src/projects/project/src/struct.d.ts (Open) *changed*
+    version: SVC-1-4 *changed*
+    containingProjects: 1
+        /home/src/projects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "geterr",
+      "arguments": {
+        "delay": 0,
+        "files": [
+          "/home/src/projects/project/src/struct.d.ts"
+        ]
+      },
+      "seq": 10,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Timeout callback:: count: 1
+3: checkOne *new*
+
+Before running Timeout callback:: count: 1
+3: checkOne
+
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/project/tsconfig.json projectStateVersion: 5 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/project/node_modules/fp-ts/lib/Struct.d.ts Text-1 "export function foo(): void"
+	/home/src/projects/project/src/Struct.d.ts SVC-1-4 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs3 from \"./struct\";\n"
+	/home/src/projects/project/src/anotherFile.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+	/home/src/projects/project/src/oneMore.ts Text-1 "import * as xs1 from \"fp-ts/lib/Struct\";\nimport * as xs2 from \"fp-ts/lib/struct\";\nimport * as xs3 from \"./Struct\";\nimport * as xs4 from \"./struct\";\n"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "syntaxDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": []
+      }
+    }
+After running Timeout callback:: count: 0
+
+Immedidate callback:: count: 1
+5: semanticCheck *new*
+
+Projects::
+/home/src/projects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 5
+    projectProgramVersion: 3 *changed*
+    dirty: false *changed*
+    documentPositionMappers: 0 *changed*
+        /home/src/projects/project/node_modules/fp-ts/lib/struct.d.ts: identitySourceMapConsumer *deleted*
+
+Before running Immedidate callback:: count: 1
+5: semanticCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "semanticDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 2,
+              "offset": 22
+            },
+            "end": {
+              "line": 2,
+              "offset": 32
+            },
+            "text": "File name '/home/src/projects/project/src/struct.d.ts' differs from already included file name '/home/src/projects/project/src/Struct.d.ts' only in casing.\n  The file is in the program because:\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/Struct.d.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/anotherFile.ts'\n    Imported via \"./Struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Imported via \"./struct\" from file '/home/src/projects/project/src/oneMore.ts'\n    Matched by default include pattern '**/*'",
+            "code": 1149,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/anotherFile.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 3,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              },
+              {
+                "span": {
+                  "start": {
+                    "line": 4,
+                    "offset": 22
+                  },
+                  "end": {
+                    "line": 4,
+                    "offset": 32
+                  },
+                  "file": "/home/src/projects/project/src/oneMore.ts"
+                },
+                "message": "File is included via import here.",
+                "category": "message",
+                "code": 1399
+              }
+            ]
+          }
+        ]
+      }
+    }
+After running Immedidate callback:: count: 1
+
+Immedidate callback:: count: 1
+6: suggestionCheck *new*
+
+Before running Immedidate callback:: count: 1
+6: suggestionCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "suggestionDiag",
+      "body": {
+        "file": "/home/src/projects/project/src/struct.d.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 1,
+              "offset": 1
+            },
+            "end": {
+              "line": 1,
+              "offset": 41
+            },
+            "text": "'xs1' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          },
+          {
+            "start": {
+              "line": 2,
+              "offset": 1
+            },
+            "end": {
+              "line": 2,
+              "offset": 33
+            },
+            "text": "'xs3' is declared but its value is never read.",
+            "code": 6133,
+            "category": "suggestion",
+            "reportsUnnecessary": true
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "requestCompleted",
+      "body": {
+        "request_seq": 10
+      }
+    }
+After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-errors.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-errors.js
@@ -80,7 +80,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-in-host-configuration.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options-in-host-configuration.js
@@ -107,7 +107,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'

--- a/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/external-project-watch-options.js
@@ -78,7 +78,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Default library for target 'es5'
 	node_modules/bar/foo.d.ts
 	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
-	  Imported via "./foo" from file 'node_modules/bar/index.d.ts'
 	  Root file specified for compilation
 	node_modules/bar/index.d.ts
 	  Imported via "bar" from file 'src/main.ts'


### PR DESCRIPTION
- Store information about file explaining diagnostics to be generated only when program diagnostics are asked. We store this already if it's the diagnostic while we are creating program graph, we now store other compiler options errors that explain file include reasons as well as lazy diagnostics to be generated and then actually populate it when program diagnostics are queried.
- In diagnostic explaining the reason why file is in program, we are caching details as well as related info that can be reused when there are multiple diagnostics for same file. The cache is cleared after population of program diagnostics is complete so doesn't stay beyond the computation of these diagnostics.


Probably fixes
- https://github.com/microsoft/TypeScript/issues/58011
- https://github.com/typescript-eslint/typescript-eslint/issues/1192
- https://github.com/microsoft/TypeScript/issues/58274


cc: @jakebailey 
As discussed offline few days ago the real issue is that `typescript-eslint` is passing in canonical file path of tsconfig and that generates lot of errors in program because of `forceConsistentCasingInFileNames` being defaulting to `true` in later versions of typescript. I have https://github.com/typescript-eslint/typescript-eslint/pull/9042 for tsconfig issue we discussed on wednesday but i dont know if there are any other eg source files or anything that are having these issues as i didnt get to look into code that deeply


Here are some perf numbers with the repro in https://github.com/microsoft/TypeScript/issues/58011#issuecomment-2092659730 where API is used with and without config file name lower casing. Special thanks to @reduckted to give us this repro so we can actually verify this. 

When diagnostics are queried (runs `emitFilesAndReportErrors`) after creating watch program:
  | tsc      (5.4.5) | eslint     (5.4.5) | delta     (5.4.5) | tsc     (fix) | eslint     (fix) | delta     (fix) | tsc     (delta with fix) | eslint     (delta with fix)
-- | -- | -- | -- | -- | -- | -- | -- | --
Files: | 4843 | 4843 |   | 4843 | 4843 |   |   |  
Memory used: | 313744K | 1366218K | 335.46% | 334185K | 363474K | 8.76% | 6.52% | -73.40%
Program time: | 9.38s | 31.98s | 240.94% | 9.16s | 9.18s | 0.22% | -2.35% | -71.29%
Total time: | 11.22s | 33.40s | 197.68% | 10.50s | 10.72s | 2.10% | -6.42% | -67.90%

<details>
<summary>Detailed Extended Diagnostics</summary>

  | tsc      (5.4.5) | eslint     (5.4.5) | delta     (5.4.5) | tsc     (fix) | eslint     (fix) | delta     (fix) | tsc     (delta with fix) | eslint     (delta with fix)
-- | -- | -- | -- | -- | -- | -- | -- | --
Files: | 4843 | 4843 |   | 4843 | 4843 |   |   |  
Lines of Library: | 38041 | 38041 |   | 38310 | 38310 |   |   |  
Lines of Definitions: | 174189 | 174189 |   | 174189 | 174189 |   |   |  
Lines of TypeScript: | 32561 | 32561 |   | 32561 | 32561 |   |   |  
Lines of JavaScript: | 30 | 30 |   | 30 | 30 |   |   |  
Lines of JSON: | 0 | 0 |   | 0 | 0 |   |   |  
Lines of Other: | 0 | 0 |   | 0 | 0 |   |   |  
Identifiers: | 201753 | 201753 |   | 201976 | 201976 |   |   |  
Symbols: | 140060 | 140060 |   | 140227 | 140227 |   |   |  
Types: | 2272 | 2272 |   | 2273 | 2273 |   |   |  
Instantiations: | 168 | 168 |   | 168 | 168 |   |   |  
Memory used: | 313744K | 1366218K | 335.46% | 334185K | 363474K | 8.76% | 6.52% | -73.40%
Assignability cache size: | 24 | 24 |   | 24 | 24 |   |   |  
Identity cache size: | 0 | 0 |   | 0 | 0 |   |   |  
Subtype cache size: | 0 | 0 |   | 0 | 0 |   |   |  
Strict subtype cache size: | 0 | 0 |   | 0 | 0 |   |   |  
I/O Read time: | 0.98s | 1.16s |   | 0.91s | 0.93s |   |   |  
Parse time: | 1.61s | 2.00s |   | 1.50s | 1.47s |   |   |  
ResolveModule time: | 1.34s | 1.51s |   | 1.25s | 1.16s |   |   |  
ResolveTypeReference time: | 0.03s | 0.03s |   | 0.03s | 0.03s |   |   |  
ResolveLibrary time: | 0.06s | 0.04s |   | 0.05s | 0.05s |   |   |  
Program time: | 9.38s | 31.98s | 240.94% | 9.16s | 9.18s | 0.22% | -2.35% | -71.29%
Bind time: | 0.61s | 0.67s |   | 0.61s | 0.67s |   |   |  
Check time: | 1.22s | 0.74s |   | 0.72s | 0.87s |   |   |  
printTime time: | 0.00s | 0.00s |   | 0.00s | 0.00s |   |   |  
Emit time: | 0.01s | 0.01s |   | 0.00s | 0.00s |   |   |  
Total time: | 11.22s | 33.40s | 197.68% | 10.50s | 10.72s | 2.10% | -6.42% | -67.90%

</details>

When diagnostics are not queried which is what es-lint does as per @jakebailey 

  | tsc      (5.4.5) | eslint     (5.4.5) | delta     (5.4.5) | tsc     (fix) | eslint     (fix) | delta     (fix) | tsc     (delta with fix) | eslint     (delta with fix)
-- | -- | -- | -- | -- | -- | -- | -- | --
Files: | 4843 | 4843 |   | 4843 | 4843 |   |   |  
Memory used: | 290762K | 1352409K | 365.13% | 324293K | 320025K | -1.32% | 11.53% | -76.34%
Program time: | 9.63s | 26.77s | 177.99% | 9.31s | 9.60s | 3.11% | -3.32% | -64.14%
Total time: | 10.30s | 27.50s | 166.99% | 9.89s | 10.13s | 14.31s | 41.26% | -63.16%

<details>
<summary>Detailed Extended Diagnostics</summary>

  | tsc      (5.4.5) | eslint     (5.4.5) | delta     (5.4.5) | tsc     (fix) | eslint     (fix) | delta     (fix) | tsc     (delta with fix) | eslint     (delta with fix)
-- | -- | -- | -- | -- | -- | -- | -- | --
Files: | 4843 | 4843 |   | 4843 | 4843 |   |   |  
Lines of Library: | 38041 | 38041 |   | 38310 | 38310 |   |   |  
Lines of Definitions: | 174189 | 174189 |   | 174189 | 174189 |   |   |  
Lines of TypeScript: | 32561 | 32561 |   | 32561 | 32561 |   |   |  
Lines of JavaScript: | 30 | 30 |   | 30 | 30 |   |   |  
Lines of JSON: | 0 | 0 |   | 0 | 0 |   |   |  
Lines of Other: | 0 | 0 |   | 0 | 0 |   |   |  
Identifiers: | 201753 | 201753 |   | 201976 | 201976 |   |   |  
Symbols: | 140029 | 140029 |   | 140196 | 140196 |   |   |  
Types: | 89 | 89 |   | 88 | 88 |   |   |  
Instantiations: | 0 | 0 |   | 0 | 0 |   |   |  
Memory used: | 290762K | 1352409K | 365.13% | 324293K | 320025K | -1.32% | 11.53% | -76.34%
Assignability cache size: | 0 | 0 |   | 0 | 0 |   |   |  
Identity cache size: | 0 | 0 |   | 0 | 0 |   |   |  
Subtype cache size: | 0 | 0 |   | 0 | 0 |   |   |  
Strict subtype cache size: | 0 | 0 |   | 0 | 0 |   |   |  
I/O Read time: | 0.97s | 0.99s |   | 0.93s | 0.99s |   |   |  
Parse time: | 1.74s | 1.66s |   | 1.51s | 1.59s |   |   |  
ResolveModule time: | 1.42s | 1.22s |   | 1.26s | 1.20s |   |   |  
ResolveTypeReference time: | 0.03s | 0.03s |   | 0.03s | 0.03s |   |   |  
ResolveLibrary time: | 0.05s | 0.03s |   | 0.06s | 0.05s |   |   |  
Program time: | 9.63s | 26.77s | 177.99% | 9.31s | 9.60s | 3.11% | -3.32% | -64.14%
Bind time: | 0.67s | 0.73s |   | 0.58s | 0.54s |   |   |  
Total time: | 10.30s | 27.50s | 166.99% | 9.89s | 10.13s | 14.31s | 41.26% | -63.16%

</details>