### PR TITLE
fix(58584): formatJSDocLink shouldn't introduce a trailing space when non link text.

### DIFF
--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1253,7 +1253,7 @@ function formatJSDocLink(link: JSDocLink | JSDocLinkCode | JSDocLinkPlain) {
         : link.kind === SyntaxKind.JSDocLinkCode ? "linkcode"
         : "linkplain";
     const name = link.name ? entityNameToString(link.name) : "";
-    const space = link.name && link.text.startsWith("://") ? "" : " ";
+    const space = link.name && (link.text === "" || link.text.startsWith("://")) ? "" : " ";
     return `{@${kind} ${name}${space}${link.text}}`;
 }
 

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -560,4 +560,22 @@ class Foo  {};
             assert.equal(ts.getTextOfJSDocComment(seeTag.comment), "{@link foo#bar label}");
         });
     });
+
+    describe("getTextOfJSDocComment", () => {
+        it("should preserve link without introducing space", () => {
+            const sourceText = `
+/**
+ *
+ * @see {@link foo}
+ */
+class Foo  {};
+`;
+
+            const root = ts.createSourceFile("foo.ts", sourceText, ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+            const [classDecl] = root.statements;
+            const [seeTag] = ts.getJSDocTags(classDecl);
+
+            assert.equal(ts.getTextOfJSDocComment(seeTag.comment), "{@link foo}");
+        });
+    });
 });

--- a/tests/baselines/reference/linkTagEmit1.js
+++ b/tests/baselines/reference/linkTagEmit1.js
@@ -63,7 +63,7 @@ declare var see3: boolean;
 type N = number;
 type D1 = {
     /**
-     * Just link to {@link NS.R } this time
+     * Just link to {@link NS.R} this time
      */
     e: 1;
     /**


### PR DESCRIPTION
fixes #58584