### PR TITLE
Fixing self import

### DIFF
--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -1149,7 +1149,7 @@ export function getExistingLocals(sourceFile: SourceFile, statements: readonly S
     for (const statement of statements) {
         forEachReference(statement, checker, s => {
             const symbol = skipAlias(s, checker);
-            if (symbol.valueDeclaration && getSourceFileOfNode(symbol.valueDeclaration) === sourceFile) {
+            if (symbol.valueDeclaration && getSourceFileOfNode(symbol.valueDeclaration).path === sourceFile.path) {
                 existingLocals.add(symbol);
             }
         });

--- a/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_pasteIntoSameFile.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_pasteIntoSameFile.js
@@ -1,0 +1,282 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+//// [/lib.d.ts]
+lib.d.ts-Text
+
+//// [/lib.decorators.d.ts]
+lib.decorators.d.ts-Text
+
+//// [/lib.decorators.legacy.d.ts]
+lib.decorators.legacy.d.ts-Text
+
+//// [/target.ts]
+const k = 1;
+console.log(k);
+
+
+console.log("test");
+
+//// [/tsconfig.json]
+{ "files": ["target.ts"] }
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "arguments": {
+        "file": "/target.ts"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /target.ts ProjectRootPath: undefined:: Result: /tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/tsconfig.json",
+        "reason": "Creating possible configured project for /target.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json : {
+ "rootNames": [
+  "/target.ts"
+ ],
+ "options": {
+  "configFilePath": "/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/target.ts SVC-1-0 "const k = 1;\nconsole.log(k);\n\n\nconsole.log(\"test\");"
+
+
+	lib.d.ts
+	  Default library for target 'es5'
+	lib.decorators.d.ts
+	  Library referenced via 'decorators' from file 'lib.d.ts'
+	lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file 'lib.d.ts'
+	target.ts
+	  Part of 'files' list in tsconfig.json
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/target.ts",
+        "configFile": "/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /target.ts ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /tsconfig.json
+After Request
+watchedFiles::
+/lib.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts: *new*
+  {"pollingInterval":500}
+/tsconfig.json: *new*
+  {"pollingInterval":2000}
+
+Projects::
+/tsconfig.json (Configured) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+
+ScriptInfos::
+/lib.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.legacy.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/target.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /tsconfig.json *default*
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 1,
+      "type": "request",
+      "arguments": {
+        "formatOptions": {
+          "indentSize": 4,
+          "tabSize": 4,
+          "newLineCharacter": "\n",
+          "convertTabsToSpaces": true,
+          "indentStyle": 2,
+          "insertSpaceAfterConstructor": false,
+          "insertSpaceAfterCommaDelimiter": true,
+          "insertSpaceAfterSemicolonInForStatements": true,
+          "insertSpaceBeforeAndAfterBinaryOperators": true,
+          "insertSpaceAfterKeywordsInControlFlowStatements": true,
+          "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
+          "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+          "insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
+          "insertSpaceBeforeFunctionParenthesis": false,
+          "placeOpenBraceOnNewLineForFunctions": false,
+          "placeOpenBraceOnNewLineForControlBlocks": false,
+          "semicolons": "ignore",
+          "trimTrailingWhitespace": true,
+          "indentSwitchCase": true
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] Format host information updated
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 1,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 2,
+      "type": "request",
+      "arguments": {
+        "file": "/target.ts",
+        "pastedText": [
+          "console.log(k);"
+        ],
+        "pasteLocations": [
+          {
+            "start": {
+              "line": 4,
+              "offset": 1
+            },
+            "end": {
+              "line": 4,
+              "offset": 1
+            }
+          }
+        ],
+        "copiedFrom": {
+          "file": "target.ts",
+          "spans": [
+            {
+              "start": {
+                "line": 2,
+                "offset": 1
+              },
+              "end": {
+                "line": 2,
+                "offset": 16
+              }
+            }
+          ]
+        }
+      },
+      "command": "getPasteEdits"
+    }
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/target.ts SVC-1-1 "const k = 1;\nconsole.log(k);\n\nconsole.log(k);\nconsole.log(\"test\");"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "getPasteEdits",
+      "request_seq": 2,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      },
+      "body": {
+        "edits": [
+          {
+            "fileName": "/target.ts",
+            "textChanges": [
+              {
+                "start": {
+                  "line": 4,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 4,
+                  "offset": 1
+                },
+                "newText": "console.log(k);"
+              }
+            ]
+          }
+        ],
+        "fixId": "providePostPasteEdits"
+      }
+    }
+After Request
+Projects::
+/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+ScriptInfos::
+/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.legacy.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/target.ts (Open) *changed*
+    version: SVC-1-2 *changed*
+    containingProjects: 1
+        /tsconfig.json *default*

--- a/tests/cases/fourslash/server/pasteEdits_pasteIntoSameFile.ts
+++ b/tests/cases/fourslash/server/pasteEdits_pasteIntoSameFile.ts
@@ -1,0 +1,28 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /target.ts
+//// const k = 1;
+//// [|console.log(k);|]
+////
+//// [||]
+//// console.log("test");
+
+// @Filename: /tsconfig.json
+////{ "files": ["target.ts"] }
+
+const range = test.ranges();
+verify.pasteEdits({
+    args: {
+        pastedText: [ `console.log(k);`],
+        pasteLocations: [range[1]],
+        copiedFrom: { file: "target.ts", range: [range[0]] },
+    },
+    newFileContents: {
+        "/target.ts":
+`const k = 1;
+console.log(k);
+
+console.log(k);
+console.log("test");`
+    }
+});


### PR DESCRIPTION
The check to see whether a symbol was existing in the same file or not was by checking if the sourceFile of the node was the same as the sourceFile that was passed, but in here the check failed, because the sourceFile of the node was the original sourceFile, and the file that was passed was the updatedSource file with the new line maps. This is fixed by comparing the file paths instead.

Fixes #58716
