### PR TITLE
Properly account for `this` argument in intersection apparent type caching

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14565,6 +14565,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getApparentTypeOfIntersectionType(type: IntersectionType, thisArgument: Type) {
+        if (type === thisArgument) {
+            return type.resolvedApparentType || (type.resolvedApparentType = getTypeWithThisArgument(type, thisArgument, /*needApparentType*/ true));
+        }
         const key = `I${getTypeId(type)},${getTypeId(thisArgument)}`;
         return getCachedType(key) ?? setCachedType(key, getTypeWithThisArgument(type, thisArgument, /*needApparentType*/ true));
     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14565,7 +14565,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getApparentTypeOfIntersectionType(type: IntersectionType, thisArgument: Type) {
-        return type.resolvedApparentType || (type.resolvedApparentType = getTypeWithThisArgument(type, thisArgument, /*needApparentType*/ true));
+        const key = `I${getTypeId(type)},${getTypeId(thisArgument)}`;
+        return getCachedType(key) ?? setCachedType(key, getTypeWithThisArgument(type, thisArgument, /*needApparentType*/ true));
     }
 
     function getResolvedTypeParameterDefault(typeParameter: TypeParameter): Type | undefined {

--- a/tests/baselines/reference/intersectionApparentTypeCaching.symbols
+++ b/tests/baselines/reference/intersectionApparentTypeCaching.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/intersectionApparentTypeCaching.ts] ////
+
+=== intersectionApparentTypeCaching.ts ===
+// https://github.com/microsoft/TypeScript/issues/58175
+
+type TX<T extends any[] & object> = T["length"];
+>TX : Symbol(TX, Decl(intersectionApparentTypeCaching.ts, 0, 0))
+>T : Symbol(T, Decl(intersectionApparentTypeCaching.ts, 2, 8))
+>T : Symbol(T, Decl(intersectionApparentTypeCaching.ts, 2, 8))
+
+type T0<U extends any[] & object> = U;
+>T0 : Symbol(T0, Decl(intersectionApparentTypeCaching.ts, 2, 48))
+>U : Symbol(U, Decl(intersectionApparentTypeCaching.ts, 3, 8))
+>U : Symbol(U, Decl(intersectionApparentTypeCaching.ts, 3, 8))
+
+type T1 = T0<string[]>;
+>T1 : Symbol(T1, Decl(intersectionApparentTypeCaching.ts, 3, 38))
+>T0 : Symbol(T0, Decl(intersectionApparentTypeCaching.ts, 2, 48))
+

--- a/tests/baselines/reference/intersectionApparentTypeCaching.types
+++ b/tests/baselines/reference/intersectionApparentTypeCaching.types
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/intersectionApparentTypeCaching.ts] ////
+
+=== intersectionApparentTypeCaching.ts ===
+// https://github.com/microsoft/TypeScript/issues/58175
+
+type TX<T extends any[] & object> = T["length"];
+>TX : TX<T>
+>   : ^^^^^
+
+type T0<U extends any[] & object> = U;
+>T0 : U
+>   : ^
+
+type T1 = T0<string[]>;
+>T1 : string[]
+>   : ^^^^^^^^
+

--- a/tests/cases/compiler/intersectionApparentTypeCaching.ts
+++ b/tests/cases/compiler/intersectionApparentTypeCaching.ts
@@ -1,0 +1,8 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/58175
+
+type TX<T extends any[] & object> = T["length"];
+type T0<U extends any[] & object> = U;
+type T1 = T0<string[]>;


### PR DESCRIPTION
Fixes #58175.