### PR TITLE
feat: make Object.keys type strict

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -243,7 +243,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: object): string[];
+    keys<T, S = keyof T>(o: T): S[];
 }
 
 /**


### PR DESCRIPTION
Makes Object.keys type strict, while still allowing devs to opt out if they want to.

Currently the following code
```typescript
interface User {
    email: string
    name: string
}

const martin: User = {name: martin, email: martin@gmail.com}

const keys = Object.keys(martin)
```
would end up in keys being of type `string[]` instead of `('email' | 'name')[]`, which usually leads to unnecessary type castings afterward.

This solution sill allows people to keep the previous behaviour by explicitly setting the types
```typescript
const keys = Object.keys<User, string>(martin) // string[]
```
