### PR TITLE
fix#8529: Make default JSX mode "react"

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,10 +6,8 @@
         "module": "Node16",
         "moduleResolution": "Node16",
         "target": "es2018",
+        "jsx": "react",
         "noEmit": true,
-        // "declaration": true,
-        // "emitDeclarationOnly": true,
-
         "strict": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
@@ -18,9 +16,10 @@
         "allowJs": true,
         "checkJs": true
     },
-
     "include": [
         "**/*.mjs",
-        "**/*.cjs"
+        "**/*.cjs",
+        "**/*.ts", 
+        "**/*.tsx" 
     ]
 }


### PR DESCRIPTION
Explanation of Changes
1) Adding jsx Option:

"jsx": "react"
This line sets the jsx option to "react", enabling JSX syntax for TypeScript files.

2) Including .ts and .tsx Files:

"include": [
    "**/*.mjs",
    "**/*.cjs",
    "**/*.ts",
    "**/*.tsx"
]

These lines ensure that the compiler processes .ts and .tsx files, allowing you to use JSX syntax in .ts files and ensuring .tsx files are included in the compilation.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
