### PR TITLE
typescript: ignore *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ package-lock.json
 .eslintcache
 *v8.log
 /lib/
+*.tsbuildinfo


### PR DESCRIPTION
TS 3.4 introduced the notion of an incremental compilation cache, stored in `.tsbuildinfo` and sometimes in `foo.tsbuildinfo` (if `out` is [configured](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#outfile))

Since this is purely build output data, committing this file is purely noise