### PR TITLE
Load unit tests more consistently (pulled from ESM branch)

### DIFF
--- a/src/testRunner/_namespaces/Harness.ts
+++ b/src/testRunner/_namespaces/Harness.ts
@@ -9,9 +9,3 @@ export * from "../fourslashRunner.js";
 export * from "../compilerRunner.js";
 export * from "../transpileRunner.js";
 export * from "../runner.js";
-
-// If running as emitted CJS, don't start executing the tests here; instead start in runner.ts.
-// If running bundled, we want this to be here so that esbuild places the tests after runner.ts.
-if (!__filename.endsWith("Harness.js")) {
-    require("../tests.js");
-}

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -25,7 +25,7 @@ import {
 import * as ts from "../_namespaces/ts.js";
 import * as Utils from "../_namespaces/Utils.js";
 
-export async function start(importTests: () => Promise<unknown>) {
+export function start(importTests: () => Promise<unknown>) {
     const Mocha = require("mocha") as typeof import("mocha");
     const Base = Mocha.reporters.Base;
     const color = Base.color;
@@ -656,6 +656,5 @@ export async function start(importTests: () => Promise<unknown>) {
         shimNoopTestInterface(global);
     }
 
-    await importTests();
-    setTimeout(() => startDelayed(perfData, totalCost), 0);
+    importTests().then(() => startDelayed(perfData, totalCost));
 }

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -25,7 +25,7 @@ import {
 import * as ts from "../_namespaces/ts.js";
 import * as Utils from "../_namespaces/Utils.js";
 
-export function start() {
+export async function start(importTests: () => Promise<unknown>) {
     const Mocha = require("mocha") as typeof import("mocha");
     const Base = Mocha.reporters.Base;
     const color = Base.color;
@@ -656,5 +656,6 @@ export function start() {
         shimNoopTestInterface(global);
     }
 
-    setTimeout(() => startDelayed(perfData, totalCost), 0); // Do real startup on next tick, so all unit tests have been collected
+    await importTests();
+    setTimeout(() => startDelayed(perfData, totalCost), 0);
 }

--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -17,6 +17,9 @@ import {
 } from "../_namespaces/Harness.Parallel.js";
 
 export function start(importTests: () => Promise<unknown>) {
+    // This brings in the tests after we finish setting things up and yield to the event loop.
+    const importTestsPromise = importTests();
+
     function hookUncaughtExceptions() {
         if (!exceptionsHooked) {
             process.on("uncaughtException", handleUncaughtException);
@@ -340,5 +343,4 @@ export function start(importTests: () => Promise<unknown>) {
     }
 
     process.on("message", processHostMessage);
-    const importTestsPromise = importTests();
 }

--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -16,7 +16,7 @@ import {
     UnitTestTask,
 } from "../_namespaces/Harness.Parallel.js";
 
-export function start() {
+export function start(importTests: () => Promise<unknown>) {
     function hookUncaughtExceptions() {
         if (!exceptionsHooked) {
             process.on("uncaughtException", handleUncaughtException);
@@ -277,7 +277,9 @@ export function start() {
         return !!tasks && Array.isArray(tasks) && tasks.length > 0 && tasks.every(validateTest);
     }
 
-    function processHostMessage(message: ParallelHostMessage) {
+    async function processHostMessage(message: ParallelHostMessage) {
+        await importTestsPromise;
+
         if (!validateHostMessage(message)) {
             console.log("Invalid message:", message);
             return;
@@ -338,4 +340,5 @@ export function start() {
     }
 
     process.on("message", processHostMessage);
+    const importTestsPromise = importTests();
 }

--- a/src/testRunner/runner.ts
+++ b/src/testRunner/runner.ts
@@ -249,6 +249,10 @@ function beginTests() {
     }
 }
 
+function importTests() {
+    return import("./tests.js");
+}
+
 export let isWorker: boolean;
 function startTestEnvironment() {
     // For debugging convenience.
@@ -256,20 +260,13 @@ function startTestEnvironment() {
 
     isWorker = handleTestConfig();
     if (isWorker) {
-        return Parallel.Worker.start();
+        return Parallel.Worker.start(importTests);
     }
     else if (taskConfigsFolder && workerCount && workerCount > 1) {
-        return Parallel.Host.start();
+        return Parallel.Host.start(importTests);
     }
     beginTests();
+    importTests();
 }
 
 startTestEnvironment();
-
-// This brings in all of the unittests.
-
-// If running as emitted CJS, we want to start the tests here after startTestEnvironment.
-// If running bundled, we will do this in Harness.ts.
-if (__filename.endsWith("runner.js")) {
-    require("./tests.js");
-}


### PR DESCRIPTION
Back when I did the module transform, I did a weird hack to get test loading to work bundled and unbundled.

Now, having actually spent more time understanding what's going on here, I think this PR is a better way to do the right thing. We just want to do some custom setup, then pull in the tests, then start running them.

Pulled out of #58419.