### PR TITLE
(type | interface) as part of an assertion should not trigger an parsing error.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2320,7 +2320,6 @@ namespace Parser {
         if (token() === SyntaxKind.AwaitKeyword && inAwaitContext()) {
             return false;
         }
-
         return token() > SyntaxKind.LastReservedWord;
     }
 
@@ -5140,7 +5139,24 @@ namespace Parser {
 
     function nextTokenIsIdentifierOnSameLine() {
         nextToken();
-        return !scanner.hasPrecedingLineBreak() && isIdentifier();
+        if (scanner.hasPrecedingLineBreak()) {
+            return false
+        }
+
+        switch(token()) {
+            case SyntaxKind.AsKeyword:
+            case SyntaxKind.SatisfiesKeyword:{
+                let truthy = false
+                lookAhead(() => {
+                    nextToken()
+                    truthy = token() === SyntaxKind.EqualsToken || token() === SyntaxKind.OpenBraceToken
+                })
+                return truthy
+            }
+            
+            default:
+                return isIdentifier();
+        }
     }
 
     function parseYieldExpression(): YieldExpression {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2320,6 +2320,7 @@ namespace Parser {
         if (token() === SyntaxKind.AwaitKeyword && inAwaitContext()) {
             return false;
         }
+        
         return token() > SyntaxKind.LastReservedWord;
     }
 

--- a/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.js
+++ b/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/typeOrInterfaceIdentifierSatisfiesExpression.ts] ////
+
+//// [typeOrInterfaceIdentifierSatisfiesExpression.ts]
+const type = 'x';
+
+type satisfies string;
+type as string;
+
+const interface = 'x';
+
+interface satisfies string;
+interface as string;
+
+//// [typeOrInterfaceIdentifierSatisfiesExpression.js]
+var type = 'x';
+type;
+type;
+var interface = 'x';
+interface;
+interface;

--- a/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.symbols
+++ b/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/typeOrInterfaceIdentifierSatisfiesExpression.ts] ////
+
+=== typeOrInterfaceIdentifierSatisfiesExpression.ts ===
+const type = 'x';
+>type : Symbol(type, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 0, 5))
+
+type satisfies string;
+>type : Symbol(type, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 0, 5))
+
+type as string;
+>type : Symbol(type, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 0, 5))
+
+const interface = 'x';
+>interface : Symbol(interface, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 5, 5))
+
+interface satisfies string;
+>interface : Symbol(interface, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 5, 5))
+
+interface as string;
+>interface : Symbol(interface, Decl(typeOrInterfaceIdentifierSatisfiesExpression.ts, 5, 5))
+

--- a/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.types
+++ b/tests/baselines/reference/typeOrInterfaceIdentifierSatisfiesExpression.types
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/typeOrInterfaceIdentifierSatisfiesExpression.ts] ////
+
+=== typeOrInterfaceIdentifierSatisfiesExpression.ts ===
+const type = 'x';
+>type : "x"
+>     : ^^^
+>'x' : "x"
+>    : ^^^
+
+type satisfies string;
+>type satisfies string : "x"
+>                      : ^^^
+>type : "x"
+>     : ^^^
+
+type as string;
+>type as string : string
+>               : ^^^^^^
+>type : "x"
+>     : ^^^
+
+const interface = 'x';
+>interface : "x"
+>          : ^^^
+>'x' : "x"
+>    : ^^^
+
+interface satisfies string;
+>interface satisfies string : "x"
+>                           : ^^^
+>interface : "x"
+>          : ^^^
+
+interface as string;
+>interface as string : string
+>                    : ^^^^^^
+>interface : "x"
+>          : ^^^
+

--- a/tests/cases/compiler/typeOrInterfaceIdentifierSatisfiesExpression.ts
+++ b/tests/cases/compiler/typeOrInterfaceIdentifierSatisfiesExpression.ts
@@ -1,0 +1,9 @@
+const type = 'x';
+
+type satisfies string;
+type as string;
+
+const interface = 'x';
+
+interface satisfies string;
+interface as string;


### PR DESCRIPTION
Will fixes #58248 

I'm not sure if there are any other cases I've missed. I'll take a closer look this week, but feel free to give feedbacks :pray: 


This should be ok:
```ts
const type = 'x';

type satisfies string;
type as string;

const interface = 'x';

interface satisfies string;
interface as string;
```