### PR TITLE
Use dprint package for dtsBundler formatting rather than dprint CLI

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,4 +1,5 @@
 {
+    // If updating this, also update the config in dtsBundler.mjs.
     "indentWidth": 4,
     "lineWidth": 1000,
     "newLineKind": "auto",

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -56,6 +56,7 @@
         "**/_namespaces/**"
     ],
     // Note: if adding new languages, make sure settings.template.json is updated too.
+    // Also, if updating typescript, update the one in package.json.
     "plugins": [
         "https://plugins.dprint.dev/typescript-0.90.5.wasm",
         "https://plugins.dprint.dev/json-0.19.2.wasm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
                 "tsserver": "bin/tsserver"
             },
             "devDependencies": {
+                "@dprint/formatter": "^0.3.0",
+                "@dprint/typescript": "^0.90.5",
                 "@esfx/canceltoken": "^1.0.0",
                 "@octokit/rest": "^20.1.1",
                 "@types/chai": "^4.3.16",
@@ -88,6 +90,12 @@
                 "darwin"
             ]
         },
+        "node_modules/@dprint/formatter": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.3.0.tgz",
+            "integrity": "sha512-N9fxCxbaBOrDkteSOzaCqwWjso5iAe+WJPsHC021JfHNj2ThInPNEF13ORDKta3llq5D1TlclODCvOvipH7bWQ==",
+            "dev": true
+        },
         "node_modules/@dprint/linux-arm64-glibc": {
             "version": "0.45.1",
             "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.45.1.tgz",
@@ -139,6 +147,12 @@
             "os": [
                 "linux"
             ]
+        },
+        "node_modules/@dprint/typescript": {
+            "version": "0.90.5",
+            "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.90.5.tgz",
+            "integrity": "sha512-/1aP6saonFvJyQN3l2is6eTOec3GnLGyW+opid/eDm8pnlhwzYl8A9p36pI6WO5jLl/a9Ghod+LWpvSOuXFGUw==",
+            "dev": true
         },
         "node_modules/@dprint/win32-x64": {
             "version": "0.45.1",
@@ -4445,6 +4459,12 @@
             "dev": true,
             "optional": true
         },
+        "@dprint/formatter": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.3.0.tgz",
+            "integrity": "sha512-N9fxCxbaBOrDkteSOzaCqwWjso5iAe+WJPsHC021JfHNj2ThInPNEF13ORDKta3llq5D1TlclODCvOvipH7bWQ==",
+            "dev": true
+        },
         "@dprint/linux-arm64-glibc": {
             "version": "0.45.1",
             "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.45.1.tgz",
@@ -4472,6 +4492,12 @@
             "integrity": "sha512-p2/gjnHDd8GRCvtey5HZO4o/He6pSmY/zpcCuIXprFW9P0vNlEj3DFhz4FPpOKXM+csrsVWWs2E0T/xr5QZtVg==",
             "dev": true,
             "optional": true
+        },
+        "@dprint/typescript": {
+            "version": "0.90.5",
+            "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.90.5.tgz",
+            "integrity": "sha512-/1aP6saonFvJyQN3l2is6eTOec3GnLGyW+opid/eDm8pnlhwzYl8A9p36pI6WO5jLl/a9Ghod+LWpvSOuXFGUw==",
+            "dev": true
         },
         "@dprint/win32-x64": {
             "version": "0.45.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@dprint/formatter": "^0.3.0",
-                "@dprint/typescript": "^0.90.5",
+                "@dprint/typescript": "0.90.5",
                 "@esfx/canceltoken": "^1.0.0",
                 "@octokit/rest": "^20.1.1",
                 "@types/chai": "^4.3.16",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
         "!**/.gitattributes"
     ],
     "devDependencies": {
+        "@dprint/formatter": "^0.3.0",
+        "@dprint/typescript": "^0.90.5",
         "@esfx/canceltoken": "^1.0.0",
         "@octokit/rest": "^20.1.1",
         "@types/chai": "^4.3.16",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ],
     "devDependencies": {
         "@dprint/formatter": "^0.3.0",
-        "@dprint/typescript": "^0.90.5",
+        "@dprint/typescript": "0.90.5",
         "@esfx/canceltoken": "^1.0.0",
         "@octokit/rest": "^20.1.1",
         "@types/chai": "^4.3.16",

--- a/scripts/dtsBundler.mjs
+++ b/scripts/dtsBundler.mjs
@@ -5,8 +5,8 @@
  * bundle as namespaces again, even though the project is modules.
  */
 
-import { createFromBuffer } from "@dprint/formatter";
-import { getPath } from "@dprint/typescript";
+import * as dprintFormatter from "@dprint/formatter";
+import * as dprintTypeScript from "@dprint/typescript";
 import assert, { fail } from "assert";
 import fs from "fs";
 import minimist from "minimist";
@@ -476,8 +476,8 @@ if (publicContents.includes("@internal")) {
     console.error("Output includes untrimmed @internal nodes!");
 }
 
-const buffer = fs.readFileSync(getPath());
-const formatter = createFromBuffer(buffer);
+const buffer = fs.readFileSync(dprintTypeScript.getPath());
+const formatter = dprintFormatter.createFromBuffer(buffer);
 formatter.setConfig({
     indentWidth: 4,
     lineWidth: 1000,

--- a/scripts/dtsBundler.mjs
+++ b/scripts/dtsBundler.mjs
@@ -479,9 +479,10 @@ if (publicContents.includes("@internal")) {
 const buffer = fs.readFileSync(getPath());
 const formatter = createFromBuffer(buffer);
 formatter.setConfig({
-    newLineKind: "lf",
     indentWidth: 4,
     lineWidth: 1000,
+    newLineKind: "auto",
+    useTabs: false,
 }, {
     quoteStyle: "preferDouble",
 });


### PR DESCRIPTION
This is a workaround for https://github.com/dprint/dprint/issues/849, avoiding calling the dprint CLI for the build.