### PR TITLE
Always send configFileDiagEvent and instead set triggerFile for more consistency

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2885,22 +2885,20 @@ export class ProjectService {
      *
      * @internal
      */
-    reloadConfiguredProject(project: ConfiguredProject, reason: string, isInitialLoad: boolean, clearSemanticCache: boolean) {
+    reloadConfiguredProject(project: ConfiguredProject, reason: string, clearSemanticCache: boolean) {
         // At this point, there is no reason to not have configFile in the host
         const host = project.getCachedDirectoryStructureHost();
         if (clearSemanticCache) this.clearSemanticCache(project);
 
         // Clear the cache since we are reloading the project from disk
         host.clearCache();
-        const configFileName = project.getConfigFilePath();
-        this.logger.info(`${isInitialLoad ? "Loading" : "Reloading"} configured project ${configFileName}`);
 
         // Load project from the disk
         this.loadConfiguredProject(project, reason);
         project.skipConfigDiagEvent = true;
         project.updateGraph();
 
-        this.sendConfigFileDiagEvent(project, configFileName);
+        this.sendConfigFileDiagEvent(project, project.getConfigFilePath());
     }
 
     /** @internal */
@@ -3697,7 +3695,7 @@ export class ProjectService {
         const updatedProjects = new Set<ConfiguredProject>();
         const reloadChildProject = (child: ConfiguredProject) => {
             if (tryAddToSet(updatedProjects, child)) {
-                this.reloadConfiguredProject(child, reason, /*isInitialLoad*/ false, /*clearSemanticCache*/ true);
+                this.reloadConfiguredProject(child, reason, /*clearSemanticCache*/ true);
             }
         };
         // try to reload config file for all open files
@@ -3716,7 +3714,7 @@ export class ProjectService {
                 const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName);
                 if (tryAddToSet(updatedProjects, project)) {
                     // reload from the disk
-                    this.reloadConfiguredProject(project, reason, /*isInitialLoad*/ false, /*clearSemanticCache*/ true);
+                    this.reloadConfiguredProject(project, reason, /*clearSemanticCache*/ true);
                     // If this project does not contain this file directly, reload the project till the reloaded project contains the script info directly
                     if (!projectContainsInfoDirectly(project, info)) {
                         const referencedProject = forEachResolvedProjectReferenceProject(

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -3914,7 +3914,6 @@ export class ProjectService {
         let project: ConfiguredProject | ExternalProject | undefined = this.findExternalProjectContainingOpenScriptInfo(info);
         let retainProjects: ConfiguredProject[] | ConfiguredProject | undefined;
         let projectForConfigFileDiag: ConfiguredProject | undefined;
-        let defaultConfigProjectIsCreated = false;
         let sentConfigDiag: Set<ConfiguredProject> | undefined;
         if (!project && this.serverMode === LanguageServiceMode.Semantic) { // Checking semantic mode is an optimization
             configFileName = this.getConfigFileNameForFile(info);
@@ -3922,7 +3921,6 @@ export class ProjectService {
                 project = this.findConfiguredProjectByProjectName(configFileName);
                 if (!project) {
                     project = this.createLoadAndUpdateConfiguredProject(configFileName, `Creating possible configured project for ${info.fileName} to open`, info.fileName);
-                    defaultConfigProjectIsCreated = true;
                     (sentConfigDiag ??= new Set()).add(project);
                 }
                 // Ensure project is ready to check if it contains opened script info
@@ -3970,10 +3968,7 @@ export class ProjectService {
                 // Send the event only if the project got created as part of this open request and info is part of the project
                 if (projectForConfigFileDiag) {
                     configFileName = projectForConfigFileDiag.getConfigFilePath();
-                    // TODO:: sheetal do this irrespective?
-                    if (projectForConfigFileDiag !== project || defaultConfigProjectIsCreated) {
-                        configFileErrors = projectForConfigFileDiag.getAllProjectErrors();
-                    }
+                    configFileErrors = projectForConfigFileDiag.getAllProjectErrors();
                 }
                 else {
                     // Since the file isnt part of configured project, do not send config file info

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -850,14 +850,11 @@ export function updateProjectIfDirty(project: Project) {
 
 /** Updates the program for triggerFile and returns true if sent configFileDiagEvent */
 function updateWithTriggerFile(project: ConfiguredProject, triggerFile: NormalizedPath, isReload: boolean): boolean {
-    project.triggerFileForConfigFileDiag = triggerFile;
     if (!isReload) {
         project.invalidateResolutionsOfFailedLookupLocations();
-        if (!project.dirty) {
-            project.triggerFileForConfigFileDiag = undefined;
-            return false;
-        }
+        if (!project.dirty) return false;
     }
+    project.triggerFileForConfigFileDiag = triggerFile;
     const updateLevel = project.pendingUpdateLevel;
     project.updateGraph();
     // On full update the event is sent by recursive updateWithTrigger through reloadConfiguredProject

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -658,8 +658,6 @@ export enum ProjectReferenceProjectLoadKind {
     Find,
     /** Find existing project or create one for the project reference */
     FindCreate,
-    /** Find existing project or create and load it for the project reference */
-    FindCreateLoad,
 }
 
 /** @internal */
@@ -667,7 +665,7 @@ export function forEachResolvedProjectReferenceProject<T>(
     project: ConfiguredProject,
     fileName: string | undefined,
     cb: (child: ConfiguredProject) => T | undefined,
-    projectReferenceProjectLoadKind: ProjectReferenceProjectLoadKind.Find | ProjectReferenceProjectLoadKind.FindCreate,
+    projectReferenceProjectLoadKind: ProjectReferenceProjectLoadKind.Find,
 ): T | undefined;
 /** @internal */
 export function forEachResolvedProjectReferenceProject<T>(
@@ -728,9 +726,7 @@ export function forEachResolvedProjectReferenceProject<T>(
             loadKind === ProjectReferenceProjectLoadKind.Find ?
                 undefined :
                 loadKind === ProjectReferenceProjectLoadKind.FindCreate ?
-                project.projectService.createConfiguredProject(configFileName) :
-                loadKind === ProjectReferenceProjectLoadKind.FindCreateLoad ?
-                project.projectService.createAndLoadConfiguredProject(configFileName, reason!) :
+                project.projectService.createConfiguredProject(configFileName, reason!) :
                 Debug.assertNever(loadKind)
         );
 
@@ -852,10 +848,23 @@ export function updateProjectIfDirty(project: Project) {
     return project.dirty && !project.updateGraph();
 }
 
-function updateConfiguredProjectWithoutConfigDiagIfDirty(project: ConfiguredProject) {
-    project.skipConfigDiagEvent = true;
-    updateProjectIfDirty(project);
-    project.skipConfigDiagEvent = undefined;
+/** Updates the program for triggerFile and returns true if sent configFileDiagEvent */
+function updateWithTriggerFile(project: ConfiguredProject, triggerFile: NormalizedPath, isReload: boolean): boolean {
+    project.triggerFileForConfigFileDiag = triggerFile;
+    if (!isReload) {
+        project.invalidateResolutionsOfFailedLookupLocations();
+        if (!project.dirty) {
+            project.triggerFileForConfigFileDiag = undefined;
+            return false;
+        }
+    }
+    const updateLevel = project.pendingUpdateLevel;
+    project.updateGraph();
+    // On full update the event is sent by recursive updateWithTrigger through reloadConfiguredProject
+    if (!project.triggerFileForConfigFileDiag && !isReload) return updateLevel === ProgramUpdateLevel.Full;
+    const sent = project.projectService.sendConfigFileDiagEvent(project, triggerFile, isReload);
+    project.triggerFileForConfigFileDiag = undefined;
+    return sent;
 }
 
 function setProjectOptionsUsed(project: ConfiguredProject | ExternalProject) {
@@ -1713,7 +1722,7 @@ export class ProjectService {
                     // Load root file names for configured project with the config file name
                     // But only schedule update if project references this config file
                     const updateLevel = configuredProjectForConfig === project ? ProgramUpdateLevel.RootNamesAndUpdate : ProgramUpdateLevel.Update;
-                    if (project.pendingUpdateLevel !== undefined && project.pendingUpdateLevel > updateLevel) return;
+                    if (project.pendingUpdateLevel > updateLevel) return;
 
                     // don't trigger callback on open, existing files
                     if (this.openFiles.has(fileOrDirectoryPath)) {
@@ -1863,7 +1872,7 @@ export class ProjectService {
             // otherwise we create a new one.
             const configFileName = this.getConfigFileNameForFile(info);
             if (configFileName) {
-                const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName);
+                const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName, reason);
                 if (tryAddToSet(updatedProjects, project)) {
                     project.pendingUpdateLevel = ProgramUpdateLevel.Full;
                     project.pendingUpdateReason = reason;
@@ -2021,7 +2030,7 @@ export class ProjectService {
                 const updateLevel = p.openFileWatchTriggered.get(info.path);
                 if (updateLevel !== undefined) {
                     p.openFileWatchTriggered.delete(info.path);
-                    if (p.pendingUpdateLevel !== undefined && p.pendingUpdateLevel < updateLevel) {
+                    if (p.pendingUpdateLevel < updateLevel) {
                         p.pendingUpdateLevel = updateLevel;
                         p.markFileAsDirty(info.path);
                     }
@@ -2514,7 +2523,7 @@ export class ProjectService {
     }
 
     /** @internal */
-    createConfiguredProject(configFileName: NormalizedPath) {
+    createConfiguredProject(configFileName: NormalizedPath, reason: string) {
         tracing?.instant(tracing.Phase.Session, "createConfiguredProject", { configFilePath: configFileName });
         this.logger.info(`Creating configuration project ${configFileName}`);
         const canonicalConfigFilePath = asNormalizedPath(this.toCanonicalFileName(configFileName));
@@ -2541,6 +2550,7 @@ export class ProjectService {
             this,
             this.documentRegistry,
             configFileExistenceInfo.config.cachedDirectoryStructureHost,
+            reason,
         );
         Debug.assert(!this.configuredProjects.has(canonicalConfigFilePath));
         this.configuredProjects.set(canonicalConfigFilePath, project);
@@ -2549,25 +2559,10 @@ export class ProjectService {
     }
 
     /** @internal */
-    private createConfiguredProjectWithDelayLoad(configFileName: NormalizedPath, reason: string) {
-        const project = this.createConfiguredProject(configFileName);
-        project.pendingUpdateLevel = ProgramUpdateLevel.Full;
-        project.pendingUpdateReason = reason;
-        return project;
-    }
-
-    /** @internal */
-    createAndLoadConfiguredProject(configFileName: NormalizedPath, reason: string) {
-        const project = this.createConfiguredProject(configFileName);
-        this.loadConfiguredProject(project, reason);
-        return project;
-    }
-
-    /** @internal */
-    private createLoadAndUpdateConfiguredProject(configFileName: NormalizedPath, reason: string) {
-        const project = this.createAndLoadConfiguredProject(configFileName, reason);
-        project.skipConfigDiagEvent = true;
-        project.updateGraph();
+    private createLoadAndUpdateConfiguredProject(configFileName: NormalizedPath, reason: string, triggerFile: NormalizedPath | undefined) {
+        const project = this.createConfiguredProject(configFileName, reason);
+        if (triggerFile) updateWithTriggerFile(project, triggerFile, /*isReload*/ false);
+        else project.updateGraph();
         return project;
     }
 
@@ -2895,10 +2890,7 @@ export class ProjectService {
 
         // Load project from the disk
         this.loadConfiguredProject(project, reason);
-        project.skipConfigDiagEvent = true;
-        project.updateGraph();
-
-        this.sendConfigFileDiagEvent(project, project.getConfigFilePath());
+        updateWithTriggerFile(project, project.triggerFileForConfigFileDiag ?? project.getConfigFilePath(), /*isReload*/ true);
     }
 
     /** @internal */
@@ -2910,23 +2902,20 @@ export class ProjectService {
     }
 
     /** @internal */
-    sendConfigFileDiagEvent(project: ConfiguredProject, triggerFile: NormalizedPath | undefined) {
-        if (!this.eventHandler || this.suppressDiagnosticEvents) {
-            return;
-        }
+    sendConfigFileDiagEvent(project: ConfiguredProject, triggerFile: NormalizedPath | undefined, force: boolean) {
+        if (!this.eventHandler || this.suppressDiagnosticEvents) return false;
         const diagnostics = project.getLanguageService().getCompilerOptionsDiagnostics();
         diagnostics.push(...project.getAllProjectErrors());
 
-        if (!triggerFile && !!diagnostics.length === !!project.hasConfigFileDiagnostics) return;
-
-        project.hasConfigFileDiagnostics = !!diagnostics.length;
-
+        if (!force && diagnostics.length === (project.configDiagDiagnosticsReported ?? 0)) return false;
+        project.configDiagDiagnosticsReported = diagnostics.length;
         this.eventHandler(
             {
                 eventName: ConfigFileDiagEvent,
                 data: { configFileName: project.getConfigFilePath(), diagnostics, triggerFile: triggerFile ?? project.getConfigFilePath() },
             } satisfies ConfigFileDiagEvent,
         );
+        return true;
     }
 
     private getOrCreateInferredProjectForProjectRootPathIfEnabled(info: ScriptInfo, projectRootPath: NormalizedPath | undefined): InferredProject | undefined {
@@ -3711,7 +3700,7 @@ export class ProjectService {
             // otherwise we create a new one.
             const configFileName = this.getConfigFileNameForFile(info);
             if (configFileName) {
-                const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName);
+                const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName, reason);
                 if (tryAddToSet(updatedProjects, project)) {
                     // reload from the disk
                     this.reloadConfiguredProject(project, reason, /*clearSemanticCache*/ true);
@@ -3725,6 +3714,7 @@ export class ProjectService {
                                 return projectContainsInfoDirectly(child, info);
                             },
                             ProjectReferenceProjectLoadKind.FindCreate,
+                            reason,
                         );
                         if (referencedProject) {
                             // Reload the project's tree that is already present
@@ -3843,7 +3833,7 @@ export class ProjectService {
                     : location;
             }
 
-            configuredProject = this.createAndLoadConfiguredProject(configFileName, `Creating project for original file: ${originalFileInfo.fileName}${location !== originalLocation ? " for location: " + location.fileName : ""}`);
+            configuredProject = this.createConfiguredProject(configFileName, `Creating project for original file: ${originalFileInfo.fileName}${location !== originalLocation ? " for location: " + location.fileName : ""}`);
         }
         updateProjectIfDirty(configuredProject);
 
@@ -3861,7 +3851,7 @@ export class ProjectService {
                     updateProjectIfDirty(child);
                     return projectContainsOriginalInfo(child) ? child : undefined;
                 },
-                ProjectReferenceProjectLoadKind.FindCreateLoad,
+                ProjectReferenceProjectLoadKind.FindCreate,
                 `Creating project referenced in solution ${configuredProject.projectName} to find possible configured project for original file: ${originalFileInfo.fileName}${location !== originalLocation ? " for location: " + location.fileName : ""}`,
             );
             if (!configuredProject) return undefined;
@@ -3928,17 +3918,19 @@ export class ProjectService {
         let retainProjects: ConfiguredProject[] | ConfiguredProject | undefined;
         let projectForConfigFileDiag: ConfiguredProject | undefined;
         let defaultConfigProjectIsCreated = false;
+        let sentConfigDiag: Set<ConfiguredProject> | undefined;
         if (!project && this.serverMode === LanguageServiceMode.Semantic) { // Checking semantic mode is an optimization
             configFileName = this.getConfigFileNameForFile(info);
             if (configFileName) {
                 project = this.findConfiguredProjectByProjectName(configFileName);
                 if (!project) {
-                    project = this.createLoadAndUpdateConfiguredProject(configFileName, `Creating possible configured project for ${info.fileName} to open`);
+                    project = this.createLoadAndUpdateConfiguredProject(configFileName, `Creating possible configured project for ${info.fileName} to open`, info.fileName);
                     defaultConfigProjectIsCreated = true;
+                    (sentConfigDiag ??= new Set()).add(project);
                 }
-                else {
-                    // Ensure project is ready to check if it contains opened script info
-                    updateConfiguredProjectWithoutConfigDiagIfDirty(project);
+                // Ensure project is ready to check if it contains opened script info
+                else if (updateWithTriggerFile(project, info.fileName, /*isReload*/ false)) {
+                    (sentConfigDiag ??= new Set()).add(project);
                 }
 
                 projectForConfigFileDiag = project.containsScriptInfo(info) ? project : undefined;
@@ -3951,7 +3943,9 @@ export class ProjectService {
                         project,
                         info.path,
                         child => {
-                            updateConfiguredProjectWithoutConfigDiagIfDirty(child);
+                            if (updateWithTriggerFile(child, info.fileName, /*isReload*/ false)) {
+                                (sentConfigDiag ??= new Set()).add(child);
+                            }
                             // Retain these projects
                             if (!isArray(retainProjects)) {
                                 retainProjects = [project as ConfiguredProject, child];
@@ -3971,7 +3965,7 @@ export class ProjectService {
                                 projectForConfigFileDiag = child;
                             }
                         },
-                        ProjectReferenceProjectLoadKind.FindCreateLoad,
+                        ProjectReferenceProjectLoadKind.FindCreate,
                         `Creating project referenced in solution ${project.projectName} to find possible configured project for ${info.fileName} to open`,
                     );
                 }
@@ -3979,9 +3973,9 @@ export class ProjectService {
                 // Send the event only if the project got created as part of this open request and info is part of the project
                 if (projectForConfigFileDiag) {
                     configFileName = projectForConfigFileDiag.getConfigFilePath();
+                    // TODO:: sheetal do this irrespective?
                     if (projectForConfigFileDiag !== project || defaultConfigProjectIsCreated) {
                         configFileErrors = projectForConfigFileDiag.getAllProjectErrors();
-                        this.sendConfigFileDiagEvent(projectForConfigFileDiag, info.fileName);
                     }
                 }
                 else {
@@ -4008,11 +4002,14 @@ export class ProjectService {
         if (info.isOrphan()) {
             // Even though this info did not belong to any of the configured projects, send the config file diag
             if (isArray(retainProjects)) {
-                retainProjects.forEach(project => this.sendConfigFileDiagEvent(project, info.fileName));
+                retainProjects.forEach(project => {
+                    if (!sentConfigDiag?.has(project)) this.sendConfigFileDiagEvent(project, info.fileName, /*force*/ true);
+                });
             }
-            else if (retainProjects) {
-                this.sendConfigFileDiagEvent(retainProjects, info.fileName);
+            else if (retainProjects && !sentConfigDiag?.has(retainProjects)) {
+                this.sendConfigFileDiagEvent(retainProjects, info.fileName, /*force*/ true);
             }
+
             Debug.assert(this.openFiles.has(info.path));
             this.assignOrphanScriptInfoToInferredProject(info, this.openFiles.get(info.path));
         }
@@ -4045,7 +4042,7 @@ export class ProjectService {
 
             // find or delay load the project
             const ancestor = this.findConfiguredProjectByProjectName(configFileName) ||
-                this.createConfiguredProjectWithDelayLoad(configFileName, `Creating project possibly referencing default composite project ${project.getProjectName()} of open file ${info.fileName}`);
+                this.createConfiguredProject(configFileName, `Creating project possibly referencing default composite project ${project.getProjectName()} of open file ${info.fileName}`);
             if (ancestor.isInitialLoadPending()) {
                 // Set a potential project reference
                 ancestor.setPotentialProjectReference(project.canonicalConfigFilePath);
@@ -4090,7 +4087,7 @@ export class ProjectService {
             // Load this project,
             const configFileName = toNormalizedPath(child.sourceFile.fileName);
             const childProject = project.projectService.findConfiguredProjectByProjectName(configFileName) ||
-                project.projectService.createAndLoadConfiguredProject(configFileName, `Creating project referenced by : ${project.projectName} as it references project ${referencedProject.sourceFile.fileName}`);
+                project.projectService.createConfiguredProject(configFileName, `Creating project referenced by : ${project.projectName} as it references project ${referencedProject.sourceFile.fileName}`);
             updateProjectIfDirty(childProject);
 
             // Ensure children for this project
@@ -4558,8 +4555,8 @@ export class ProjectService {
                     if (!project) {
                         // errors are stored in the project, do not need to update the graph
                         project = this.getHostPreferences().lazyConfiguredProjectsFromExternalProject ?
-                            this.createConfiguredProjectWithDelayLoad(normalized, `Creating configured project in external project: ${proj.projectFileName}`) :
-                            this.createLoadAndUpdateConfiguredProject(normalized, `Creating configured project in external project: ${proj.projectFileName}`);
+                            this.createConfiguredProject(normalized, `Creating configured project in external project: ${proj.projectFileName}`) :
+                            this.createLoadAndUpdateConfiguredProject(normalized, `Creating configured project in external project: ${proj.projectFileName}`, /*triggerFile*/ undefined);
                     }
                     if (!existingConfiguredProjects?.has(project)) {
                         // keep project alive even if no documents are opened - its lifetime is bound to the lifetime of containing external project

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2845,7 +2845,6 @@ export class ConfiguredProject extends Project {
      */
     override updateGraph(): boolean {
         if (this.deferredClose) return false;
-        const isInitialLoad = this.isInitialLoadPending();
         this.isInitialLoadPending = returnFalse;
         const updateLevel = this.pendingUpdateLevel;
         this.pendingUpdateLevel = ProgramUpdateLevel.Update;
@@ -2859,7 +2858,7 @@ export class ConfiguredProject extends Project {
                 this.openFileWatchTriggered.clear();
                 const reason = Debug.checkDefined(this.pendingUpdateReason);
                 this.pendingUpdateReason = undefined;
-                this.projectService.reloadConfiguredProject(this, reason, isInitialLoad, /*clearSemanticCache*/ false);
+                this.projectService.reloadConfiguredProject(this, reason, /*clearSemanticCache*/ false);
                 result = true;
                 break;
             default:

--- a/tests/baselines/reference/tsserver/autoImportProvider/Does-not-create-auto-import-providers-upon-opening-projects-for-find-all-references.js
+++ b/tests/baselines/reference/tsserver/autoImportProvider/Does-not-create-auto-import-providers-upon-opening-projects-for-find-all-references.js
@@ -315,7 +315,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] Finding references to /packages/b/index.ts position 12 in project /packages/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/cachingFileSystemInformation/npm-install-works-when-timeout-occurs-inbetween-installation.js
+++ b/tests/baselines/reference/tsserver/cachingFileSystemInformation/npm-install-works-when-timeout-occurs-inbetween-installation.js
@@ -1364,6 +1364,23 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	/user/username/rootfolder/otherfolder/a/b/app.ts SVC-1-0 "import _ from 'lodash';"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/rootfolder/otherfolder/a/b/tsconfig.json",
+        "configFile": "/user/username/rootfolder/otherfolder/a/b/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot find type definition file for 'lodash'.\n  The file is in the program because:\n    Entry point for implicit type library 'lodash'",
+            "code": 2688,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/rootfolder/otherfolder/a/b/tsconfig.json' (Configured)
@@ -2212,6 +2229,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/rootfolder/otherfolder/a/b/tsconfig.json",
+        "configFile": "/user/username/rootfolder/otherfolder/a/b/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/rootfolder/otherfolder/a/b/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-false.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-false.js
@@ -332,6 +332,23 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot write file '/user/username/projects/myproject/test/file1.d.ts' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": false,

--- a/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-true.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-true.js
@@ -335,6 +335,23 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot write file '/user/username/projects/myproject/test/file1.d.ts' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": {

--- a/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-undefined.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/emit-with-richRepsonse-as-undefined.js
@@ -330,6 +330,23 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot write file '/user/username/projects/myproject/test/file1.d.ts' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": false,

--- a/tests/baselines/reference/tsserver/configFileSearch/tsconfig-for-the-file-does-not-exist.js
+++ b/tests/baselines/reference/tsserver/configFileSearch/tsconfig-for-the-file-does-not-exist.js
@@ -158,7 +158,6 @@ Projects::
     projectProgramVersion: 1
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/projects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configFileSearch/tsconfig-for-the-file-exists.js
+++ b/tests/baselines/reference/tsserver/configFileSearch/tsconfig-for-the-file-exists.js
@@ -335,7 +335,6 @@ Projects::
     projectProgramVersion: 1
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/projects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/Open-ref-of-configured-project-when-open-file-gets-added-to-the-project-as-part-of-configured-file-update-buts-its-open-file-references-are-all-closed-when-the-update-happens.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/Open-ref-of-configured-project-when-open-file-gets-added-to-the-project-as-part-of-configured-file-update-buts-its-open-file-references-are-all-closed-when-the-update-happens.js
@@ -645,7 +645,6 @@ Before running Timeout callback:: count: 2
 3: *ensureProjectForOpenFiles*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/Open-ref-of-configured-project-when-open-file-gets-added-to-the-project-as-part-of-configured-file-update.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/Open-ref-of-configured-project-when-open-file-gets-added-to-the-project-as-part-of-configured-file-update.js
@@ -523,7 +523,6 @@ Projects::
     projectProgramVersion: 1
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-in-a-folder-with-loose-files.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-in-a-folder-with-loose-files.js
@@ -225,7 +225,6 @@ Projects::
     dirty: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -574,7 +573,6 @@ Projects::
     deferredClose: undefined *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1485,7 +1483,6 @@ Projects::
     deferredClose: undefined *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-when-parent-folder-has-config-file.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-when-parent-folder-has-config-file.js
@@ -332,7 +332,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "triggerFile": "/user/username/projects/myproject/folder/commonFile2.ts",
         "configFile": "/user/username/projects/myproject/tsconfig.json",
         "diagnostics": []
       }
@@ -2419,7 +2419,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "triggerFile": "/user/username/projects/myproject/folder/commonFile2.ts",
         "configFile": "/user/username/projects/myproject/tsconfig.json",
         "diagnostics": []
       }
@@ -3031,7 +3031,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "triggerFile": "/user/username/projects/myproject/folder/commonFile2.ts",
         "configFile": "/user/username/projects/myproject/tsconfig.json",
         "diagnostics": []
       }
@@ -3814,7 +3814,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "triggerFile": "/user/username/projects/myproject/folder/commonFile2.ts",
         "configFile": "/user/username/projects/myproject/tsconfig.json",
         "diagnostics": []
       }

--- a/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-when-parent-folder-has-config-file.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/add-and-then-remove-a-config-file-when-parent-folder-has-config-file.js
@@ -240,7 +240,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/folder/commonFile2.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -421,7 +420,6 @@ Projects::
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/folder/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/folder/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1290,7 +1288,6 @@ Projects::
     dirty: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1512,7 +1509,6 @@ Projects::
     projectProgramVersion: 1
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/folder/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/folder/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2372,7 +2368,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/folder/commonFile2.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2985,7 +2980,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/folder/commonFile2.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3769,7 +3763,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/folder/commonFile2.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-in-list-of-files).js
+++ b/tests/baselines/reference/tsserver/configuredProjects/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-in-list-of-files).js
@@ -225,7 +225,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/can-update-configured-project-when-set-of-root-files-was-not-changed.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/can-update-configured-project-when-set-of-root-files-was-not-changed.js
@@ -239,7 +239,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/open-file-become-a-part-of-configured-project-if-it-is-referenced-from-root-file.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/open-file-become-a-part-of-configured-project-if-it-is-referenced-from-root-file.js
@@ -309,7 +309,6 @@ Projects::
     dirty: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/a/c/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/a/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/should-properly-handle-module-resolution-changes-in-config-file.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-properly-handle-module-resolution-changes-in-config-file.js
@@ -377,7 +377,6 @@ Projects::
     projectProgramVersion: 1
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/configuredProjects/should-watch-the-extended-configs-of-multiple-projects.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/should-watch-the-extended-configs-of-multiple-projects.js
@@ -478,7 +478,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -582,7 +581,6 @@ Info seq  [hh:mm:ss:mss] event:
       }
     }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -769,7 +767,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -942,7 +939,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1158,7 +1154,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1251,7 +1246,6 @@ Info seq  [hh:mm:ss:mss] event:
       }
     }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLanguageServiceState/language-service-disabled-events-are-triggered.js
+++ b/tests/baselines/reference/tsserver/events/projectLanguageServiceState/language-service-disabled-events-are-triggered.js
@@ -261,7 +261,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/jsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/jsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-an-extended-config-file-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-an-extended-config-file-when-using-default-event-handler.js
@@ -214,7 +214,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-an-extended-config-file-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-an-extended-config-file-when-using-event-handler.js
@@ -211,7 +211,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-the-config-file-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-the-config-file-when-using-default-event-handler.js
@@ -203,7 +203,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-the-config-file-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/change-is-detected-in-the-config-file-when-using-event-handler.js
@@ -200,7 +200,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-disabled-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-disabled-when-using-default-event-handler.js
@@ -103,7 +103,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 3,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-disabled-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-disabled-when-using-event-handler.js
@@ -103,7 +103,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 3,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-false-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-false-when-using-default-event-handler.js
@@ -160,6 +160,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/a/tsconfig.json",
+        "configFile": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/a/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (2)
 

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-false-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-false-when-using-event-handler.js
@@ -157,6 +157,17 @@ Info seq  [hh:mm:ss:mss] event:
         "version": "FakeVersion"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/user/username/projects/a/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/a/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (2)
 

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-default-event-handler.js
@@ -199,7 +199,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/a/tsconfig.json",
+        "triggerFile": "/user/username/projects/a/a.ts",
         "configFile": "/user/username/projects/a/tsconfig.json",
         "diagnostics": []
       }

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-default-event-handler.js
@@ -102,7 +102,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-event-handler.js
@@ -198,7 +198,7 @@ Info seq  [hh:mm:ss:mss] event:
       "body": {
         "configFileName": "/user/username/projects/a/tsconfig.json",
         "diagnostics": [],
-        "triggerFile": "/user/username/projects/a/tsconfig.json"
+        "triggerFile": "/user/username/projects/a/a.ts"
       }
     }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/a/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/lazyConfiguredProjectsFromExternalProject-is-true-and-file-is-opened-when-using-event-handler.js
@@ -102,7 +102,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-disableSourceOfProjectReferenceRedirect-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-disableSourceOfProjectReferenceRedirect-when-using-default-event-handler.js
@@ -367,6 +367,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/a/tsconfig.json",
+        "configFile": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/a/a.ts position 13 in project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-disableSourceOfProjectReferenceRedirect-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-disableSourceOfProjectReferenceRedirect-when-using-event-handler.js
@@ -361,6 +361,17 @@ Info seq  [hh:mm:ss:mss] event:
         "version": "FakeVersion"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/user/username/projects/a/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/a/a.ts position 13 in project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-when-using-default-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-when-using-default-event-handler.js
@@ -358,6 +358,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/a/tsconfig.json",
+        "configFile": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/a/a.ts position 13 in project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-when-using-event-handler.js
+++ b/tests/baselines/reference/tsserver/events/projectLoading/opening-original-location-project-when-using-event-handler.js
@@ -352,6 +352,17 @@ Info seq  [hh:mm:ss:mss] event:
         "version": "FakeVersion"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/user/username/projects/a/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/user/username/projects/a/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/a/a.ts ProjectRootPath: undefined:: Result: /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/a/a.ts position 13 in project /user/username/projects/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
@@ -377,6 +377,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
@@ -372,6 +372,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-deleted-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-deleted-files.js
@@ -382,6 +382,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-newly-created-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-newly-created-files.js
@@ -394,6 +394,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-the-reference-map-changes.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-be-up-to-date-with-the-reference-map-changes.js
@@ -390,6 +390,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-contains-only-itself.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-contains-only-itself.js
@@ -370,6 +370,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-changes-in-non-root-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-changes-in-non-root-files.js
@@ -334,6 +334,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-non-existing-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-non-existing-code-file.js
@@ -311,6 +311,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-removed-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-detect-removed-code-file.js
@@ -297,6 +297,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-return-all-files-if-a-global-file-changed-shape.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-return-all-files-if-a-global-file-changed-shape.js
@@ -370,6 +370,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-return-cascaded-affected-file-list.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-return-cascaded-affected-file-list.js
@@ -410,6 +410,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-work-fine-for-files-with-circular-references.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/when-event-handler-is-set-in-the-session-and-should-work-fine-for-files-with-circular-references.js
@@ -303,6 +303,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Referenced via './file1.ts' from file 'file2.ts'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "CustomHandler::configFileDiag",
+      "body": {
+        "configFileName": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [],
+        "triggerFile": "/users/username/projects/project/tsconfig.json"
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
@@ -380,6 +380,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
@@ -375,6 +375,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-deleted-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-deleted-files.js
@@ -385,6 +385,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-newly-created-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-newly-created-files.js
@@ -397,6 +397,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-the-reference-map-changes.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-the-reference-map-changes.js
@@ -393,6 +393,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-contains-only-itself.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-contains-only-itself.js
@@ -373,6 +373,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-changes-in-non-root-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-changes-in-non-root-files.js
@@ -337,6 +337,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-non-existing-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-non-existing-code-file.js
@@ -314,6 +314,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-removed-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-detect-removed-code-file.js
@@ -300,6 +300,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-return-all-files-if-a-global-file-changed-shape.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-return-all-files-if-a-global-file-changed-shape.js
@@ -373,6 +373,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-return-cascaded-affected-file-list.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-return-cascaded-affected-file-list.js
@@ -413,6 +413,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-work-fine-for-files-with-circular-references.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/with-noGetErrOnBackgroundUpdate-and-should-work-fine-for-files-with-circular-references.js
@@ -306,6 +306,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Referenced via './file1.ts' from file 'file2.ts'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---isolatedModules-is-specified.js
@@ -380,6 +380,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-always-return-the-file-itself-if---out-or---outFile-is-specified.js
@@ -375,6 +375,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-deleted-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-deleted-files.js
@@ -385,6 +385,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-newly-created-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-newly-created-files.js
@@ -397,6 +397,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-the-reference-map-changes.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-be-up-to-date-with-the-reference-map-changes.js
@@ -393,6 +393,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-contains-only-itself.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-contains-only-itself.js
@@ -373,6 +373,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-changes-in-non-root-files.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-changes-in-non-root-files.js
@@ -337,6 +337,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-non-existing-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-non-existing-code-file.js
@@ -314,6 +314,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-removed-code-file.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-detect-removed-code-file.js
@@ -300,6 +300,17 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-return-all-files-if-a-global-file-changed-shape.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-return-all-files-if-a-global-file-changed-shape.js
@@ -373,6 +373,17 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-return-cascaded-affected-file-list.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-return-cascaded-affected-file-list.js
@@ -413,6 +413,17 @@ Info seq  [hh:mm:ss:mss] 	Files (7)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-work-fine-for-files-with-circular-references.js
+++ b/tests/baselines/reference/tsserver/events/projectUpdatedInBackground/without-noGetErrOnBackgroundUpdate-and-should-work-fine-for-files-with-circular-references.js
@@ -306,6 +306,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Referenced via './file1.ts' from file 'file2.ts'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing-with-lazyConfiguredProjectsFromExternalProject.js
+++ b/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing-with-lazyConfiguredProjectsFromExternalProject.js
@@ -91,7 +91,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /a/b/app.ts ProjectRootPath: undefined:: Result: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /A/B/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing-with-lazyConfiguredProjectsFromExternalProject.js
+++ b/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing-with-lazyConfiguredProjectsFromExternalProject.js
@@ -169,23 +169,6 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/A/B/tsconfig.json",
-        "configFile": "/A/B/tsconfig.json",
-        "diagnostics": [
-          {
-            "text": "No inputs were found in config file '/A/B/tsconfig.json'. Specified 'include' paths were '[]' and 'exclude' paths were '[]'.",
-            "code": 18003,
-            "category": "error"
-          }
-        ]
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
         "triggerFile": "/a/b/app.ts",
         "configFile": "/A/B/tsconfig.json",
         "diagnostics": [

--- a/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing.js
+++ b/tests/baselines/reference/tsserver/externalProjects/can-handle-tsconfig-file-name-with-difference-casing.js
@@ -129,6 +129,23 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/A/B/tsconfig.json",
+        "configFile": "/A/B/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "No inputs were found in config file '/A/B/tsconfig.json'. Specified 'include' paths were '[]' and 'exclude' paths were '[]'.",
+            "code": 18003,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/A/B/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (0)
 

--- a/tests/baselines/reference/tsserver/externalProjects/correctly-handles-changes-in-lib-section-of-config-file.js
+++ b/tests/baselines/reference/tsserver/externalProjects/correctly-handles-changes-in-lib-section-of-config-file.js
@@ -259,7 +259,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /src/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /src/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---1-with-lazyConfiguredProjectsFromExternalProject.js
+++ b/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---1-with-lazyConfiguredProjectsFromExternalProject.js
@@ -304,7 +304,6 @@ ScriptInfos::
     deferredDelete: true
     containingProjects: 0
 
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---1.js
+++ b/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---1.js
@@ -326,6 +326,63 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/tsconfig.json",
+        "configFile": "/a/b/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/a/b/proj1' (External)
 Info seq  [hh:mm:ss:mss] 	Files (2)

--- a/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---2-with-lazyConfiguredProjectsFromExternalProject.js
+++ b/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---2-with-lazyConfiguredProjectsFromExternalProject.js
@@ -226,7 +226,6 @@ ScriptInfos::
     containingProjects: 0 *changed*
         /a/b/proj1 *deleted*
 
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -369,7 +368,6 @@ Info seq  [hh:mm:ss:mss] event:
         ]
       }
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/d/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -884,7 +882,6 @@ ScriptInfos::
     version: Text-1
     containingProjects: 0
 
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -985,7 +982,6 @@ Info seq  [hh:mm:ss:mss] event:
         ]
       }
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/d/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---2.js
+++ b/tests/baselines/reference/tsserver/externalProjects/correctly-handling-add-or-remove-tsconfig---2.js
@@ -250,6 +250,63 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/c/tsconfig.json",
+        "configFile": "/a/b/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /a/b/d/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/b/d/tsconfig.json 2000 undefined Project: /a/b/d/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] event:
@@ -335,6 +392,63 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/d/tsconfig.json",
+        "configFile": "/a/b/d/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
       }
     }
 Info seq  [hh:mm:ss:mss] `remove Project::
@@ -691,6 +805,63 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/a/b/c/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/c/tsconfig.json",
+        "configFile": "/a/b/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /a/b/d/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/b/d/tsconfig.json 2000 undefined Project: /a/b/d/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] event:
@@ -734,6 +905,63 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/a/b/d/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/d/tsconfig.json",
+        "configFile": "/a/b/d/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
       }
     }
 Info seq  [hh:mm:ss:mss] `remove Project::

--- a/tests/baselines/reference/tsserver/externalProjects/deleting-config-file-opened-from-the-external-project-works.js
+++ b/tests/baselines/reference/tsserver/externalProjects/deleting-config-file-opened-from-the-external-project-works.js
@@ -153,6 +153,23 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/someuser/project/tsconfig.json",
+        "configFile": "/user/someuser/project/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "No inputs were found in config file '/user/someuser/project/tsconfig.json'. Specified 'include' paths were '[\"**/*\"]' and 'exclude' paths were '[]'.",
+            "code": 18003,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/user/someuser/project/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (0)
 

--- a/tests/baselines/reference/tsserver/externalProjects/external-project-that-included-config-files.js
+++ b/tests/baselines/reference/tsserver/externalProjects/external-project-that-included-config-files.js
@@ -131,6 +131,63 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/tsconfig.json",
+        "configFile": "/a/b/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /a/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/c/tsconfig.json 2000 undefined Project: /a/c/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] event:
@@ -212,6 +269,63 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/c/tsconfig.json",
+        "configFile": "/a/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
       }
     }
 Info seq  [hh:mm:ss:mss] Project '/a/b/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/externalProjects/handles-creation-of-external-project-with-jsconfig-before-jsconfig-creation-watcher-is-invoked.js
+++ b/tests/baselines/reference/tsserver/externalProjects/handles-creation-of-external-project-with-jsconfig-before-jsconfig-creation-watcher-is-invoked.js
@@ -119,6 +119,23 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "No inputs were found in config file '/user/username/projects/myproject/tsconfig.json'. Specified 'include' paths were '[\"**/*\"]' and 'exclude' paths were '[]'.",
+            "code": 18003,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (0)
 
@@ -676,6 +693,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/jsconfig.json",
+        "configFile": "/user/username/projects/myproject/jsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/externalProjects/handles-loads-existing-configured-projects-of-external-projects-when-lazyConfiguredProjectsFromExternalProject-is-disabled.js
+++ b/tests/baselines/reference/tsserver/externalProjects/handles-loads-existing-configured-projects-of-external-projects-when-lazyConfiguredProjectsFromExternalProject-is-disabled.js
@@ -90,7 +90,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 3,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/externalProjects/handles-loads-existing-configured-projects-of-external-projects-when-lazyConfiguredProjectsFromExternalProject-is-disabled.js
+++ b/tests/baselines/reference/tsserver/externalProjects/handles-loads-existing-configured-projects-of-external-projects-when-lazyConfiguredProjectsFromExternalProject-is-disabled.js
@@ -398,6 +398,63 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/a/b/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/tsconfig.json",
+        "configFile": "/a/b/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/a/b/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (1)
 

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_stripSrc.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_stripSrc.js
@@ -175,6 +175,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 12,
+              "offset": 18
+            },
+            "end": {
+              "line": 12,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 12,
+              "offset": 3
+            },
+            "end": {
+              "line": 12,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -222,46 +262,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 12,
-              "offset": 18
-            },
-            "end": {
-              "line": 12,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 12,
-              "offset": 3
-            },
-            "end": {
-              "line": 12,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_toDist.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_toDist.js
@@ -175,6 +175,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 12,
+              "offset": 18
+            },
+            "end": {
+              "line": 12,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 12,
+              "offset": 3
+            },
+            "end": {
+              "line": 12,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -222,46 +262,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 12,
-              "offset": 18
-            },
-            "end": {
-              "line": 12,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 12,
-              "offset": 3
-            },
-            "end": {
-              "line": 12,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_toSrc.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_paths_toSrc.js
@@ -175,6 +175,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 12,
+              "offset": 18
+            },
+            "end": {
+              "line": 12,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 12,
+              "offset": 3
+            },
+            "end": {
+              "line": 12,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -222,46 +262,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 12,
-              "offset": 18
-            },
-            "end": {
-              "line": 12,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 12,
-              "offset": 3
-            },
-            "end": {
-              "line": 12,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_stripSrc.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_stripSrc.js
@@ -141,6 +141,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 11,
+              "offset": 18
+            },
+            "end": {
+              "line": 11,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 11,
+              "offset": 3
+            },
+            "end": {
+              "line": 11,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -190,46 +230,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 11,
-              "offset": 18
-            },
-            "end": {
-              "line": 11,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 11,
-              "offset": 3
-            },
-            "end": {
-              "line": 11,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_toDist.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_toDist.js
@@ -141,6 +141,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 11,
+              "offset": 18
+            },
+            "end": {
+              "line": 11,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 11,
+              "offset": 3
+            },
+            "end": {
+              "line": 11,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -190,46 +230,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 11,
-              "offset": 18
-            },
-            "end": {
-              "line": 11,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 11,
-              "offset": 3
-            },
-            "end": {
-              "line": 11,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_toSrc.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportCrossProject_symlinks_toSrc.js
@@ -132,6 +132,46 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/app/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/packages/app/package.json",
+        "configFile": "/packages/app/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 8,
+              "offset": 18
+            },
+            "end": {
+              "line": 8,
+              "offset": 38
+            },
+            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
+            "code": 6306,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          },
+          {
+            "start": {
+              "line": 8,
+              "offset": 3
+            },
+            "end": {
+              "line": 8,
+              "offset": 15
+            },
+            "text": "',' expected.",
+            "code": 1005,
+            "category": "error",
+            "fileName": "/packages/app/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/dep/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -181,46 +221,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/dep/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/packages/app/package.json",
-        "configFile": "/packages/app/tsconfig.json",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 8,
-              "offset": 18
-            },
-            "end": {
-              "line": 8,
-              "offset": 38
-            },
-            "text": "Referenced project '/packages/dep' must have setting \"composite\": true.",
-            "code": 6306,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          },
-          {
-            "start": {
-              "line": 8,
-              "offset": 3
-            },
-            "end": {
-              "line": 8,
-              "offset": 15
-            },
-            "text": "',' expected.",
-            "code": 1005,
-            "category": "error",
-            "fileName": "/packages/app/tsconfig.json"
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider4.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider4.js
@@ -104,50 +104,6 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/a/tsconfig.json"
       }
     }
-Info seq  [hh:mm:ss:mss] Creating configuration project /b/tsconfig.json
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "projectLoadingStart",
-      "body": {
-        "projectName": "/b/tsconfig.json",
-        "reason": "Creating project referenced in solution /a/tsconfig.json to find possible configured project for /a/package.json to open"
-      }
-    }
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /b/index.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /b/tsconfig.json
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /b/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/b/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (4)
-	/lib.d.ts Text-1 lib.d.ts-Text
-	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
-	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
-	/b/index.ts Text-1 "export class Shape {}"
-
-
-	../lib.d.ts
-	  Default library for target 'es5'
-	../lib.decorators.d.ts
-	  Library referenced via 'decorators' from file '../lib.d.ts'
-	../lib.decorators.legacy.d.ts
-	  Library referenced via 'decorators.legacy' from file '../lib.d.ts'
-	index.ts
-	  Matched by default include pattern '**/*'
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "projectLoadingFinish",
-      "body": {
-        "projectName": "/b/tsconfig.json"
-      }
-    }
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -221,6 +177,50 @@ Info seq  [hh:mm:ss:mss] event:
             "category": "error"
           }
         ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] Creating configuration project /b/tsconfig.json
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/b/tsconfig.json",
+        "reason": "Creating project referenced in solution /a/tsconfig.json to find possible configured project for /a/package.json to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /b/index.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /b/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /b/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/b/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/b/index.ts Text-1 "export class Shape {}"
+
+
+	../lib.d.ts
+	  Default library for target 'es5'
+	../lib.decorators.d.ts
+	  Library referenced via 'decorators' from file '../lib.d.ts'
+	../lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file '../lib.d.ts'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/b/tsconfig.json"
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/getFileReferences_deduplicate.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/getFileReferences_deduplicate.js
@@ -106,6 +106,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /tsconfig.build.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -154,6 +165,41 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/tsconfig.build.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/tsconfig.build.json",
+        "diagnostics": [
+          {
+            "text": "File '/index.ts' is not under 'rootDir' '/src'. 'rootDir' is expected to contain all source files.\n  The file is in the program because:\n    Part of 'files' list in tsconfig.json",
+            "code": 6059,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 1,
+                    "offset": 97
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 107
+                  },
+                  "file": "/tsconfig.build.json"
+                },
+                "message": "File is matched by 'files' list specified here.",
+                "category": "message",
+                "code": 1410
+              }
+            ]
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /tsconfig.test.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -200,52 +246,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/tsconfig.test.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/tsconfig.json",
-        "configFile": "/tsconfig.json",
-        "diagnostics": []
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/tsconfig.json",
-        "configFile": "/tsconfig.build.json",
-        "diagnostics": [
-          {
-            "text": "File '/index.ts' is not under 'rootDir' '/src'. 'rootDir' is expected to contain all source files.\n  The file is in the program because:\n    Part of 'files' list in tsconfig.json",
-            "code": 6059,
-            "category": "error",
-            "relatedInformation": [
-              {
-                "span": {
-                  "start": {
-                    "line": 1,
-                    "offset": 97
-                  },
-                  "end": {
-                    "line": 1,
-                    "offset": 107
-                  },
-                  "file": "/tsconfig.build.json"
-                },
-                "message": "File is matched by 'files' list specified here.",
-                "category": "message",
-                "code": 1410
-              }
-            ]
-          }
-        ]
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/getFileReferences_server2.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/getFileReferences_server2.js
@@ -143,6 +143,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/server/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -199,6 +210,28 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/packages/server/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/packages/server/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot write file '/packages/server/index.js' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          },
+          {
+            "text": "Cannot write file '/packages/server/router.js' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -238,6 +271,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/shared/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/packages/shared/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /packages/client/tsconfig.json
@@ -283,50 +327,6 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/packages/client/tsconfig.json"
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/tsconfig.json",
-        "configFile": "/tsconfig.json",
-        "diagnostics": []
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/tsconfig.json",
-        "configFile": "/packages/server/tsconfig.json",
-        "diagnostics": [
-          {
-            "text": "Cannot write file '/packages/server/index.js' because it would overwrite input file.",
-            "code": 5055,
-            "category": "error"
-          },
-          {
-            "text": "Cannot write file '/packages/server/router.js' because it would overwrite input file.",
-            "code": 5055,
-            "category": "error"
-          }
-        ]
-      }
-    }
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/tsconfig.json",
-        "configFile": "/packages/shared/tsconfig.json",
-        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossGlobalProjects.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossGlobalProjects.js
@@ -535,6 +535,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/b/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/b/tsconfig.json",
+        "configFile": "/b/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /b/index.ts ProjectRootPath: undefined:: Result: /b/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /b/index.ts ProjectRootPath: undefined:: Result: /b/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /c/index.ts ProjectRootPath: undefined:: Result: /c/tsconfig.json
@@ -576,6 +587,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/c/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/c/tsconfig.json",
+        "configFile": "/c/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /c/index.ts ProjectRootPath: undefined:: Result: /c/tsconfig.json

--- a/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossGlobalProjects.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossGlobalProjects.js
@@ -309,7 +309,6 @@ Info seq  [hh:mm:ss:mss] request:
       "command": "references-full"
     }
 Info seq  [hh:mm:ss:mss] Finding references to /a/index.ts position 35 in project /a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossModuleProjects.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossModuleProjects.js
@@ -617,6 +617,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/c/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/c/tsconfig.json",
+        "configFile": "/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /c/index.ts ProjectRootPath: undefined:: Result: /c/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /c/index.ts ProjectRootPath: undefined:: Result: /c/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /c/index.ts position 70 in project /c/tsconfig.json
@@ -665,6 +676,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/a2/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a2/tsconfig.json",
+        "configFile": "/a2/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /c/index.ts position 70 in project /a2/tsconfig.json

--- a/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossModuleProjects.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/isDefinitionAcrossModuleProjects.js
@@ -352,7 +352,6 @@ Info seq  [hh:mm:ss:mss] request:
       "command": "references-full"
     }
 Info seq  [hh:mm:ss:mss] Finding references to /a/index.ts position 128 in project /a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/inferredProjects/should-use-only-one-inferred-project-if-useOneInferredProject-is-set.js
+++ b/tests/baselines/reference/tsserver/inferredProjects/should-use-only-one-inferred-project-if-useOneInferredProject-is-set.js
@@ -355,7 +355,6 @@ Projects::
     dirty: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/myproject/a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/libraryResolution/with-config-with-redirection.js
+++ b/tests/baselines/reference/tsserver/libraryResolution/with-config-with-redirection.js
@@ -1726,7 +1726,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project1/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2030,7 +2029,6 @@ ScriptInfos::
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project1/tsconfig.jsonFailedLookupInvalidation
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project1/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/libraryResolution/with-config.js
+++ b/tests/baselines/reference/tsserver/libraryResolution/with-config.js
@@ -1601,7 +1601,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project1/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1899,7 +1898,6 @@ ScriptInfos::
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/moduleSpecifierCache/invalidates-the-cache-when-module-resolution-settings-change.js
+++ b/tests/baselines/reference/tsserver/moduleSpecifierCache/invalidates-the-cache-when-module-resolution-settings-change.js
@@ -1010,7 +1010,6 @@ Projects::
     autoImportProviderHost: /dev/null/autoImportProviderProject1*
 
 Info seq  [hh:mm:ss:mss] Running: /tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
+++ b/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
@@ -254,7 +254,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 2,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/plugins/gets-external-files-with-config-file-reload.js
+++ b/tests/baselines/reference/tsserver/plugins/gets-external-files-with-config-file-reload.js
@@ -247,7 +247,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/pluginsAsync/project-is-deferred-closed-before-plugins-are-loaded.js
+++ b/tests/baselines/reference/tsserver/pluginsAsync/project-is-deferred-closed-before-plugins-are-loaded.js
@@ -246,7 +246,6 @@ Projects::
     deferredClose: undefined *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
@@ -195,7 +195,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -318,7 +317,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-corrupted-config-1.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-corrupted-config-1.js
@@ -325,7 +325,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 4,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-corrupted-config-2.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-corrupted-config-2.js
@@ -297,7 +297,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 4,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-missing-files.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configured-projects---diagnostics-for-missing-files.js
@@ -295,6 +295,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/tsconfig.json",
+        "configFile": "/a/b/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": [],

--- a/tests/baselines/reference/tsserver/projectErrors/diagnostics-after-noUnusedLabels-changes.js
+++ b/tests/baselines/reference/tsserver/projectErrors/diagnostics-after-noUnusedLabels-changes.js
@@ -220,7 +220,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectErrors/when-options-change.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-options-change.js
@@ -322,7 +322,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 3,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
+++ b/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
@@ -661,7 +661,6 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/container/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
+++ b/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
@@ -665,6 +665,17 @@ Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
       "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/lib/tsconfig.json",
+        "configFile": "/user/username/projects/container/lib/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
       "event": "projectLoadingStart",
       "body": {
         "projectName": "/user/username/projects/container/tsconfig.json",
@@ -859,6 +870,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/exec/tsconfig.json",
+        "configFile": "/user/username/projects/container/exec/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/container/lib/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/container/lib/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
+++ b/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
@@ -546,7 +546,6 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/container/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
+++ b/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
@@ -550,6 +550,17 @@ Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
       "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/lib/tsconfig.json",
+        "configFile": "/user/username/projects/container/lib/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
       "event": "projectLoadingStart",
       "body": {
         "projectName": "/user/username/projects/container/tsconfig.json",
@@ -744,6 +755,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/exec/tsconfig.json",
+        "configFile": "/user/username/projects/container/exec/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/container/lib/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/container/lib/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -1170,7 +1170,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1282,7 +1281,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -290,6 +290,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1005,6 +1016,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -1149,7 +1149,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1241,7 +1240,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-indirect1.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -243,6 +243,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -972,6 +983,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -969,7 +969,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
@@ -381,6 +381,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/lib/tsconfig.json",
+        "configFile": "/user/username/projects/container/lib/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/container/exec/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] event:
@@ -482,6 +493,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/exec/tsconfig.json",
+        "configFile": "/user/username/projects/container/exec/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/container/compositeExec/tsconfig.json
@@ -591,6 +613,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/compositeExec/tsconfig.json",
+        "configFile": "/user/username/projects/container/compositeExec/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/container/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/container/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] event:
@@ -677,6 +710,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/container/tsconfig.json",
+        "configFile": "/user/username/projects/container/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/container/lib/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
@@ -338,7 +338,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/compiler/program.ts position 110 in project /user/username/projects/solution/compiler/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
@@ -541,6 +541,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/services/tsconfig.json",
+        "configFile": "/user/username/projects/solution/services/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/types.d.ts 2000 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Missing generated file
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/compiler/types.ts position 103 in project /user/username/projects/solution/services/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/compiler/types.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/compiler/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/finding-references-in-overlapping-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-references-in-overlapping-projects.js
@@ -448,7 +448,6 @@ Info seq  [hh:mm:ss:mss] event:
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/a/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/a/index.ts position 34 in project /user/username/projects/solution/a/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/finding-references-in-overlapping-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-references-in-overlapping-projects.js
@@ -446,6 +446,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/a/tsconfig.json",
+        "configFile": "/user/username/projects/solution/a/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/a/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/a/index.ts position 34 in project /user/username/projects/solution/a/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
@@ -687,6 +698,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/c/tsconfig.json",
+        "configFile": "/user/username/projects/solution/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/solution/d/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -794,6 +816,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/d/tsconfig.json",
+        "configFile": "/user/username/projects/solution/d/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/a/index.ts position 34 in project /user/username/projects/solution/c/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -286,6 +286,41 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/projects/project2/class2.ts SVC-1-0 "class class2 {}"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.\n  The file is in the program because:\n    Output from referenced project '/user/username/projects/myproject/projects/project1/tsconfig.json' included because '--module' is specified as 'none'",
+            "code": 6053,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 8,
+                    "offset": 5
+                  },
+                  "end": {
+                    "line": 10,
+                    "offset": 6
+                  },
+                  "file": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+                },
+                "message": "File is output from referenced project specified here.",
+                "category": "message",
+                "code": 1413
+              }
+            ]
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -428,6 +463,17 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -585,6 +631,41 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.\n  The file is in the program because:\n    Output from referenced project '/user/username/projects/myproject/projects/project1/tsconfig.json' included because '--module' is specified as 'none'",
+            "code": 6053,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 8,
+                    "offset": 5
+                  },
+                  "end": {
+                    "line": 10,
+                    "offset": 6
+                  },
+                  "file": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+                },
+                "message": "File is output from referenced project specified here.",
+                "category": "message",
+                "code": 1413
+              }
+            ]
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -689,6 +770,17 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -478,6 +478,41 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/projects/project2/class2.ts SVC-1-0 "class class2 {}"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.\n  The file is in the program because:\n    Output from referenced project '/user/username/projects/myproject/projects/project1/tsconfig.json' included because '--module' is specified as 'none'",
+            "code": 6053,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 8,
+                    "offset": 5
+                  },
+                  "end": {
+                    "line": 10,
+                    "offset": 6
+                  },
+                  "file": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+                },
+                "message": "File is output from referenced project specified here.",
+                "category": "message",
+                "code": 1413
+              }
+            ]
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/projects/project1/tsconfig.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
@@ -690,6 +725,17 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -888,6 +934,41 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.\n  The file is in the program because:\n    Output from referenced project '/user/username/projects/myproject/projects/project1/tsconfig.json' included because '--module' is specified as 'none'",
+            "code": 6053,
+            "category": "error",
+            "relatedInformation": [
+              {
+                "span": {
+                  "start": {
+                    "line": 8,
+                    "offset": 5
+                  },
+                  "end": {
+                    "line": 10,
+                    "offset": 6
+                  },
+                  "file": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+                },
+                "message": "File is output from referenced project specified here.",
+                "category": "message",
+                "code": 1413
+              }
+            ]
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -1020,6 +1101,17 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/projects/project2/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
@@ -201,6 +201,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -942,6 +953,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1427,6 +1449,32 @@ Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.jso
 Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 3,
+              "offset": 5
+            },
+            "end": {
+              "line": 5,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -1672,6 +1720,17 @@ Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.jso
 Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -3326,6 +3385,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -3370,6 +3440,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-src.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
@@ -1673,7 +1673,6 @@ Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2098,7 +2097,6 @@ Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2279,7 +2277,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2352,7 +2349,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
@@ -288,6 +288,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1087,6 +1098,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1590,6 +1612,46 @@ Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.jso
 Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 11,
+              "offset": 5
+            },
+            "end": {
+              "line": 13,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig-indirect1.json"
+          },
+          {
+            "start": {
+              "line": 11,
+              "offset": 5
+            },
+            "end": {
+              "line": 13,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig-indirect2.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -1839,6 +1901,17 @@ Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.jso
 Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -2861,6 +2934,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -2954,6 +3038,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
@@ -4099,6 +4194,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -4143,6 +4249,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-src.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
@@ -4200,6 +4317,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig-indirect1.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -4248,6 +4376,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-indirect2.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/myproject/src/helpers/functions.ts position 13 in project /user/username/projects/myproject/tsconfig-indirect1.json

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
@@ -1840,7 +1840,6 @@ Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2273,7 +2272,6 @@ Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2458,7 +2456,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2569,7 +2566,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
@@ -682,7 +682,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/project/src/tsconfig.json",
+        "triggerFile": "/user/username/projects/project/src/terminal.ts",
         "configFile": "/user/username/projects/project/src/tsconfig.json",
         "diagnostics": []
       }

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
@@ -541,7 +541,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/project/src/terminal.ts ProjectRootPath: undefined:: Result: /user/username/projects/project/src/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/project/src/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
@@ -678,7 +678,7 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "configFileDiag",
       "body": {
-        "triggerFile": "/user/username/projects/project/src/tsconfig.json",
+        "triggerFile": "/user/username/projects/project/src/terminal.ts",
         "configFile": "/user/username/projects/project/src/tsconfig.json",
         "diagnostics": []
       }

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
@@ -541,7 +541,6 @@ Info seq  [hh:mm:ss:mss] request:
       "type": "request"
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/project/src/terminal.ts ProjectRootPath: undefined:: Result: /user/username/projects/project/src/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/project/src/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -334,6 +334,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1187,6 +1198,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -1382,7 +1382,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1521,7 +1520,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -1319,7 +1319,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -1438,7 +1437,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-indirect1.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -287,6 +287,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -389,7 +400,7 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "configFileDiag",
       "body": {
         "triggerFile": "/user/username/projects/myproject/src/main.ts",
-        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
         "diagnostics": []
       }
     }
@@ -1123,6 +1134,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1179,7 +1201,7 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "configFileDiag",
       "body": {
         "triggerFile": "/user/username/projects/myproject/src/main.ts",
-        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
         "diagnostics": []
       }
     }

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -949,7 +949,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
@@ -241,6 +241,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1074,6 +1085,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1607,6 +1629,32 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	/user/username/projects/myproject/own/main.ts Text-2 "import { foo } from 'main';\nfoo;\nexport function bar() {}"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 7,
+              "offset": 5
+            },
+            "end": {
+              "line": 9,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -1807,6 +1855,17 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	/user/username/projects/myproject/own/main.ts Text-2 "import { foo } from 'main';\nfoo;\nexport function bar() {}"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -3490,6 +3549,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -3534,6 +3604,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-src.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
@@ -1808,7 +1808,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2158,7 +2157,6 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2285,7 +2283,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2381,7 +2378,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
@@ -332,6 +332,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1269,6 +1280,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/src/main.ts",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1871,6 +1893,46 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 11,
+              "offset": 5
+            },
+            "end": {
+              "line": 13,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig-indirect1.json"
+          },
+          {
+            "start": {
+              "line": 11,
+              "offset": 5
+            },
+            "end": {
+              "line": 13,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/tsconfig-src.json' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/tsconfig-indirect2.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -2115,6 +2177,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -3092,6 +3165,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/indirect1/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/indirect1/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/myproject/indirect1/main.ts position 9 in project /user/username/projects/myproject/tsconfig-indirect1.json
@@ -3190,6 +3274,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
@@ -4451,6 +4546,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -4495,6 +4601,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-src.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-src.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
@@ -4557,6 +4674,17 @@ Info seq  [hh:mm:ss:mss] event:
         "projectName": "/user/username/projects/myproject/tsconfig-indirect1.json"
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect1.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/indirect1/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/myproject/indirect1/main.ts ProjectRootPath: undefined:: Result: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/myproject/src/main.ts position 9 in project /user/username/projects/myproject/tsconfig-src.json
@@ -4614,6 +4742,17 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "projectLoadingFinish",
       "body": {
         "projectName": "/user/username/projects/myproject/tsconfig-indirect2.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "configFile": "/user/username/projects/myproject/tsconfig-indirect2.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/myproject/src/helpers/functions.ts position 13 in project /user/username/projects/myproject/tsconfig-indirect2.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
@@ -2116,7 +2116,6 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2525,7 +2524,6 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig-src.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2655,7 +2653,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2793,7 +2790,6 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig-src.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-types.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-types.js
@@ -428,7 +428,6 @@ Info seq  [hh:mm:ss:mss] event:
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 21 in project /user/username/projects/solution/shared/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-types.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-types.js
@@ -426,6 +426,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "configFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 21 in project /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
@@ -640,6 +651,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/app/tsconfig.json",
+        "configFile": "/user/username/projects/solution/app/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 21 in project /user/username/projects/solution/app/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
@@ -427,6 +427,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "configFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 16 in project /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
@@ -428,7 +428,6 @@ Info seq  [hh:mm:ss:mss] event:
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 13 in project /user/username/projects/solution/shared/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
@@ -426,6 +426,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "configFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 13 in project /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
@@ -640,6 +651,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/app/tsconfig.json",
+        "configFile": "/user/username/projects/solution/app/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 13 in project /user/username/projects/solution/app/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
@@ -428,6 +428,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "configFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 27 in project /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
@@ -642,6 +653,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/app/tsconfig.json",
+        "configFile": "/user/username/projects/solution/app/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 27 in project /user/username/projects/solution/app/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
@@ -430,7 +430,6 @@ Info seq  [hh:mm:ss:mss] event:
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 27 in project /user/username/projects/solution/shared/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
@@ -428,7 +428,6 @@ Info seq  [hh:mm:ss:mss] event:
     }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 22 in project /user/username/projects/solution/shared/tsconfig.json
-Info seq  [hh:mm:ss:mss] Loading configured project /user/username/projects/solution/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
@@ -426,6 +426,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "configFile": "/user/username/projects/solution/shared/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /user/username/projects/solution/shared/src/index.ts ProjectRootPath: undefined:: Result: /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 22 in project /user/username/projects/solution/shared/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
@@ -640,6 +651,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/solution/app/tsconfig.json",
+        "configFile": "/user/username/projects/solution/app/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Finding references to /user/username/projects/solution/shared/src/index.ts position 22 in project /user/username/projects/solution/app/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
@@ -963,6 +963,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/indirect/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/indirect/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/coreRef1/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1049,6 +1060,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/coreRef1/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/coreRef1/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json
@@ -1140,6 +1162,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1227,6 +1260,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/refToCoreRef3/tsconfig.json
@@ -1317,6 +1361,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/refToCoreRef3/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/refToCoreRef3/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/myproject/coreRef3/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -1403,6 +1458,17 @@ Info seq  [hh:mm:ss:mss] event:
           "languageServiceEnabled": true,
           "version": "FakeVersion"
         }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/coreRef3/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/coreRef3/tsconfig.json",
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/src/file1.d.ts 2000 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Missing generated file

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configHasNoReference/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configHasNoReference/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -948,7 +948,6 @@ Projects::
         /user/username/projects/myproject/dependency/tsconfig.json
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2100,7 +2099,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2652,7 +2650,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3363,7 +3360,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3852,7 +3848,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -4562,7 +4557,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -5321,7 +5315,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -5731,7 +5724,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configHasNoReference/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configHasNoReference/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -545,6 +545,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": {

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configWithReference/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configWithReference/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -558,6 +558,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": {
@@ -3637,6 +3648,32 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 7,
+              "offset": 5
+            },
+            "end": {
+              "line": 9,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/dependency' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/main/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
@@ -3853,6 +3890,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -4999,6 +5047,32 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 7,
+              "offset": 5
+            },
+            "end": {
+              "line": 9,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/dependency' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/main/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
@@ -5458,6 +5532,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configWithReference/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/configWithReference/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -939,7 +939,6 @@ Projects::
         /user/username/projects/myproject/main/tsconfig.json
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2045,7 +2044,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2569,7 +2567,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3230,7 +3227,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3858,7 +3854,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -4609,7 +4604,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -5465,7 +5459,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -5953,7 +5946,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/disabledSourceRef/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/disabledSourceRef/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -563,6 +563,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/dependency/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": {
@@ -3847,6 +3858,32 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/main/main.ts SVC-1-0 "import {\n    fn1,\n    fn2,\n    fn3,\n    fn4,\n    fn5\n} from '../decls/fns'\n\nfn1();\nfn2();\nfn3();\nfn4();\nfn5();\n"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 8,
+              "offset": 5
+            },
+            "end": {
+              "line": 10,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/dependency' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/main/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
@@ -4030,6 +4067,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/main/main.ts SVC-1-0 "import {\n    fn1,\n    fn2,\n    fn3,\n    fn4,\n    fn5\n} from '../decls/fns'\n\nfn1();\nfn2();\nfn3();\nfn4();\nfn5();\n"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -5225,6 +5273,32 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/main/main.ts SVC-1-0 "import {\n    fn1,\n    fn2,\n    fn3,\n    fn4,\n    fn5\n} from '../decls/fns'\n\nfn1();\nfn2();\nfn3();\nfn4();\nfn5();\n"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 8,
+              "offset": 5
+            },
+            "end": {
+              "line": 10,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/dependency' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/main/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
@@ -5671,6 +5745,17 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	/user/username/projects/myproject/main/main.ts SVC-1-0 "import {\n    fn1,\n    fn2,\n    fn3,\n    fn4,\n    fn5\n} from '../decls/fns'\n\nfn1();\nfn2();\nfn3();\nfn4();\nfn5();\n"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/main/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {

--- a/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/disabledSourceRef/goToDef-and-rename-locations-and-deleting-config-file.js
+++ b/tests/baselines/reference/tsserver/projectReferencesSourcemap/dependencyAndUsage/disabledSourceRef/goToDef-and-rename-locations-and-deleting-config-file.js
@@ -972,7 +972,6 @@ Projects::
         /user/username/projects/myproject/dependency/tsconfig.json
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2137,7 +2136,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -2696,7 +2694,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -3420,7 +3417,6 @@ Projects::
     noOpenRef: true
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/main/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/main/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -4035,7 +4031,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -4816,7 +4811,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -5678,7 +5672,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -6154,7 +6147,6 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/dependency/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/dependency/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projects/Orphan-source-files-are-handled-correctly-on-watch-trigger.js
+++ b/tests/baselines/reference/tsserver/projects/Orphan-source-files-are-handled-correctly-on-watch-trigger.js
@@ -225,7 +225,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projects/deferred-files-in-the-project-context-with-lazyConfiguredProjectsFromExternalProject.js
+++ b/tests/baselines/reference/tsserver/projects/deferred-files-in-the-project-context-with-lazyConfiguredProjectsFromExternalProject.js
@@ -123,7 +123,6 @@ Projects::
     dirty: true
 
 Info seq  [hh:mm:ss:mss] Calling ensureInferredProjectsUpToDate_TestOnly
-Info seq  [hh:mm:ss:mss] Loading configured project /tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projects/deferred-files-in-the-project-context.js
+++ b/tests/baselines/reference/tsserver/projects/deferred-files-in-the-project-context.js
@@ -182,6 +182,63 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/tsconfig.json",
+        "configFile": "/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (1)
 

--- a/tests/baselines/reference/tsserver/projects/file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/file-opened-is-in-configured-project-that-will-be-removed.js
@@ -430,6 +430,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts",
+        "configFile": "/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)

--- a/tests/baselines/reference/tsserver/projects/js-file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/js-file-opened-is-in-configured-project-that-will-be-removed.js
@@ -417,6 +417,23 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js",
+        "configFile": "/user/username/projects/myproject/apps/editor/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot write file '/user/username/projects/myproject/apps/editor/src/src.js' because it would overwrite input file.",
+            "code": 5055,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)

--- a/tests/baselines/reference/tsserver/projects/references-on-file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/references-on-file-opened-is-in-configured-project-that-will-be-removed.js
@@ -430,6 +430,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts",
+        "configFile": "/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (4)

--- a/tests/baselines/reference/tsserver/projects/should-create-new-inferred-projects-for-files-excluded-from-a-configured-project.js
+++ b/tests/baselines/reference/tsserver/projects/should-create-new-inferred-projects-for-files-excluded-from-a-configured-project.js
@@ -231,7 +231,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projects/synchronizeProjectList-provides-updates-to-redirect-info-when-requested.js
+++ b/tests/baselines/reference/tsserver/projects/synchronizeProjectList-provides-updates-to-redirect-info-when-requested.js
@@ -667,7 +667,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 5,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Reloading configured project /users/username/projects/project/A/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projects/tsconfig-script-block-support.js
+++ b/tests/baselines/reference/tsserver/projects/tsconfig-script-block-support.js
@@ -224,7 +224,6 @@ Info seq  [hh:mm:ss:mss] request:
     }
 Info seq  [hh:mm:ss:mss] reload projects.
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /a/b/f1.ts ProjectRootPath: undefined:: Result: /a/b/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /a/b/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-deleting-referenced-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-deleting-referenced-config-file.js
@@ -414,6 +414,32 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 14,
+              "offset": 5
+            },
+            "end": {
+              "line": 16,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/b' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/c/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)
@@ -631,6 +657,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-deleting-transitively-referenced-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-deleting-transitively-referenced-config-file.js
@@ -400,6 +400,32 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	/user/username/projects/myproject/c/index.ts SVC-1-0 "import {b} from '../b';\nimport {X} from \"@ref/a\";\nb;\nX;"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 15,
+              "offset": 5
+            },
+            "end": {
+              "line": 17,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/a' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/b/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)
@@ -494,6 +520,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	/user/username/projects/myproject/c/index.ts SVC-1-0 "import {b} from '../b';\nimport {X} from \"@ref/a\";\nb;\nX;"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-edit-on-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/transitive-references-with-edit-on-config-file.js
@@ -405,7 +405,6 @@ Projects::
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.jsonFailedLookupInvalidation
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -645,7 +644,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-deleting-referenced-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-deleting-referenced-config-file.js
@@ -420,6 +420,32 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 11,
+              "offset": 5
+            },
+            "end": {
+              "line": 13,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/b' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/c/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)
@@ -640,6 +666,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-deleting-transitively-referenced-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-deleting-transitively-referenced-config-file.js
@@ -404,6 +404,32 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	/user/username/projects/myproject/c/index.ts SVC-1-0 "import {b} from '../b';\nimport {X} from \"@ref/a\";\nb;\nX;"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 12,
+              "offset": 5
+            },
+            "end": {
+              "line": 14,
+              "offset": 6
+            },
+            "text": "File '/user/username/projects/myproject/a' not found.",
+            "code": 6053,
+            "category": "error",
+            "fileName": "/user/username/projects/myproject/b/tsconfig.json"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)
@@ -497,6 +523,17 @@ Info seq  [hh:mm:ss:mss] 	Files (5)
 	/user/username/projects/myproject/c/index.ts SVC-1-0 "import {b} from '../b';\nimport {X} from \"@ref/a\";\nb;\nX;"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/c/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/c/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-edit-on-config-file.js
+++ b/tests/baselines/reference/tsserver/projectsWithReferences/trasitive-references-without-files-with-edit-on-config-file.js
@@ -401,7 +401,6 @@ Projects::
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.jsonFailedLookupInvalidation
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -640,7 +639,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/c/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/c/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/reloadProjects/configured-project.js
+++ b/tests/baselines/reference/tsserver/reloadProjects/configured-project.js
@@ -269,7 +269,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -462,7 +461,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -652,7 +650,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/reloadProjects/external-project-with-config-file.js
+++ b/tests/baselines/reference/tsserver/reloadProjects/external-project-with-config-file.js
@@ -340,7 +340,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -533,7 +532,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -723,7 +721,6 @@ Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/project
 Info seq  [hh:mm:ss:mss] ExcludeWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/file2.ts"],"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Reloading configured project /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/reloadProjects/external-project-with-config-file.js
+++ b/tests/baselines/reference/tsserver/reloadProjects/external-project-with-config-file.js
@@ -197,6 +197,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/user/username/projects/myproject/tsconfig.json",
+        "configFile": "/user/username/projects/myproject/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
 

--- a/tests/baselines/reference/tsserver/rename/with-symlinks-and-case-difference.js
+++ b/tests/baselines/reference/tsserver/rename/with-symlinks-and-case-difference.js
@@ -262,7 +262,6 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 2,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] Loading configured project c:/temp/test/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/rename/with-symlinks-and-case-difference.js
+++ b/tests/baselines/reference/tsserver/rename/with-symlinks-and-case-difference.js
@@ -472,6 +472,17 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "c:/temp/test/project2/tsconfig.json",
+        "configFile": "c:/temp/test/project2/tsconfig.json",
+        "diagnostics": []
+      }
+    }
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/temp/test/project1/index.d.ts 2000 undefined Project: c:/temp/test/project1/tsconfig.json WatchType: Missing generated file
 Info seq  [hh:mm:ss:mss] response:
     {

--- a/tests/baselines/reference/tsserver/resolutionCache/should-property-handle-missing-config-files.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/should-property-handle-missing-config-files.js
@@ -211,6 +211,63 @@ Info seq  [hh:mm:ss:mss] event:
         }
       }
     }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a/b/tsconfig.json",
+        "configFile": "/a/b/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project 'project1' (External)
 Info seq  [hh:mm:ss:mss] 	Files (1)

--- a/tests/baselines/reference/tsserver/resolutionCache/works-correctly-when-typings-are-added-or-removed.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/works-correctly-when-typings-are-added-or-removed.js
@@ -303,6 +303,68 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/users/username/projects/project/tsconfig.json",
+        "configFile": "/users/username/projects/project/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "Cannot find type definition file for 'lib1'.\n  The file is in the program because:\n    Entry point for implicit type library 'lib1'",
+            "code": 2688,
+            "category": "error"
+          },
+          {
+            "text": "File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library for target 'es5'",
+            "code": 6053,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Array'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Boolean'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Function'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'IArguments'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Number'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'Object'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'RegExp'.",
+            "code": 2318,
+            "category": "error"
+          },
+          {
+            "text": "Cannot find global type 'String'.",
+            "code": 2318,
+            "category": "error"
+          }
+        ]
+      }
+    }
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
@@ -683,7 +683,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
@@ -751,7 +751,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/tsserver/configDir-template.js
+++ b/tests/baselines/reference/tsserver/tsserver/configDir-template.js
@@ -471,7 +471,6 @@ Projects::
     dirty: true *changed*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/projects/myproject/tsconfig.json
-Info seq  [hh:mm:ss:mss] Reloading configured project /home/src/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types-has-import.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types-has-import.js
@@ -683,6 +683,105 @@ Info seq  [hh:mm:ss:mss] event:
       }
     }
 TI:: [hh:mm:ss:mss] No new typings were requested as a result of typings discovery
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /jsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /jsconfig.json projectStateVersion: 4 projectProgramVersion: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/jsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	/tmp/node_modules/@types/jquery/index.d.ts Text-1 ""
+	/app.js SVC-1-0 "import \"jquery\";"
+
+
+	tmp/node_modules/@types/jquery/index.d.ts
+	  Imported via "jquery" from file 'app.js'
+	app.js
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Got install request
+    {
+      "projectName": "/jsconfig.json",
+      "fileNames": [
+        "/app.js"
+      ],
+      "compilerOptions": {
+        "allowJs": true,
+        "maxNodeModuleJsDepth": 2,
+        "allowSyntheticDefaultImports": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "types": [],
+        "configFilePath": "/jsconfig.json",
+        "allowNonTsExtensions": true
+      },
+      "typeAcquisition": {
+        "enable": true,
+        "include": [],
+        "exclude": []
+      },
+      "unresolvedImports": [],
+      "projectRootPath": "/",
+      "kind": "discover"
+    }
+TI:: [hh:mm:ss:mss] Explicitly included types: []
+TI:: [hh:mm:ss:mss] Inferred typings from unresolved imports: []
+TI:: [hh:mm:ss:mss] Finished typings discovery:
+    {
+      "cachedTypingPaths": [],
+      "newTypingNames": [],
+      "filesToWatch": []
+    }
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/jsconfig.json'
+TI:: [hh:mm:ss:mss] No watchers are registered for project '/jsconfig.json'
+TI:: [hh:mm:ss:mss] Sending response:
+    {
+      "projectName": "/jsconfig.json",
+      "typeAcquisition": {
+        "enable": true,
+        "include": [],
+        "exclude": []
+      },
+      "compilerOptions": {
+        "allowJs": true,
+        "maxNodeModuleJsDepth": 2,
+        "allowSyntheticDefaultImports": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "types": [],
+        "configFilePath": "/jsconfig.json",
+        "allowNonTsExtensions": true
+      },
+      "typings": [],
+      "unresolvedImports": [],
+      "kind": "action::set"
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "setTypings",
+      "body": {
+        "projectName": "/jsconfig.json",
+        "typeAcquisition": {
+          "enable": true,
+          "include": [],
+          "exclude": []
+        },
+        "compilerOptions": {
+          "allowJs": true,
+          "maxNodeModuleJsDepth": 2,
+          "allowSyntheticDefaultImports": true,
+          "skipLibCheck": true,
+          "noEmit": true,
+          "types": [],
+          "configFilePath": "/jsconfig.json",
+          "allowNonTsExtensions": true
+        },
+        "typings": [],
+        "unresolvedImports": [],
+        "kind": "action::set"
+      }
+    }
+TI:: [hh:mm:ss:mss] No new typings were requested as a result of typings discovery
 After running Timeout callback:: count: 2
 
 Timeout callback:: count: 2
@@ -693,8 +792,8 @@ Timeout callback:: count: 2
 Projects::
 /jsconfig.json (Configured) *changed*
     projectStateVersion: 4 *changed*
-    projectProgramVersion: 2 *changed*
-    dirty: true
+    projectProgramVersion: 3 *changed*
+    dirty: false *changed*
 
 ScriptInfos::
 /app.js (Open)
@@ -707,4 +806,5 @@ ScriptInfos::
         /jsconfig.json *deleted*
 /tmp/node_modules/@types/jquery/index.d.ts *new*
     version: Text-1
-    containingProjects: 0
+    containingProjects: 1
+        /jsconfig.json

--- a/tests/baselines/reference/tsserver/typingsInstaller/scoped-name-discovery.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/scoped-name-discovery.js
@@ -722,6 +722,117 @@ Info seq  [hh:mm:ss:mss] event:
         "kind": "action::set"
       }
     }
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /jsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /jsconfig.json projectStateVersion: 4 projectProgramVersion: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/jsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+	/app.js SVC-1-0 ""
+
+
+	app.js
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Got install request
+    {
+      "projectName": "/jsconfig.json",
+      "fileNames": [
+        "/app.js"
+      ],
+      "compilerOptions": {
+        "allowJs": true,
+        "maxNodeModuleJsDepth": 2,
+        "allowSyntheticDefaultImports": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "configFilePath": "/jsconfig.json",
+        "allowNonTsExtensions": true
+      },
+      "typeAcquisition": {
+        "enable": true,
+        "include": [],
+        "exclude": []
+      },
+      "unresolvedImports": [],
+      "projectRootPath": "/",
+      "kind": "discover"
+    }
+TI:: [hh:mm:ss:mss] Explicitly included types: []
+TI:: [hh:mm:ss:mss] Typing names in '/package.json' dependencies: ["@zkat/cacache"]
+TI:: [hh:mm:ss:mss] Searching for typing names in /node_modules; all files: ["/node_modules/@zkat/cacache/package.json"]
+TI:: [hh:mm:ss:mss]     Found package names: ["@zkat/cacache"]
+TI:: [hh:mm:ss:mss] Inferred typings from unresolved imports: []
+TI:: [hh:mm:ss:mss] Finished typings discovery:
+    {
+      "cachedTypingPaths": [],
+      "newTypingNames": [
+        "@zkat/cacache"
+      ],
+      "filesToWatch": [
+        "/bower_components",
+        "/package.json",
+        "/node_modules"
+      ]
+    }
+TI:: [hh:mm:ss:mss] Sending response:
+    {
+      "kind": "action::watchTypingLocations",
+      "projectName": "/jsconfig.json"
+    }
+TI:: [hh:mm:ss:mss] Installing typings ["@zkat/cacache"]
+TI:: [hh:mm:ss:mss] '@zkat/cacache':: 'zkat__cacache' already has an up-to-date typing - skipping...
+TI:: [hh:mm:ss:mss] All typings are known to be missing or invalid - no need to install more typings
+TI:: [hh:mm:ss:mss] Sending response:
+    {
+      "projectName": "/jsconfig.json",
+      "typeAcquisition": {
+        "enable": true,
+        "include": [],
+        "exclude": []
+      },
+      "compilerOptions": {
+        "allowJs": true,
+        "maxNodeModuleJsDepth": 2,
+        "allowSyntheticDefaultImports": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "configFilePath": "/jsconfig.json",
+        "allowNonTsExtensions": true
+      },
+      "typings": [],
+      "unresolvedImports": [],
+      "kind": "action::set"
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "setTypings",
+      "body": {
+        "projectName": "/jsconfig.json",
+        "typeAcquisition": {
+          "enable": true,
+          "include": [],
+          "exclude": []
+        },
+        "compilerOptions": {
+          "allowJs": true,
+          "maxNodeModuleJsDepth": 2,
+          "allowSyntheticDefaultImports": true,
+          "skipLibCheck": true,
+          "noEmit": true,
+          "configFilePath": "/jsconfig.json",
+          "allowNonTsExtensions": true
+        },
+        "typings": [],
+        "unresolvedImports": [],
+        "kind": "action::set"
+      }
+    }
 After running Timeout callback:: count: 2
 
 Timeout callback:: count: 2
@@ -736,8 +847,8 @@ Projects::
     dirty: true *changed*
 /jsconfig.json (Configured) *changed*
     projectStateVersion: 4 *changed*
-    projectProgramVersion: 2 *changed*
-    dirty: true
+    projectProgramVersion: 3 *changed*
+    dirty: false *changed*
     autoImportProviderHost: /dev/null/autoImportProviderProject1*
 
 ScriptInfos::


### PR DESCRIPTION
We have following rules on when to send the `configFileDiagEvent`
- When file is opened, we want to send the event for all the config files that get loaded for the first time
- If the project was already loaded, we don't want to send the same `configFileDiagEvent`
- But then if the file will be added to inferred project, we want to send `configFileDiagEvent` event for all loaded/looked up projects so that we can figure out if there are errors in config file which is the reason why the file went into inferred project
- When there is change in config file, we always want to send `configFileDiagEvent`
- We also want to send `configFileDiagEvent` if the diagnostics changed any time program update happens
So this handles that ensuring we arent sending duplicate event

468d91c deletes the unnecessary comment about loading/reloading configured project
f738ccd actual change