### PR TITLE
Improve the performance of isolatedDeclarations quickfix 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1763,6 +1763,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getImmediateAliasedSymbol,
         getAliasedSymbol: resolveAlias,
         getEmitResolver,
+        requiresAddingImplicitUndefined,
         getExportsOfModule: getExportsOfModuleAsArray,
         getExportsAndPropertiesOfModule,
         forEachExportAndPropertyOfModule,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5265,6 +5265,7 @@ export interface TypeChecker {
     /** @internal */ getDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): Diagnostic[];
     /** @internal */ getGlobalDiagnostics(): Diagnostic[];
     /** @internal */ getEmitResolver(sourceFile?: SourceFile, cancellationToken?: CancellationToken, forceDts?: boolean): EmitResolver;
+    /** @internal */ requiresAddingImplicitUndefined(parameter: ParameterDeclaration | JSDocParameterTag): boolean;
 
     /** @internal */ getNodeCount(): number;
     /** @internal */ getIdentifierCount(): number;

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -886,7 +886,7 @@ function withContext<T>(
             type = widenedType;
         }
 
-        if (isParameter(node) && typeChecker.getEmitResolver().requiresAddingImplicitUndefined(node)) {
+        if (isParameter(node) && typeChecker.requiresAddingImplicitUndefined(node)) {
             type = typeChecker.getUnionType([typeChecker.getUndefinedType(), type], UnionReduction.None);
         }
         const flags = (

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -237,7 +237,6 @@ function withContext<T>(
     const sourceFile: SourceFile = context.sourceFile;
     const program = context.program;
     const typeChecker: TypeChecker = program.getTypeChecker();
-    const emitResolver = typeChecker.getEmitResolver();
     const scriptTarget = getEmitScriptTarget(program.getCompilerOptions());
     const importAdder = createImportAdder(context.sourceFile, context.program, context.preferences, context.host);
     const fixedNodes = new Set<Node>();
@@ -887,7 +886,7 @@ function withContext<T>(
             type = widenedType;
         }
 
-        if (isParameter(node) && emitResolver.requiresAddingImplicitUndefined(node)) {
+        if (isParameter(node) && typeChecker.getEmitResolver().requiresAddingImplicitUndefined(node)) {
             type = typeChecker.getUnionType([typeChecker.getUndefinedType(), type], UnionReduction.None);
         }
         const flags = (


### PR DESCRIPTION
It turns out that `typeChecker.getEmitResolver()` can be expensive, so avoid calling it unless necessary.

Hopefully helps #58426, in particularly the performance issue (bullet 1)