### PR TITLE
Check resolution of tslib per file

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -49505,41 +49505,43 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkExternalEmitHelpers(location: Node, helpers: ExternalEmitHelpers) {
-        const sourceFile = getSourceFileOfNode(location);
-        if (compilerOptions.importHelpers && isEffectiveExternalModule(sourceFile, compilerOptions) && !(location.flags & NodeFlags.Ambient)) {
-            const helpersModule = resolveHelpersModule(sourceFile, location);
-            if (helpersModule !== unknownSymbol) {
-                const links = getSymbolLinks(helpersModule);
-                links.requestedExternalEmitHelpers ??= 0 as ExternalEmitHelpers;
-                if ((links.requestedExternalEmitHelpers & helpers) !== helpers) {
-                    const uncheckedHelpers = helpers & ~links.requestedExternalEmitHelpers;
-                    for (let helper = ExternalEmitHelpers.FirstEmitHelper; helper <= ExternalEmitHelpers.LastEmitHelper; helper <<= 1) {
-                        if (uncheckedHelpers & helper) {
-                            for (const name of getHelperNames(helper)) {
-                                const symbol = resolveSymbol(getSymbol(getExportsOfModule(helpersModule), escapeLeadingUnderscores(name), SymbolFlags.Value));
-                                if (!symbol) {
-                                    error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_which_does_not_exist_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name);
-                                }
-                                else if (helper & ExternalEmitHelpers.ClassPrivateFieldGet) {
-                                    if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 3)) {
-                                        error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 4);
+        if (compilerOptions.importHelpers) {
+            const sourceFile = getSourceFileOfNode(location);
+            if (isEffectiveExternalModule(sourceFile, compilerOptions) && !(location.flags & NodeFlags.Ambient)) {
+                const helpersModule = resolveHelpersModule(sourceFile, location);
+                if (helpersModule !== unknownSymbol) {
+                    const links = getSymbolLinks(helpersModule);
+                    links.requestedExternalEmitHelpers ??= 0 as ExternalEmitHelpers;
+                    if ((links.requestedExternalEmitHelpers & helpers) !== helpers) {
+                        const uncheckedHelpers = helpers & ~links.requestedExternalEmitHelpers;
+                        for (let helper = ExternalEmitHelpers.FirstEmitHelper; helper <= ExternalEmitHelpers.LastEmitHelper; helper <<= 1) {
+                            if (uncheckedHelpers & helper) {
+                                for (const name of getHelperNames(helper)) {
+                                    const symbol = resolveSymbol(getSymbol(getExportsOfModule(helpersModule), escapeLeadingUnderscores(name), SymbolFlags.Value));
+                                    if (!symbol) {
+                                        error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_which_does_not_exist_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name);
                                     }
-                                }
-                                else if (helper & ExternalEmitHelpers.ClassPrivateFieldSet) {
-                                    if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 4)) {
-                                        error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 5);
+                                    else if (helper & ExternalEmitHelpers.ClassPrivateFieldGet) {
+                                        if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 3)) {
+                                            error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 4);
+                                        }
                                     }
-                                }
-                                else if (helper & ExternalEmitHelpers.SpreadArray) {
-                                    if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 2)) {
-                                        error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 3);
+                                    else if (helper & ExternalEmitHelpers.ClassPrivateFieldSet) {
+                                        if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 4)) {
+                                            error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 5);
+                                        }
+                                    }
+                                    else if (helper & ExternalEmitHelpers.SpreadArray) {
+                                        if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 2)) {
+                                            error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 3);
+                                        }
                                     }
                                 }
                             }
                         }
                     }
+                    links.requestedExternalEmitHelpers |= helpers;
                 }
-                links.requestedExternalEmitHelpers |= helpers;
             }
         }
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5953,6 +5953,7 @@ export interface SymbolLinks {
     tupleLabelDeclaration?: NamedTupleMember | ParameterDeclaration; // Declaration associated with the tuple's label
     accessibleChainCache?: Map<string, Symbol[] | undefined>;
     filteredIndexSymbolCache?: Map<string, Symbol> //Symbol with applicable declarations
+    requestedExternalEmitHelpers?: ExternalEmitHelpers; // External emit helpers already checked for this symbol.
 }
 
 // dprint-ignore
@@ -6139,7 +6140,6 @@ export interface NodeLinks {
     parameterInitializerContainsUndefined?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
     fakeScopeForSignatureDeclaration?: "params" | "typeParams"; // If present, this is a fake scope injected into an enclosing declaration chain.
     assertionExpressionType?: Type;     // Cached type of the expression of a type assertion
-    requestedExternalEmitHelpers?: ExternalEmitHelpers; // External emit helpers already requested for this node.
     externalHelpersModule?: Symbol;     // Resolved symbol for the external helpers module
 }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6139,6 +6139,8 @@ export interface NodeLinks {
     parameterInitializerContainsUndefined?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
     fakeScopeForSignatureDeclaration?: "params" | "typeParams"; // If present, this is a fake scope injected into an enclosing declaration chain.
     assertionExpressionType?: Type;     // Cached type of the expression of a type assertion
+    requestedExternalEmitHelpers?: ExternalEmitHelpers; // External emit helpers already requested for this node.
+    externalHelpersModule?: Symbol;     // Resolved symbol for the external helpers module
 }
 
 /** @internal */

--- a/tests/baselines/reference/esModuleInteropTslibHelpers.errors.txt
+++ b/tests/baselines/reference/esModuleInteropTslibHelpers.errors.txt
@@ -1,4 +1,6 @@
 file2.ts(1,1): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+file3.ts(1,9): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+file4.ts(1,14): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
 
 
 ==== refs.d.ts (0 errors) ====
@@ -13,11 +15,15 @@ file2.ts(1,1): error TS2354: This syntax requires an imported helper but module 
 !!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
     path.resolve("", "../");
     export class Foo2 { }
-==== file3.ts (0 errors) ====
+==== file3.ts (1 errors) ====
     import {default as resolve} from "path";
+            ~~~~~~~~~~~~~~~~~~
+!!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
     resolve("", "../");
     export class Foo3 { }
-==== file4.ts (0 errors) ====
+==== file4.ts (1 errors) ====
     import {Bar, default as resolve} from "path";
+                 ~~~~~~~~~~~~~~~~~~
+!!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
     resolve("", "../");
     export { Bar }

--- a/tests/baselines/reference/tslibMissingHelper.errors.txt
+++ b/tests/baselines/reference/tslibMissingHelper.errors.txt
@@ -1,0 +1,36 @@
+/package1/index.ts(2,16): error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+        "compilerOptions": {
+            "strict": true,
+            "target": "ES2016",
+            "importHelpers": true,
+            "module": "commonjs",
+        }
+    }
+    
+==== /package1/index.ts (1 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+                   ~~~
+!!! error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+    async function bar(): Promise<void> {}
+    
+==== /package2/index.ts (0 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+    
+==== /node_modules/tslib/package.json (0 errors) ====
+    {
+        "name": "tslib",
+        "main": "tslib.js",
+        "typings": "tslib.d.ts"
+    }
+    
+==== /node_modules/tslib/tslib.d.ts (0 errors) ====
+    export const notAHelper: any;
+    
+==== /node_modules/tslib/tslib.js (0 errors) ====
+    module.exports.notAHelper = 3;

--- a/tests/baselines/reference/tslibMissingHelper.js
+++ b/tests/baselines/reference/tslibMissingHelper.js
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/tslibMissingHelper.ts] ////
+
+//// [package.json]
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+//// [tslib.d.ts]
+export const notAHelper: any;
+
+//// [tslib.js]
+module.exports.notAHelper = 3;
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+function bar() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}

--- a/tests/baselines/reference/tslibMissingHelper.symbols
+++ b/tests/baselines/reference/tslibMissingHelper.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/tslibMissingHelper.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+async function bar(): Promise<void> {}
+>bar : Symbol(bar, Decl(index.ts, 1, 38))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : Symbol(notAHelper, Decl(tslib.d.ts, --, --))
+

--- a/tests/baselines/reference/tslibMissingHelper.types
+++ b/tests/baselines/reference/tslibMissingHelper.types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/tslibMissingHelper.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+async function bar(): Promise<void> {}
+>bar : () => Promise<void>
+>    : ^^^^^^             
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+=== /node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : any
+>           : ^^^
+

--- a/tests/baselines/reference/tslibMultipleMissingHelper.errors.txt
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.errors.txt
@@ -1,4 +1,5 @@
 /package1/index.ts(2,16): error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+/package1/other.ts(3,32): error TS2343: This syntax requires an imported helper named '__rest' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
 /package2/index.ts(2,16): error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
 
 
@@ -18,6 +19,15 @@
                    ~~~
 !!! error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
     async function bar(): Promise<void> {}
+    
+==== /package1/other.ts (1 errors) ====
+    export {};
+    export async function noop(): Promise<void> {}
+    export function spread({ a, ...rest }: { a: number, b: number}) {
+                                   ~~~~
+!!! error TS2343: This syntax requires an imported helper named '__rest' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+        return { c: "c", ...rest };
+    }
     
 ==== /package2/index.ts (1 errors) ====
     export {};

--- a/tests/baselines/reference/tslibMultipleMissingHelper.errors.txt
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.errors.txt
@@ -1,0 +1,52 @@
+/package1/index.ts(2,16): error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+/package2/index.ts(2,16): error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+        "compilerOptions": {
+            "strict": true,
+            "target": "ES2016",
+            "importHelpers": true,
+            "module": "commonjs",
+        }
+    }
+    
+==== /package1/index.ts (1 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+                   ~~~
+!!! error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+    async function bar(): Promise<void> {}
+    
+==== /package2/index.ts (1 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+                   ~~~
+!!! error TS2343: This syntax requires an imported helper named '__awaiter' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
+    
+==== /package1/node_modules/tslib/package.json (0 errors) ====
+    {
+        "name": "tslib",
+        "main": "tslib.js",
+        "typings": "tslib.d.ts"
+    }
+    
+==== /package1/node_modules/tslib/tslib.d.ts (0 errors) ====
+    export const notAHelper: any;
+    
+==== /package1/node_modules/tslib/tslib.js (0 errors) ====
+    module.exports.notAHelper = 3;
+    
+==== /package2/node_modules/tslib/package.json (0 errors) ====
+    {
+        "name": "tslib",
+        "main": "tslib.js",
+        "typings": "tslib.d.ts"
+    }
+    
+==== /package2/node_modules/tslib/tslib.d.ts (0 errors) ====
+    export const notAHelper: any;
+    
+==== /package2/node_modules/tslib/tslib.js (0 errors) ====
+    module.exports.notAHelper = 3;

--- a/tests/baselines/reference/tslibMultipleMissingHelper.js
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.js
@@ -30,6 +30,13 @@ export {};
 async function foo(): Promise<void> {}
 async function bar(): Promise<void> {}
 
+//// [other.ts]
+export {};
+export async function noop(): Promise<void> {}
+export function spread({ a, ...rest }: { a: number, b: number}) {
+    return { c: "c", ...rest };
+}
+
 //// [index.ts]
 export {};
 async function foo(): Promise<void> {}
@@ -44,6 +51,19 @@ function foo() {
 }
 function bar() {
     return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+//// [other.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.noop = noop;
+exports.spread = spread;
+const tslib_1 = require("tslib");
+function noop() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+function spread(_a) {
+    var { a } = _a, rest = tslib_1.__rest(_a, ["a"]);
+    return Object.assign({ c: "c" }, rest);
 }
 //// [index.js]
 "use strict";

--- a/tests/baselines/reference/tslibMultipleMissingHelper.js
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.js
@@ -1,0 +1,54 @@
+//// [tests/cases/compiler/tslibMultipleMissingHelper.ts] ////
+
+//// [package.json]
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+//// [tslib.d.ts]
+export const notAHelper: any;
+
+//// [tslib.js]
+module.exports.notAHelper = 3;
+
+//// [package.json]
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+//// [tslib.d.ts]
+export const notAHelper: any;
+
+//// [tslib.js]
+module.exports.notAHelper = 3;
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+function bar() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}

--- a/tests/baselines/reference/tslibMultipleMissingHelper.symbols
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.symbols
@@ -10,6 +10,24 @@ async function bar(): Promise<void> {}
 >bar : Symbol(bar, Decl(index.ts, 1, 38))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
+=== /package1/other.ts ===
+export {};
+export async function noop(): Promise<void> {}
+>noop : Symbol(noop, Decl(other.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+export function spread({ a, ...rest }: { a: number, b: number}) {
+>spread : Symbol(spread, Decl(other.ts, 1, 46))
+>a : Symbol(a, Decl(other.ts, 2, 24))
+>rest : Symbol(rest, Decl(other.ts, 2, 27))
+>a : Symbol(a, Decl(other.ts, 2, 40))
+>b : Symbol(b, Decl(other.ts, 2, 51))
+
+    return { c: "c", ...rest };
+>c : Symbol(c, Decl(other.ts, 3, 12))
+>rest : Symbol(rest, Decl(other.ts, 2, 27))
+}
+
 === /package2/index.ts ===
 export {};
 async function foo(): Promise<void> {}

--- a/tests/baselines/reference/tslibMultipleMissingHelper.symbols
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/tslibMultipleMissingHelper.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+async function bar(): Promise<void> {}
+>bar : Symbol(bar, Decl(index.ts, 1, 38))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /package1/node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : Symbol(notAHelper, Decl(tslib.d.ts, --, --))
+
+=== /package2/node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : Symbol(notAHelper, Decl(tslib.d.ts, --, --))
+

--- a/tests/baselines/reference/tslibMultipleMissingHelper.types
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.types
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/tslibMultipleMissingHelper.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+async function bar(): Promise<void> {}
+>bar : () => Promise<void>
+>    : ^^^^^^             
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+=== /package1/node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : any
+>           : ^^^
+
+=== /package2/node_modules/tslib/tslib.d.ts ===
+export const notAHelper: any;
+>notAHelper : any
+>           : ^^^
+

--- a/tests/baselines/reference/tslibMultipleMissingHelper.types
+++ b/tests/baselines/reference/tslibMultipleMissingHelper.types
@@ -10,6 +10,35 @@ async function bar(): Promise<void> {}
 >bar : () => Promise<void>
 >    : ^^^^^^             
 
+=== /package1/other.ts ===
+export {};
+export async function noop(): Promise<void> {}
+>noop : () => Promise<void>
+>     : ^^^^^^             
+
+export function spread({ a, ...rest }: { a: number, b: number}) {
+>spread : ({ a, ...rest }: { a: number; b: number; }) => { b: number; c: string; }
+>       : ^              ^^                         ^^^^^^^^^^      ^^^^^^^^^^^^^^
+>a : number
+>  : ^^^^^^
+>rest : { b: number; }
+>     : ^^^^^      ^^^
+>a : number
+>  : ^^^^^^
+>b : number
+>  : ^^^^^^
+
+    return { c: "c", ...rest };
+>{ c: "c", ...rest } : { b: number; c: string; }
+>                    : ^^^^^      ^^^^^^^^^^^^^^
+>c : string
+>  : ^^^^^^
+>"c" : "c"
+>    : ^^^
+>rest : { b: number; }
+>     : ^^^^^      ^^^
+}
+
 === /package2/index.ts ===
 export {};
 async function foo(): Promise<void> {}

--- a/tests/baselines/reference/tslibNotFoundDifferentModules.errors.txt
+++ b/tests/baselines/reference/tslibNotFoundDifferentModules.errors.txt
@@ -1,0 +1,52 @@
+/package2/index.ts(2,16): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+        "compilerOptions": {
+            "strict": true,
+            "target": "ES2016",
+            "importHelpers": true,
+            "module": "commonjs",
+        }
+    }
+    
+==== /package1/index.ts (0 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+    async function bar(): Promise<void> {}
+    
+==== /package2/index.ts (1 errors) ====
+    export {};
+    async function foo(): Promise<void> {}
+                   ~~~
+!!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+==== /package1/node_modules/tslib/package.json (0 errors) ====
+    {
+        "name": "tslib",
+        "main": "tslib.js",
+        "typings": "tslib.d.ts"
+    }
+    
+==== /package1/node_modules/tslib/tslib.d.ts (0 errors) ====
+    /**
+     * Converts a generator function into a pseudo-async function, by treating each `yield` as an `await`.
+     *
+     * @param thisArg The reference to use as the `this` value in the generator function
+     * @param _arguments The optional arguments array
+     * @param P The optional promise constructor argument, defaults to the `Promise` property of the global object.
+     * @param generator The generator function
+     */
+    export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+    
+==== /package1/node_modules/tslib/tslib.js (0 errors) ====
+    module.exports.__awaiter = function (thisArg, _arguments, P, generator) {
+        function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+    

--- a/tests/baselines/reference/tslibNotFoundDifferentModules.js
+++ b/tests/baselines/reference/tslibNotFoundDifferentModules.js
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/tslibNotFoundDifferentModules.ts] ////
+
+//// [package.json]
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+//// [tslib.d.ts]
+/**
+ * Converts a generator function into a pseudo-async function, by treating each `yield` as an `await`.
+ *
+ * @param thisArg The reference to use as the `this` value in the generator function
+ * @param _arguments The optional arguments array
+ * @param P The optional promise constructor argument, defaults to the `Promise` property of the global object.
+ * @param generator The generator function
+ */
+export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+
+//// [tslib.js]
+module.exports.__awaiter = function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+//// [index.ts]
+export {};
+async function foo(): Promise<void> {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+function bar() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+function foo() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+}

--- a/tests/baselines/reference/tslibNotFoundDifferentModules.symbols
+++ b/tests/baselines/reference/tslibNotFoundDifferentModules.symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/tslibNotFoundDifferentModules.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+async function bar(): Promise<void> {}
+>bar : Symbol(bar, Decl(index.ts, 1, 38))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : Symbol(foo, Decl(index.ts, 0, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+=== /package1/node_modules/tslib/tslib.d.ts ===
+/**
+ * Converts a generator function into a pseudo-async function, by treating each `yield` as an `await`.
+ *
+ * @param thisArg The reference to use as the `this` value in the generator function
+ * @param _arguments The optional arguments array
+ * @param P The optional promise constructor argument, defaults to the `Promise` property of the global object.
+ * @param generator The generator function
+ */
+export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+>__awaiter : Symbol(__awaiter, Decl(tslib.d.ts, --, --))
+>thisArg : Symbol(thisArg, Decl(tslib.d.ts, --, --))
+>_arguments : Symbol(_arguments, Decl(tslib.d.ts, --, --))
+>P : Symbol(P, Decl(tslib.d.ts, --, --))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>generator : Symbol(generator, Decl(tslib.d.ts, --, --))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+

--- a/tests/baselines/reference/tslibNotFoundDifferentModules.types
+++ b/tests/baselines/reference/tslibNotFoundDifferentModules.types
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/tslibNotFoundDifferentModules.ts] ////
+
+=== /package1/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+async function bar(): Promise<void> {}
+>bar : () => Promise<void>
+>    : ^^^^^^             
+
+=== /package2/index.ts ===
+export {};
+async function foo(): Promise<void> {}
+>foo : () => Promise<void>
+>    : ^^^^^^             
+
+=== /package1/node_modules/tslib/tslib.d.ts ===
+/**
+ * Converts a generator function into a pseudo-async function, by treating each `yield` as an `await`.
+ *
+ * @param thisArg The reference to use as the `this` value in the generator function
+ * @param _arguments The optional arguments array
+ * @param P The optional promise constructor argument, defaults to the `Promise` property of the global object.
+ * @param generator The generator function
+ */
+export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+>__awaiter : (thisArg: any, _arguments: any, P: Function, generator: Function) => any
+>          : ^       ^^   ^^          ^^   ^^ ^^        ^^         ^^        ^^^^^   
+>thisArg : any
+>_arguments : any
+>P : Function
+>  : ^^^^^^^^
+>generator : Function
+>          : ^^^^^^^^
+

--- a/tests/baselines/reference/tslibNotFoundDifferentModules.types
+++ b/tests/baselines/reference/tslibNotFoundDifferentModules.types
@@ -29,7 +29,9 @@ export declare function __awaiter(thisArg: any, _arguments: any, P: Function, ge
 >__awaiter : (thisArg: any, _arguments: any, P: Function, generator: Function) => any
 >          : ^       ^^   ^^          ^^   ^^ ^^        ^^         ^^        ^^^^^   
 >thisArg : any
+>        : ^^^
 >_arguments : any
+>           : ^^^
 >P : Function
 >  : ^^^^^^^^
 >generator : Function

--- a/tests/cases/compiler/tslibMissingHelper.ts
+++ b/tests/cases/compiler/tslibMissingHelper.ts
@@ -1,0 +1,31 @@
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+        "strict": true,
+        "target": "ES2016",
+        "importHelpers": true,
+        "module": "commonjs",
+    }
+}
+
+// @filename: /package1/index.ts
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+// @filename: /package2/index.ts
+export {};
+async function foo(): Promise<void> {}
+
+// @filename: /node_modules/tslib/package.json
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+// @filename: /node_modules/tslib/tslib.d.ts
+export const notAHelper: any;
+
+// @filename: /node_modules/tslib/tslib.js
+module.exports.notAHelper = 3;

--- a/tests/cases/compiler/tslibMultipleMissingHelper.ts
+++ b/tests/cases/compiler/tslibMultipleMissingHelper.ts
@@ -13,6 +13,13 @@ export {};
 async function foo(): Promise<void> {}
 async function bar(): Promise<void> {}
 
+// @filename: /package1/other.ts
+export {};
+export async function noop(): Promise<void> {}
+export function spread({ a, ...rest }: { a: number, b: number}) {
+    return { c: "c", ...rest };
+}
+
 // @filename: /package1/node_modules/tslib/package.json
 {
     "name": "tslib",

--- a/tests/cases/compiler/tslibMultipleMissingHelper.ts
+++ b/tests/cases/compiler/tslibMultipleMissingHelper.ts
@@ -1,0 +1,44 @@
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+        "strict": true,
+        "target": "ES2016",
+        "importHelpers": true,
+        "module": "commonjs",
+    }
+}
+
+// @filename: /package1/index.ts
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+// @filename: /package1/node_modules/tslib/package.json
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+// @filename: /package1/node_modules/tslib/tslib.d.ts
+export const notAHelper: any;
+
+// @filename: /package1/node_modules/tslib/tslib.js
+module.exports.notAHelper = 3;
+
+// @filename: /package2/index.ts
+export {};
+async function foo(): Promise<void> {}
+
+// @filename: /package2/node_modules/tslib/package.json
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+// @filename: /package2/node_modules/tslib/tslib.d.ts
+export const notAHelper: any;
+
+// @filename: /package2/node_modules/tslib/tslib.js
+module.exports.notAHelper = 3;

--- a/tests/cases/compiler/tslibNotFoundDifferentModules.ts
+++ b/tests/cases/compiler/tslibNotFoundDifferentModules.ts
@@ -1,0 +1,47 @@
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+        "strict": true,
+        "target": "ES2016",
+        "importHelpers": true,
+        "module": "commonjs",
+    }
+}
+
+// @filename: /package1/index.ts
+export {};
+async function foo(): Promise<void> {}
+async function bar(): Promise<void> {}
+
+// @filename: /package1/node_modules/tslib/package.json
+{
+    "name": "tslib",
+    "main": "tslib.js",
+    "typings": "tslib.d.ts"
+}
+
+// @filename: /package1/node_modules/tslib/tslib.d.ts
+/**
+ * Converts a generator function into a pseudo-async function, by treating each `yield` as an `await`.
+ *
+ * @param thisArg The reference to use as the `this` value in the generator function
+ * @param _arguments The optional arguments array
+ * @param P The optional promise constructor argument, defaults to the `Promise` property of the global object.
+ * @param generator The generator function
+ */
+export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+
+// @filename: /package1/node_modules/tslib/tslib.js
+module.exports.__awaiter = function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+// @filename: /package2/index.ts
+export {};
+async function foo(): Promise<void> {}


### PR DESCRIPTION
This issue was raised by @andrewbranch during design meeting.

When the compiler option [`importHelpers`](https://www.typescriptlang.org/tsconfig/#importHelpers) is on, when we emit a module file, we will insert an appropriate import from `tslib` when an emit helper is needed.
To make sure this emitted import will be valid, during type checking, we try to resolve `tslib` whenever we detect we will need an emit helper, and error if we can't resolve it.
However, that resolution and respective error is currently not done per every file that will need the emit helper during emit, it is only done once per type checker and the resolution result is cached. This means that we could be missing errors in situations where for the first file we check `tslib` resolution, it resolves, but for a future file it would not resolve.

The newly added test case `tslibNotFoundDifferentModules` illustrates this: we have two packages in a project, one of them (`package1`) that has `tslib` in its `node_modules/`, and the other (`package2`) that doesn't. We first check the file in `project1`, and there we are able to resolve `tslib`, and so when we go and check the file in `project2`, we don't error saying `tslib` is missing, but we should.

This PR fixes this problem by making this `tslib` resolution check for every file an emit helper will be used.
