### PR TITLE
feat(58447): JS object destructuring: allow to shorten expression when assignment is renamed back to original property value

### DIFF
--- a/tests/baselines/reference/renameDuplicateDestructuringBindingElements.baseline.jsonc
+++ b/tests/baselines/reference/renameDuplicateDestructuringBindingElements.baseline.jsonc
@@ -1,0 +1,4 @@
+// === findRenameLocations ===
+// === /tests/cases/fourslash/a.ts ===
+// const foo = { a: 1 };
+// <|const { [|a: aRENAME|]/*RENAME*/ } = foo;|>

--- a/tests/cases/fourslash/renameDuplicateDestructuringBindingElements.ts
+++ b/tests/cases/fourslash/renameDuplicateDestructuringBindingElements.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+//// const foo = { a: 1 };
+//// const { a: a/**/ } = foo;
+
+verify.baselineRename("");


### PR DESCRIPTION
Fixes #58447