### PR TITLE
Respect `importModuleSpecifierPreference` in sort order between fixes for the same symbol from different files

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -9774,6 +9774,7 @@ export interface ModulePath {
 
 /** @internal */
 export interface ResolvedModuleSpecifierInfo {
+    kind: "node_modules" | "paths" | "redirect" | "relative" | "ambient" | undefined;
     modulePaths: readonly ModulePath[] | undefined;
     moduleSpecifiers: readonly string[] | undefined;
     isBlockedByPackageJsonDependencies: boolean | undefined;
@@ -9787,7 +9788,7 @@ export interface ModuleSpecifierOptions {
 /** @internal */
 export interface ModuleSpecifierCache {
     get(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions): Readonly<ResolvedModuleSpecifierInfo> | undefined;
-    set(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, modulePaths: readonly ModulePath[], moduleSpecifiers: readonly string[]): void;
+    set(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, kind: ResolvedModuleSpecifierInfo["kind"], modulePaths: readonly ModulePath[], moduleSpecifiers: readonly string[]): void;
     setBlockedByPackageJsonDependencies(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, isBlockedByPackageJsonDependencies: boolean): void;
     setModulePaths(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, modulePaths: readonly ModulePath[]): void;
     clear(): void;

--- a/src/server/moduleSpecifierCache.ts
+++ b/src/server/moduleSpecifierCache.ts
@@ -27,8 +27,8 @@ export function createModuleSpecifierCache(host: ModuleSpecifierResolutionCacheH
             if (!cache || currentKey !== key(fromFileName, preferences, options)) return undefined;
             return cache.get(toFileName);
         },
-        set(fromFileName, toFileName, preferences, options, modulePaths, moduleSpecifiers) {
-            ensureCache(fromFileName, preferences, options).set(toFileName, createInfo(modulePaths, moduleSpecifiers, /*isBlockedByPackageJsonDependencies*/ false));
+        set(fromFileName, toFileName, preferences, options, kind, modulePaths, moduleSpecifiers) {
+            ensureCache(fromFileName, preferences, options).set(toFileName, createInfo(kind, modulePaths, moduleSpecifiers, /*isBlockedByPackageJsonDependencies*/ false));
 
             // If any module specifiers were generated based off paths in node_modules,
             // a package.json file in that package was read and is an input to the cached.
@@ -58,7 +58,7 @@ export function createModuleSpecifierCache(host: ModuleSpecifierResolutionCacheH
                 info.modulePaths = modulePaths;
             }
             else {
-                cache.set(toFileName, createInfo(modulePaths, /*moduleSpecifiers*/ undefined, /*isBlockedByPackageJsonDependencies*/ undefined));
+                cache.set(toFileName, createInfo(/*kind*/ undefined, modulePaths, /*moduleSpecifiers*/ undefined, /*isBlockedByPackageJsonDependencies*/ undefined));
             }
         },
         setBlockedByPackageJsonDependencies(fromFileName, toFileName, preferences, options, isBlockedByPackageJsonDependencies) {
@@ -68,7 +68,7 @@ export function createModuleSpecifierCache(host: ModuleSpecifierResolutionCacheH
                 info.isBlockedByPackageJsonDependencies = isBlockedByPackageJsonDependencies;
             }
             else {
-                cache.set(toFileName, createInfo(/*modulePaths*/ undefined, /*moduleSpecifiers*/ undefined, isBlockedByPackageJsonDependencies));
+                cache.set(toFileName, createInfo(/*kind*/ undefined, /*modulePaths*/ undefined, /*moduleSpecifiers*/ undefined, isBlockedByPackageJsonDependencies));
             }
         },
         clear() {
@@ -100,10 +100,11 @@ export function createModuleSpecifierCache(host: ModuleSpecifierResolutionCacheH
     }
 
     function createInfo(
+        kind: ResolvedModuleSpecifierInfo["kind"] | undefined,
         modulePaths: readonly ModulePath[] | undefined,
         moduleSpecifiers: readonly string[] | undefined,
         isBlockedByPackageJsonDependencies: boolean | undefined,
     ): ResolvedModuleSpecifierInfo {
-        return { modulePaths, moduleSpecifiers, isBlockedByPackageJsonDependencies };
+        return { kind, modulePaths, moduleSpecifiers, isBlockedByPackageJsonDependencies };
     }
 }

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_importsMap1.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_importsMap1.js
@@ -352,28 +352,6 @@ Info seq  [hh:mm:ss:mss] response:
       "body": [
         {
           "fixName": "import",
-          "description": "Add import from \"./env/browser.js\"",
-          "changes": [
-            {
-              "fileName": "/src/a.ts",
-              "textChanges": [
-                {
-                  "start": {
-                    "line": 1,
-                    "offset": 1
-                  },
-                  "end": {
-                    "line": 1,
-                    "offset": 1
-                  },
-                  "newText": "import { isBrowser } from \"./env/browser.js\";\r\n\r\n"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "fixName": "import",
           "description": "Add import from \"#is-browser\"",
           "changes": [
             {
@@ -389,6 +367,28 @@ Info seq  [hh:mm:ss:mss] response:
                     "offset": 1
                   },
                   "newText": "import { isBrowser } from \"#is-browser\";\r\n\r\n"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "fixName": "import",
+          "description": "Add import from \"./env/browser.js\"",
+          "changes": [
+            {
+              "fileName": "/src/a.ts",
+              "textChanges": [
+                {
+                  "start": {
+                    "line": 1,
+                    "offset": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "offset": 1
+                  },
+                  "newText": "import { isBrowser } from \"./env/browser.js\";\r\n\r\n"
                 }
               ]
             }

--- a/tests/baselines/reference/tsserver/moduleSpecifierCache/caches-module-specifiers-within-a-file.js
+++ b/tests/baselines/reference/tsserver/moduleSpecifierCache/caches-module-specifiers-within-a-file.js
@@ -1094,6 +1094,7 @@ Info seq  [hh:mm:ss:mss] response:
 After request
 
 Info seq  [hh:mm:ss:mss] mobxCache: {
+  "kind": "node_modules",
   "modulePaths": [
     {
       "path": "/node_modules/mobx/index.d.ts",

--- a/tests/cases/fourslash/completionsImport_packageJsonImportsPreference.ts
+++ b/tests/cases/fourslash/completionsImport_packageJsonImportsPreference.ts
@@ -1,0 +1,57 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+// @allowImportingTsExtensions: true
+
+// @Filename: /project/package.json
+//// {
+////   "name": "project",
+////   "version": "1.0.0",
+////   "imports": {
+////     "#internal/*": "./src/internal/*.ts"
+////   }
+//// }
+
+// @Filename: /project/src/internal/foo.ts
+//// export const internalFoo = 0;
+
+// @Filename: /project/src/other.ts
+//// export * from "./internal/foo.ts";
+
+// @Filename: /project/src/main.ts
+//// internalFoo/**/
+
+goTo.marker("");
+verify.completions({
+  includes: [
+    {
+      name: "internalFoo",
+      source: "#internal/foo",
+      sourceDisplay: "#internal/foo",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    importModuleSpecifierPreference: "non-relative"
+  },
+});
+
+verify.completions({
+  includes: [
+    {
+      name: "internalFoo",
+      source: "./other",
+      sourceDisplay: "./other",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    importModuleSpecifierPreference: "relative"
+  },
+});

--- a/tests/cases/fourslash/completionsImport_windowsPathsProjectRelative.ts
+++ b/tests/cases/fourslash/completionsImport_windowsPathsProjectRelative.ts
@@ -1,0 +1,99 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: c:/project/tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "paths": {
+////       "~/noIndex/*": ["./src/noIndex/*"],
+////       "~/withIndex": ["./src/withIndex/index.ts"]
+////     }
+////   }
+//// }
+
+// @Filename: c:/project/package.json
+//// {}
+
+// @Filename: c:/project/src/noIndex/a.ts
+//// export const myFunctionA = () => {};
+
+// @Filename: c:/project/src/withIndex/b.ts
+//// export const myFunctionB = () => {};
+
+// @Filename: c:/project/src/withIndex/index.ts
+//// export * from './b';
+
+// @Filename: c:/project/src/reproduction/1.ts
+//// myFunction/**/
+
+goTo.marker("");
+verify.completions({
+  includes: [
+    {
+      name: "myFunctionA",
+      source: "~/noIndex/a",
+      sourceDisplay: "~/noIndex/a",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+    {
+      name: "myFunctionB",
+      source: "~/withIndex",
+      sourceDisplay: "~/withIndex",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    importModuleSpecifierPreference: "non-relative"
+  },
+});
+
+verify.completions({
+  includes: [
+    {
+      name: "myFunctionA",
+      source: "../noIndex/a",
+      sourceDisplay: "../noIndex/a",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+    {
+      name: "myFunctionB",
+      source: "../withIndex",
+      sourceDisplay: "../withIndex",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    importModuleSpecifierPreference: "relative"
+  },
+});
+
+verify.completions({
+  includes: [
+    {
+      name: "myFunctionA",
+      source: "../noIndex/a",
+      sourceDisplay: "../noIndex/a",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+    {
+      name: "myFunctionB",
+      source: "../withIndex",
+      sourceDisplay: "../withIndex",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    importModuleSpecifierPreference: "project-relative"
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_importsMap1.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_importsMap1.ts
@@ -29,4 +29,4 @@
 // @Filename: /src/a.ts
 //// isBrowser/**/
 
-verify.importFixModuleSpecifiers("", ["./env/browser.js", "#is-browser"]);
+verify.importFixModuleSpecifiers("", ["#is-browser", "./env/browser.js"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55863

There were two bugs in play:

1. `importModuleSpecifierPreference` was only being considered in how to generate module specifiers between a given pair of files. But when computing auto-imports, there may be multiple files a missing symbol can be imported from, so the module specifier generation code is called multiple times, and multiple fixes are generated. Those fixes are then sorted, but the sort logic didn’t consider `importModuleSpecifierPreference`. In most cases, all the generated fixes either successfully satisfied the preference or didn’t, but it’s possible, as in the bug repro and test case, that e.g. the symbol being imported is available from one file that can only be reached by relative path and another file that can be reached by a non-relative `paths`/`baseUrl` module specifier.
2. In the import fix sorting, we also sort by whether the module specifier for the fix is a listed package.json dependency whenever that specifier is non-relative. But a non-relative specifier may be a node_modules package, or it may be generated from `paths`/`baseUrl`. We were incorrectly checking whether these `paths`/`baseUrl` specifiers were package.json dependencies, which would further deprioritize them under relative paths. (Writing this out makes me realize that I need to follow up with a separate test to ensure that package.json `imports` and self-name imports are not being deprioritized for the same reason.)