### PR TITLE
Declaration emit should avoid issuing errors on unresolved names

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5864,7 +5864,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // Verify if the symbol is accessible
         return (symbol && hasVisibleDeclarations(symbol, shouldComputeAliasToMakeVisible)) || {
-            accessibility: SymbolAccessibility.NotAccessible,
+            accessibility: SymbolAccessibility.NotResolved,
             errorSymbolName: getTextOfNode(firstIdentifier),
             errorNode: firstIdentifier,
         };

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -324,7 +324,8 @@ export function transformDeclarations(context: TransformationContext) {
             }
             // TODO: Do all these accessibility checks inside/after the first pass in the checker when declarations are enabled, if possible
         }
-        else {
+        // The checker should issue errors on unresolvable names, skip the declaration emit error for using a private/unreachable name for those
+        else if (symbolAccessibilityResult.accessibility !== SymbolAccessibility.NotResolved) {
             // Report error
             const errorInfo = getSymbolAccessibilityDiagnostic(symbolAccessibilityResult);
             if (errorInfo) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5544,6 +5544,7 @@ export const enum SymbolAccessibility {
     Accessible,
     NotAccessible,
     CannotBeNamed,
+    NotResolved,
 }
 
 /** @internal */

--- a/tests/baselines/reference/accessorDeclarationEmitVisibilityErrors.errors.txt
+++ b/tests/baselines/reference/accessorDeclarationEmitVisibilityErrors.errors.txt
@@ -1,12 +1,9 @@
 accessorDeclarationEmitVisibilityErrors.ts(2,18): error TS2304: Cannot find name 'DoesNotExist'.
-accessorDeclarationEmitVisibilityErrors.ts(2,18): error TS4106: Parameter 'arg' of accessor has or is using private name 'DoesNotExist'.
 
 
-==== accessorDeclarationEmitVisibilityErrors.ts (2 errors) ====
+==== accessorDeclarationEmitVisibilityErrors.ts (1 errors) ====
     export class Q {
         set bet(arg: DoesNotExist) {}
                      ~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'DoesNotExist'.
-                     ~~~~~~~~~~~~
-!!! error TS4106: Parameter 'arg' of accessor has or is using private name 'DoesNotExist'.
     }

--- a/tests/baselines/reference/accessorDeclarationEmitVisibilityErrors.js
+++ b/tests/baselines/reference/accessorDeclarationEmitVisibilityErrors.js
@@ -9,3 +9,9 @@ export class Q {
 export class Q {
     set bet(arg) { }
 }
+
+
+//// [accessorDeclarationEmitVisibilityErrors.d.ts]
+export declare class Q {
+    set bet(arg: DoesNotExist);
+}

--- a/tests/baselines/reference/declarationEmitExpressionInExtends4.errors.txt
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends4.errors.txt
@@ -1,10 +1,9 @@
 declarationEmitExpressionInExtends4.ts(5,17): error TS2315: Type 'D' is not generic.
 declarationEmitExpressionInExtends4.ts(9,18): error TS2304: Cannot find name 'SomeUndefinedFunction'.
 declarationEmitExpressionInExtends4.ts(14,18): error TS2304: Cannot find name 'SomeUndefinedFunction'.
-declarationEmitExpressionInExtends4.ts(14,18): error TS4020: 'extends' clause of exported class 'C3' has or is using private name 'SomeUndefinedFunction'.
 
 
-==== declarationEmitExpressionInExtends4.ts (4 errors) ====
+==== declarationEmitExpressionInExtends4.ts (3 errors) ====
     function getSomething() {
         return class D { }
     }
@@ -25,7 +24,5 @@ declarationEmitExpressionInExtends4.ts(14,18): error TS4020: 'extends' clause of
     class C3 extends SomeUndefinedFunction {
                      ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SomeUndefinedFunction'.
-                     ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4020: 'extends' clause of exported class 'C3' has or is using private name 'SomeUndefinedFunction'.
     
     }

--- a/tests/baselines/reference/declarationEmitExpressionInExtends4.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends4.js
@@ -62,3 +62,19 @@ var C3 = /** @class */ (function (_super) {
     }
     return C3;
 }(SomeUndefinedFunction));
+
+
+//// [declarationEmitExpressionInExtends4.d.ts]
+declare function getSomething(): {
+    new (): {};
+};
+declare const C_base: {
+    new (): {};
+};
+declare class C extends C_base<number, string> {
+}
+declare const C2_base: any;
+declare class C2 extends C2_base<number, string> {
+}
+declare class C3 extends SomeUndefinedFunction {
+}

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.errors.txt
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.errors.txt
@@ -1,11 +1,8 @@
 declarationEmitExpressionInExtends7.ts(1,30): error TS2304: Cannot find name 'SomeUndefinedFunction'.
-declarationEmitExpressionInExtends7.ts(1,30): error TS4021: 'extends' clause of exported class has or is using private name 'SomeUndefinedFunction'.
 
 
-==== declarationEmitExpressionInExtends7.ts (2 errors) ====
+==== declarationEmitExpressionInExtends7.ts (1 errors) ====
     export default class extends SomeUndefinedFunction {}
                                  ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SomeUndefinedFunction'.
-                                 ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4021: 'extends' clause of exported class has or is using private name 'SomeUndefinedFunction'.
     

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.js
@@ -30,3 +30,8 @@ var default_1 = /** @class */ (function (_super) {
     return default_1;
 }(SomeUndefinedFunction));
 exports.default = default_1;
+
+
+//// [declarationEmitExpressionInExtends7.d.ts]
+export default class extends SomeUndefinedFunction {
+}

--- a/tests/baselines/reference/declarationEmitIndexTypeNotFound.errors.txt
+++ b/tests/baselines/reference/declarationEmitIndexTypeNotFound.errors.txt
@@ -1,16 +1,13 @@
 declarationEmitIndexTypeNotFound.ts(2,6): error TS1268: An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type.
 declarationEmitIndexTypeNotFound.ts(2,13): error TS2304: Cannot find name 'TypeNotFound'.
-declarationEmitIndexTypeNotFound.ts(2,13): error TS4092: Parameter 'index' of index signature from exported interface has or is using private name 'TypeNotFound'.
 
 
-==== declarationEmitIndexTypeNotFound.ts (3 errors) ====
+==== declarationEmitIndexTypeNotFound.ts (2 errors) ====
     export interface Test {
         [index: TypeNotFound]: any;
          ~~~~~
 !!! error TS1268: An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type.
                 ~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'TypeNotFound'.
-                ~~~~~~~~~~~~
-!!! error TS4092: Parameter 'index' of index signature from exported interface has or is using private name 'TypeNotFound'.
     }
     

--- a/tests/baselines/reference/declarationEmitIndexTypeNotFound.js
+++ b/tests/baselines/reference/declarationEmitIndexTypeNotFound.js
@@ -9,3 +9,9 @@ export interface Test {
 //// [declarationEmitIndexTypeNotFound.js]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+//// [declarationEmitIndexTypeNotFound.d.ts]
+export interface Test {
+    [index: TypeNotFound]: any;
+}

--- a/tests/baselines/reference/declarationEmitInvalidExport.errors.txt
+++ b/tests/baselines/reference/declarationEmitInvalidExport.errors.txt
@@ -1,14 +1,11 @@
-declarationEmitInvalidExport.ts(4,30): error TS4081: Exported type alias 'MyClass' has or is using private name 'myClass'.
 declarationEmitInvalidExport.ts(5,1): error TS1128: Declaration or statement expected.
 
 
-==== declarationEmitInvalidExport.ts (2 errors) ====
+==== declarationEmitInvalidExport.ts (1 errors) ====
     if (false) {
       export var myClass = 0;
     }
     export type MyClass = typeof myClass;
-                                 ~~~~~~~
-!!! error TS4081: Exported type alias 'MyClass' has or is using private name 'myClass'.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/tests/baselines/reference/declarationEmitInvalidExport.js
+++ b/tests/baselines/reference/declarationEmitInvalidExport.js
@@ -14,3 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 if (false) {
     exports.myClass = 0;
 }
+
+
+//// [declarationEmitInvalidExport.d.ts]
+export type MyClass = typeof myClass;

--- a/tests/baselines/reference/declarationEmitLambdaWithMissingTypeParameterNoCrash.errors.txt
+++ b/tests/baselines/reference/declarationEmitLambdaWithMissingTypeParameterNoCrash.errors.txt
@@ -1,20 +1,14 @@
 declarationEmitLambdaWithMissingTypeParameterNoCrash.ts(2,27): error TS2304: Cannot find name 'T2'.
-declarationEmitLambdaWithMissingTypeParameterNoCrash.ts(2,27): error TS4016: Type parameter 'T1' of exported function has or is using private name 'T2'.
 declarationEmitLambdaWithMissingTypeParameterNoCrash.ts(3,33): error TS2304: Cannot find name 'T2'.
-declarationEmitLambdaWithMissingTypeParameterNoCrash.ts(3,33): error TS4006: Type parameter 'T1' of constructor signature from exported interface has or is using private name 'T2'.
 
 
-==== declarationEmitLambdaWithMissingTypeParameterNoCrash.ts (4 errors) ====
+==== declarationEmitLambdaWithMissingTypeParameterNoCrash.ts (2 errors) ====
     export interface Foo {
         preFetch: <T1 extends T2> (c: T1) => void; // Type T2 is not defined
                               ~~
 !!! error TS2304: Cannot find name 'T2'.
-                              ~~
-!!! error TS4016: Type parameter 'T1' of exported function has or is using private name 'T2'.
         preFetcher: new <T1 extends T2> (c: T1) => void; // Type T2 is not defined
                                     ~~
 !!! error TS2304: Cannot find name 'T2'.
-                                    ~~
-!!! error TS4006: Type parameter 'T1' of constructor signature from exported interface has or is using private name 'T2'.
     }
     

--- a/tests/baselines/reference/declarationEmitLambdaWithMissingTypeParameterNoCrash.js
+++ b/tests/baselines/reference/declarationEmitLambdaWithMissingTypeParameterNoCrash.js
@@ -10,3 +10,10 @@ export interface Foo {
 //// [declarationEmitLambdaWithMissingTypeParameterNoCrash.js]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+//// [declarationEmitLambdaWithMissingTypeParameterNoCrash.d.ts]
+export interface Foo {
+    preFetch: <T1 extends T2>(c: T1) => void;
+    preFetcher: new <T1 extends T2>(c: T1) => void;
+}

--- a/tests/baselines/reference/declarationEmitMappedPrivateTypeTypeParameter.errors.txt
+++ b/tests/baselines/reference/declarationEmitMappedPrivateTypeTypeParameter.errors.txt
@@ -1,15 +1,12 @@
 /FromFactor.ts(2,15): error TS2304: Cannot find name 'StringKeyOf'.
-/FromFactor.ts(2,15): error TS4103: Type parameter 'TName' of exported mapped object type is using private name 'StringKeyOf'.
 
 
 ==== /Helpers.ts (0 errors) ====
     export type StringKeyOf<TObj> = Extract<string, keyof TObj>;
     
-==== /FromFactor.ts (2 errors) ====
+==== /FromFactor.ts (1 errors) ====
     export type RowToColumns<TColumns> = {
         [TName in StringKeyOf<TColumns>]: any;
                   ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'StringKeyOf'.
-                  ~~~~~~~~~~~
-!!! error TS4103: Type parameter 'TName' of exported mapped object type is using private name 'StringKeyOf'.
     }

--- a/tests/baselines/reference/declarationEmitMappedPrivateTypeTypeParameter.js
+++ b/tests/baselines/reference/declarationEmitMappedPrivateTypeTypeParameter.js
@@ -18,3 +18,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [Helpers.d.ts]
 export type StringKeyOf<TObj> = Extract<string, keyof TObj>;
+//// [FromFactor.d.ts]
+export type RowToColumns<TColumns> = {
+    [TName in StringKeyOf<TColumns>]: any;
+};

--- a/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.errors.txt
+++ b/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.errors.txt
@@ -1,10 +1,7 @@
 declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts(1,18): error TS2304: Cannot find name 'Unknown'.
-declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts(1,18): error TS4083: Type parameter 'T' of exported type alias has or is using private name 'Unknown'.
 
 
-==== declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts (2 errors) ====
+==== declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts (1 errors) ====
     type A<T extends Unknown> = {}
                      ~~~~~~~
 !!! error TS2304: Cannot find name 'Unknown'.
-                     ~~~~~~~
-!!! error TS4083: Type parameter 'T' of exported type alias has or is using private name 'Unknown'.

--- a/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js
+++ b/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js
@@ -4,3 +4,7 @@
 type A<T extends Unknown> = {}
 
 //// [declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js]
+
+
+//// [declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.d.ts]
+type A<T extends Unknown> = {};

--- a/tests/baselines/reference/declarationEmitUnknownImport.errors.txt
+++ b/tests/baselines/reference/declarationEmitUnknownImport.errors.txt
@@ -1,10 +1,9 @@
 declarationEmitUnknownImport.ts(1,1): error TS2303: Circular definition of import alias 'Foo'.
 declarationEmitUnknownImport.ts(1,14): error TS2304: Cannot find name 'SomeNonExistingName'.
 declarationEmitUnknownImport.ts(1,14): error TS2503: Cannot find namespace 'SomeNonExistingName'.
-declarationEmitUnknownImport.ts(1,14): error TS4000: Import declaration 'Foo' is using private name 'SomeNonExistingName'.
 
 
-==== declarationEmitUnknownImport.ts (4 errors) ====
+==== declarationEmitUnknownImport.ts (3 errors) ====
     import Foo = SomeNonExistingName
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2303: Circular definition of import alias 'Foo'.
@@ -12,6 +11,4 @@ declarationEmitUnknownImport.ts(1,14): error TS4000: Import declaration 'Foo' is
 !!! error TS2304: Cannot find name 'SomeNonExistingName'.
                  ~~~~~~~~~~~~~~~~~~~
 !!! error TS2503: Cannot find namespace 'SomeNonExistingName'.
-                 ~~~~~~~~~~~~~~~~~~~
-!!! error TS4000: Import declaration 'Foo' is using private name 'SomeNonExistingName'.
     export {Foo}

--- a/tests/baselines/reference/declarationEmitUnknownImport.js
+++ b/tests/baselines/reference/declarationEmitUnknownImport.js
@@ -10,3 +10,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Foo = void 0;
 var Foo = SomeNonExistingName;
 exports.Foo = Foo;
+
+
+//// [declarationEmitUnknownImport.d.ts]
+import Foo = SomeNonExistingName;
+export { Foo };

--- a/tests/baselines/reference/declarationEmitUnknownImport2.errors.txt
+++ b/tests/baselines/reference/declarationEmitUnknownImport2.errors.txt
@@ -2,11 +2,10 @@ declarationEmitUnknownImport2.ts(1,1): error TS2303: Circular definition of impo
 declarationEmitUnknownImport2.ts(1,12): error TS1005: '=' expected.
 declarationEmitUnknownImport2.ts(1,12): error TS2304: Cannot find name 'From'.
 declarationEmitUnknownImport2.ts(1,12): error TS2503: Cannot find namespace 'From'.
-declarationEmitUnknownImport2.ts(1,12): error TS4000: Import declaration 'Foo' is using private name 'From'.
 declarationEmitUnknownImport2.ts(1,17): error TS1005: ';' expected.
 
 
-==== declarationEmitUnknownImport2.ts (6 errors) ====
+==== declarationEmitUnknownImport2.ts (5 errors) ====
     import Foo From './Foo'; // Syntax error
     ~~~~~~~~~~~~~~~
 !!! error TS2303: Circular definition of import alias 'Foo'.
@@ -16,8 +15,6 @@ declarationEmitUnknownImport2.ts(1,17): error TS1005: ';' expected.
 !!! error TS2304: Cannot find name 'From'.
                ~~~~
 !!! error TS2503: Cannot find namespace 'From'.
-               ~~~~
-!!! error TS4000: Import declaration 'Foo' is using private name 'From'.
                     ~~~~~~~
 !!! error TS1005: ';' expected.
     export default Foo

--- a/tests/baselines/reference/declarationEmitUnknownImport2.js
+++ b/tests/baselines/reference/declarationEmitUnknownImport2.js
@@ -10,3 +10,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var Foo = From;
 './Foo'; // Syntax error
 exports.default = Foo;
+
+
+//// [declarationEmitUnknownImport2.d.ts]
+import Foo = From;
+export default Foo;

--- a/tests/baselines/reference/genericDefaultsErrors.errors.txt
+++ b/tests/baselines/reference/genericDefaultsErrors.errors.txt
@@ -22,11 +22,10 @@ genericDefaultsErrors.ts(32,15): error TS2707: Generic type 'i09<T, U, V>' requi
 genericDefaultsErrors.ts(33,15): error TS2707: Generic type 'i09<T, U, V>' requires between 2 and 3 type arguments.
 genericDefaultsErrors.ts(36,15): error TS2707: Generic type 'i09<T, U, V>' requires between 2 and 3 type arguments.
 genericDefaultsErrors.ts(38,20): error TS2304: Cannot find name 'T'.
-genericDefaultsErrors.ts(38,20): error TS4033: Property 'x' of exported interface has or is using private name 'T'.
 genericDefaultsErrors.ts(42,29): error TS2716: Type parameter 'T' has a circular default.
 
 
-==== genericDefaultsErrors.ts (22 errors) ====
+==== genericDefaultsErrors.ts (21 errors) ====
     declare const x: any;
     
     declare function f03<T extends string = number>(): void; // error
@@ -111,8 +110,6 @@ genericDefaultsErrors.ts(42,29): error TS2716: Type parameter 'T' has a circular
     interface i10 { x: T; } // error
                        ~
 !!! error TS2304: Cannot find name 'T'.
-                       ~
-!!! error TS4033: Property 'x' of exported interface has or is using private name 'T'.
     interface i10<T = number> {}
     
     // https://github.com/Microsoft/TypeScript/issues/16221

--- a/tests/baselines/reference/genericDefaultsErrors.js
+++ b/tests/baselines/reference/genericDefaultsErrors.js
@@ -52,3 +52,45 @@ f11(); // ok
 f11(); // error
 f12(); // ok
 f12("a"); // error
+
+
+//// [genericDefaultsErrors.d.ts]
+declare const x: any;
+declare function f03<T extends string = number>(): void;
+declare function f04<T extends string, U extends number = T>(): void;
+declare function f05<T, U extends number = T>(): void;
+declare function f06<T, U extends T = number>(): void;
+declare function f11<T, U, V = number>(): void;
+declare function f12<T, U = T>(a?: U): void;
+interface i00<T> {
+}
+interface i00<U = number> {
+}
+interface i01<T = number> {
+}
+interface i01<T = string> {
+}
+interface i04<T = number, U> {
+}
+interface i05<T extends string = number> {
+}
+interface i06<T extends string, U extends number = T> {
+}
+interface i07<T, U extends number = T> {
+}
+interface i08<T, U extends T = number> {
+}
+interface i09<T, U, V = number> {
+}
+type i09t00 = i09;
+type i09t01 = i09<1>;
+type i09t02 = i09<1, 2>;
+type i09t03 = i09<1, 2, 3>;
+type i09t04 = i09<1, 2, 3, 4>;
+interface i10 {
+    x: T;
+}
+interface i10<T = number> {
+}
+interface SelfReference<T = SelfReference> {
+}

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -13,15 +13,13 @@ inferTypes1.ts(83,16): error TS1338: 'infer' declarations are only permitted in 
 inferTypes1.ts(83,43): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
 inferTypes1.ts(83,53): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
 inferTypes1.ts(84,15): error TS2304: Cannot find name 'U'.
-inferTypes1.ts(84,15): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
 inferTypes1.ts(84,43): error TS2304: Cannot find name 'U'.
-inferTypes1.ts(84,43): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
 inferTypes1.ts(91,44): error TS2344: Type 'U' does not satisfy the constraint 'string'.
   Type 'number' is not assignable to type 'string'.
 inferTypes1.ts(153,40): error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
 
 
-==== inferTypes1.ts (16 errors) ====
+==== inferTypes1.ts (14 errors) ====
     type Unpacked<T> =
         T extends (infer U)[] ? U :
         T extends (...args: any[]) => infer U ? U :
@@ -132,12 +130,8 @@ inferTypes1.ts(153,40): error TS2322: Type 'T' is not assignable to type 'string
     type T62<T> = U extends (infer U)[] ? U : U;  // Error
                   ~
 !!! error TS2304: Cannot find name 'U'.
-                  ~
-!!! error TS4081: Exported type alias 'T62' has or is using private name 'U'.
                                               ~
 !!! error TS2304: Cannot find name 'U'.
-                                              ~
-!!! error TS4081: Exported type alias 'T62' has or is using private name 'U'.
     type T63<T> = T extends ((infer A) extends infer B ? infer C : infer D) ? string : number;
     
     type T70<T extends string> = { x: T };

--- a/tests/baselines/reference/inferTypes1.js
+++ b/tests/baselines/reference/inferTypes1.js
@@ -219,3 +219,197 @@ function invoker(key) {
     return function (obj) { return obj[key].apply(obj, args); };
 }
 var result = invoker('test', true)({ test: function (a) { return 123; } });
+
+
+//// [inferTypes1.d.ts]
+type Unpacked<T> = T extends (infer U)[] ? U : T extends (...args: any[]) => infer U ? U : T extends Promise<infer U> ? U : T;
+type T00 = Unpacked<string>;
+type T01 = Unpacked<string[]>;
+type T02 = Unpacked<() => string>;
+type T03 = Unpacked<Promise<string>>;
+type T04 = Unpacked<Unpacked<Promise<string>[]>>;
+type T05 = Unpacked<any>;
+type T06 = Unpacked<never>;
+declare function f1(s: string): {
+    a: number;
+    b: string;
+};
+declare class C {
+    x: number;
+    y: number;
+}
+declare abstract class Abstract {
+    x: number;
+    y: number;
+}
+type T10 = ReturnType<() => string>;
+type T11 = ReturnType<(s: string) => void>;
+type T12 = ReturnType<(<T>() => T)>;
+type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;
+type T14 = ReturnType<typeof f1>;
+type T15 = ReturnType<any>;
+type T16 = ReturnType<never>;
+type T17 = ReturnType<string>;
+type T18 = ReturnType<Function>;
+type T19<T extends any[]> = ReturnType<(x: string, ...args: T) => T[]>;
+type U10 = InstanceType<typeof C>;
+type U11 = InstanceType<any>;
+type U12 = InstanceType<never>;
+type U13 = InstanceType<string>;
+type U14 = InstanceType<Function>;
+type U15 = InstanceType<typeof Abstract>;
+type U16<T extends any[]> = InstanceType<new (x: string, ...args: T) => T[]>;
+type U17<T extends any[]> = InstanceType<abstract new (x: string, ...args: T) => T[]>;
+type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
+type T20 = ArgumentType<() => void>;
+type T21 = ArgumentType<(x: string) => number>;
+type T22 = ArgumentType<(x?: string) => number>;
+type T23 = ArgumentType<(...args: string[]) => number>;
+type T24 = ArgumentType<(x: string, y: string) => number>;
+type T25 = ArgumentType<Function>;
+type T26 = ArgumentType<any>;
+type T27 = ArgumentType<never>;
+type X1<T extends {
+    x: any;
+    y: any;
+}> = T extends {
+    x: infer X;
+    y: infer Y;
+} ? [X, Y] : any;
+type T30 = X1<{
+    x: any;
+    y: any;
+}>;
+type T31 = X1<{
+    x: number;
+    y: string;
+}>;
+type T32 = X1<{
+    x: number;
+    y: string;
+    z: boolean;
+}>;
+type X2<T> = T extends {
+    a: infer U;
+    b: infer U;
+} ? U : never;
+type T40 = X2<{}>;
+type T41 = X2<{
+    a: string;
+}>;
+type T42 = X2<{
+    a: string;
+    b: string;
+}>;
+type T43 = X2<{
+    a: number;
+    b: string;
+}>;
+type T44 = X2<{
+    a: number;
+    b: string;
+    c: boolean;
+}>;
+type X3<T> = T extends {
+    a: (x: infer U) => void;
+    b: (x: infer U) => void;
+} ? U : never;
+type T50 = X3<{}>;
+type T51 = X3<{
+    a: (x: string) => void;
+}>;
+type T52 = X3<{
+    a: (x: string) => void;
+    b: (x: string) => void;
+}>;
+type T53 = X3<{
+    a: (x: number) => void;
+    b: (x: string) => void;
+}>;
+type T54 = X3<{
+    a: (x: number) => void;
+    b: () => void;
+}>;
+type T60 = infer U;
+type T61<T> = (infer A) extends infer B ? infer C : infer D;
+type T62<T> = U extends (infer U)[] ? U : U;
+type T63<T> = T extends ((infer A) extends infer B ? infer C : infer D) ? string : number;
+type T70<T extends string> = {
+    x: T;
+};
+type T71<T> = T extends T70<infer U> ? T70<U> : never;
+type T72<T extends number> = {
+    y: T;
+};
+type T73<T> = T extends T72<infer U> ? T70<U> : never;
+type T74<T extends number, U extends string> = {
+    x: T;
+    y: U;
+};
+type T75<T> = T extends T74<infer U, infer U> ? T70<U> | T72<U> | T74<U, U> : never;
+type T76<T extends T[], U extends T> = {
+    x: T;
+};
+type T77<T> = T extends T76<infer X, infer Y> ? T76<X, Y> : never;
+type T78<T> = T extends T76<infer X, infer X> ? T76<X, X> : never;
+type Foo<T extends string, U extends T> = [T, U];
+type Bar<T> = T extends Foo<infer X, infer Y> ? Foo<X, Y> : never;
+type T90 = Bar<[string, string]>;
+type T91 = Bar<[string, "a"]>;
+type T92 = Bar<[string, "a"] & {
+    x: string;
+}>;
+type T93 = Bar<["a", string]>;
+type T94 = Bar<[number, number]>;
+type JsonifiedObject<T extends object> = {
+    [K in keyof T]: Jsonified<T[K]>;
+};
+type Jsonified<T> = T extends string | number | boolean | null ? T : T extends undefined | Function ? never : T extends {
+    toJSON(): infer R;
+} ? R : T extends object ? JsonifiedObject<T> : "what is this";
+type Example = {
+    str: "literalstring";
+    fn: () => void;
+    date: Date;
+    customClass: MyClass;
+    obj: {
+        prop: "property";
+        clz: MyClass;
+        nested: {
+            attr: Date;
+        };
+    };
+};
+declare class MyClass {
+    toJSON(): "correct";
+}
+type JsonifiedExample = Jsonified<Example>;
+declare let ex: JsonifiedExample;
+declare const z1: "correct";
+declare const z2: string;
+type A1<T, U extends A1<any, any>> = [T, U];
+type B1<S> = S extends A1<infer T, infer U> ? [T, U] : never;
+type A2<T, U extends void> = [T, U];
+type B2<S> = S extends A2<infer T, infer U> ? [T, U] : never;
+type C2<S, U extends void> = S extends A2<infer T, U> ? [T, U] : never;
+type A<T> = T extends string ? {
+    [P in T]: void;
+} : T;
+type B<T> = string extends T ? {
+    [P in T]: void;
+} : T;
+type MatchingKeys<T, U, K extends keyof T = keyof T> = K extends keyof T ? T[K] extends U ? K : never : never;
+type VoidKeys<T> = MatchingKeys<T, void>;
+interface test {
+    a: 1;
+    b: void;
+}
+type T80 = MatchingKeys<test, void>;
+type T81 = VoidKeys<test>;
+type MustBeString<T extends string> = T;
+type EnsureIsString<T> = T extends MustBeString<infer U> ? U : never;
+type Test1 = EnsureIsString<"hello">;
+type Test2 = EnsureIsString<42>;
+declare function invoker<K extends string | number | symbol, A extends any[]>(key: K, ...args: A): <T extends Record<K, (...args: A) => any>>(obj: T) => ReturnType<T[K]>;
+declare const result: number;
+type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;

--- a/tests/baselines/reference/inferTypesInvalidExtendsDeclaration.errors.txt
+++ b/tests/baselines/reference/inferTypesInvalidExtendsDeclaration.errors.txt
@@ -1,11 +1,8 @@
 inferTypesInvalidExtendsDeclaration.ts(1,42): error TS2304: Cannot find name 'B'.
-inferTypesInvalidExtendsDeclaration.ts(1,42): error TS4085: Extends clause for inferred type 'A' has or is using private name 'B'.
 
 
-==== inferTypesInvalidExtendsDeclaration.ts (2 errors) ====
+==== inferTypesInvalidExtendsDeclaration.ts (1 errors) ====
     type Test<T> = T extends infer A extends B ? number : string;
                                              ~
 !!! error TS2304: Cannot find name 'B'.
-                                             ~
-!!! error TS4085: Extends clause for inferred type 'A' has or is using private name 'B'.
     

--- a/tests/baselines/reference/inferTypesInvalidExtendsDeclaration.js
+++ b/tests/baselines/reference/inferTypesInvalidExtendsDeclaration.js
@@ -5,3 +5,7 @@ type Test<T> = T extends infer A extends B ? number : string;
 
 
 //// [inferTypesInvalidExtendsDeclaration.js]
+
+
+//// [inferTypesInvalidExtendsDeclaration.d.ts]
+type Test<T> = T extends infer A extends B ? number : string;

--- a/tests/baselines/reference/intrinsics.errors.txt
+++ b/tests/baselines/reference/intrinsics.errors.txt
@@ -1,14 +1,11 @@
 intrinsics.ts(1,21): error TS2749: 'hasOwnProperty' refers to a value, but is being used as a type here. Did you mean 'typeof hasOwnProperty'?
-intrinsics.ts(1,21): error TS4025: Exported variable 'hasOwnProperty' has or is using private name 'hasOwnProperty'.
 intrinsics.ts(10,1): error TS2304: Cannot find name '__proto__'.
 
 
-==== intrinsics.ts (3 errors) ====
+==== intrinsics.ts (2 errors) ====
     var hasOwnProperty: hasOwnProperty; // Error
                         ~~~~~~~~~~~~~~
 !!! error TS2749: 'hasOwnProperty' refers to a value, but is being used as a type here. Did you mean 'typeof hasOwnProperty'?
-                        ~~~~~~~~~~~~~~
-!!! error TS4025: Exported variable 'hasOwnProperty' has or is using private name 'hasOwnProperty'.
     
     module m1 {
         export var __proto__;

--- a/tests/baselines/reference/intrinsics.js
+++ b/tests/baselines/reference/intrinsics.js
@@ -34,3 +34,13 @@ var Foo = /** @class */ (function () {
     return Foo;
 }());
 var foo;
+
+
+//// [intrinsics.d.ts]
+declare var hasOwnProperty: hasOwnProperty;
+declare namespace m1 {
+    var __proto__: any;
+}
+declare class Foo<__proto__> {
+}
+declare var foo: (__proto__: number) => void;

--- a/tests/baselines/reference/isolatedDeclarationErrorsClasses.errors.txt
+++ b/tests/baselines/reference/isolatedDeclarationErrorsClasses.errors.txt
@@ -8,7 +8,6 @@ isolatedDeclarationErrorsClasses.ts(12,9): error TS7032: Property 'setOnly' impl
 isolatedDeclarationErrorsClasses.ts(12,17): error TS7006: Parameter 'value' implicitly has an 'any' type.
 isolatedDeclarationErrorsClasses.ts(36,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 isolatedDeclarationErrorsClasses.ts(36,6): error TS2304: Cannot find name 'missing'.
-isolatedDeclarationErrorsClasses.ts(36,6): error TS4031: Public property '[missing]' of exported class has or is using private name 'missing'.
 isolatedDeclarationErrorsClasses.ts(42,5): error TS9008: Method must have an explicit return type annotation with --isolatedDeclarations.
 isolatedDeclarationErrorsClasses.ts(42,5): error TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
 isolatedDeclarationErrorsClasses.ts(44,5): error TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
@@ -24,7 +23,7 @@ isolatedDeclarationErrorsClasses.ts(56,5): error TS7010: '[noAnnotationLiteralNa
 isolatedDeclarationErrorsClasses.ts(56,5): error TS9013: Expression type can't be inferred with --isolatedDeclarations.
 
 
-==== isolatedDeclarationErrorsClasses.ts (24 errors) ====
+==== isolatedDeclarationErrorsClasses.ts (23 errors) ====
     export class Cls {
     
         field = 1 + 1;
@@ -86,8 +85,6 @@ isolatedDeclarationErrorsClasses.ts(56,5): error TS9013: Expression type can't b
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~~~~~~
 !!! error TS2304: Cannot find name 'missing'.
-         ~~~~~~~
-!!! error TS4031: Public property '[missing]' of exported class has or is using private name 'missing'.
         
         [noAnnotationLiteralName](): void { }
     

--- a/tests/baselines/reference/mappedTypeNoTypeNoCrash.errors.txt
+++ b/tests/baselines/reference/mappedTypeNoTypeNoCrash.errors.txt
@@ -1,16 +1,10 @@
 mappedTypeNoTypeNoCrash.ts(1,51): error TS2304: Cannot find name 'K'.
-mappedTypeNoTypeNoCrash.ts(1,51): error TS4081: Exported type alias 'T0' has or is using private name 'K'.
 mappedTypeNoTypeNoCrash.ts(1,57): error TS2304: Cannot find name 'K'.
-mappedTypeNoTypeNoCrash.ts(1,57): error TS4081: Exported type alias 'T0' has or is using private name 'K'.
 
 
-==== mappedTypeNoTypeNoCrash.ts (4 errors) ====
+==== mappedTypeNoTypeNoCrash.ts (2 errors) ====
     type T0<T> = ({[K in keyof T]}) extends ({[key in K]: T[K]}) ? number : never;
                                                       ~
 !!! error TS2304: Cannot find name 'K'.
-                                                      ~
-!!! error TS4081: Exported type alias 'T0' has or is using private name 'K'.
                                                             ~
 !!! error TS2304: Cannot find name 'K'.
-                                                            ~
-!!! error TS4081: Exported type alias 'T0' has or is using private name 'K'.

--- a/tests/baselines/reference/mappedTypeNoTypeNoCrash.js
+++ b/tests/baselines/reference/mappedTypeNoTypeNoCrash.js
@@ -4,3 +4,11 @@
 type T0<T> = ({[K in keyof T]}) extends ({[key in K]: T[K]}) ? number : never;
 
 //// [mappedTypeNoTypeNoCrash.js]
+
+
+//// [mappedTypeNoTypeNoCrash.d.ts]
+type T0<T> = ({
+    [K in keyof T]: ;
+}) extends ({
+    [key in K]: T[K];
+}) ? number : never;

--- a/tests/baselines/reference/transpile/declarationUnresolvedGlobalReferencesNoErrors.d.ts
+++ b/tests/baselines/reference/transpile/declarationUnresolvedGlobalReferencesNoErrors.d.ts
@@ -1,0 +1,23 @@
+//// [declarationUnresolvedGlobalReferencesNoErrors.ts] ////
+export const x: MissingGlobalType = null!;
+export const fn = (a: MissingGlobalType): MissingGlobalType => null!;
+export const fn2 = (a: MissingGlobalType) => null! as MissingGlobalType;
+
+export const x2: typeof missingGlobalValue = null!;
+export const fn3 = (a: typeof missingGlobalValue): typeof missingGlobalValue => null!;
+export const fn4 = (a: typeof missingGlobalValue) => null! as typeof missingGlobalValue;
+
+
+export const o : {
+    [missingGlobalValue]: string
+} = null!;
+//// [declarationUnresolvedGlobalReferencesNoErrors.d.ts] ////
+export declare const x: MissingGlobalType;
+export declare const fn: (a: MissingGlobalType) => MissingGlobalType;
+export declare const fn2: (a: MissingGlobalType) => MissingGlobalType;
+export declare const x2: typeof missingGlobalValue;
+export declare const fn3: (a: typeof missingGlobalValue) => typeof missingGlobalValue;
+export declare const fn4: (a: typeof missingGlobalValue) => typeof missingGlobalValue;
+export declare const o: {
+    [missingGlobalValue]: string;
+};

--- a/tests/baselines/reference/tsc/declarationEmit/when-using-Windows-paths-and-uppercase-letters.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-using-Windows-paths-and-uppercase-letters.js
@@ -119,11 +119,6 @@ Output::
     [7m  [0m [96m              ~~~~~~~~[0m
     File is default library for target specified here.
 
-[96msrc/utils/type-helpers.ts[0m:[93m5[0m:[93m42[0m - [91merror[0m[90m TS4022: [0m'extends' clause of exported interface 'MyType' has or is using private name 'Function'.
-
-[7m5[0m export interface MyType<T = any> extends Function {
-[7m [0m [91m                                         ~~~~~~~~[0m
-
 src/utils/type-helpers.ts
   Imported via './type-helpers' from file 'src/utils/index.ts'
   Matched by include pattern 'src' in 'tsconfig.json'
@@ -133,7 +128,7 @@ src/utils/index.ts
 src/main.ts
   Matched by include pattern 'src' in 'tsconfig.json'
 
-Found 10 errors in the same file, starting at: src/utils/type-helpers.ts[90m:5[0m
+Found 9 errors.
 
 
 
@@ -144,6 +139,15 @@ Found 10 errors in the same file, starting at: src/utils/type-helpers.ts[90m:5
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 //# sourceMappingURL=type-helpers.js.map
+
+//// [D:/Work/pkg1/dist/utils/type-helpers.d.ts]
+export type MyReturnType = {
+    new (...args: any[]): any;
+};
+export interface MyType<T = any> extends Function {
+    new (...args: any[]): T;
+}
+
 
 //// [D:/Work/pkg1/dist/utils/index.js.map]
 {"version":3,"file":"index.js","sourceRoot":"","sources":["../../src/utils/index.ts"],"names":[],"mappings":";;AAEA,kCAMC;AAND,SAAgB,WAAW,CAAI,QAAmB;IAC9C,MAAe,gBAAgB;QAC3B,gBAAe,CAAC;KACnB;IAED,OAAO,gBAAgC,CAAC;AAC5C,CAAC"}
@@ -225,4 +229,4 @@ D:/Work/pkg1/src/utils/type-helpers.ts
 D:/Work/pkg1/src/utils/index.ts
 D:/Work/pkg1/src/main.ts
 
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated

--- a/tests/baselines/reference/typePredicateOnVariableDeclaration02.errors.txt
+++ b/tests/baselines/reference/typePredicateOnVariableDeclaration02.errors.txt
@@ -1,15 +1,12 @@
 typePredicateOnVariableDeclaration02.ts(1,8): error TS2304: Cannot find name 'z'.
-typePredicateOnVariableDeclaration02.ts(1,8): error TS4025: Exported variable 'y' has or is using private name 'z'.
 typePredicateOnVariableDeclaration02.ts(1,10): error TS1005: ',' expected.
 typePredicateOnVariableDeclaration02.ts(1,13): error TS1005: ',' expected.
 
 
-==== typePredicateOnVariableDeclaration02.ts (4 errors) ====
+==== typePredicateOnVariableDeclaration02.ts (3 errors) ====
     var y: z is number;
            ~
 !!! error TS2304: Cannot find name 'z'.
-           ~
-!!! error TS4025: Exported variable 'y' has or is using private name 'z'.
              ~~
 !!! error TS1005: ',' expected.
                 ~~~~~~

--- a/tests/baselines/reference/typePredicateOnVariableDeclaration02.js
+++ b/tests/baselines/reference/typePredicateOnVariableDeclaration02.js
@@ -5,3 +5,7 @@ var y: z is number;
 
 //// [typePredicateOnVariableDeclaration02.js]
 var y, is, number;
+
+
+//// [typePredicateOnVariableDeclaration02.d.ts]
+declare var y: z, is: any, number: any;

--- a/tests/cases/transpile/declarationUnresolvedGlobalReferencesNoErrors.ts
+++ b/tests/cases/transpile/declarationUnresolvedGlobalReferencesNoErrors.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+export const x: MissingGlobalType = null!;
+export const fn = (a: MissingGlobalType): MissingGlobalType => null!;
+export const fn2 = (a: MissingGlobalType) => null! as MissingGlobalType;
+
+export const x2: typeof missingGlobalValue = null!;
+export const fn3 = (a: typeof missingGlobalValue): typeof missingGlobalValue => null!;
+export const fn4 = (a: typeof missingGlobalValue) => null! as typeof missingGlobalValue;
+
+
+export const o : {
+    [missingGlobalValue]: string
+} = null!;


### PR DESCRIPTION
These already will get errors in the checker when the file is typechecked, so the declaration emitter doesn't need to double up and also error on them.

This basically allows the declaration emitter to copy inputs with unresolvable names into the output without the output being blocked by a declaration-emitter issued error.

Fixes #58496
Fixes #58535