### PR TITLE
Added NoTruncation flag to completions

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -219,7 +219,8 @@ export function addNewNodeForMemberSymbol(
     switch (kind) {
         case SyntaxKind.PropertySignature:
         case SyntaxKind.PropertyDeclaration:
-            const flags = quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : undefined;
+            let flags = NodeBuilderFlags.NoTruncation;
+            flags |= quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : 0;
             let typeNode = checker.typeToTypeNode(type, enclosingDeclaration, flags, getNoopSymbolTrackerWithResolver(context));
             if (importAdder) {
                 const importableReference = tryGetAutoImportableReferenceFromTypeNode(typeNode, scriptTarget);


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/58666#issuecomment-2132408261

The crash is generated due to completions not being able to format a node. The node happens to be synthetized node created with text `... 1 more ....` I believe formatting is not working because is invalid syntax.
