### PR TITLE
Provide Spelling Suggestions for Named Capture Group References in Regular Expressions

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -3478,6 +3478,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
         forEach(groupNameReferences, reference => {
             if (!groupSpecifiers?.has(reference.name)) {
                 error(Diagnostics.There_is_no_capturing_group_named_0_in_this_regular_expression, reference.pos, reference.end - reference.pos, reference.name);
+                if (groupSpecifiers) {
+                    const suggestion = getSpellingSuggestion(reference.name, groupSpecifiers, identity);
+                    if (suggestion) {
+                        error(Diagnostics.Did_you_mean_0, reference.pos, reference.end - reference.pos, suggestion);
+                    }
+                }
             }
         });
         forEach(decimalEscapes, escape => {

--- a/tests/baselines/reference/regularExpressionGroupNameSuggestions.errors.txt
+++ b/tests/baselines/reference/regularExpressionGroupNameSuggestions.errors.txt
@@ -1,0 +1,12 @@
+regularExpressionGroupNameSuggestions.ts(1,18): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionGroupNameSuggestions.ts(1,27): error TS1532: There is no capturing group named 'Foo' in this regular expression.
+
+
+==== regularExpressionGroupNameSuggestions.ts (2 errors) ====
+    const regex = /(?<foo>)\k<Foo>/;
+                     ~~~~~
+!!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+                              ~~~
+!!! error TS1532: There is no capturing group named 'Foo' in this regular expression.
+!!! related TS1369: Did you mean 'foo'?
+    

--- a/tests/baselines/reference/regularExpressionGroupNameSuggestions.js
+++ b/tests/baselines/reference/regularExpressionGroupNameSuggestions.js
@@ -1,0 +1,8 @@
+//// [tests/cases/compiler/regularExpressionGroupNameSuggestions.ts] ////
+
+//// [regularExpressionGroupNameSuggestions.ts]
+const regex = /(?<foo>)\k<Foo>/;
+
+
+//// [regularExpressionGroupNameSuggestions.js]
+var regex = /(?<foo>)\k<Foo>/;

--- a/tests/baselines/reference/regularExpressionGroupNameSuggestions.symbols
+++ b/tests/baselines/reference/regularExpressionGroupNameSuggestions.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/compiler/regularExpressionGroupNameSuggestions.ts] ////
+
+=== regularExpressionGroupNameSuggestions.ts ===
+const regex = /(?<foo>)\k<Foo>/;
+>regex : Symbol(regex, Decl(regularExpressionGroupNameSuggestions.ts, 0, 5))
+

--- a/tests/baselines/reference/regularExpressionGroupNameSuggestions.types
+++ b/tests/baselines/reference/regularExpressionGroupNameSuggestions.types
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/regularExpressionGroupNameSuggestions.ts] ////
+
+=== regularExpressionGroupNameSuggestions.ts ===
+const regex = /(?<foo>)\k<Foo>/;
+>regex : RegExp
+>      : ^^^^^^
+>/(?<foo>)\k<Foo>/ : RegExp
+>                  : ^^^^^^
+

--- a/tests/cases/compiler/regularExpressionGroupNameSuggestions.ts
+++ b/tests/cases/compiler/regularExpressionGroupNameSuggestions.ts
@@ -1,0 +1,1 @@
+const regex = /(?<foo>)\k<Foo>/;


### PR DESCRIPTION
#55600 already provides spelling suggestions for Unicode property value expressions (https://github.com/microsoft/TypeScript/pull/55600/commits/1a5228d20452db775930201826fe8b46409a1097), this PR extends it to capturing group names.