### PR TITLE
In reScanSlashToken use 'charCodeChecked' not 'codePointChecked'

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2558,7 +2558,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 pos++;
                 let regExpFlags = RegularExpressionFlags.None;
                 while (true) {
-                    const ch = codePointChecked(pos);
+                    const ch = charCodeChecked(pos);
                     if (ch === CharacterCodes.EOF || !isIdentifierPart(ch, languageVersion)) {
                         break;
                     }


### PR DESCRIPTION
This fixes a typo that was overlooked in the review for #58289.
