### PR TITLE
Check cancellation token in isolatedDeclarations codefix

### DIFF
--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -254,6 +254,8 @@ function withContext<T>(
     };
 
     function addTypeAnnotation(span: TextSpan) {
+        context.cancellationToken.throwIfCancellationRequested();
+
         const nodeWithDiag = getTokenAtPosition(sourceFile, span.start);
 
         const expandoFunction = findExpandoFunction(nodeWithDiag);
@@ -331,6 +333,8 @@ function withContext<T>(
     }
 
     function addInlineAssertion(span: TextSpan): DiagnosticOrDiagnosticAndArguments | undefined {
+        context.cancellationToken.throwIfCancellationRequested();
+
         const nodeWithDiag = getTokenAtPosition(sourceFile, span.start);
         const expandoFunction = findExpandoFunction(nodeWithDiag);
         // No inline assertions for expando members
@@ -406,6 +410,8 @@ function withContext<T>(
     }
 
     function extractAsVariable(span: TextSpan): DiagnosticOrDiagnosticAndArguments | undefined {
+        context.cancellationToken.throwIfCancellationRequested();
+
         const nodeWithDiag = getTokenAtPosition(sourceFile, span.start);
         const targetNode = findBestFittingNode(nodeWithDiag, span) as Expression;
         if (!targetNode || isValueSignatureDeclaration(targetNode) || isValueSignatureDeclaration(targetNode.parent)) return;


### PR DESCRIPTION
These are the main three entrypoints into the fixer. It's possible that there's some common hot function we could check instead (`inferTypes`?) but the call tree didn't make one super clear.