### PR TITLE
feat(58453): Add a rule to the compiler options to disallow the assert keyword for import attributes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46517,6 +46517,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkImportAttributes(declaration: ImportDeclaration | ExportDeclaration | JSDocImportTag) {
         const node = declaration.attributes;
         if (node) {
+            if (compilerOptions.disallowAssertKeywords && node.token === SyntaxKind.AssertKeyword) {
+                grammarErrorOnFirstToken(node, Diagnostics.The_assert_keyword_is_disallowed_Use_the_with_keyword_instead_for_import_attributes);
+            }
+
             const importAttributesType = getGlobalImportAttributesType(/*reportErrors*/ true);
             if (importAttributesType !== emptyObjectType) {
                 checkTypeAssignableTo(getTypeFromImportAttributes(node), getNullableType(importAttributesType, TypeFlags.Undefined), node);
@@ -51194,6 +51198,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (nodeArguments.length > 1) {
                 const importAttributesArgument = nodeArguments[1];
                 return grammarErrorOnNode(importAttributesArgument, Diagnostics.Dynamic_imports_only_support_a_second_argument_when_the_module_option_is_set_to_esnext_node16_or_nodenext);
+            }
+        }
+
+        if (compilerOptions.disallowAssertKeywords && nodeArguments.length > 1) {
+            const importAttributesArgument = nodeArguments[1];
+            if (isObjectLiteralExpression(importAttributesArgument) && importAttributesArgument.properties.length) {
+                const importAttributeName = find(importAttributesArgument.properties, p => !!p.name && isIdentifier(p.name) && idText(p.name) === tokenToString(SyntaxKind.AssertKeyword));
+                if (importAttributeName && importAttributeName.name) {
+                    grammarErrorOnNode(importAttributeName.name, Diagnostics.The_assert_keyword_is_disallowed_Use_the_with_keyword_instead_for_import_attributes);
+                }
             }
         }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1601,6 +1601,13 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         type: "string",
         defaultValueDescription: undefined,
     },
+    {
+        name: "disallowAssertKeywords",
+        type: "boolean",
+        category: Diagnostics.Backwards_Compatibility,
+        description: Diagnostics.Disallow_using_assert_keywords_in_import_attributes,
+        defaultValueDescription: false,
+    },
 ];
 
 /** @internal */

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3903,6 +3903,10 @@
         "category": "Error",
         "code": 2868
     },
+    "The `assert` keyword is disallowed. Use the `with` keyword instead for import attributes.": {
+        "category": "Error",
+        "code": 2869
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
@@ -5958,6 +5962,10 @@
     "Enable error reporting in type-checked JavaScript files.": {
         "category": "Message",
         "code": 6609
+    },
+    "Disallow using 'assert' keywords in import attributes.": {
+        "category": "Message",
+        "code": 6610
     },
     "Enable constraints that allow a TypeScript project to be used with project references.": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7377,6 +7377,7 @@ export interface CompilerOptions {
     esModuleInterop?: boolean;
     /** @internal */ showConfig?: boolean;
     useDefineForClassFields?: boolean;
+    disallowAssertKeywords?: boolean;
 
     [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
 }

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -131,6 +131,7 @@ class CompilerTest {
         "allowImportingTsExtensions",
         "allowSyntheticDefaultImports",
         "alwaysStrict",
+        "disallowAssertKeywords",
         "downlevelIteration",
         "experimentalDecorators",
         "emitDecoratorMetadata",

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7020,6 +7020,7 @@ declare namespace ts {
         verbatimModuleSyntax?: boolean;
         esModuleInterop?: boolean;
         useDefineForClassFields?: boolean;
+        disallowAssertKeywords?: boolean;
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }
     interface WatchOptions {

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/disallowAssertKeywords/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/disallowAssertKeywords/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "disallowAssertKeywords": true
+    }
+}

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).js
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).js
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+//// [a.ts]
+export const a = 1;
+export const b = 2;
+
+//// [b.ts]
+import './a' assert { type: "json" }
+
+//// [c.ts]
+const b = import('./a', { assert: { type: "json" } });
+
+
+//// [a.js]
+export const a = 1;
+export const b = 2;
+//// [b.js]
+import './a' assert { type: "json" };
+//// [c.js]
+const b = import('./a', { assert: { type: "json" } });

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).symbols
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+=== a.ts ===
+export const a = 1;
+>a : Symbol(a, Decl(a.ts, 0, 12))
+
+export const b = 2;
+>b : Symbol(b, Decl(a.ts, 1, 12))
+
+=== b.ts ===
+
+import './a' assert { type: "json" }
+
+=== c.ts ===
+const b = import('./a', { assert: { type: "json" } });
+>b : Symbol(b, Decl(c.ts, 0, 5))
+>'./a' : Symbol("a", Decl(a.ts, 0, 0))
+>assert : Symbol(assert, Decl(c.ts, 0, 25))
+>type : Symbol(type, Decl(c.ts, 0, 35))
+

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).types
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=false).types
@@ -1,0 +1,38 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+=== a.ts ===
+export const a = 1;
+>a : 1
+>  : ^
+>1 : 1
+>  : ^
+
+export const b = 2;
+>b : 2
+>  : ^
+>2 : 2
+>  : ^
+
+=== b.ts ===
+import './a' assert { type: "json" }
+>type : error
+
+=== c.ts ===
+const b = import('./a', { assert: { type: "json" } });
+>b : Promise<typeof import("a")>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./a', { assert: { type: "json" } }) : Promise<typeof import("a")>
+>                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'./a' : "./a"
+>      : ^^^^^
+>{ assert: { type: "json" } } : { assert: { type: string; }; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>assert : { type: string; }
+>       : ^^^^^^^^^^^^^^^^^
+>{ type: "json" } : { type: string; }
+>                 : ^^^^^^^^^^^^^^^^^
+>type : string
+>     : ^^^^^^
+>"json" : "json"
+>       : ^^^^^^
+

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).errors.txt
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).errors.txt
@@ -1,0 +1,18 @@
+b.ts(1,14): error TS2869: The `assert` keyword is disallowed. Use the `with` keyword instead for import attributes.
+c.ts(1,27): error TS2869: The `assert` keyword is disallowed. Use the `with` keyword instead for import attributes.
+
+
+==== a.ts (0 errors) ====
+    export const a = 1;
+    export const b = 2;
+    
+==== b.ts (1 errors) ====
+    import './a' assert { type: "json" }
+                 ~~~~~~
+!!! error TS2869: The `assert` keyword is disallowed. Use the `with` keyword instead for import attributes.
+    
+==== c.ts (1 errors) ====
+    const b = import('./a', { assert: { type: "json" } });
+                              ~~~~~~
+!!! error TS2869: The `assert` keyword is disallowed. Use the `with` keyword instead for import attributes.
+    

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).js
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).js
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+//// [a.ts]
+export const a = 1;
+export const b = 2;
+
+//// [b.ts]
+import './a' assert { type: "json" }
+
+//// [c.ts]
+const b = import('./a', { assert: { type: "json" } });
+
+
+//// [a.js]
+export const a = 1;
+export const b = 2;
+//// [b.js]
+import './a' assert { type: "json" };
+//// [c.js]
+const b = import('./a', { assert: { type: "json" } });

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).symbols
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+=== a.ts ===
+export const a = 1;
+>a : Symbol(a, Decl(a.ts, 0, 12))
+
+export const b = 2;
+>b : Symbol(b, Decl(a.ts, 1, 12))
+
+=== b.ts ===
+
+import './a' assert { type: "json" }
+
+=== c.ts ===
+const b = import('./a', { assert: { type: "json" } });
+>b : Symbol(b, Decl(c.ts, 0, 5))
+>'./a' : Symbol("a", Decl(a.ts, 0, 0))
+>assert : Symbol(assert, Decl(c.ts, 0, 25))
+>type : Symbol(type, Decl(c.ts, 0, 35))
+

--- a/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).types
+++ b/tests/baselines/reference/importAssertion6(disallowassertkeywords=true).types
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/importAssertion/importAssertion6.ts] ////
+
+=== a.ts ===
+export const a = 1;
+>a : 1
+>  : ^
+>1 : 1
+>  : ^
+
+export const b = 2;
+>b : 2
+>  : ^
+>2 : 2
+>  : ^
+
+=== b.ts ===
+import './a' assert { type: "json" }
+>type : any
+>     : ^^^
+
+=== c.ts ===
+const b = import('./a', { assert: { type: "json" } });
+>b : Promise<typeof import("a")>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./a', { assert: { type: "json" } }) : Promise<typeof import("a")>
+>                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'./a' : "./a"
+>      : ^^^^^
+>{ assert: { type: "json" } } : { assert: { type: string; }; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>assert : { type: string; }
+>       : ^^^^^^^^^^^^^^^^^
+>{ type: "json" } : { type: string; }
+>                 : ^^^^^^^^^^^^^^^^^
+>type : string
+>     : ^^^^^^
+>"json" : "json"
+>       : ^^^^^^
+

--- a/tests/cases/conformance/importAssertion/importAssertion6.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion6.ts
@@ -1,0 +1,13 @@
+// @module: esnext
+// @target: esnext
+// @disallowAssertKeywords: true,false
+
+// @filename: a.ts
+export const a = 1;
+export const b = 2;
+
+// @filename: b.ts
+import './a' assert { type: "json" }
+
+// @filename: c.ts
+const b = import('./a', { assert: { type: "json" } });


### PR DESCRIPTION
Fixes #58453