### PR TITLE
Handling statements from a known source file

### DIFF
--- a/src/services/pasteEdits.ts
+++ b/src/services/pasteEdits.ts
@@ -79,7 +79,15 @@ function pasteEdits(
                 const statementsInSourceFile = copiedFrom.file.statements;
                 const startNodeIndex = findIndex(statementsInSourceFile, s => s.end > copy.pos);
                 if (startNodeIndex === -1) return undefined;
-                const endNodeIndex = findIndex(statementsInSourceFile, s => s.end >= copy.end, startNodeIndex);
+                let endNodeIndex = findIndex(statementsInSourceFile, s => s.end >= copy.end, startNodeIndex);
+                /**
+                 * [|console.log(a);
+                 * |]
+                 * console.log(b);
+                 */
+                if (endNodeIndex !== -1 && copy.end <= statementsInSourceFile[endNodeIndex].getStart()) {
+                    endNodeIndex--;
+                }
                 statements.push(...statementsInSourceFile.slice(startNodeIndex, endNodeIndex === -1 ? statementsInSourceFile.length : endNodeIndex + 1));
             });
             const usage = getUsageInfo(copiedFrom.file, statements, originalProgram!.getTypeChecker(), getExistingLocals(updatedFile, statements, originalProgram!.getTypeChecker()));

--- a/src/services/pasteEdits.ts
+++ b/src/services/pasteEdits.ts
@@ -1,6 +1,4 @@
-import {
-    findIndex,
-} from "../compiler/core.js";
+import { findIndex } from "../compiler/core.js";
 import {
     CancellationToken,
     Program,

--- a/src/services/pasteEdits.ts
+++ b/src/services/pasteEdits.ts
@@ -1,5 +1,4 @@
 import {
-    addRange,
     findIndex,
 } from "../compiler/core.js";
 import {
@@ -11,7 +10,6 @@ import {
     TextRange,
     UserPreferences,
 } from "../compiler/types.js";
-import { getLineOfLocalPosition } from "../compiler/utilities.js";
 import {
     codefix,
     Debug,

--- a/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_blankTargetFile.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_blankTargetFile.js
@@ -9,6 +9,8 @@ import { abc } from "./a";
 console.log(abc);
 
 
+console.log("abc");
+
 //// [/c.ts]
 
 
@@ -71,7 +73,7 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/c.ts SVC-1-0 ""
 	/a.ts Text-1 "export const abc = 10;"
-	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n"
+	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n\n\nconsole.log(\"abc\");"
 
 
 	lib.d.ts
@@ -233,8 +235,8 @@ Info seq  [hh:mm:ss:mss] request:
                 "offset": 1
               },
               "end": {
-                "line": 3,
-                "offset": 18
+                "line": 5,
+                "offset": 1
               }
             }
           ]
@@ -251,7 +253,7 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/c.ts SVC-1-1 "console.log(abc);"
 	/a.ts Text-1 "export const abc = 10;"
-	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n"
+	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n\n\nconsole.log(\"abc\");"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] getExportInfoMap: cache miss or empty; calculating new results

--- a/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_blankTargetFile.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_blankTargetFile.js
@@ -5,7 +5,9 @@ export const abc = 10;
 
 //// [/b.ts]
 import { abc } from "./a";
+
 console.log(abc);
+
 
 //// [/c.ts]
 
@@ -69,7 +71,7 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/c.ts SVC-1-0 ""
 	/a.ts Text-1 "export const abc = 10;"
-	/b.ts Text-1 "import { abc } from \"./a\";\nconsole.log(abc);"
+	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n"
 
 
 	lib.d.ts
@@ -221,7 +223,22 @@ Info seq  [hh:mm:ss:mss] request:
               "offset": 1
             }
           }
-        ]
+        ],
+        "copiedFrom": {
+          "file": "b.ts",
+          "spans": [
+            {
+              "start": {
+                "line": 3,
+                "offset": 1
+              },
+              "end": {
+                "line": 3,
+                "offset": 18
+              }
+            }
+          ]
+        }
       },
       "command": "getPasteEdits"
     }
@@ -234,9 +251,11 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/c.ts SVC-1-1 "console.log(abc);"
 	/a.ts Text-1 "export const abc = 10;"
-	/b.ts Text-1 "import { abc } from \"./a\";\nconsole.log(abc);"
+	/b.ts Text-1 "import { abc } from \"./a\";\n\nconsole.log(abc);\n"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] getExportInfoMap: cache miss or empty; calculating new results
+Info seq  [hh:mm:ss:mss] getExportInfoMap: done in * ms
 Info seq  [hh:mm:ss:mss] response:
     {
       "seq": 0,

--- a/tests/cases/fourslash/server/pasteEdits_blankTargetFile.ts
+++ b/tests/cases/fourslash/server/pasteEdits_blankTargetFile.ts
@@ -8,7 +8,9 @@
 
 // @Filename: /b.ts
 //// import { abc } from "./a";
-//// console.log(abc);
+////
+//// [|console.log(abc);|]
+////
 
 // @Filename: /tsconfig.json
 ////{ "files": ["c.ts", "a.ts", "b.ts"] }
@@ -18,6 +20,7 @@ verify.pasteEdits({
     args: {
         pastedText: [`console.log(abc);`],
         pasteLocations: [range[0]],
+        copiedFrom: { file: "b.ts", range: [range[1]] },
     },
     newFileContents: {
         "/c.ts":

--- a/tests/cases/fourslash/server/pasteEdits_blankTargetFile.ts
+++ b/tests/cases/fourslash/server/pasteEdits_blankTargetFile.ts
@@ -9,8 +9,10 @@
 // @Filename: /b.ts
 //// import { abc } from "./a";
 ////
-//// [|console.log(abc);|]
-////
+//// [|console.log(abc);
+//// 
+//// |]
+//// console.log("abc");
 
 // @Filename: /tsconfig.json
 ////{ "files": ["c.ts", "a.ts", "b.ts"] }


### PR DESCRIPTION
While testing copy/paste functionality, it was found that imports were not getting adding from a file. The reason behind this was because the right statements were not getting extracted from the `copiedFrom` file. Whenever there was a newline, the line number and position would cause a problem in extracting the statements. This pr fixes that problem.