### PR TITLE
Ensure jsDocParsingMode is passed to LanguageService document registry

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1596,7 +1596,7 @@ const invalidOperationsInSyntacticMode: readonly (keyof LanguageService)[] = [
 ];
 export function createLanguageService(
     host: LanguageServiceHost,
-    documentRegistry: DocumentRegistry = createDocumentRegistry(host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames(), host.getCurrentDirectory()),
+    documentRegistry: DocumentRegistry = createDocumentRegistry(host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames(), host.getCurrentDirectory(), host.jsDocParsingMode),
     syntaxOnlyOrLanguageServiceMode?: boolean | LanguageServiceMode,
 ): LanguageService {
     let languageServiceMode: LanguageServiceMode;


### PR DESCRIPTION
Noticed this inconsistency when looking into an ESLint crash (but this wouldn't fix that).