### PR TITLE
Changing the method name from full-width characters ("fＡ") to half-width characters ("fA")

### DIFF
--- a/tests/cases/fourslash/codeFixClassImplementInterfaceInheritsAbstractMethod.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceInheritsAbstractMethod.ts
@@ -2,7 +2,7 @@
 
 ////abstract class C1 { }
 ////abstract class C2 {
-////    abstract fＡ<T extends number>(): T;
+////    abstract fA<T extends number>(): T;
 ////}
 ////interface I1 extends C1, C2 { }
 ////class C3 implements I1 {[| |]}
@@ -12,11 +12,11 @@ verify.codeFix({
     newFileContent:
 `abstract class C1 { }
 abstract class C2 {
-    abstract fＡ<T extends number>(): T;
+    abstract fA<T extends number>(): T;
 }
 interface I1 extends C1, C2 { }
 class C3 implements I1 {
-    fＡ<T extends number>(): T {
+    fA<T extends number>(): T {
         throw new Error("Method not implemented.");
     }
 }`,


### PR DESCRIPTION
This pull request addresses an issue related to method name consistency and readability in the TypeScript project. It proposes changing the method name from full-width characters ("fＡ") to half-width characters ("fA").

The reasons for this modification are as follows:

Readability: The use of half-width characters improves code readability and reduces potential confusion for developers, as it aligns with common coding practices and conventions.

Community Alignment: preference for using half-width characters in method names. This change aligns with community recommendations and promotes consistency across the codebase.

By making this adjustment, we enhance the understanding and maintainability of the code, making it more accessible to developers globally. This modification, although seemingly minor, contributes to the overall integrity and quality of the project.

Please consider merging this pull request to improve the consistency and readability of the codebase.


Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**) (#58472 )
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change (no logic change not necessary)


