### PR TITLE
feat(lib): allow `NonNullable<T, K>` to select specific properties

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1605,9 +1605,21 @@ type Extract<T, U> = T extends U ? T : never;
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 /**
- * Exclude null and undefined from T
+ * Exclude null and undefined from T, or from specific properties K if provided.
  */
-type NonNullable<T> = T & {};
+type NonNullable<T, K extends keyof T = keyof T> =
+  keyof T extends K
+    ? T & {}
+    : Omit<T, K> & {
+        [P in K]-?: NonNullable<T[P]> 
+      };
+
+/**
+ * Construct a type with the properties of T, where keys K are non-nullable
+ */
+type NonNullableProperties<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};
 
 /**
  * Obtain the parameters of a function type in a tuple


### PR DESCRIPTION
What are our thoughts on this pattern? It seems like a lot to ask people to find the ideal syntax to flag properties as non-nullable:

```ts
type NonNullableProperties<T, K extends keyof T> = Omit<T, K> & {
  [P in K]-?: NonNullable<T[P]>;
};
```

It seems like it makes sense to just update `NonNullable` and retain the fast path over adding a new lib type. I expect there will just be pushback on this and it will be closed, but just a suggestion.
