### PR TITLE
Fix class decorator detection in class fields transform

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -89,6 +89,7 @@ import {
     isClassDeclaration,
     isClassElement,
     isClassExpression,
+    isClassLike,
     isClassNamedEvaluationHelperBlock,
     isClassStaticBlockDeclaration,
     isClassThisAssignmentBlock,
@@ -1713,7 +1714,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function getClassFacts(node: ClassLikeDeclaration) {
         let facts = ClassFacts.None;
         const original = getOriginalNode(node);
-        if (isClassDeclaration(original) && classOrConstructorParameterIsDecorated(legacyDecorators, original)) {
+        if (isClassLike(original) && classOrConstructorParameterIsDecorated(legacyDecorators, original)) {
             facts |= ClassFacts.ClassWasDecorated;
         }
         if (shouldTransformPrivateElementsOrClassStaticBlocks && (classHasClassThisAssignment(node) || classHasExplicitlyAssignedName(node))) {

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -86,7 +86,6 @@ import {
     isCallChain,
     isCallToHelper,
     isCatchClause,
-    isClassDeclaration,
     isClassElement,
     isClassExpression,
     isClassLike,
@@ -902,10 +901,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
         }
     }
 
-    function getClassThis() {
+    function tryGetClassThis() {
         const lex = getClassLexicalEnvironment();
-        const classThis = lex.classThis ?? lex.classConstructor ?? currentClassContainer?.name;
-        return Debug.checkDefined(classThis);
+        return lex.classThis ?? lex.classConstructor ?? currentClassContainer?.name;
     }
 
     function transformAutoAccessor(node: AutoAccessorPropertyDeclaration): VisitResult<Node> {
@@ -947,7 +945,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
         setEmitFlags(backingField, EmitFlags.NoComments);
         setSourceMapRange(backingField, sourceMapRange);
 
-        const receiver = isStatic(node) ? getClassThis() : factory.createThis();
+        const receiver = isStatic(node) ? tryGetClassThis() ?? factory.createThis() : factory.createThis();
         const getter = createAccessorPropertyGetRedirector(factory, node, modifiers, getterName, receiver);
         setOriginalNode(getter, node);
         setCommentRange(getter, commentRange);

--- a/tests/baselines/reference/esDecorators-classExpression-commentPreservation(target=es2015).js
+++ b/tests/baselines/reference/esDecorators-classExpression-commentPreservation(target=es2015).js
@@ -116,63 +116,62 @@ class C {
     let _z_decorators;
     let _z_initializers = [];
     let _z_extraInitializers = [];
-    var C = (_classThis = class {
-            /*5*/
-            method() { }
-            /*8*/
-            get x() { return 1; }
-            /*11*/
-            set x(value) { }
-            /*17*/
-            get z() { return __classPrivateFieldGet(this, _C_z_1_accessor_storage, "f"); }
-            set z(value) { __classPrivateFieldSet(this, _C_z_1_accessor_storage, value, "f"); }
-            constructor() {
-                /*14*/
-                this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, 1));
-                _C_z_1_accessor_storage.set(this, (__runInitializers(this, _y_extraInitializers), __runInitializers(this, _z_initializers, 1)));
-                __runInitializers(this, _z_extraInitializers);
-            }
-        },
-        _C_z_1_accessor_storage = new WeakMap(),
-        _C_method_get = function _C_method_get() { return _static_private_method_descriptor.value; },
-        _C_x_get = function _C_x_get() { return _static_private_get_x_descriptor.get.call(this); },
-        _C_x_set = function _C_x_set(value) { return _static_private_set_x_descriptor.set.call(this, value); },
-        _C_z_get = function _C_z_get() { return _static_private_z_descriptor.get.call(this); },
-        _C_z_set = function _C_z_set(value) { return _static_private_z_descriptor.set.call(this, value); },
-        __setFunctionName(_classThis, "C"),
-        (() => {
-            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-            _method_decorators = [dec, dec];
-            _get_x_decorators = [dec, dec];
-            _set_x_decorators = [dec, dec];
-            _y_decorators = [dec, dec];
-            _z_decorators = [dec, dec];
-            _static_private_method_decorators = [dec, dec];
-            _static_private_get_x_decorators = [dec, dec];
-            _static_private_set_x_decorators = [dec, dec];
-            _static_private_y_decorators = [dec, dec];
-            _static_private_z_decorators = [dec, dec];
-            __esDecorate(_classThis, _static_private_method_descriptor = { value: __setFunctionName(function () { }, "#method") }, _static_private_method_decorators, { kind: "method", name: "#method", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_method_get) }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, _static_private_get_x_descriptor = { get: __setFunctionName(function () { return 1; }, "#x", "get") }, _static_private_get_x_decorators, { kind: "getter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_x_get) }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, _static_private_set_x_descriptor = { set: __setFunctionName(function (value) { }, "#x", "set") }, _static_private_set_x_decorators, { kind: "setter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_x_set); } }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, _static_private_z_descriptor = { get: __setFunctionName(function () { return __classPrivateFieldGet(_classThis, _classThis, "f", _C_z_accessor_storage); }, "#z", "get"), set: __setFunctionName(function (value) { __classPrivateFieldSet(_classThis, _classThis, value, "f", _C_z_accessor_storage); }, "#z", "set") }, _static_private_z_decorators, { kind: "accessor", name: "#z", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_z_get), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_z_set); } }, metadata: _metadata }, _static_private_z_initializers, _static_private_z_extraInitializers);
-            __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(_classThis, null, _get_x_decorators, { kind: "getter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, get: obj => obj.x }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(_classThis, null, _z_decorators, { kind: "accessor", name: "z", static: false, private: false, access: { has: obj => "z" in obj, get: obj => obj.z, set: (obj, value) => { obj.z = value; } }, metadata: _metadata }, _z_initializers, _z_extraInitializers);
-            __esDecorate(null, null, _static_private_y_decorators, { kind: "field", name: "#y", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "f", _C_y), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "f", _C_y); } }, metadata: _metadata }, _static_private_y_initializers, _static_private_y_extraInitializers);
-            __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
-            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-            C = _classThis = _classDescriptor.value;
-            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-        })(),
-        /*29*/
-        _C_y = { value: (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_private_y_initializers, 1)) },
-        _C_z_accessor_storage = { value: (__runInitializers(_classThis, _static_private_y_extraInitializers), __runInitializers(_classThis, _static_private_z_initializers, 1)) },
-        (() => {
-            __runInitializers(_classThis, _static_private_z_extraInitializers);
-            __runInitializers(_classThis, _classExtraInitializers);
-        })(),
-        _classThis);
+    var C = _classThis = class {
+        /*5*/
+        method() { }
+        /*8*/
+        get x() { return 1; }
+        /*11*/
+        set x(value) { }
+        /*17*/
+        get z() { return __classPrivateFieldGet(this, _C_z_1_accessor_storage, "f"); }
+        set z(value) { __classPrivateFieldSet(this, _C_z_1_accessor_storage, value, "f"); }
+        constructor() {
+            /*14*/
+            this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, 1));
+            _C_z_1_accessor_storage.set(this, (__runInitializers(this, _y_extraInitializers), __runInitializers(this, _z_initializers, 1)));
+            __runInitializers(this, _z_extraInitializers);
+        }
+    };
+    _C_z_1_accessor_storage = new WeakMap();
+    _C_method_get = function _C_method_get() { return _static_private_method_descriptor.value; };
+    _C_x_get = function _C_x_get() { return _static_private_get_x_descriptor.get.call(this); };
+    _C_x_set = function _C_x_set(value) { return _static_private_set_x_descriptor.set.call(this, value); };
+    _C_z_get = function _C_z_get() { return _static_private_z_descriptor.get.call(this); };
+    _C_z_set = function _C_z_set(value) { return _static_private_z_descriptor.set.call(this, value); };
+    __setFunctionName(_classThis, "C");
+    (() => {
+        const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+        _method_decorators = [dec, dec];
+        _get_x_decorators = [dec, dec];
+        _set_x_decorators = [dec, dec];
+        _y_decorators = [dec, dec];
+        _z_decorators = [dec, dec];
+        _static_private_method_decorators = [dec, dec];
+        _static_private_get_x_decorators = [dec, dec];
+        _static_private_set_x_decorators = [dec, dec];
+        _static_private_y_decorators = [dec, dec];
+        _static_private_z_decorators = [dec, dec];
+        __esDecorate(_classThis, _static_private_method_descriptor = { value: __setFunctionName(function () { }, "#method") }, _static_private_method_decorators, { kind: "method", name: "#method", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_method_get) }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, _static_private_get_x_descriptor = { get: __setFunctionName(function () { return 1; }, "#x", "get") }, _static_private_get_x_decorators, { kind: "getter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_x_get) }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, _static_private_set_x_descriptor = { set: __setFunctionName(function (value) { }, "#x", "set") }, _static_private_set_x_decorators, { kind: "setter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_x_set); } }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, _static_private_z_descriptor = { get: __setFunctionName(function () { return __classPrivateFieldGet(_classThis, _classThis, "f", _C_z_accessor_storage); }, "#z", "get"), set: __setFunctionName(function (value) { __classPrivateFieldSet(_classThis, _classThis, value, "f", _C_z_accessor_storage); }, "#z", "set") }, _static_private_z_decorators, { kind: "accessor", name: "#z", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_z_get), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_z_set); } }, metadata: _metadata }, _static_private_z_initializers, _static_private_z_extraInitializers);
+        __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(_classThis, null, _get_x_decorators, { kind: "getter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, get: obj => obj.x }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(_classThis, null, _z_decorators, { kind: "accessor", name: "z", static: false, private: false, access: { has: obj => "z" in obj, get: obj => obj.z, set: (obj, value) => { obj.z = value; } }, metadata: _metadata }, _z_initializers, _z_extraInitializers);
+        __esDecorate(null, null, _static_private_y_decorators, { kind: "field", name: "#y", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "f", _C_y), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "f", _C_y); } }, metadata: _metadata }, _static_private_y_initializers, _static_private_y_extraInitializers);
+        __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
+        __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+        C = _classThis = _classDescriptor.value;
+        if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+    })();
+    /*29*/
+    _C_y = { value: (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_private_y_initializers, 1)) };
+    _C_z_accessor_storage = { value: (__runInitializers(_classThis, _static_private_y_extraInitializers), __runInitializers(_classThis, _static_private_z_initializers, 1)) };
+    (() => {
+        __runInitializers(_classThis, _static_private_z_extraInitializers);
+        __runInitializers(_classThis, _classExtraInitializers);
+    })();
     return C = _classThis;
 })());

--- a/tests/baselines/reference/esDecorators-classExpression-commentPreservation(target=es2022).js
+++ b/tests/baselines/reference/esDecorators-classExpression-commentPreservation(target=es2022).js
@@ -87,7 +87,7 @@ class C {
 //// [esDecorators-classExpression-commentPreservation.js]
 /*1*/
 ((() => {
-    var _C_method_get, _C_x_get, _C_x_set, _C_y, _C_z_accessor_storage, _C_z_get, _C_z_set, _a;
+    var _C_method_get, _C_x_get, _C_x_set, _C_y, _C_z_accessor_storage, _C_z_get, _C_z_set;
     let _classDecorators = [dec, dec];
     let _classDescriptor;
     let _classExtraInitializers = [];
@@ -116,66 +116,62 @@ class C {
     let _z_decorators;
     let _z_initializers = [];
     let _z_extraInitializers = [];
-    var C = (_a = class {
-            static { _classThis = this; }
-            static { __setFunctionName(this, "C"); }
-            static { _C_method_get = function _C_method_get() { return _static_private_method_descriptor.value; }, _C_x_get = function _C_x_get() { return _static_private_get_x_descriptor.get.call(this); }, _C_x_set = function _C_x_set(value) { return _static_private_set_x_descriptor.set.call(this, value); }, _C_z_get = function _C_z_get() { return _static_private_z_descriptor.get.call(this); }, _C_z_set = function _C_z_set(value) { return _static_private_z_descriptor.set.call(this, value); }; }
-            static {
-                const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-                _method_decorators = [dec, dec];
-                _get_x_decorators = [dec, dec];
-                _set_x_decorators = [dec, dec];
-                _y_decorators = [dec, dec];
-                _z_decorators = [dec, dec];
-                _static_private_method_decorators = [dec, dec];
-                _static_private_get_x_decorators = [dec, dec];
-                _static_private_set_x_decorators = [dec, dec];
-                _static_private_y_decorators = [dec, dec];
-                _static_private_z_decorators = [dec, dec];
-                __esDecorate(this, _static_private_method_descriptor = { value: __setFunctionName(function () { }, "#method") }, _static_private_method_decorators, { kind: "method", name: "#method", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_method_get) }, metadata: _metadata }, null, _staticExtraInitializers);
-                __esDecorate(this, _static_private_get_x_descriptor = { get: __setFunctionName(function () { return 1; }, "#x", "get") }, _static_private_get_x_decorators, { kind: "getter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_x_get) }, metadata: _metadata }, null, _staticExtraInitializers);
-                __esDecorate(this, _static_private_set_x_descriptor = { set: __setFunctionName(function (value) { }, "#x", "set") }, _static_private_set_x_decorators, { kind: "setter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_x_set); } }, metadata: _metadata }, null, _staticExtraInitializers);
-                __esDecorate(this, _static_private_z_descriptor = { get: __setFunctionName(function () { return __classPrivateFieldGet(this, _classThis, "f", _C_z_accessor_storage); }, "#z", "get"), set: __setFunctionName(function (value) { __classPrivateFieldSet(this, _classThis, value, "f", _C_z_accessor_storage); }, "#z", "set") }, _static_private_z_decorators, { kind: "accessor", name: "#z", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_z_get), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_z_set); } }, metadata: _metadata }, _static_private_z_initializers, _static_private_z_extraInitializers);
-                __esDecorate(this, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
-                __esDecorate(this, null, _get_x_decorators, { kind: "getter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, get: obj => obj.x }, metadata: _metadata }, null, _instanceExtraInitializers);
-                __esDecorate(this, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
-                __esDecorate(this, null, _z_decorators, { kind: "accessor", name: "z", static: false, private: false, access: { has: obj => "z" in obj, get: obj => obj.z, set: (obj, value) => { obj.z = value; } }, metadata: _metadata }, _z_initializers, _z_extraInitializers);
-                __esDecorate(null, null, _static_private_y_decorators, { kind: "field", name: "#y", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "f", _C_y), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "f", _C_y); } }, metadata: _metadata }, _static_private_y_initializers, _static_private_y_extraInitializers);
-                __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
-                __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-                C = _classThis = _classDescriptor.value;
-                if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-            }
-            /*5*/
-            method() { }
-            /*8*/
-            get x() { return 1; }
-            /*11*/
-            set x(value) { }
-            /*14*/
-            y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, 1));
-            #z_1_accessor_storage = (__runInitializers(this, _y_extraInitializers), __runInitializers(this, _z_initializers, 1));
-            /*17*/
-            get z() { return this.#z_1_accessor_storage; }
-            set z(value) { this.#z_1_accessor_storage = value; }
-            static {
-                /*29*/
-                _C_y = { value: (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_private_y_initializers, 1)) };
-            }
-            static {
-                _C_z_accessor_storage = { value: (__runInitializers(_classThis, _static_private_y_extraInitializers), __runInitializers(_classThis, _static_private_z_initializers, 1)) };
-            }
-            constructor() {
-                __runInitializers(this, _z_extraInitializers);
-            }
-            static {
-                __runInitializers(_classThis, _static_private_z_extraInitializers);
-                __runInitializers(_classThis, _classExtraInitializers);
-            }
-        },
-        /*29*/
-        _C_y = { value: (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_private_y_initializers, 1)) },
-        _C_z_accessor_storage = { value: (__runInitializers(_classThis, _static_private_y_extraInitializers), __runInitializers(_classThis, _static_private_z_initializers, 1)) },
-        _a);
+    var C = class {
+        static { _classThis = this; }
+        static { __setFunctionName(this, "C"); }
+        static { _C_method_get = function _C_method_get() { return _static_private_method_descriptor.value; }, _C_x_get = function _C_x_get() { return _static_private_get_x_descriptor.get.call(this); }, _C_x_set = function _C_x_set(value) { return _static_private_set_x_descriptor.set.call(this, value); }, _C_z_get = function _C_z_get() { return _static_private_z_descriptor.get.call(this); }, _C_z_set = function _C_z_set(value) { return _static_private_z_descriptor.set.call(this, value); }; }
+        static {
+            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+            _method_decorators = [dec, dec];
+            _get_x_decorators = [dec, dec];
+            _set_x_decorators = [dec, dec];
+            _y_decorators = [dec, dec];
+            _z_decorators = [dec, dec];
+            _static_private_method_decorators = [dec, dec];
+            _static_private_get_x_decorators = [dec, dec];
+            _static_private_set_x_decorators = [dec, dec];
+            _static_private_y_decorators = [dec, dec];
+            _static_private_z_decorators = [dec, dec];
+            __esDecorate(this, _static_private_method_descriptor = { value: __setFunctionName(function () { }, "#method") }, _static_private_method_decorators, { kind: "method", name: "#method", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_method_get) }, metadata: _metadata }, null, _staticExtraInitializers);
+            __esDecorate(this, _static_private_get_x_descriptor = { get: __setFunctionName(function () { return 1; }, "#x", "get") }, _static_private_get_x_decorators, { kind: "getter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_x_get) }, metadata: _metadata }, null, _staticExtraInitializers);
+            __esDecorate(this, _static_private_set_x_descriptor = { set: __setFunctionName(function (value) { }, "#x", "set") }, _static_private_set_x_decorators, { kind: "setter", name: "#x", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_x_set); } }, metadata: _metadata }, null, _staticExtraInitializers);
+            __esDecorate(this, _static_private_z_descriptor = { get: __setFunctionName(function () { return __classPrivateFieldGet(this, _classThis, "f", _C_z_accessor_storage); }, "#z", "get"), set: __setFunctionName(function (value) { __classPrivateFieldSet(this, _classThis, value, "f", _C_z_accessor_storage); }, "#z", "set") }, _static_private_z_decorators, { kind: "accessor", name: "#z", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "a", _C_z_get), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "a", _C_z_set); } }, metadata: _metadata }, _static_private_z_initializers, _static_private_z_extraInitializers);
+            __esDecorate(this, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
+            __esDecorate(this, null, _get_x_decorators, { kind: "getter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, get: obj => obj.x }, metadata: _metadata }, null, _instanceExtraInitializers);
+            __esDecorate(this, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
+            __esDecorate(this, null, _z_decorators, { kind: "accessor", name: "z", static: false, private: false, access: { has: obj => "z" in obj, get: obj => obj.z, set: (obj, value) => { obj.z = value; } }, metadata: _metadata }, _z_initializers, _z_extraInitializers);
+            __esDecorate(null, null, _static_private_y_decorators, { kind: "field", name: "#y", static: true, private: true, access: { has: obj => __classPrivateFieldIn(_classThis, obj), get: obj => __classPrivateFieldGet(obj, _classThis, "f", _C_y), set: (obj, value) => { __classPrivateFieldSet(obj, _classThis, value, "f", _C_y); } }, metadata: _metadata }, _static_private_y_initializers, _static_private_y_extraInitializers);
+            __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
+            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+            C = _classThis = _classDescriptor.value;
+            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+        }
+        /*5*/
+        method() { }
+        /*8*/
+        get x() { return 1; }
+        /*11*/
+        set x(value) { }
+        /*14*/
+        y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, 1));
+        #z_1_accessor_storage = (__runInitializers(this, _y_extraInitializers), __runInitializers(this, _z_initializers, 1));
+        /*17*/
+        get z() { return this.#z_1_accessor_storage; }
+        set z(value) { this.#z_1_accessor_storage = value; }
+        static {
+            /*29*/
+            _C_y = { value: (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_private_y_initializers, 1)) };
+        }
+        static {
+            _C_z_accessor_storage = { value: (__runInitializers(_classThis, _static_private_y_extraInitializers), __runInitializers(_classThis, _static_private_z_initializers, 1)) };
+        }
+        constructor() {
+            __runInitializers(this, _z_extraInitializers);
+        }
+        static {
+            __runInitializers(_classThis, _static_private_z_extraInitializers);
+            __runInitializers(_classThis, _classExtraInitializers);
+        }
+    };
     return C = _classThis;
 })());

--- a/tests/baselines/reference/esDecorators-emitDecoratorMetadata(target=es2015).js
+++ b/tests/baselines/reference/esDecorators-emitDecoratorMetadata(target=es2015).js
@@ -119,40 +119,39 @@ let C = (() => {
     let _y_decorators;
     let _y_initializers = [];
     let _y_extraInitializers = [];
-    var C = (_classThis = class {
-            constructor(x) {
-                this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, void 0));
-                __runInitializers(this, _y_extraInitializers);
-            }
-            method(x) { }
-            set x(x) { }
-            static method(x) { }
-            static set x(x) { }
-        },
-        __setFunctionName(_classThis, "C"),
-        (() => {
-            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-            _method_decorators = [dec];
-            _set_x_decorators = [dec];
-            _y_decorators = [dec];
-            _static_method_decorators = [dec];
-            _static_set_x_decorators = [dec];
-            _static_y_decorators = [dec];
-            __esDecorate(_classThis, null, _static_method_decorators, { kind: "method", name: "method", static: true, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, null, _static_set_x_decorators, { kind: "setter", name: "x", static: true, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(null, null, _static_y_decorators, { kind: "field", name: "y", static: true, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _static_y_initializers, _static_y_extraInitializers);
-            __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
-            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-            C = _classThis = _classDescriptor.value;
-            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-        })(),
-        _classThis.y = (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_y_initializers, void 0)),
-        (() => {
-            __runInitializers(_classThis, _static_y_extraInitializers);
-            __runInitializers(_classThis, _classExtraInitializers);
-        })(),
-        _classThis);
+    var C = _classThis = class {
+        constructor(x) {
+            this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, void 0));
+            __runInitializers(this, _y_extraInitializers);
+        }
+        method(x) { }
+        set x(x) { }
+        static method(x) { }
+        static set x(x) { }
+    };
+    __setFunctionName(_classThis, "C");
+    (() => {
+        const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+        _method_decorators = [dec];
+        _set_x_decorators = [dec];
+        _y_decorators = [dec];
+        _static_method_decorators = [dec];
+        _static_set_x_decorators = [dec];
+        _static_y_decorators = [dec];
+        __esDecorate(_classThis, null, _static_method_decorators, { kind: "method", name: "method", static: true, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, null, _static_set_x_decorators, { kind: "setter", name: "x", static: true, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: obj => "method" in obj, get: obj => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: obj => "x" in obj, set: (obj, value) => { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(null, null, _static_y_decorators, { kind: "field", name: "y", static: true, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _static_y_initializers, _static_y_extraInitializers);
+        __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: obj => "y" in obj, get: obj => obj.y, set: (obj, value) => { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
+        __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+        C = _classThis = _classDescriptor.value;
+        if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+    })();
+    _classThis.y = (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_y_initializers, void 0));
+    (() => {
+        __runInitializers(_classThis, _static_y_extraInitializers);
+        __runInitializers(_classThis, _classExtraInitializers);
+    })();
     return C = _classThis;
 })());

--- a/tests/baselines/reference/esDecorators-emitDecoratorMetadata(target=es5).js
+++ b/tests/baselines/reference/esDecorators-emitDecoratorMetadata(target=es5).js
@@ -128,49 +128,48 @@ var C = function () {
     var _y_decorators;
     var _y_initializers = [];
     var _y_extraInitializers = [];
-    var C = (_classThis = /** @class */ (function () {
-            function class_1(x) {
-                this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, void 0));
-                __runInitializers(this, _y_extraInitializers);
-            }
-            class_1.prototype.method = function (x) { };
-            Object.defineProperty(class_1.prototype, "x", {
-                set: function (x) { },
-                enumerable: false,
-                configurable: true
-            });
-            class_1.method = function (x) { };
-            Object.defineProperty(class_1, "x", {
-                set: function (x) { },
-                enumerable: false,
-                configurable: true
-            });
-            return class_1;
-        }()),
-        __setFunctionName(_classThis, "C"),
-        (function () {
-            var _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-            _method_decorators = [dec];
-            _set_x_decorators = [dec];
-            _y_decorators = [dec];
-            _static_method_decorators = [dec];
-            _static_set_x_decorators = [dec];
-            _static_y_decorators = [dec];
-            __esDecorate(_classThis, null, _static_method_decorators, { kind: "method", name: "method", static: true, private: false, access: { has: function (obj) { return "method" in obj; }, get: function (obj) { return obj.method; } }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, null, _static_set_x_decorators, { kind: "setter", name: "x", static: true, private: false, access: { has: function (obj) { return "x" in obj; }, set: function (obj, value) { obj.x = value; } }, metadata: _metadata }, null, _staticExtraInitializers);
-            __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: function (obj) { return "method" in obj; }, get: function (obj) { return obj.method; } }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: function (obj) { return "x" in obj; }, set: function (obj, value) { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
-            __esDecorate(null, null, _static_y_decorators, { kind: "field", name: "y", static: true, private: false, access: { has: function (obj) { return "y" in obj; }, get: function (obj) { return obj.y; }, set: function (obj, value) { obj.y = value; } }, metadata: _metadata }, _static_y_initializers, _static_y_extraInitializers);
-            __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: function (obj) { return "y" in obj; }, get: function (obj) { return obj.y; }, set: function (obj, value) { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
-            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-            C = _classThis = _classDescriptor.value;
-            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-        })(),
-        _classThis.y = (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_y_initializers, void 0)),
-        (function () {
-            __runInitializers(_classThis, _static_y_extraInitializers);
-            __runInitializers(_classThis, _classExtraInitializers);
-        })(),
-        _classThis);
+    var C = _classThis = /** @class */ (function () {
+        function class_1(x) {
+            this.y = (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _y_initializers, void 0));
+            __runInitializers(this, _y_extraInitializers);
+        }
+        class_1.prototype.method = function (x) { };
+        Object.defineProperty(class_1.prototype, "x", {
+            set: function (x) { },
+            enumerable: false,
+            configurable: true
+        });
+        class_1.method = function (x) { };
+        Object.defineProperty(class_1, "x", {
+            set: function (x) { },
+            enumerable: false,
+            configurable: true
+        });
+        return class_1;
+    }());
+    __setFunctionName(_classThis, "C");
+    (function () {
+        var _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+        _method_decorators = [dec];
+        _set_x_decorators = [dec];
+        _y_decorators = [dec];
+        _static_method_decorators = [dec];
+        _static_set_x_decorators = [dec];
+        _static_y_decorators = [dec];
+        __esDecorate(_classThis, null, _static_method_decorators, { kind: "method", name: "method", static: true, private: false, access: { has: function (obj) { return "method" in obj; }, get: function (obj) { return obj.method; } }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, null, _static_set_x_decorators, { kind: "setter", name: "x", static: true, private: false, access: { has: function (obj) { return "x" in obj; }, set: function (obj, value) { obj.x = value; } }, metadata: _metadata }, null, _staticExtraInitializers);
+        __esDecorate(_classThis, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: function (obj) { return "method" in obj; }, get: function (obj) { return obj.method; } }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(_classThis, null, _set_x_decorators, { kind: "setter", name: "x", static: false, private: false, access: { has: function (obj) { return "x" in obj; }, set: function (obj, value) { obj.x = value; } }, metadata: _metadata }, null, _instanceExtraInitializers);
+        __esDecorate(null, null, _static_y_decorators, { kind: "field", name: "y", static: true, private: false, access: { has: function (obj) { return "y" in obj; }, get: function (obj) { return obj.y; }, set: function (obj, value) { obj.y = value; } }, metadata: _metadata }, _static_y_initializers, _static_y_extraInitializers);
+        __esDecorate(null, null, _y_decorators, { kind: "field", name: "y", static: false, private: false, access: { has: function (obj) { return "y" in obj; }, get: function (obj) { return obj.y; }, set: function (obj, value) { obj.y = value; } }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
+        __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+        C = _classThis = _classDescriptor.value;
+        if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+    })();
+    _classThis.y = (__runInitializers(_classThis, _staticExtraInitializers), __runInitializers(_classThis, _static_y_initializers, void 0));
+    (function () {
+        __runInitializers(_classThis, _static_y_extraInitializers);
+        __runInitializers(_classThis, _classExtraInitializers);
+    })();
     return C = _classThis;
 })());

--- a/tests/baselines/reference/esDecoratorsClassFieldsCrash.js
+++ b/tests/baselines/reference/esDecoratorsClassFieldsCrash.js
@@ -1,0 +1,104 @@
+//// [tests/cases/compiler/esDecoratorsClassFieldsCrash.ts] ////
+
+//// [esDecoratorsClassFieldsCrash.ts]
+// https://github.com/microsoft/TypeScript/issues/58436
+const dec = (x: number, y: number, z: number, t: number) => (_: any, ctx: DecoratorContext): any => { };
+const Foo = class {
+    @dec(1, 3, 3, 1) field: undefined
+    @dec(2, 2, 0, 0) static field: undefined
+    @dec(3, 1, 4, 1) accessor accessor: undefined
+    @dec(4, 0, 1, 0) static accessor accessor: undefined
+    //               ~~~~~~~~~~~~~~~ along with compiler options above caused the following crash:
+    //
+    // Error: Debug Failure.
+    //  at getClassThis (src\compiler\transformers\classFields.ts:906:22)
+    //  at transformAutoAccessor (src\compiler\transformers\classFields.ts:948:43
+    //  ...
+}
+
+
+//// [esDecoratorsClassFieldsCrash.js]
+var __esDecorate = (this && this.__esDecorate) || function (ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+    function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+    var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+    var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+    var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+    var _, done = false;
+    for (var i = decorators.length - 1; i >= 0; i--) {
+        var context = {};
+        for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+        for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+        context.addInitializer = function (f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+        var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+        if (kind === "accessor") {
+            if (result === void 0) continue;
+            if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+            if (_ = accept(result.get)) descriptor.get = _;
+            if (_ = accept(result.set)) descriptor.set = _;
+            if (_ = accept(result.init)) initializers.unshift(_);
+        }
+        else if (_ = accept(result)) {
+            if (kind === "field") initializers.unshift(_);
+            else descriptor[key] = _;
+        }
+    }
+    if (target) Object.defineProperty(target, contextIn.name, descriptor);
+    done = true;
+};
+var __runInitializers = (this && this.__runInitializers) || function (thisArg, initializers, value) {
+    var useValue = arguments.length > 2;
+    for (var i = 0; i < initializers.length; i++) {
+        value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+    }
+    return useValue ? value : void 0;
+};
+var __setFunctionName = (this && this.__setFunctionName) || function (f, name, prefix) {
+    if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+    return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+// https://github.com/microsoft/TypeScript/issues/58436
+const dec = (x, y, z, t) => (_, ctx) => { };
+const Foo = (() => {
+    let _static_field_decorators;
+    let _static_field_initializers = [];
+    let _static_field_extraInitializers = [];
+    let _static_accessor_decorators;
+    let _static_accessor_initializers = [];
+    let _static_accessor_extraInitializers = [];
+    let _field_decorators;
+    let _field_initializers = [];
+    let _field_extraInitializers = [];
+    let _accessor_decorators;
+    let _accessor_initializers = [];
+    let _accessor_extraInitializers = [];
+    return class {
+        static { __setFunctionName(this, "Foo"); }
+        static {
+            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+            _field_decorators = [dec(1, 3, 3, 1)];
+            _static_field_decorators = [dec(2, 2, 0, 0)];
+            _accessor_decorators = [dec(3, 1, 4, 1)];
+            _static_accessor_decorators = [dec(4, 0, 1, 0)];
+            __esDecorate(this, null, _static_accessor_decorators, { kind: "accessor", name: "accessor", static: true, private: false, access: { has: obj => "accessor" in obj, get: obj => obj.accessor, set: (obj, value) => { obj.accessor = value; } }, metadata: _metadata }, _static_accessor_initializers, _static_accessor_extraInitializers);
+            __esDecorate(this, null, _accessor_decorators, { kind: "accessor", name: "accessor", static: false, private: false, access: { has: obj => "accessor" in obj, get: obj => obj.accessor, set: (obj, value) => { obj.accessor = value; } }, metadata: _metadata }, _accessor_initializers, _accessor_extraInitializers);
+            __esDecorate(null, null, _static_field_decorators, { kind: "field", name: "field", static: true, private: false, access: { has: obj => "field" in obj, get: obj => obj.field, set: (obj, value) => { obj.field = value; } }, metadata: _metadata }, _static_field_initializers, _static_field_extraInitializers);
+            __esDecorate(null, null, _field_decorators, { kind: "field", name: "field", static: false, private: false, access: { has: obj => "field" in obj, get: obj => obj.field, set: (obj, value) => { obj.field = value; } }, metadata: _metadata }, _field_initializers, _field_extraInitializers);
+            if (_metadata) Object.defineProperty(this, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+        }
+        static { this.field = __runInitializers(this, _static_field_initializers, void 0); }
+        #accessor_accessor_storage;
+        get accessor() { return this.#accessor_accessor_storage; }
+        set accessor(value) { this.#accessor_accessor_storage = value; }
+        static #accessor_1_accessor_storage = (__runInitializers(this, _static_field_extraInitializers), __runInitializers(this, _static_accessor_initializers, void 0));
+        static get accessor() { return this.#accessor_1_accessor_storage; }
+        static set accessor(value) { this.#accessor_1_accessor_storage = value; }
+        constructor() {
+            this.field = __runInitializers(this, _field_initializers, void 0);
+            this.#accessor_accessor_storage = (__runInitializers(this, _field_extraInitializers), __runInitializers(this, _accessor_initializers, void 0));
+            __runInitializers(this, _accessor_extraInitializers);
+        }
+        static {
+            __runInitializers(this, _static_accessor_extraInitializers);
+        }
+    };
+})();

--- a/tests/baselines/reference/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.js
+++ b/tests/baselines/reference/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.js
@@ -128,18 +128,17 @@ try {
         let _classDescriptor;
         let _classExtraInitializers = [];
         let _classThis;
-        var class_1 = (_classThis = class {
-                static [Symbol.dispose]() { }
-            },
-            __setFunctionName(_classThis, "C3"),
-            (() => {
-                const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-                __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-                class_1 = _classThis = _classDescriptor.value;
-                if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-                __runInitializers(_classThis, _classExtraInitializers);
-            })(),
-            _classThis);
+        var class_1 = _classThis = class {
+            static [Symbol.dispose]() { }
+        };
+        __setFunctionName(_classThis, "C3");
+        (() => {
+            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+            class_1 = _classThis = _classDescriptor.value;
+            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+            __runInitializers(_classThis, _classExtraInitializers);
+        })();
         return class_1 = _classThis;
     })(), false);
     C4 = __addDisposableResource(env_1, (() => {
@@ -147,21 +146,20 @@ try {
         let _classDescriptor;
         let _classExtraInitializers = [];
         let _classThis;
-        var class_2 = (_classThis = class {
-                static [Symbol.dispose]() { }
-            },
-            __setFunctionName(_classThis, "C4"),
-            (() => {
-                const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-                __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
-                class_2 = _classThis = _classDescriptor.value;
-                if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
-            })(),
-            _classThis.x = 1,
-            (() => {
-                __runInitializers(_classThis, _classExtraInitializers);
-            })(),
-            _classThis);
+        var class_2 = _classThis = class {
+            static [Symbol.dispose]() { }
+        };
+        __setFunctionName(_classThis, "C4");
+        (() => {
+            const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+            __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+            class_2 = _classThis = _classDescriptor.value;
+            if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+        })();
+        _classThis.x = 1;
+        (() => {
+            __runInitializers(_classThis, _classExtraInitializers);
+        })();
         return class_2 = _classThis;
     })(), false);
 }

--- a/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
+++ b/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
@@ -1,0 +1,18 @@
+// @target: esnext
+// @useDefineForClassFields: false
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/58436
+const dec = (x: number, y: number, z: number, t: number) => (_: any, ctx: DecoratorContext): any => { };
+const Foo = class {
+    @dec(1, 3, 3, 1) field: undefined
+    @dec(2, 2, 0, 0) static field: undefined
+    @dec(3, 1, 4, 1) accessor accessor: undefined
+    @dec(4, 0, 1, 0) static accessor accessor: undefined
+    //               ~~~~~~~~~~~~~~~ along with compiler options above caused the following crash:
+    //
+    // Error: Debug Failure.
+    //  at getClassThis (src\compiler\transformers\classFields.ts:906:22)
+    //  at transformAutoAccessor (src\compiler\transformers\classFields.ts:948:43
+    //  ...
+}


### PR DESCRIPTION
This fixes the class fields transform to properly detect original nodes that were decorated class expressions.

Fixes #58436
