### PR TITLE
Write buildInfo even if we dont emit js or dts for --outFile scenarios

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -135,7 +135,7 @@ export interface ReusableBuilderProgramState extends BuilderState {
     /**
      * Cache of bind and check diagnostics for files with their Path being the key
      */
-    semanticDiagnosticsPerFile?: Map<Path, readonly ReusableDiagnostic[] | readonly Diagnostic[]> | undefined;
+    semanticDiagnosticsPerFile: Map<Path, readonly ReusableDiagnostic[] | readonly Diagnostic[]>;
     /** Cache of dts emit diagnostics for files with their Path being the key */
     emitDiagnosticsPerFile?: Map<Path, readonly ReusableDiagnostic[] | readonly Diagnostic[]> | undefined;
     /**
@@ -201,7 +201,7 @@ export interface BuilderProgramState extends BuilderState, ReusableBuilderProgra
     /**
      * Cache of bind and check diagnostics for files with their Path being the key
      */
-    semanticDiagnosticsPerFile: Map<Path, readonly Diagnostic[]> | undefined;
+    semanticDiagnosticsPerFile: Map<Path, readonly Diagnostic[]>;
     /** Cache of dts emit diagnostics for files with their Path being the key */
     emitDiagnosticsPerFile?: Map<Path, readonly Diagnostic[]> | undefined;
     /**
@@ -248,6 +248,8 @@ export interface BuilderProgramState extends BuilderState, ReusableBuilderProgra
      * Already seen emitted files
      */
     seenEmittedFiles: Map<Path, BuilderFileEmit> | undefined;
+    /** Already seen program emit */
+    seenProgramEmit: BuilderFileEmit | undefined;
 }
 
 /** @internal */
@@ -256,6 +258,7 @@ export type SavedBuildProgramEmitState =
         BuilderProgramState,
         | "affectedFilesPendingEmit"
         | "seenEmittedFiles"
+        | "seenProgramEmit"
         | "programEmitPending"
         | "emitSignatures"
         | "outSignature"
@@ -314,11 +317,8 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
     const compilerOptions = newProgram.getCompilerOptions();
     state.compilerOptions = compilerOptions;
     const outFilePath = compilerOptions.outFile;
-    // With --out or --outFile, any change affects all semantic diagnostics so no need to cache them
-    if (!outFilePath) {
-        state.semanticDiagnosticsPerFile = new Map();
-    }
-    else if (compilerOptions.composite && oldState?.outSignature && outFilePath === oldState.compilerOptions.outFile) {
+    state.semanticDiagnosticsPerFile = new Map();
+    if (outFilePath && compilerOptions.composite && oldState?.outSignature && outFilePath === oldState.compilerOptions.outFile) {
         state.outSignature = oldState.outSignature && getEmitSignatureFromOldSignature(compilerOptions, oldState.compilerOptions, oldState.outSignature);
     }
     state.changedFilesSet = new Set();
@@ -326,7 +326,7 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
 
     const useOldState = BuilderState.canReuseOldState(state.referencedMap, oldState);
     const oldCompilerOptions = useOldState ? oldState!.compilerOptions : undefined;
-    const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile &&
+    let canCopySemanticDiagnostics = useOldState &&
         !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldCompilerOptions!);
     // We can only reuse emit signatures (i.e. .d.ts signatures) if the .d.ts file is unchanged,
     // which will eg be depedent on change in options like declarationDir and outDir options are unchanged.
@@ -338,6 +338,7 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
         oldState?.emitSignatures &&
         !outFilePath &&
         !compilerOptionsAffectDeclarationPath(compilerOptions, oldState.compilerOptions);
+    let canCopyEmitDiagnostics = true;
     if (useOldState) {
         // Copy old state's changed files set
         oldState!.changedFilesSet?.forEach(value => state.changedFilesSet.add(value));
@@ -346,6 +347,12 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
             state.seenAffectedFiles = new Set();
         }
         state.programEmitPending = oldState!.programEmitPending;
+        // If there is changeSet with --outFile, cannot copy semantic diagnsotics or emitDiagnostics
+        // as they all need to be calculated again all together since we dont know whats the affected file set because of the way d.ts works
+        if (outFilePath && state.changedFilesSet.size) {
+            canCopySemanticDiagnostics = false;
+            canCopyEmitDiagnostics = false;
+        }
     }
     else {
         // We arent using old state, so atleast emit buildInfo with current information
@@ -376,11 +383,12 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
             newReferences && forEachKey(newReferences, path => !state.fileInfos.has(path) && oldState!.fileInfos.has(path))
         ) {
             // Register file as changed file and do not copy semantic diagnostics, since all changed files need to be re-evaluated
-            addFileToChangeSet(state, sourceFilePath);
+            addFileToChangeSet(sourceFilePath);
         }
         else {
             const sourceFile = newProgram.getSourceFileByPath(sourceFilePath)!;
-            const emitDiagnostics = oldState!.emitDiagnosticsPerFile?.get(sourceFilePath);
+            const emitDiagnostics = canCopyEmitDiagnostics ?
+                oldState!.emitDiagnosticsPerFile?.get(sourceFilePath) : undefined;
             if (emitDiagnostics) {
                 (state.emitDiagnosticsPerFile ??= new Map()).set(
                     sourceFilePath,
@@ -395,9 +403,9 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
                 if (sourceFile.hasNoDefaultLib && !copyLibFileDiagnostics) return;
 
                 // Unchanged file copy diagnostics
-                const diagnostics = oldState!.semanticDiagnosticsPerFile!.get(sourceFilePath);
+                const diagnostics = oldState!.semanticDiagnosticsPerFile.get(sourceFilePath);
                 if (diagnostics) {
-                    state.semanticDiagnosticsPerFile!.set(
+                    state.semanticDiagnosticsPerFile.set(
                         sourceFilePath,
                         oldState!.hasReusableDiagnostic ?
                             convertToDiagnostics(diagnostics as readonly ReusableDiagnostic[], sourceFilePath, newProgram) :
@@ -419,14 +427,14 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
     if (
         useOldState && forEachEntry(oldState!.fileInfos, (info, sourceFilePath) => {
             if (state.fileInfos.has(sourceFilePath)) return false;
-            if (outFilePath || info.affectsGlobalScope) return true;
+            if (info.affectsGlobalScope) return true;
             // if file is deleted we need to write buildInfo again
             state.buildInfoEmitPending = true;
-            return false;
+            return !!outFilePath;
         })
     ) {
         BuilderState.getAllFilesExcludingDefaultLibraryFile(state, newProgram, /*firstSourceFile*/ undefined)
-            .forEach(file => addFileToChangeSet(state, file.resolvedPath));
+            .forEach(file => addFileToChangeSet(file.resolvedPath));
     }
     else if (oldCompilerOptions) {
         // If options affect emit, then we need to do complete emit per compiler options
@@ -449,23 +457,32 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
                 });
                 Debug.assert(!state.seenAffectedFiles || !state.seenAffectedFiles.size);
                 state.seenAffectedFiles = state.seenAffectedFiles || new Set();
-                state.buildInfoEmitPending = true;
             }
-            else {
+            else if (!state.changedFilesSet.size) {
                 state.programEmitPending = state.programEmitPending ?
                     state.programEmitPending | pendingEmitKind :
                     pendingEmitKind;
             }
+            state.buildInfoEmitPending = true;
         }
     }
     return state;
-}
 
-function addFileToChangeSet(state: BuilderProgramState, path: Path) {
-    state.changedFilesSet.add(path);
-    state.buildInfoEmitPending = true;
-    // Setting this to undefined as changed files means full emit so no need to track emit explicitly
-    state.programEmitPending = undefined;
+    function addFileToChangeSet(path: Path) {
+        state.changedFilesSet.add(path);
+        if (outFilePath) {
+            // If there is changeSet with --outFile, cannot copy semantic diagnsotics or emitDiagnostics
+            // as they all need to be calculated again all together since we dont know whats the affected file set because of the way d.ts works
+            canCopySemanticDiagnostics = false;
+            canCopyEmitDiagnostics = false;
+            state.semanticDiagnosticsFromOldState = undefined;
+            state.semanticDiagnosticsPerFile.clear();
+            state.emitDiagnosticsPerFile = undefined;
+        }
+        state.buildInfoEmitPending = true;
+        // Setting this to undefined as changed files means full emit so no need to track emit explicitly
+        state.programEmitPending = undefined;
+    }
 }
 
 /**
@@ -570,6 +587,7 @@ function backupBuilderProgramEmitState(state: Readonly<BuilderProgramState>): Sa
     return {
         affectedFilesPendingEmit: state.affectedFilesPendingEmit && new Map(state.affectedFilesPendingEmit),
         seenEmittedFiles: state.seenEmittedFiles && new Map(state.seenEmittedFiles),
+        seenProgramEmit: state.seenProgramEmit,
         programEmitPending: state.programEmitPending,
         emitSignatures: state.emitSignatures && new Map(state.emitSignatures),
         outSignature: state.outSignature,
@@ -584,6 +602,7 @@ function backupBuilderProgramEmitState(state: Readonly<BuilderProgramState>): Sa
 function restoreBuilderProgramEmitState(state: BuilderProgramState, savedEmitState: SavedBuildProgramEmitState) {
     state.affectedFilesPendingEmit = savedEmitState.affectedFilesPendingEmit;
     state.seenEmittedFiles = savedEmitState.seenEmittedFiles;
+    state.seenProgramEmit = savedEmitState.seenProgramEmit;
     state.programEmitPending = savedEmitState.programEmitPending;
     state.emitSignatures = savedEmitState.emitSignatures;
     state.outSignature = savedEmitState.outSignature;
@@ -592,13 +611,17 @@ function restoreBuilderProgramEmitState(state: BuilderProgramState, savedEmitSta
     state.buildInfoEmitPending = savedEmitState.buildInfoEmitPending;
     state.emitDiagnosticsPerFile = savedEmitState.emitDiagnosticsPerFile;
     if (savedEmitState.changedFilesSet) state.changedFilesSet = savedEmitState.changedFilesSet;
+    if (state.compilerOptions.outFile && state.changedFilesSet.size) {
+        state.semanticDiagnosticsPerFile.clear();
+        state.emitDiagnosticsPerFile = undefined;
+    }
 }
 
 /**
  * Verifies that source file is ok to be used in calls that arent handled by next
  */
 function assertSourceFileOkWithoutNextAffectedCall(state: BuilderProgramState, sourceFile: SourceFile | undefined) {
-    Debug.assert(!sourceFile || !state.affectedFiles || state.affectedFiles[state.affectedFilesIndex! - 1] !== sourceFile || !state.semanticDiagnosticsPerFile!.has(sourceFile.resolvedPath));
+    Debug.assert(!sourceFile || !state.affectedFiles || state.affectedFiles[state.affectedFilesIndex! - 1] !== sourceFile || !state.semanticDiagnosticsPerFile.has(sourceFile.resolvedPath));
 }
 
 /**
@@ -653,10 +676,7 @@ function getNextAffectedFile(
         // so operations are performed directly on program, return program
         const program = Debug.checkDefined(state.program);
         const compilerOptions = program.getCompilerOptions();
-        if (compilerOptions.outFile) {
-            Debug.assert(!state.semanticDiagnosticsPerFile);
-            return program;
-        }
+        if (compilerOptions.outFile) return program;
 
         // Get next batch of affected files
         state.affectedFiles = BuilderState.getFilesAffectedByWithOldState(
@@ -673,14 +693,23 @@ function getNextAffectedFile(
 }
 
 function clearAffectedFilesPendingEmit(state: BuilderProgramState, emitOnlyDtsFiles: boolean | undefined) {
-    if (!state.affectedFilesPendingEmit?.size) return;
-    if (!emitOnlyDtsFiles) return state.affectedFilesPendingEmit = undefined;
-    state.affectedFilesPendingEmit.forEach((emitKind, path) => {
+    if (!state.affectedFilesPendingEmit?.size && !state.programEmitPending) return;
+    if (!emitOnlyDtsFiles) {
+        state.affectedFilesPendingEmit = undefined;
+        state.programEmitPending = undefined;
+    }
+    state.affectedFilesPendingEmit?.forEach((emitKind, path) => {
         // Mark the files as pending only if they are pending on js files, remove the dts emit pending flag
         const pending = emitKind & BuilderFileEmit.AllJs;
         if (!pending) state.affectedFilesPendingEmit!.delete(path);
         else state.affectedFilesPendingEmit!.set(path, pending);
     });
+    // Mark the program as pending only if its pending on js files, remove the dts emit pending flag
+    if (state.programEmitPending) {
+        const pending = state.programEmitPending & BuilderFileEmit.AllJs;
+        if (!pending) state.programEmitPending = undefined;
+        else state.programEmitPending = pending;
+    }
 }
 
 /**
@@ -812,7 +841,7 @@ function removeSemanticDiagnosticsOf(state: BuilderProgramState, path: Path) {
         return true;
     }
     state.semanticDiagnosticsFromOldState.delete(path);
-    state.semanticDiagnosticsPerFile!.delete(path);
+    state.semanticDiagnosticsPerFile.delete(path);
     return !state.semanticDiagnosticsFromOldState.size;
 }
 
@@ -950,9 +979,14 @@ function handleDtsMayChangeOfFileAndExportsOfFile(
  * Gets semantic diagnostics for the file which are
  * bindAndCheckDiagnostics (from cache) and program diagnostics
  */
-function getSemanticDiagnosticsOfFile(state: BuilderProgramState, sourceFile: SourceFile, cancellationToken?: CancellationToken): readonly Diagnostic[] {
+function getSemanticDiagnosticsOfFile(
+    state: BuilderProgramState,
+    sourceFile: SourceFile,
+    cancellationToken: CancellationToken | undefined,
+    semanticDiagnosticsPerFile?: BuilderProgramState["semanticDiagnosticsPerFile"],
+): readonly Diagnostic[] {
     return concatenate(
-        getBinderAndCheckerDiagnosticsOfFile(state, sourceFile, cancellationToken),
+        getBinderAndCheckerDiagnosticsOfFile(state, sourceFile, cancellationToken, semanticDiagnosticsPerFile),
         Debug.checkDefined(state.program).getProgramDiagnostics(sourceFile),
     );
 }
@@ -961,21 +995,23 @@ function getSemanticDiagnosticsOfFile(state: BuilderProgramState, sourceFile: So
  * Gets the binder and checker diagnostics either from cache if present, or otherwise from program and caches it
  * Note that it is assumed that when asked about binder and checker diagnostics, the file has been taken out of affected files/changed file set
  */
-function getBinderAndCheckerDiagnosticsOfFile(state: BuilderProgramState, sourceFile: SourceFile, cancellationToken?: CancellationToken): readonly Diagnostic[] {
+function getBinderAndCheckerDiagnosticsOfFile(
+    state: BuilderProgramState,
+    sourceFile: SourceFile,
+    cancellationToken: CancellationToken | undefined,
+    semanticDiagnosticsPerFile: BuilderProgramState["semanticDiagnosticsPerFile"] | undefined,
+): readonly Diagnostic[] {
+    semanticDiagnosticsPerFile ??= state.semanticDiagnosticsPerFile;
     const path = sourceFile.resolvedPath;
-    if (state.semanticDiagnosticsPerFile) {
-        const cachedDiagnostics = state.semanticDiagnosticsPerFile.get(path);
-        // Report the bind and check diagnostics from the cache if we already have those diagnostics present
-        if (cachedDiagnostics) {
-            return filterSemanticDiagnostics(cachedDiagnostics, state.compilerOptions);
-        }
+    const cachedDiagnostics = semanticDiagnosticsPerFile.get(path);
+    // Report the bind and check diagnostics from the cache if we already have those diagnostics present
+    if (cachedDiagnostics) {
+        return filterSemanticDiagnostics(cachedDiagnostics, state.compilerOptions);
     }
 
     // Diagnostics werent cached, get them from program, and cache the result
     const diagnostics = Debug.checkDefined(state.program).getBindAndCheckDiagnostics(sourceFile, cancellationToken);
-    if (state.semanticDiagnosticsPerFile) {
-        state.semanticDiagnosticsPerFile.set(path, diagnostics);
-    }
+    semanticDiagnosticsPerFile.set(path, diagnostics);
     return filterSemanticDiagnostics(diagnostics, state.compilerOptions);
 }
 
@@ -1071,6 +1107,9 @@ export interface ProgramBundleEmitBuildInfo {
     root: readonly ProgramBuildInfoRoot[];
     resolvedRoot: readonly ProgramBuildInfoResolvedRoot[] | undefined;
     options: CompilerOptions | undefined;
+    semanticDiagnosticsPerFile: ProgramBuildInfoDiagnostic[] | undefined;
+    emitDiagnosticsPerFile: ProgramBuildInfoEmitDiagnostic[] | undefined;
+    changeFileSet: readonly ProgramBuildInfoFileId[] | undefined;
     outSignature: EmitSignature | undefined;
     latestChangedDtsFile: string | undefined;
     pendingEmit: ProgramBuildInfoBundlePendingEmit | undefined;
@@ -1113,6 +1152,9 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             root,
             resolvedRoot: toResolvedRoot(),
             options: convertToProgramBuildInfoCompilerOptions(state.compilerOptions),
+            semanticDiagnosticsPerFile: convertToProgramBuildInfoDiagnostics(),
+            emitDiagnosticsPerFile: convertToProgramBuildInfoEmitDiagnostics(),
+            changeFileSet: toChangeFileSet(),
             outSignature: state.outSignature,
             latestChangedDtsFile,
             pendingEmit: !state.programEmitPending ?
@@ -1195,13 +1237,6 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
         }
     }
 
-    let changeFileSet: ProgramBuildInfoFileId[] | undefined;
-    if (state.changedFilesSet.size) {
-        for (const path of arrayFrom(state.changedFilesSet.keys()).sort(compareStringsCaseSensitive)) {
-            changeFileSet = append(changeFileSet, toFileId(path));
-        }
-    }
-    const emitDiagnosticsPerFile = convertToProgramBuildInfoEmitDiagnostics();
     const program: ProgramMultiFileEmitBuildInfo = {
         fileNames,
         fileInfos,
@@ -1211,9 +1246,9 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
         fileIdsList,
         referencedMap,
         semanticDiagnosticsPerFile,
-        emitDiagnosticsPerFile,
+        emitDiagnosticsPerFile: convertToProgramBuildInfoEmitDiagnostics(),
         affectedFilesPendingEmit,
-        changeFileSet,
+        changeFileSet: toChangeFileSet(),
         emitSignatures,
         latestChangedDtsFile,
     };
@@ -1314,7 +1349,7 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
     function convertToProgramBuildInfoDiagnostics() {
         let result: ProgramBuildInfoDiagnostic[] | undefined;
         state.fileInfos.forEach((_value, key) => {
-            const value = state.semanticDiagnosticsPerFile?.get(key);
+            const value = state.semanticDiagnosticsPerFile.get(key);
             if (!value) {
                 if (!state.changedFilesSet.has(key)) result = append(result, toFileId(key));
             }
@@ -1395,6 +1430,16 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             }
             return result;
         }) || array;
+    }
+
+    function toChangeFileSet() {
+        let changeFileSet: ProgramBuildInfoFileId[] | undefined;
+        if (state.changedFilesSet.size) {
+            for (const path of arrayFrom(state.changedFilesSet.keys()).sort(compareStringsCaseSensitive)) {
+                changeFileSet = append(changeFileSet, toFileId(path));
+            }
+        }
+        return changeFileSet;
     }
 }
 
@@ -1561,7 +1606,11 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
         if (!affected) {
             if (!state.compilerOptions.outFile) {
                 const pendingAffectedFile = getNextAffectedFilePendingEmit(state, emitOnlyDtsFiles);
-                if (!pendingAffectedFile) {
+                if (pendingAffectedFile) {
+                    // Emit pending affected file
+                    ({ affectedFile: affected, emitKind } = pendingAffectedFile);
+                }
+                else {
                     const pendingForDiagnostics = getNextPendingEmitDiagnosticsFile(state);
                     if (pendingForDiagnostics) {
                         (state.seenEmittedFiles ??= new Map()).set(pendingForDiagnostics.affectedFile.resolvedPath, pendingForDiagnostics.seenKind | BuilderFileEmit.AllDts);
@@ -1570,44 +1619,52 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
                             affected: pendingForDiagnostics.affectedFile,
                         };
                     }
-                    // Emit buildinfo if pending
-                    if (!state.buildInfoEmitPending) return undefined;
-                    const affected = state.program!;
-                    const result = affected.emitBuildInfo(writeFile || maybeBind(host, host.writeFile), cancellationToken);
-                    state.buildInfoEmitPending = false;
-                    return { result, affected };
                 }
-                // Emit pending affected file
-                ({ affectedFile: affected, emitKind } = pendingAffectedFile);
             }
             else {
                 // Emit program if it was pending emit
-                if (!state.programEmitPending) return undefined;
-                emitKind = state.programEmitPending;
-                if (emitOnlyDtsFiles) emitKind = emitKind & BuilderFileEmit.AllDts;
-                if (!emitKind) return undefined;
-                affected = state.program!;
+                if (state.programEmitPending) {
+                    emitKind = state.programEmitPending;
+                    if (emitOnlyDtsFiles) emitKind = emitKind & BuilderFileEmit.AllDts;
+                    if (emitKind) affected = state.program!;
+                }
+                // Pending emit diagnostics
+                if (!affected && state.emitDiagnosticsPerFile?.size) {
+                    const seenKind = state.seenProgramEmit || BuilderFileEmit.None;
+                    if (!(seenKind & BuilderFileEmit.AllDts)) {
+                        state.seenProgramEmit = BuilderFileEmit.AllDts | seenKind;
+                        const diagnostics: Diagnostic[] = [];
+                        state.emitDiagnosticsPerFile.forEach(d => addRange(diagnostics, d));
+                        return {
+                            result: { emitSkipped: true, diagnostics },
+                            affected: state.program!,
+                        };
+                    }
+                }
+            }
+
+            if (!affected) {
+                // Emit buildinfo if pending
+                if (!state.buildInfoEmitPending) return undefined;
+                const affected = state.program!;
+                const result = affected.emitBuildInfo(writeFile || maybeBind(host, host.writeFile), cancellationToken);
+                state.buildInfoEmitPending = false;
+                return { result, affected };
             }
         }
         // Determine if we can do partial emit
         let emitOnly: EmitOnly | undefined;
         if (emitKind & BuilderFileEmit.AllJs) emitOnly = EmitOnly.Js;
         if (emitKind & BuilderFileEmit.AllDts) emitOnly = emitOnly === undefined ? EmitOnly.Dts : undefined;
-        if (affected === state.program) {
-            // Set up programEmit before calling emit so that its set in buildInfo
-            state.programEmitPending = state.changedFilesSet.size ?
-                getPendingEmitKind(programEmitKind, emitKind) :
-                state.programEmitPending ?
-                getPendingEmitKind(state.programEmitPending, emitKind) :
-                undefined;
-        }
-        // Actual emit
+        // Actual emit without buildInfo as we want to emit it later so the state is updated
         const result = state.program!.emit(
             affected === state.program ? undefined : affected as SourceFile,
             getWriteFileCallback(writeFile, customTransformers),
             cancellationToken,
             emitOnly,
             customTransformers,
+            /*forceDtsEmit*/ undefined,
+            /*skipBuildInfo*/ true,
         );
         if (affected !== state.program) {
             // update affected files
@@ -1626,8 +1683,26 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
             if (result.diagnostics.length) (state.emitDiagnosticsPerFile ??= new Map()).set(affectedSourceFile.resolvedPath, result.diagnostics);
         }
         else {
-            // In program clear our changed files since any emit handles all changes
+            // No more changes remaining to emit
             state.changedFilesSet.clear();
+            // Update program emit kind
+            state.programEmitPending = state.changedFilesSet.size ?
+                getPendingEmitKind(programEmitKind, emitKind) :
+                state.programEmitPending ?
+                getPendingEmitKind(state.programEmitPending, emitKind) :
+                undefined;
+            state.seenProgramEmit = emitKind | (state.seenProgramEmit || BuilderFileEmit.None);
+            // Update the d.ts diagnostics since they always come with Location, skip diagnsotics without file,
+            // they could be semantic diagnsotic with noEmitOnError or other kind of diagnostics
+            let emitDiagnosticsPerFile: Map<Path, Diagnostic[]> | undefined;
+            result.diagnostics.forEach(d => {
+                if (!d.file) return; // Dont cache without fileName
+                let diagnostics = emitDiagnosticsPerFile?.get(d.file.resolvedPath);
+                if (!diagnostics) (emitDiagnosticsPerFile ??= new Map()).set(d.file.resolvedPath, diagnostics = []);
+                diagnostics.push(d);
+            });
+            if (emitDiagnosticsPerFile) state.emitDiagnosticsPerFile = emitDiagnosticsPerFile;
+            state.buildInfoEmitPending = true;
         }
         return { result, affected };
     }
@@ -1791,9 +1866,24 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
             }
             else {
                 // When whole program is affected, get all semantic diagnostics (eg when --out or --outFile is specified)
-                result = state.program.getSemanticDiagnostics(/*sourceFile*/ undefined, cancellationToken);
+                let diagnostics: Diagnostic[] | undefined;
+                const semanticDiagnosticsPerFile: BuilderProgramState["semanticDiagnosticsPerFile"] = new Map();
+                state.program.getSourceFiles().forEach(sourceFile =>
+                    diagnostics = addRange(
+                        diagnostics,
+                        getSemanticDiagnosticsOfFile(
+                            state,
+                            sourceFile,
+                            cancellationToken,
+                            semanticDiagnosticsPerFile,
+                        ),
+                    )
+                );
+                state.semanticDiagnosticsPerFile = semanticDiagnosticsPerFile;
+                result = diagnostics || emptyArray;
                 state.changedFilesSet.clear();
                 state.programEmitPending = getBuilderFileEmit(state.compilerOptions);
+                state.buildInfoEmitPending = true;
             }
             return { result, affected };
         }
@@ -1809,21 +1899,17 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
      */
     function getSemanticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): readonly Diagnostic[] {
         assertSourceFileOkWithoutNextAffectedCall(state, sourceFile);
-        const compilerOptions = Debug.checkDefined(state.program).getCompilerOptions();
-        if (compilerOptions.outFile) {
-            Debug.assert(!state.semanticDiagnosticsPerFile);
-            // We dont need to cache the diagnostics just return them from program
-            return Debug.checkDefined(state.program).getSemanticDiagnostics(sourceFile, cancellationToken);
-        }
-
         if (sourceFile) {
             return getSemanticDiagnosticsOfFile(state, sourceFile, cancellationToken);
         }
 
         // When semantic builder asks for diagnostics of the whole program,
         // ensure that all the affected files are handled
-        // eslint-disable-next-line no-empty
-        while (getSemanticDiagnosticsOfNextAffectedFile(cancellationToken)) {
+        while (true) {
+            const affectedResult = getSemanticDiagnosticsOfNextAffectedFile(cancellationToken);
+            if (!affectedResult) break;
+            // If we already calculated diagnostics for all files, return them
+            if (affectedResult.affected === state.program) return affectedResult.result;
         }
 
         let diagnostics: Diagnostic[] | undefined;
@@ -1869,8 +1955,9 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
     const filePaths = program.fileNames?.map(toPathInBuildInfoDirectory);
     let filePathsSetList: Set<Path>[] | undefined;
     const latestChangedDtsFile = program.latestChangedDtsFile ? toAbsolutePath(program.latestChangedDtsFile) : undefined;
+    const fileInfos = new Map<Path, BuilderState.FileInfo>();
+    const changedFilesSet = new Set(map(program.changeFileSet, toFilePath));
     if (isProgramBundleEmitBuildInfo(program)) {
-        const fileInfos = new Map<Path, BuilderState.FileInfo>();
         program.fileInfos.forEach((fileInfo, index) => {
             const path = toFilePath(index + 1 as ProgramBuildInfoFileId);
             fileInfos.set(path, isString(fileInfo) ? { version: fileInfo, signature: undefined, affectsGlobalScope: undefined, impliedFormat: undefined } : fileInfo);
@@ -1878,6 +1965,10 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
         state = {
             fileInfos,
             compilerOptions: program.options ? convertToOptionsWithAbsolutePaths(program.options, toAbsolutePath) : {},
+            semanticDiagnosticsPerFile: toPerFileSemanticDiagnostics(program.semanticDiagnosticsPerFile),
+            emitDiagnosticsPerFile: toPerFileEmitDiagnostics(program.emitDiagnosticsPerFile),
+            hasReusableDiagnostic: true,
+            changedFilesSet,
             latestChangedDtsFile,
             outSignature: program.outSignature,
             programEmitPending: program.pendingEmit === undefined ? undefined : toProgramEmitPending(program.pendingEmit, program.options),
@@ -1885,7 +1976,6 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
     }
     else {
         filePathsSetList = program.fileIdsList?.map(fileIds => new Set(fileIds.map(toFilePath)));
-        const fileInfos = new Map<Path, BuilderState.FileInfo>();
         const emitSignatures = program.options?.composite && !program.options.outFile ? new Map<Path, EmitSignature>() : undefined;
         program.fileInfos.forEach((fileInfo, index) => {
             const path = toFilePath(index + 1 as ProgramBuildInfoFileId);
@@ -1906,13 +1996,12 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
                 );
             }
         });
-        const changedFilesSet = new Set(map(program.changeFileSet, toFilePath));
         const fullEmitForOptions = program.affectedFilesPendingEmit ? getBuilderFileEmit(program.options || {}) : undefined;
         state = {
             fileInfos,
             compilerOptions: program.options ? convertToOptionsWithAbsolutePaths(program.options, toAbsolutePath) : {},
             referencedMap: toManyToManyPathMap(program.referencedMap, program.options ?? {}),
-            semanticDiagnosticsPerFile: toPerFileSemanticDiagnostics(program.semanticDiagnosticsPerFile, fileInfos, changedFilesSet),
+            semanticDiagnosticsPerFile: toPerFileSemanticDiagnostics(program.semanticDiagnosticsPerFile),
             emitDiagnosticsPerFile: toPerFileEmitDiagnostics(program.emitDiagnosticsPerFile),
             hasReusableDiagnostic: true,
             affectedFilesPendingEmit: program.affectedFilesPendingEmit && arrayToMap(program.affectedFilesPendingEmit, value => toFilePath(isNumber(value) ? value : value[0]), value => toBuilderFileEmit(value, fullEmitForOptions!)),
@@ -1973,9 +2062,7 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
 
     function toPerFileSemanticDiagnostics(
         diagnostics: readonly ProgramBuildInfoDiagnostic[] | undefined,
-        fileInfos: Map<Path, BuilderState.FileInfo>,
-        changedFilesSet: Set<Path>,
-    ): Map<Path, readonly ReusableDiagnostic[]> | undefined {
+    ) {
         const semanticDiagnostics = new Map<Path, readonly ReusableDiagnostic[]>(
             mapDefinedIterator(
                 fileInfos.keys(),
@@ -1986,7 +2073,7 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
             if (isNumber(value)) semanticDiagnostics.delete(toFilePath(value));
             else semanticDiagnostics.set(toFilePath(value[0]), value[1]);
         });
-        return semanticDiagnostics.size ? semanticDiagnostics : undefined;
+        return semanticDiagnostics;
     }
 
     function toPerFileEmitDiagnostics(diagnostics: readonly ProgramBuildInfoEmitDiagnostic[] | undefined): Map<Path, readonly ReusableDiagnostic[]> | undefined {

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -1452,7 +1452,6 @@ function buildErrors<T extends BuilderProgram>(
     buildResult: BuildResultFlags,
     errorType: string,
 ) {
-    // Since buildinfo has changeset and diagnostics when doing multi file emit, only --out cannot emit buildinfo if it has errors
     reportAndStoreErrors(state, resolvedPath, diagnostics);
     state.projectStatus.set(resolvedPath, { type: UpToDateStatusType.Unbuildable, reason: `${errorType} errors` });
     return { buildResult, step: BuildStep.EmitBuildInfo };

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -90,6 +90,7 @@ import {
     PollingInterval,
     Program,
     ProgramBuildInfo,
+    ProgramBundleEmitBuildInfo,
     ProgramHost,
     ProgramMultiFileEmitBuildInfo,
     ProgramUpdateLevel,
@@ -1074,8 +1075,6 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
             ({ buildResult, step } = buildErrors(
                 state,
                 projectPath,
-                program,
-                config,
                 diagnostics,
                 errorFlags,
                 errorType,
@@ -1132,8 +1131,6 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
             ({ buildResult, step } = buildErrors(
                 state,
                 projectPath,
-                program,
-                config,
                 declDiagnostics,
                 BuildResultFlags.DeclarationEmitErrors,
                 "Declaration file",
@@ -1208,8 +1205,6 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
             ({ buildResult, step } = buildErrors(
                 state,
                 projectPath,
-                program,
-                config,
                 emitDiagnostics,
                 BuildResultFlags.EmitErrors,
                 "Emit",
@@ -1453,20 +1448,14 @@ function afterProgramDone<T extends BuilderProgram>(
 function buildErrors<T extends BuilderProgram>(
     state: SolutionBuilderState<T>,
     resolvedPath: ResolvedConfigFilePath,
-    program: T | undefined,
-    config: ParsedCommandLine,
     diagnostics: readonly Diagnostic[],
     buildResult: BuildResultFlags,
     errorType: string,
 ) {
     // Since buildinfo has changeset and diagnostics when doing multi file emit, only --out cannot emit buildinfo if it has errors
-    const canEmitBuildInfo = program && !program.getCompilerOptions().outFile;
-
     reportAndStoreErrors(state, resolvedPath, diagnostics);
     state.projectStatus.set(resolvedPath, { type: UpToDateStatusType.Unbuildable, reason: `${errorType} errors` });
-    if (canEmitBuildInfo) return { buildResult, step: BuildStep.EmitBuildInfo };
-    afterProgramDone(state, program);
-    return { buildResult, step: BuildStep.QueueReferencingProjects };
+    return { buildResult, step: BuildStep.EmitBuildInfo };
 }
 
 function isFileWatcherWithModifiedTime(value: FileWatcherWithModifiedTime | Date): value is FileWatcherWithModifiedTime {
@@ -1692,11 +1681,12 @@ function getUpToDateStatusWorker<T extends BuilderProgram>(state: SolutionBuilde
             // But if noEmit is true, affectedFilesPendingEmit will have file list even if there are no semantic errors to preserve list of files to be emitted when running with noEmit false
             // So with noEmit set to true, check on semantic diagnostics needs to be explicit as oppose to when it is false when only files pending emit is sufficient
             if (
-                (buildInfo.program as ProgramMultiFileEmitBuildInfo).changeFileSet?.length ||
+                buildInfo.program.changeFileSet?.length ||
                 (!project.options.noEmit ?
                     (buildInfo.program as ProgramMultiFileEmitBuildInfo).affectedFilesPendingEmit?.length ||
-                    (buildInfo.program as ProgramMultiFileEmitBuildInfo).emitDiagnosticsPerFile?.length :
-                    (buildInfo.program as ProgramMultiFileEmitBuildInfo).semanticDiagnosticsPerFile?.length)
+                    buildInfo.program.emitDiagnosticsPerFile?.length ||
+                    (buildInfo.program as ProgramBundleEmitBuildInfo).pendingEmit !== undefined :
+                    buildInfo.program.semanticDiagnosticsPerFile?.length)
             ) {
                 return {
                     type: UpToDateStatusType.OutOfDateBuildInfo,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4707,7 +4707,7 @@ export interface Program extends ScriptReferenceHost {
      */
     emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
     /** @internal */
-    emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnly?: boolean | EmitOnly, customTransformers?: CustomTransformers, forceDtsEmit?: boolean): EmitResult;
+    emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnly?: boolean | EmitOnly, customTransformers?: CustomTransformers, forceDtsEmit?: boolean, skipBuildInfo?: boolean): EmitResult;
 
     getOptionsDiagnostics(cancellationToken?: CancellationToken): readonly Diagnostic[];
     getGlobalDiagnostics(cancellationToken?: CancellationToken): readonly Diagnostic[];

--- a/src/testRunner/unittests/helpers/baseline.ts
+++ b/src/testRunner/unittests/helpers/baseline.ts
@@ -74,7 +74,7 @@ function baselineProgram(baseline: string[], [program, builderProgram]: CommandL
     if (builderProgram !== oldProgram?.[1]) {
         const state = builderProgram.getState();
         const internalState = state as unknown as ts.BuilderProgramState;
-        if (state.semanticDiagnosticsPerFile?.size) {
+        if (state.semanticDiagnosticsPerFile.size) {
             baseline.push("Semantic diagnostics in builder refreshed for::");
             for (const file of program.getSourceFiles()) {
                 if (!internalState.semanticDiagnosticsFromOldState || !internalState.semanticDiagnosticsFromOldState.has(file.resolvedPath)) {
@@ -154,25 +154,53 @@ export type ReadableProgramBuildInfoResolvedRoot = [
     original: ts.ProgramBuildInfoResolvedRoot,
     readable: [resolved: string, root: string],
 ];
-export type ReadableProgramMultiFileEmitBuildInfo = Omit<ts.ProgramMultiFileEmitBuildInfo, "fileIdsList" | "fileInfos" | "root" | "resolvedRoot" | "referencedMap" | "semanticDiagnosticsPerFile" | "emitDiagnosticsPerFile" | "affectedFilesPendingEmit" | "changeFileSet" | "emitSignatures"> & {
-    fileNamesList: readonly (readonly string[])[] | undefined;
-    fileInfos: ts.MapLike<ReadableProgramBuildInfoFileInfo<ts.ProgramMultiFileEmitBuildInfoFileInfo>>;
-    root: readonly ReadableProgramBuildInfoRoot[];
-    resolvedRoot: readonly ReadableProgramBuildInfoResolvedRoot[] | undefined;
-    referencedMap: ts.MapLike<string[]> | undefined;
-    semanticDiagnosticsPerFile: readonly ReadableProgramBuildInfoDiagnostic[] | undefined;
-    emitDiagnosticsPerFile: readonly ReadableProgramBuildInfoEmitDiagnostic[] | undefined;
-    affectedFilesPendingEmit: readonly ReadableProgramBuilderInfoFilePendingEmit[] | undefined;
-    changeFileSet: readonly string[] | undefined;
-    emitSignatures: readonly ReadableProgramBuildInfoEmitSignature[] | undefined;
-};
+export type ReadableProgramMultiFileEmitBuildInfo =
+    & Omit<
+        ts.ProgramMultiFileEmitBuildInfo,
+        | "fileIdsList"
+        | "fileInfos"
+        | "root"
+        | "resolvedRoot"
+        | "referencedMap"
+        | "semanticDiagnosticsPerFile"
+        | "emitDiagnosticsPerFile"
+        | "affectedFilesPendingEmit"
+        | "changeFileSet"
+        | "emitSignatures"
+    >
+    & {
+        fileNamesList: readonly (readonly string[])[] | undefined;
+        fileInfos: ts.MapLike<ReadableProgramBuildInfoFileInfo<ts.ProgramMultiFileEmitBuildInfoFileInfo>>;
+        root: readonly ReadableProgramBuildInfoRoot[];
+        resolvedRoot: readonly ReadableProgramBuildInfoResolvedRoot[] | undefined;
+        referencedMap: ts.MapLike<string[]> | undefined;
+        semanticDiagnosticsPerFile: readonly ReadableProgramBuildInfoDiagnostic[] | undefined;
+        emitDiagnosticsPerFile: readonly ReadableProgramBuildInfoEmitDiagnostic[] | undefined;
+        affectedFilesPendingEmit: readonly ReadableProgramBuilderInfoFilePendingEmit[] | undefined;
+        changeFileSet: readonly string[] | undefined;
+        emitSignatures: readonly ReadableProgramBuildInfoEmitSignature[] | undefined;
+    };
 export type ReadableProgramBuildInfoBundlePendingEmit = [emitKind: ReadableBuilderFileEmit, original: ts.ProgramBuildInfoBundlePendingEmit];
-export type ReadableProgramBundleEmitBuildInfo = Omit<ts.ProgramBundleEmitBuildInfo, "fileInfos" | "root" | "resolvedRoot" | "pendingEmit"> & {
-    fileInfos: ts.MapLike<string | ReadableProgramBuildInfoFileInfo<ts.BuilderState.FileInfo>>;
-    root: readonly ReadableProgramBuildInfoRoot[];
-    resolvedRoot: readonly ReadableProgramBuildInfoResolvedRoot[] | undefined;
-    pendingEmit: ReadableProgramBuildInfoBundlePendingEmit | undefined;
-};
+export type ReadableProgramBundleEmitBuildInfo =
+    & Omit<
+        ts.ProgramBundleEmitBuildInfo,
+        | "fileInfos"
+        | "root"
+        | "resolvedRoot"
+        | "semanticDiagnosticsPerFile"
+        | "emitDiagnosticsPerFile"
+        | "changeFileSet"
+        | "pendingEmit"
+    >
+    & {
+        fileInfos: ts.MapLike<string | ReadableProgramBuildInfoFileInfo<ts.BuilderState.FileInfo>>;
+        root: readonly ReadableProgramBuildInfoRoot[];
+        resolvedRoot: readonly ReadableProgramBuildInfoResolvedRoot[] | undefined;
+        semanticDiagnosticsPerFile: readonly ReadableProgramBuildInfoDiagnostic[] | undefined;
+        emitDiagnosticsPerFile: readonly ReadableProgramBuildInfoEmitDiagnostic[] | undefined;
+        changeFileSet: readonly string[] | undefined;
+        pendingEmit: ReadableProgramBuildInfoBundlePendingEmit | undefined;
+    };
 
 export type ReadableProgramBuildInfo = ReadableProgramMultiFileEmitBuildInfo | ReadableProgramBundleEmitBuildInfo;
 
@@ -196,6 +224,9 @@ function generateBuildInfoProgramBaseline(sys: ts.System, buildInfoPath: string,
             fileInfos,
             root: buildInfo.program.root.map(toReadableProgramBuildInfoRoot),
             resolvedRoot: buildInfo.program.resolvedRoot?.map(toReadableProgramBuildInfoResolvedRoot),
+            semanticDiagnosticsPerFile: toReadableProgramBuildInfoDiagnosticsPerFile(buildInfo.program.semanticDiagnosticsPerFile),
+            emitDiagnosticsPerFile: toReadableProgramBuildInfoEmitDiagnosticsPerFile(buildInfo.program.emitDiagnosticsPerFile),
+            changeFileSet: buildInfo.program.changeFileSet?.map(toFileName),
             pendingEmit: pendingEmit === undefined ?
                 undefined :
                 [

--- a/src/testRunner/unittests/tsbuild/commandLine.ts
+++ b/src/testRunner/unittests/tsbuild/commandLine.ts
@@ -36,16 +36,6 @@ describe("unittests:: tsbuild:: commandLine::", () => {
                 ],
             };
         }
-        function withEmitDeclarationOnlyChangeAndDiscrepancyExplanation(caption: string): TestTscEdit {
-            const edit = withOptionChangeAndDiscrepancyExplanation(caption, "--emitDeclarationOnly");
-            const discrepancyExplanation = edit.discrepancyExplanation!;
-            edit.discrepancyExplanation = () => [
-                ...discrepancyExplanation(),
-                `Clean build info does not have js section because its fresh build`,
-                `Incremental build info has js section from old build`,
-            ];
-            return edit;
-        }
         function nochangeWithIncrementalDeclarationFromBeforeExplaination(): TestTscEdit {
             return {
                 ...noChangeRun,
@@ -54,16 +44,6 @@ describe("unittests:: tsbuild:: commandLine::", () => {
                     `Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap`,
                 ],
             };
-        }
-        function nochangeWithIncrementalOutDeclarationFromBeforeExplaination(): TestTscEdit {
-            const edit = nochangeWithIncrementalDeclarationFromBeforeExplaination();
-            const discrepancyExplanation = edit.discrepancyExplanation!;
-            edit.discrepancyExplanation = () => [
-                ...discrepancyExplanation(),
-                `Clean build does not have dts bundle section`,
-                `Incremental build contains the dts build section from before`,
-            ];
-            return edit;
         }
         function localChange(): TestTscEdit {
             return {
@@ -96,7 +76,7 @@ describe("unittests:: tsbuild:: commandLine::", () => {
                     withOptionChangeAndDiscrepancyExplanation("with emitDeclarationOnly should not emit anything", "--emitDeclarationOnly"),
                     noChangeRun,
                     localChange(),
-                    !options.outFile ? withOptionChangeAndDiscrepancyExplanation("with declaration should not emit anything", "--declaration") : withEmitDeclarationOnlyChangeAndDiscrepancyExplanation("with emitDeclarationOnly should not emit anything"),
+                    withOptionChangeAndDiscrepancyExplanation("with declaration should not emit anything", "--declaration"),
                     withOptionChange("with inlineSourceMap", "--inlineSourceMap"),
                     withOptionChange("with sourceMap", "--sourceMap"),
                 ],
@@ -112,10 +92,10 @@ describe("unittests:: tsbuild:: commandLine::", () => {
                     withOptionChange("should re-emit only js so they dont contain sourcemap"),
                     withOptionChange("with declaration, emit Dts and should not emit js", "--declaration"),
                     withOptionChange("with declaration and declarationMap", "--declaration", "--declarationMap"),
-                    !options.outFile ? nochangeWithIncrementalDeclarationFromBeforeExplaination() : nochangeWithIncrementalOutDeclarationFromBeforeExplaination(),
+                    nochangeWithIncrementalDeclarationFromBeforeExplaination(),
                     localChange(),
                     withOptionChange("with declaration and declarationMap", "--declaration", "--declarationMap"),
-                    !options.outFile ? nochangeWithIncrementalDeclarationFromBeforeExplaination() : nochangeWithIncrementalOutDeclarationFromBeforeExplaination(),
+                    nochangeWithIncrementalDeclarationFromBeforeExplaination(),
                     withOptionChange("with inlineSourceMap", "--inlineSourceMap"),
                     withOptionChange("with sourceMap", "--sourceMap"),
                     noChangeWithSubscenario("emit js files"),

--- a/src/testRunner/unittests/tsbuild/configFileErrors.ts
+++ b/src/testRunner/unittests/tsbuild/configFileErrors.ts
@@ -74,10 +74,10 @@ describe("unittests:: tsbuild:: configFileErrors:: reports syntax errors in conf
         "declaration": true,`,
                         ),
                     caption: "reports syntax errors after change to config file",
-                    discrepancyExplanation: !outFile ? () => [
+                    discrepancyExplanation: () => [
                         "During incremental build, tsbuildinfo is not emitted, so declaration option is not present",
                         "Clean build has declaration option in tsbuildinfo",
-                    ] : undefined,
+                    ],
                 },
                 {
                     edit: fs => appendText(fs, "/src/a.ts", "export function fooBar() { }"),

--- a/src/testRunner/unittests/tsbuild/fileDelete.ts
+++ b/src/testRunner/unittests/tsbuild/fileDelete.ts
@@ -63,6 +63,10 @@ describe("unittests:: tsbuild:: fileDelete::", () => {
         edits: [{
             caption: "delete child2 file",
             edit: fs => fs.rimrafSync("/src/child/child2.ts"),
+            discrepancyExplanation: () => [
+                "Clean build will not have latestChangedDtsFile as there was no emit and outSignature as undefined for files",
+                "Incremental will store the past latestChangedDtsFile and outSignature",
+            ],
         }],
     });
 

--- a/src/testRunner/unittests/tsc/incremental.ts
+++ b/src/testRunner/unittests/tsc/incremental.ts
@@ -443,16 +443,6 @@ console.log(a);`,
                 ],
             };
         }
-        function withEmitDeclarationOnlyChangeAndDiscrepancyExplanation(caption: string): TestTscEdit {
-            const edit = withOptionChangeAndDiscrepancyExplanation(caption, "--emitDeclarationOnly");
-            const discrepancyExplanation = edit.discrepancyExplanation!;
-            edit.discrepancyExplanation = () => [
-                ...discrepancyExplanation(),
-                `Clean build info does not have js section because its fresh build`,
-                `Incremental build info has js section from old build`,
-            ];
-            return edit;
-        }
         function nochangeWithIncrementalDeclarationFromBeforeExplaination(): TestTscEdit {
             return {
                 ...noChangeRun,
@@ -461,16 +451,6 @@ console.log(a);`,
                     `Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap`,
                 ],
             };
-        }
-        function nochangeWithIncrementalOutDeclarationFromBeforeExplaination(): TestTscEdit {
-            const edit = nochangeWithIncrementalDeclarationFromBeforeExplaination();
-            const discrepancyExplanation = edit.discrepancyExplanation!;
-            edit.discrepancyExplanation = () => [
-                ...discrepancyExplanation(),
-                `Clean build does not have dts bundle section`,
-                `Incremental build contains the dts build section from before`,
-            ];
-            return edit;
         }
         function localChange(): TestTscEdit {
             return {
@@ -513,9 +493,7 @@ console.log(a);`,
                     noChangeRun,
                     withOptionChange("with declaration and declarationMap", "--declaration", "--declarationMap"),
                     noChangeWithSubscenario("should re-emit only dts so they dont contain sourcemap"),
-                    !options.outFile ?
-                        withOptionChangeAndDiscrepancyExplanation("with emitDeclarationOnly should not emit anything", "--emitDeclarationOnly") :
-                        withEmitDeclarationOnlyChangeAndDiscrepancyExplanation("with emitDeclarationOnly should not emit anything"),
+                    withOptionChangeAndDiscrepancyExplanation("with emitDeclarationOnly should not emit anything", "--emitDeclarationOnly"),
                     noChangeRun,
                     localChange(),
                     withOptionChangeAndDiscrepancyExplanation("with declaration should not emit anything", "--declaration"),
@@ -536,14 +514,10 @@ console.log(a);`,
                     noChangeWithSubscenario("should re-emit only js so they dont contain sourcemap"),
                     withOptionChange("with declaration, emit Dts and should not emit js", "--declaration"),
                     withOptionChange("with declaration and declarationMap", "--declaration", "--declarationMap"),
-                    !options.outFile ?
-                        nochangeWithIncrementalDeclarationFromBeforeExplaination() :
-                        nochangeWithIncrementalOutDeclarationFromBeforeExplaination(),
+                    nochangeWithIncrementalDeclarationFromBeforeExplaination(),
                     localChange(),
                     withOptionChange("with declaration and declarationMap", "--declaration", "--declarationMap"),
-                    !options.outFile ?
-                        nochangeWithIncrementalDeclarationFromBeforeExplaination() :
-                        nochangeWithIncrementalOutDeclarationFromBeforeExplaination(),
+                    nochangeWithIncrementalDeclarationFromBeforeExplaination(),
                     withOptionChange("with inlineSourceMap", "--inlineSourceMap"),
                     withOptionChange("with sourceMap", "--sourceMap"),
                     noChangeWithSubscenario("emit js files"),

--- a/src/testRunner/unittests/tsc/noEmit.ts
+++ b/src/testRunner/unittests/tsc/noEmit.ts
@@ -30,7 +30,7 @@ describe("unittests:: tsc:: noEmit::", () => {
                 ...noChangeRun,
                 caption: "No Change run with noEmit",
                 commandLineArgs: ["--p", "src/project", "--noEmit"],
-                discrepancyExplanation: compilerOptions.composite && !compilerOptions.outFile ?
+                discrepancyExplanation: compilerOptions.composite ?
                     discrepancyExplanation :
                     undefined,
             };
@@ -61,7 +61,7 @@ describe("unittests:: tsc:: noEmit::", () => {
                         caption: "Introduce error but still noEmit",
                         commandLineArgs: ["--p", "src/project", "--noEmit"],
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop", "prop1"),
-                        discrepancyExplanation: compilerOptions.composite && !compilerOptions.outFile ?
+                        discrepancyExplanation: compilerOptions.composite ?
                             discrepancyExplanation :
                             undefined,
                     },
@@ -85,7 +85,7 @@ describe("unittests:: tsc:: noEmit::", () => {
                         caption: "Fix error and no emit",
                         commandLineArgs: ["--p", "src/project", "--noEmit"],
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop1", "prop"),
-                        discrepancyExplanation: compilerOptions.composite && !compilerOptions.outFile ?
+                        discrepancyExplanation: compilerOptions.composite ?
                             discrepancyExplanation :
                             undefined,
                     },
@@ -111,7 +111,7 @@ describe("unittests:: tsc:: noEmit::", () => {
                     {
                         caption: "Fix error and no emit",
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop1", "prop"),
-                        discrepancyExplanation: compilerOptions.composite && !compilerOptions.outFile ?
+                        discrepancyExplanation: compilerOptions.composite ?
                             discrepancyExplanation :
                             undefined,
                     },

--- a/src/testRunner/unittests/tsc/noEmitOnError.ts
+++ b/src/testRunner/unittests/tsc/noEmitOnError.ts
@@ -124,6 +124,10 @@ const a: string = 10;`,
                 caption: "error and enable declarationMap",
                 edit: fs => replaceText(fs, "/src/project/a.ts", "x", "x: 20"),
                 commandLineArgs: ["--p", "/src/project", "--declarationMap"],
+                discrepancyExplanation: () => [
+                    `Clean build does not emit any file so will not have outSignature`,
+                    `Incremental build has outSignature from before`,
+                ],
             },
             {
                 caption: "fix error declarationMap",

--- a/src/testRunner/unittests/tscWatch/incremental.ts
+++ b/src/testRunner/unittests/tscWatch/incremental.ts
@@ -201,10 +201,10 @@ describe("unittests:: tsc-watch:: emit file --incremental", () => {
 
                 assert.equal(ts.arrayFrom(state.referencedMap!.keys()).length, 0);
 
-                assert.equal(state.semanticDiagnosticsPerFile!.size, 3);
-                assert.deepEqual(state.semanticDiagnosticsPerFile!.get(libFile.path as ts.Path), ts.emptyArray);
-                assert.deepEqual(state.semanticDiagnosticsPerFile!.get(file1.path as ts.Path), ts.emptyArray);
-                assert.deepEqual(state.semanticDiagnosticsPerFile!.get(file2.path as ts.Path), [{
+                assert.equal(state.semanticDiagnosticsPerFile.size, 3);
+                assert.deepEqual(state.semanticDiagnosticsPerFile.get(libFile.path as ts.Path), ts.emptyArray);
+                assert.deepEqual(state.semanticDiagnosticsPerFile.get(file1.path as ts.Path), ts.emptyArray);
+                assert.deepEqual(state.semanticDiagnosticsPerFile.get(file2.path as ts.Path), [{
                     file: state.program!.getSourceFileByPath(file2.path as ts.Path)!,
                     start: 13,
                     length: 1,

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/prepend-reports-deprecation-error.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/prepend-reports-deprecation-error.js
@@ -106,6 +106,82 @@ Found 1 error.
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
+//// [/src/app/module.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../lib/module.d.ts","./file3.ts","./file4.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"29754794677-declare const myGlob = 20;\ndeclare module \"file1\" {\n    export const x = 10;\n}\ndeclare module \"file2\" {\n    export const y = 20;\n}\ndeclare const globalConst = 10;\n","impliedFormat":1},{"version":"-10505171738-export const z = 30;\nimport { x } from \"file1\";\n","impliedFormat":1},{"version":"1463681686-const myVar = 30;","impliedFormat":1}],"root":[3,4],"options":{"composite":true,"declarationMap":true,"module":2,"outFile":"./module.js","sourceMap":true,"strict":false,"target":1},"changeFileSet":[1,3,4,2]},"version":"FakeTSVersion"}
+
+//// [/src/app/module.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../lib/module.d.ts",
+      "./file3.ts",
+      "./file4.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../lib/module.d.ts": {
+        "original": {
+          "version": "29754794677-declare const myGlob = 20;\ndeclare module \"file1\" {\n    export const x = 10;\n}\ndeclare module \"file2\" {\n    export const y = 20;\n}\ndeclare const globalConst = 10;\n",
+          "impliedFormat": 1
+        },
+        "version": "29754794677-declare const myGlob = 20;\ndeclare module \"file1\" {\n    export const x = 10;\n}\ndeclare module \"file2\" {\n    export const y = 20;\n}\ndeclare const globalConst = 10;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file3.ts": {
+        "original": {
+          "version": "-10505171738-export const z = 30;\nimport { x } from \"file1\";\n",
+          "impliedFormat": 1
+        },
+        "version": "-10505171738-export const z = 30;\nimport { x } from \"file1\";\n",
+        "impliedFormat": "commonjs"
+      },
+      "./file4.ts": {
+        "original": {
+          "version": "1463681686-const myVar = 30;",
+          "impliedFormat": 1
+        },
+        "version": "1463681686-const myVar = 30;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        3,
+        "./file3.ts"
+      ],
+      [
+        4,
+        "./file4.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declarationMap": true,
+      "module": 2,
+      "outFile": "./module.js",
+      "sourceMap": true,
+      "strict": false,
+      "target": 1
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "./file3.ts",
+      "./file4.ts",
+      "../lib/module.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1153
+}
+
 //// [/src/lib/module.d.ts]
 declare const myGlob = 20;
 declare module "file1" {
@@ -477,7 +553,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/lib/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/app/tsconfig.json' is out of date because output file 'src/app/module.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/app/tsconfig.json' is out of date because buildinfo file 'src/app/module.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/app/tsconfig.json'...
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-discrepancies.js
@@ -204,11 +204,9 @@ IncrementalBuild:
   },
   "version": "FakeTSVersion"
 }
-9:: with emitDeclarationOnly should not emit anything
-Clean build tsbuildinfo will have compilerOptions with composite and emitDeclarationOnly
+9:: with declaration should not emit anything
+Clean build tsbuildinfo will have compilerOptions with composite and declaration
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option composite only
-Clean build info does not have js section because its fresh build
-Incremental build info has js section from old build
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {
@@ -251,7 +249,7 @@ CleanBuild:
     ],
     "options": {
       "composite": true,
-      "emitDeclarationOnly": true,
+      "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
     },

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-with-incremental-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-with-incremental-discrepancies.js
@@ -1,8 +1,6 @@
 4:: no-change-run
 Clean build tsbuildinfo will have compilerOptions {}
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap
-Clean build does not have dts bundle section
-Incremental build contains the dts build section from before
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {
@@ -101,8 +99,6 @@ IncrementalBuild:
 7:: no-change-run
 Clean build tsbuildinfo will have compilerOptions {}
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap
-Clean build does not have dts bundle section
-Incremental build contains the dts build section from before
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/different-options-with-incremental.js
@@ -68,7 +68,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -217,7 +222,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -369,7 +374,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -518,7 +523,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -655,7 +660,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -813,7 +818,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -963,7 +973,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1103,7 +1113,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1253,7 +1263,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1405,7 +1415,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1555,7 +1565,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/different-options.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/different-options.js
@@ -68,7 +68,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -235,7 +240,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -390,7 +395,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -575,7 +580,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -717,7 +722,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -889,7 +894,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -1006,12 +1016,12 @@ define("d", ["require", "exports", "b"], function (require, exports, b_1) {
 
 
 
-Change:: with emitDeclarationOnly should not emit anything
+Change:: with declaration should not emit anything
 Input::
 
 
 Output::
-/lib/tsc --b /src/project --verbose --emitDeclarationOnly
+/lib/tsc --b /src/project --verbose --declaration
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/project/tsconfig.json
 
@@ -1057,7 +1067,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1210,7 +1220,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration-and-incremental-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration-and-incremental-discrepancies.js
@@ -98,3 +98,112 @@ IncrementalBuild:
   },
   "version": "FakeTSVersion"
 }
+TsBuild info text without affectedFilesPendingEmit:: /src/project2/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": false,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration-and-incremental.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration-and-incremental.js
@@ -114,7 +114,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -239,6 +244,92 @@ declare module "d" {
   "size": 1067
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"emitDeclarationOnly":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1265
+}
+
 
 
 Change:: no-change-run
@@ -253,7 +344,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Project 'src/project1/src/tsconfig.json' is up to date because newest input 'src/project1/src/d.ts' is older than output 'src/project1/outFile.tsbuildinfo'
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -315,7 +406,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -354,7 +445,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -481,7 +577,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -520,7 +616,7 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -660,6 +756,92 @@ define("d", ["require", "exports", "b"], function (require, exports, b_1) {
   "size": 1082
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"emitDeclarationOnly":false,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": false,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1266
+}
+
 
 
 Change:: no-change-run
@@ -674,7 +856,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Project 'src/project1/src/tsconfig.json' is up to date because newest input 'src/project1/src/a.ts' is older than output 'src/project1/outFile.tsbuildinfo'
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -731,7 +913,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Project 'src/project1/src/tsconfig.json' is up to date because newest input 'src/project1/src/a.ts' is older than output 'src/project1/outFile.tsbuildinfo'
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -793,7 +975,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -832,7 +1014,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline-with-declaration.js
@@ -111,7 +111,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -268,7 +273,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -352,7 +362,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -581,7 +596,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-false-on-commandline.js
@@ -99,7 +99,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -123,7 +128,12 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/outFile.d.ts
+/src/project2/src/e.ts
+/src/project2/src/f.ts
+/src/project2/src/g.ts
 
 No shapes updated in the builder::
 
@@ -382,7 +392,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -512,7 +527,7 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -536,7 +551,7 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -838,7 +853,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration-and-incremental-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration-and-incremental-discrepancies.js
@@ -97,3 +97,221 @@ IncrementalBuild:
   },
   "version": "FakeTSVersion"
 }
+TsBuild info text without affectedFilesPendingEmit:: /src/project2/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+6:: local change
+*** Needs explanation
+TsBuild info text without affectedFilesPendingEmit:: /src/project2/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration-and-incremental.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration-and-incremental.js
@@ -112,7 +112,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -237,6 +242,92 @@ declare module "d" {
   "size": 1067
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"emitDeclarationOnly":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-25657667359-declare module \"a\" {\n    export const a = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1265
+}
+
 
 
 Change:: no-change-run
@@ -251,7 +342,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Project 'src/project1/src/tsconfig.json' is up to date because newest input 'src/project1/src/d.ts' is older than output 'src/project1/outFile.tsbuildinfo'
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -313,7 +404,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -352,7 +443,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -482,7 +578,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -521,7 +617,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -647,6 +748,92 @@ declare module "d" {
   "size": 1102
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"emitDeclarationOnly":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1290
+}
+
 
 
 Change:: emit js files
@@ -663,7 +850,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -701,7 +888,7 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -840,6 +1027,91 @@ define("d", ["require", "exports", "b"], function (require, exports, b_1) {
   "size": 1075
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "106974224-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1263
+}
+
 
 
 Change:: no-change-run
@@ -854,7 +1126,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Project 'src/project1/src/tsconfig.json' is up to date because newest input 'src/project1/src/a.ts' is older than output 'src/project1/outFile.tsbuildinfo'
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -916,7 +1188,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -954,7 +1226,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1114,7 +1391,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -1153,7 +1430,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1283,7 +1565,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -1322,7 +1604,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1449,6 +1736,92 @@ declare module "d" {
   "size": 1160
 }
 
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-3908737535-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"emitDeclarationOnly":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "-3908737535-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-3908737535-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1322
+}
+
 
 
 Change:: js emit with change without emitDeclarationOnly
@@ -1468,7 +1841,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because output file 'src/project2/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project2/src/tsconfig.json' is out of date because buildinfo file 'src/project2/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project2/src/tsconfig.json'...
 
@@ -1506,7 +1879,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1665,5 +2043,90 @@ define("d", ["require", "exports", "b"], function (require, exports, b_1) {
   },
   "version": "FakeTSVersion",
   "size": 1155
+}
+
+//// [/src/project2/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../project1/outfile.d.ts","./src/e.ts","./src/f.ts","./src/g.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1646858368-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n    export const a2 = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n","impliedFormat":1},{"version":"-13789510868-export const e = 10;","impliedFormat":1},{"version":"-4849089835-import { a } from \"a\"; export const f = a;","impliedFormat":1},{"version":"-18341999015-import { b } from \"b\"; export const g = b;","impliedFormat":1}],"root":[[3,5]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3,4,5]},"version":"FakeTSVersion"}
+
+//// [/src/project2/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "../project1/outfile.d.ts": {
+        "original": {
+          "version": "1646858368-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n    export const a2 = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "1646858368-declare module \"a\" {\n    export const a = 10;\n    export const aaa = 10;\n}\ndeclare module \"b\" {\n    export const b = 10;\n    export const aaaaa = 10;\n    export const a2 = 10;\n}\ndeclare module \"c\" {\n    export const c = 10;\n}\ndeclare module \"d\" {\n    export const d = 10;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/e.ts": {
+        "original": {
+          "version": "-13789510868-export const e = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13789510868-export const e = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/f.ts": {
+        "original": {
+          "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+          "impliedFormat": 1
+        },
+        "version": "-4849089835-import { a } from \"a\"; export const f = a;",
+        "impliedFormat": "commonjs"
+      },
+      "./src/g.ts": {
+        "original": {
+          "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+          "impliedFormat": 1
+        },
+        "version": "-18341999015-import { b } from \"b\"; export const g = b;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          3,
+          5
+        ],
+        [
+          "./src/e.ts",
+          "./src/f.ts",
+          "./src/g.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../lib/lib.d.ts",
+      "../project1/outfile.d.ts",
+      "./src/e.ts",
+      "./src/f.ts",
+      "./src/g.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1321
 }
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline-with-declaration.js
@@ -109,7 +109,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -266,7 +271,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -353,7 +363,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -451,7 +466,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -623,7 +643,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -741,7 +766,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -828,7 +858,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -930,7 +965,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline.js
+++ b/tests/baselines/reference/tsbuild/commandLine/outFile/emitDeclarationOnly-on-commandline.js
@@ -97,7 +97,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -121,7 +126,12 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/outFile.d.ts
+/src/project2/src/e.ts
+/src/project2/src/f.ts
+/src/project2/src/g.ts
 
 No shapes updated in the builder::
 
@@ -380,7 +390,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -513,7 +528,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -537,7 +557,12 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/outFile.d.ts
+/src/project2/src/e.ts
+/src/project2/src/f.ts
+/src/project2/src/g.ts
 
 No shapes updated in the builder::
 
@@ -762,7 +787,7 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -785,7 +810,7 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1066,7 +1091,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1230,7 +1260,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1363,7 +1398,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1387,7 +1427,12 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/outFile.d.ts
+/src/project2/src/e.ts
+/src/project2/src/f.ts
+/src/project2/src/g.ts
 
 No shapes updated in the builder::
 
@@ -1616,7 +1661,12 @@ Program files::
 /src/project1/src/c.ts
 /src/project1/src/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/src/a.ts
+/src/project1/src/b.ts
+/src/project1/src/c.ts
+/src/project1/src/d.ts
 
 No shapes updated in the builder::
 
@@ -1639,7 +1689,12 @@ Program files::
 /src/project2/src/f.ts
 /src/project2/src/g.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project1/outFile.d.ts
+/src/project2/src/e.ts
+/src/project2/src/f.ts
+/src/project2/src/g.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/configFileErrors/outFile/reports-syntax-errors-in-config-file-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/configFileErrors/outFile/reports-syntax-errors-in-config-file-discrepancies.js
@@ -1,0 +1,85 @@
+0:: reports syntax errors after change to config file
+During incremental build, tsbuildinfo is not emitted, so declaration option is not present
+Clean build has declaration option in tsbuildinfo
+TsBuild info text without affectedFilesPendingEmit:: /outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "version": "4646078106-export function foo() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./src/b.ts": {
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ],
+      [
+        3,
+        "./src/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "version": "4646078106-export function foo() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./src/b.ts": {
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ],
+      [
+        3,
+        "./src/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsbuild/configFileErrors/outFile/reports-syntax-errors-in-config-file.js
+++ b/tests/baselines/reference/tsbuild/configFileErrors/outFile/reports-syntax-errors-in-config-file.js
@@ -50,6 +50,68 @@ Found 1 error.
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts","./src/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"4646078106-export function foo() { }","impliedFormat":1},{"version":"1045484683-export function bar() { }","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3]},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "4646078106-export function foo() { }",
+          "impliedFormat": 1
+        },
+        "version": "4646078106-export function foo() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./src/b.ts": {
+        "original": {
+          "version": "1045484683-export function bar() { }",
+          "impliedFormat": 1
+        },
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ],
+      [
+        3,
+        "./src/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 821
+}
+
 
 
 Change:: reports syntax errors after change to config file
@@ -105,6 +167,69 @@ Found 1 error.
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
+
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts","./src/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"9819159940-export function foo() { }export function fooBar() { }","impliedFormat":1},{"version":"1045484683-export function bar() { }","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"declaration":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3]},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "9819159940-export function foo() { }export function fooBar() { }",
+          "impliedFormat": 1
+        },
+        "version": "9819159940-export function foo() { }export function fooBar() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./src/b.ts": {
+        "original": {
+          "version": "1045484683-export function bar() { }",
+          "impliedFormat": 1
+        },
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ],
+      [
+        3,
+        "./src/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "./lib/lib.d.ts",
+      "./src/a.ts",
+      "./src/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 868
+}
 
 
 

--- a/tests/baselines/reference/tsbuild/declarationEmit/outFile/reports-dts-generation-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/outFile/reports-dts-generation-errors-with-incremental.js
@@ -74,6 +74,7 @@ Output::
 [7m2[0m export const api = ky.extend({});
 [7m [0m [91m             ~~~[0m
 
+TSFILE: /src/project/outFile.tsbuildinfo
 lib/lib.d.ts
   Default library for target 'es5'
 src/project/ky.d.ts
@@ -86,6 +87,65 @@ Found 1 error.
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
+//// [/src/project/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","./ky.d.ts","./src/index.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n","impliedFormat":1},{"version":"-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n","impliedFormat":1}],"root":[3],"options":{"declaration":true,"module":2,"outFile":"./outFile.js","skipDefaultLibCheck":true,"skipLibCheck":true},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/project/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "./ky.d.ts",
+      "./src/index.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./ky.d.ts": {
+        "original": {
+          "version": "10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n",
+          "impliedFormat": 1
+        },
+        "version": "10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/index.ts": {
+        "original": {
+          "version": "-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n",
+          "impliedFormat": 1
+        },
+        "version": "-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        3,
+        "./src/index.ts"
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js",
+      "skipDefaultLibCheck": true,
+      "skipLibCheck": true
+    },
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1012
+}
+
 
 
 Change:: no-change-run
@@ -97,7 +157,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/project/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/project/tsconfig.json' is out of date because output file 'src/project/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project/tsconfig.json' is out of date because buildinfo file 'src/project/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project/tsconfig.json'...
 

--- a/tests/baselines/reference/tsbuild/fileDelete/outFile/detects-deleted-file-discrepancies.js
+++ b/tests/baselines/reference/tsbuild/fileDelete/outFile/detects-deleted-file-discrepancies.js
@@ -1,0 +1,88 @@
+0:: delete child2 file
+Clean build will not have latestChangedDtsFile as there was no emit and outSignature as undefined for files
+Incremental will store the past latestChangedDtsFile and outSignature
+TsBuild info text without affectedFilesPendingEmit:: /src/childresult.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./child/child.ts": {
+        "version": "-11458139532-import { child2 } from \"../child/child2\";\nexport function child() {\n    child2();\n}\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./child/child.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./childResult.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./child/child.ts",
+        [
+          {
+            "start": 23,
+            "length": 17,
+            "messageText": "Cannot find module '../child/child2'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?",
+            "category": 1,
+            "code": 2792
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./child/child.ts": {
+        "version": "-11458139532-import { child2 } from \"../child/child2\";\nexport function child() {\n    child2();\n}\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./child/child.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./childResult.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./child/child.ts",
+        [
+          {
+            "start": 23,
+            "length": 17,
+            "messageText": "Cannot find module '../child/child2'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?",
+            "category": 1,
+            "code": 2792
+          }
+        ]
+      ]
+    ],
+    "outSignature": "2074776633-declare module \"child2\" {\n    export function child2(): void;\n}\ndeclare module \"child\" {\n    export function child(): void;\n}\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsbuild/fileDelete/outFile/detects-deleted-file.js
+++ b/tests/baselines/reference/tsbuild/fileDelete/outFile/detects-deleted-file.js
@@ -337,3 +337,67 @@ Found 1 error.
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
+//// [/src/childResult.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./child/child.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-11458139532-import { child2 } from \"../child/child2\";\nexport function child() {\n    child2();\n}\n","impliedFormat":1}],"root":[2],"options":{"composite":true,"module":2,"outFile":"./childResult.js"},"semanticDiagnosticsPerFile":[[2,[{"start":23,"length":17,"messageText":"Cannot find module '../child/child2'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?","category":1,"code":2792}]]],"outSignature":"2074776633-declare module \"child2\" {\n    export function child2(): void;\n}\ndeclare module \"child\" {\n    export function child(): void;\n}\n","latestChangedDtsFile":"./childResult.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/childResult.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./child/child.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./child/child.ts": {
+        "original": {
+          "version": "-11458139532-import { child2 } from \"../child/child2\";\nexport function child() {\n    child2();\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-11458139532-import { child2 } from \"../child/child2\";\nexport function child() {\n    child2();\n}\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./child/child.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./childResult.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./child/child.ts",
+        [
+          {
+            "start": 23,
+            "length": 17,
+            "messageText": "Cannot find module '../child/child2'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?",
+            "category": 1,
+            "code": 2792
+          }
+        ]
+      ]
+    ],
+    "outSignature": "2074776633-declare module \"child2\" {\n    export function child2(): void;\n}\ndeclare module \"child\" {\n    export function child(): void;\n}\n",
+    "latestChangedDtsFile": "./childResult.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1267
+}
+

--- a/tests/baselines/reference/tsbuild/noEmit/outFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmit/outFile/semantic-errors-with-incremental.js
@@ -60,10 +60,72 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
+
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1311033573-const a: number = \"hello\"","impliedFormat":1}],"root":[2],"options":{"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":6,"length":1,"code":2322,"category":1,"messageText":"Type 'string' is not assignable to type 'number'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "1311033573-const a: number = \"hello\"",
+          "impliedFormat": 1
+        },
+        "version": "1311033573-const a: number = \"hello\"",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ]
+    ],
+    "options": {
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./src/a.ts",
+        [
+          {
+            "start": 6,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'string' is not assignable to type 'number'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 858
+}
 
 
 
@@ -76,7 +138,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because buildinfo file 'outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
 
@@ -103,7 +165,7 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -122,7 +184,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because buildinfo file 'outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
 
@@ -141,10 +203,58 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
+
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"4011451714-const a = \"hello\"","impliedFormat":1}],"root":[2],"options":{"outFile":"./outFile.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "4011451714-const a = \"hello\"",
+          "impliedFormat": 1
+        },
+        "version": "4011451714-const a = \"hello\"",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ]
+    ],
+    "options": {
+      "outFile": "./outFile.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 699
+}
 
 
 
@@ -157,27 +267,8 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
-
-[[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is up to date because newest input 'src/a.ts' is older than output 'outFile.tsbuildinfo'
 
 exitCode:: ExitStatus.Success
-Program root files: [
-  "/src/a.ts"
-]
-Program options: {
-  "outFile": "/outFile.js",
-  "noEmit": true,
-  "incremental": true,
-  "configFilePath": "/src/tsconfig.json"
-}
-Program structureReused: Not
-Program files::
-/lib/lib.d.ts
-/src/a.ts
-
-No cached semantic diagnostics in the builder::
-
-No shapes updated in the builder::
 
 

--- a/tests/baselines/reference/tsbuild/noEmit/outFile/semantic-errors.js
+++ b/tests/baselines/reference/tsbuild/noEmit/outFile/semantic-errors.js
@@ -59,7 +59,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
@@ -101,7 +103,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
@@ -138,7 +142,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
@@ -172,7 +178,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmit/outFile/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmit/outFile/syntax-errors-with-incremental.js
@@ -65,6 +65,52 @@ No cached semantic diagnostics in the builder::
 No shapes updated in the builder::
 
 
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"2464268576-const a = \"hello","impliedFormat":1}],"root":[2],"options":{"outFile":"./outFile.js"},"changeFileSet":[1,2]},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "2464268576-const a = \"hello",
+          "impliedFormat": 1
+        },
+        "version": "2464268576-const a = \"hello",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ]
+    ],
+    "options": {
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "./lib/lib.d.ts",
+      "./src/a.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 699
+}
+
 
 
 Change:: no-change-run
@@ -76,7 +122,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because buildinfo file 'outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
 
@@ -122,7 +168,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because buildinfo file 'outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
 
@@ -141,10 +187,58 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
+
+//// [/outFile.tsbuildinfo]
+{"program":{"fileNames":["./lib/lib.d.ts","./src/a.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"4011451714-const a = \"hello\"","impliedFormat":1}],"root":[2],"options":{"outFile":"./outFile.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "./lib/lib.d.ts",
+      "./src/a.ts"
+    ],
+    "fileInfos": {
+      "./lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./src/a.ts": {
+        "original": {
+          "version": "4011451714-const a = \"hello\"",
+          "impliedFormat": 1
+        },
+        "version": "4011451714-const a = \"hello\"",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./src/a.ts"
+      ]
+    ],
+    "options": {
+      "outFile": "./outFile.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 699
+}
 
 
 
@@ -157,27 +251,8 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is out of date because output file 'outFile.tsbuildinfo' does not exist
-
-[[90mHH:MM:SS AM[0m] Building project '/src/tsconfig.json'...
+[[90mHH:MM:SS AM[0m] Project 'src/tsconfig.json' is up to date because newest input 'src/a.ts' is older than output 'outFile.tsbuildinfo'
 
 exitCode:: ExitStatus.Success
-Program root files: [
-  "/src/a.ts"
-]
-Program options: {
-  "outFile": "/outFile.js",
-  "noEmit": true,
-  "incremental": true,
-  "configFilePath": "/src/tsconfig.json"
-}
-Program structureReused: Not
-Program files::
-/lib/lib.d.ts
-/src/a.ts
-
-No cached semantic diagnostics in the builder::
-
-No shapes updated in the builder::
 
 

--- a/tests/baselines/reference/tsbuild/noEmit/outFile/syntax-errors.js
+++ b/tests/baselines/reference/tsbuild/noEmit/outFile/syntax-errors.js
@@ -138,7 +138,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 
@@ -172,7 +174,9 @@ Program files::
 /lib/lib.d.ts
 /src/a.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/a.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-declaration-with-incremental.js
@@ -81,10 +81,102 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1216
+}
 
 
 
@@ -97,7 +189,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -130,7 +222,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -150,7 +242,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -175,7 +267,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-declaration.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-declaration.js
@@ -79,7 +79,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -127,7 +131,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -171,7 +179,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors-with-incremental.js
@@ -79,10 +79,101 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1197
+}
 
 
 
@@ -95,7 +186,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -127,7 +218,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -147,7 +238,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -171,7 +262,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/semantic-errors.js
@@ -77,7 +77,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -124,7 +128,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -167,7 +175,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-declaration-with-incremental.js
@@ -89,6 +89,82 @@ No cached semantic diagnostics in the builder::
 No shapes updated in the builder::
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"changeFileSet":[1,2,3,4]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1086
+}
+
 
 
 Change:: no-change-run
@@ -100,7 +176,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -155,7 +231,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -180,7 +256,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-declaration.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-declaration.js
@@ -176,7 +176,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors-with-incremental.js
@@ -87,6 +87,81 @@ No cached semantic diagnostics in the builder::
 No shapes updated in the builder::
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"changeFileSet":[1,2,3,4]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1067
+}
+
 
 
 Change:: no-change-run
@@ -98,7 +173,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -152,7 +227,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -176,7 +251,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/outFile/syntax-errors.js
@@ -172,7 +172,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/configFileErrors/outFile/reports-syntax-errors-in-config-file.js
+++ b/tests/baselines/reference/tsbuildWatch/configFileErrors/outFile/reports-syntax-errors-in-config-file.js
@@ -48,6 +48,68 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/a.ts","./myproject/b.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"4646078106-export function foo() { }","impliedFormat":1},{"version":"1045484683-export function bar() { }","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.ts",
+      "./myproject/b.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/a.ts": {
+        "original": {
+          "version": "4646078106-export function foo() { }",
+          "impliedFormat": 1
+        },
+        "version": "4646078106-export function foo() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/b.ts": {
+        "original": {
+          "version": "1045484683-export function bar() { }",
+          "impliedFormat": 1
+        },
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/a.ts"
+      ],
+      [
+        3,
+        "./myproject/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.ts",
+      "./myproject/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 762
+}
+
 
 PolledWatches::
 /a/lib/package.json: *new*
@@ -190,6 +252,69 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/a.ts","./myproject/b.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-3260843409-export function fooBar() { }","impliedFormat":1},{"version":"1045484683-export function bar() { }","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"declaration":true,"module":2,"outFile":"./outFile.js"},"changeFileSet":[1,2,3]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.ts",
+      "./myproject/b.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/a.ts": {
+        "original": {
+          "version": "-3260843409-export function fooBar() { }",
+          "impliedFormat": 1
+        },
+        "version": "-3260843409-export function fooBar() { }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/b.ts": {
+        "original": {
+          "version": "1045484683-export function bar() { }",
+          "impliedFormat": 1
+        },
+        "version": "1045484683-export function bar() { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/a.ts"
+      ],
+      [
+        3,
+        "./myproject/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.ts",
+      "./myproject/b.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 785
+}
+
 
 
 Program root files: [
@@ -302,30 +427,6 @@ Output::
 
 
 
-//// [/user/username/projects/outFile.js]
-define("a", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.fooBar = fooBar;
-    function fooBar() { }
-});
-define("b", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.bar = bar;
-    function bar() { }
-});
-
-
-//// [/user/username/projects/outFile.d.ts]
-declare module "a" {
-    export function fooBar(): void;
-}
-declare module "b" {
-    export function bar(): void;
-}
-
-
 //// [/user/username/projects/outFile.tsbuildinfo]
 {"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/a.ts","./myproject/b.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-3260843409-export function fooBar() { }","impliedFormat":1},{"version":"1045484683-export function bar() { }","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"declaration":true,"module":2,"outFile":"./outFile.js"},"outSignature":"771185302-declare module \"a\" {\n    export function fooBar(): void;\n}\ndeclare module \"b\" {\n    export function bar(): void;\n}\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
 
@@ -386,6 +487,30 @@ declare module "b" {
   "size": 954
 }
 
+//// [/user/username/projects/outFile.js]
+define("a", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.fooBar = fooBar;
+    function fooBar() { }
+});
+define("b", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.bar = bar;
+    function bar() { }
+});
+
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "a" {
+    export function fooBar(): void;
+}
+declare module "b" {
+    export function bar(): void;
+}
+
+
 
 
 Program root files: [
@@ -406,7 +531,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmit/outFile/does-not-go-in-loop-when-watching-when-no-files-are-emitted-with-incremental.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmit/outFile/does-not-go-in-loop-when-watching-when-no-files-are-emitted-with-incremental.js
@@ -47,6 +47,66 @@ Output::
 
 
 
+//// [/user/username/projects/out.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/a.js","./myproject/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"5381-","impliedFormat":1},{"version":"5381-","impliedFormat":1}],"root":[2,3],"options":{"allowJs":true,"outFile":"./out.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/out.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.js",
+      "./myproject/b.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/a.js": {
+        "original": {
+          "version": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "5381-",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/b.ts": {
+        "original": {
+          "version": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "5381-",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/a.js"
+      ],
+      [
+        3,
+        "./myproject/b.ts"
+      ]
+    ],
+    "options": {
+      "allowJs": true,
+      "outFile": "./out.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 759
+}
+
 
 PolledWatches::
 /a/lib/package.json: *new*
@@ -94,7 +154,10 @@ Program files::
 /user/username/projects/myproject/a.js
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.js
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -117,37 +180,13 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../out.tsbuildinfo' does not exist
-
-[[90mHH:MM:SS AM[0m] Building project '/user/username/projects/myproject/tsconfig.json'...
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is up to date but needs to update timestamps of output files that are older than input files
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
 
 
 
-
-Program root files: [
-  "/user/username/projects/myproject/a.js",
-  "/user/username/projects/myproject/b.ts"
-]
-Program options: {
-  "allowJs": true,
-  "noEmit": true,
-  "outFile": "/user/username/projects/out.js",
-  "watch": true,
-  "incremental": true,
-  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
-}
-Program structureReused: Not
-Program files::
-/a/lib/lib.d.ts
-/user/username/projects/myproject/a.js
-/user/username/projects/myproject/b.ts
-
-No cached semantic diagnostics in the builder::
-
-No shapes updated in the builder::
 
 exitCode:: ExitStatus.undefined
 
@@ -170,13 +209,73 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../out.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output '../out.tsbuildinfo' is older than input 'a.js'
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/myproject/tsconfig.json'...
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
 
+
+//// [/user/username/projects/out.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/a.js","./myproject/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"5029505981-const x = 10;","impliedFormat":1},{"version":"5381-","impliedFormat":1}],"root":[2,3],"options":{"allowJs":true,"outFile":"./out.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/out.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/a.js",
+      "./myproject/b.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/a.js": {
+        "original": {
+          "version": "5029505981-const x = 10;",
+          "impliedFormat": 1
+        },
+        "version": "5029505981-const x = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/b.ts": {
+        "original": {
+          "version": "5381-",
+          "impliedFormat": 1
+        },
+        "version": "5381-",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/a.js"
+      ],
+      [
+        3,
+        "./myproject/b.ts"
+      ]
+    ],
+    "options": {
+      "allowJs": true,
+      "outFile": "./out.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 778
+}
 
 
 
@@ -198,7 +297,10 @@ Program files::
 /user/username/projects/myproject/a.js
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.js
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmit/outFile/does-not-go-in-loop-when-watching-when-no-files-are-emitted.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmit/outFile/does-not-go-in-loop-when-watching-when-no-files-are-emitted.js
@@ -93,7 +93,10 @@ Program files::
 /user/username/projects/myproject/a.js
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.js
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -143,7 +146,7 @@ Program files::
 /user/username/projects/myproject/a.js
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -195,7 +198,10 @@ Program files::
 /user/username/projects/myproject/a.js
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.js
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-declaration-with-incremental.js
@@ -66,6 +66,82 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"changeFileSet":[1,2,3,4]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1086
+}
+
 
 PolledWatches::
 /a/lib/package.json: *new*
@@ -147,7 +223,7 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -211,43 +287,12 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = {
-        lastName: 'sdsd'
-    };
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
-
-
-//// [/user/username/projects/dev-build.d.ts]
-declare module "shared/types/db" {
-    export interface A {
-        name: string;
-    }
-}
-declare module "src/main" { }
-declare module "src/other" {
-    export {};
-}
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -320,6 +365,37 @@ declare module "src/other" {
   "size": 1059
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = {
+        lastName: 'sdsd'
+    };
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
+//// [/user/username/projects/dev-build.d.ts]
+declare module "shared/types/db" {
+    export interface A {
+        name: string;
+    }
+}
+declare module "src/main" { }
+declare module "src/other" {
+    export {};
+}
+
+
 
 
 Program root files: [
@@ -343,7 +419,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -382,6 +462,94 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1216
+}
+
 
 
 Program root files: [
@@ -405,7 +573,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -428,7 +600,7 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output '../dev-build.tsbuildinfo' is older than input 'src/main.ts'
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -464,7 +636,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -490,7 +662,7 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output '../dev-build.tsbuildinfo' is older than input 'src/main.ts'
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -498,24 +670,6 @@ Output::
 
 
 
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = "hello";
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
-
-
-//// [/user/username/projects/dev-build.d.ts] file written with same contents
 //// [/user/username/projects/dev-build.tsbuildinfo]
 {"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-8373351622-import { A } from \"../shared/types/db\";\nconst a: string = \"hello\";","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"}},"version":"FakeTSVersion"}
 
@@ -586,6 +740,24 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1050
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = "hello";
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
+//// [/user/username/projects/dev-build.d.ts] file written with same contents
 
 
 Program root files: [
@@ -609,7 +781,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-declaration.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-declaration.js
@@ -269,7 +269,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -330,7 +334,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -388,7 +396,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -462,7 +470,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -519,7 +531,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-incremental.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error-with-incremental.js
@@ -65,6 +65,81 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"changeFileSet":[1,2,3,4]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "changeFileSet": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1067
+}
+
 
 PolledWatches::
 /a/lib/package.json: *new*
@@ -145,7 +220,7 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -208,31 +283,12 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file '../dev-build.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = {
-        lastName: 'sdsd'
-    };
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -304,6 +360,25 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1040
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = {
+        lastName: 'sdsd'
+    };
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
 
 
 Program root files: [
@@ -326,7 +401,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -365,6 +444,93 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1197
+}
+
 
 
 Program root files: [
@@ -387,7 +553,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -410,7 +580,7 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output '../dev-build.tsbuildinfo' is older than input 'src/main.ts'
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
@@ -445,7 +615,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -471,29 +641,12 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
 
-[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output '../dev-build.tsbuildinfo' is older than input 'src/main.ts'
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file '../dev-build.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = "hello";
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -565,6 +718,23 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1031
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = "hello";
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
 
 
 Program root files: [
@@ -587,7 +757,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error.js
+++ b/tests/baselines/reference/tsbuildWatch/noEmitOnError/outFile/does-not-emit-any-files-on-error.js
@@ -253,7 +253,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -313,7 +317,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -370,7 +378,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -442,7 +450,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -497,7 +509,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsbuildWatch/programUpdates/with-outFile-and-non-local-change.js
+++ b/tests/baselines/reference/tsbuildWatch/programUpdates/with-outFile-and-non-local-change.js
@@ -222,7 +222,9 @@ Program files::
 /a/lib/lib.d.ts
 /user/username/projects/sample1/core/index.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/sample1/core/index.ts
 
 No shapes updated in the builder::
 
@@ -242,7 +244,10 @@ Program files::
 /user/username/projects/sample1/core/index.d.ts
 /user/username/projects/sample1/logic/index.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/sample1/core/index.d.ts
+/user/username/projects/sample1/logic/index.ts
 
 No shapes updated in the builder::
 
@@ -346,7 +351,9 @@ Program files::
 /a/lib/lib.d.ts
 /user/username/projects/sample1/core/index.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/sample1/core/index.ts
 
 No shapes updated in the builder::
 
@@ -440,7 +447,10 @@ Program files::
 /user/username/projects/sample1/core/index.d.ts
 /user/username/projects/sample1/logic/index.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/sample1/core/index.d.ts
+/user/username/projects/sample1/logic/index.ts
 
 No shapes updated in the builder::
 
@@ -539,7 +549,9 @@ Program files::
 /a/lib/lib.d.ts
 /user/username/projects/sample1/core/index.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/sample1/core/index.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/declarationEmit/outFile/reports-dts-generation-errors-with-incremental.js
+++ b/tests/baselines/reference/tsc/declarationEmit/outFile/reports-dts-generation-errors-with-incremental.js
@@ -68,6 +68,7 @@ Output::
 [7m [0m [91m             ~~~[0m
 
 TSFILE: /src/project/outFile.js
+TSFILE: /src/project/outFile.tsbuildinfo
 lib/lib.d.ts
   Default library for target 'es5'
 src/project/ky.d.ts
@@ -89,6 +90,75 @@ define("src/index", ["require", "exports", "ky"], function (require, exports, ky
 });
 
 
+//// [/src/project/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","./ky.d.ts","./src/index.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n","impliedFormat":1},{"version":"-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n","impliedFormat":1}],"root":[3],"options":{"composite":true,"module":2,"outFile":"./outFile.js","skipDefaultLibCheck":true,"skipLibCheck":true},"emitDiagnosticsPerFile":[[3,[{"start":34,"length":3,"messageText":"Exported variable 'api' has or is using name 'KyInstance' from external module \"/src/project/ky\" but cannot be named.","category":1,"code":4023}]]]},"version":"FakeTSVersion"}
+
+//// [/src/project/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "./ky.d.ts",
+      "./src/index.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./ky.d.ts": {
+        "original": {
+          "version": "10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n",
+          "impliedFormat": 1
+        },
+        "version": "10101889135-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./src/index.ts": {
+        "original": {
+          "version": "-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n",
+          "impliedFormat": 1
+        },
+        "version": "-383421929-import ky from 'ky';\nexport const api = ky.extend({});\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        3,
+        "./src/index.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js",
+      "skipDefaultLibCheck": true,
+      "skipLibCheck": true
+    },
+    "emitDiagnosticsPerFile": [
+      [
+        "./src/index.ts",
+        [
+          {
+            "start": 34,
+            "length": 3,
+            "messageText": "Exported variable 'api' has or is using name 'KyInstance' from external module \"/src/project/ky\" but cannot be named.",
+            "category": 1,
+            "code": 4023
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1208
+}
+
 
 
 Change:: no-change-run
@@ -102,7 +172,6 @@ Output::
 [7m2[0m export const api = ky.extend({});
 [7m [0m [91m             ~~~[0m
 
-TSFILE: /src/project/outFile.js
 lib/lib.d.ts
   Default library for target 'es5'
 src/project/ky.d.ts
@@ -115,7 +184,6 @@ Found 1 error in src/project/src/index.ts[90m:2[0m
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
-//// [/src/project/outFile.js] file written with same contents
 
 
 Change:: no-change-run
@@ -127,7 +195,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Projects in this build: 
     * src/project/tsconfig.json
 
-[[90mHH:MM:SS AM[0m] Project 'src/project/tsconfig.json' is out of date because output file 'src/project/outFile.tsbuildinfo' does not exist
+[[90mHH:MM:SS AM[0m] Project 'src/project/tsconfig.json' is out of date because buildinfo file 'src/project/outFile.tsbuildinfo' indicates that some of the changes were not emitted
 
 [[90mHH:MM:SS AM[0m] Building project '/src/project/tsconfig.json'...
 

--- a/tests/baselines/reference/tsc/incremental/outFile/different-options-discrepancies.js
+++ b/tests/baselines/reference/tsc/incremental/outFile/different-options-discrepancies.js
@@ -104,8 +104,6 @@ IncrementalBuild:
 6:: with emitDeclarationOnly should not emit anything
 Clean build tsbuildinfo will have compilerOptions with composite and emitDeclarationOnly
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option composite only
-Clean build info does not have js section because its fresh build
-Incremental build info has js section from old build
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {

--- a/tests/baselines/reference/tsc/incremental/outFile/different-options-with-incremental-discrepancies.js
+++ b/tests/baselines/reference/tsc/incremental/outFile/different-options-with-incremental-discrepancies.js
@@ -1,8 +1,6 @@
 4:: no-change-run
 Clean build tsbuildinfo will have compilerOptions {}
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap
-Clean build does not have dts bundle section
-Incremental build contains the dts build section from before
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {
@@ -101,8 +99,6 @@ IncrementalBuild:
 7:: no-change-run
 Clean build tsbuildinfo will have compilerOptions {}
 Incremental build will detect that it doesnt need to rebuild so tsbuild info is from before which has option declaration and declarationMap
-Clean build does not have dts bundle section
-Incremental build contains the dts build section from before
 TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
 CleanBuild:
 {

--- a/tests/baselines/reference/tsc/incremental/outFile/different-options-with-incremental.js
+++ b/tests/baselines/reference/tsc/incremental/outFile/different-options-with-incremental.js
@@ -62,7 +62,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -205,7 +210,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -351,7 +356,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -494,7 +499,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -625,7 +630,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -758,7 +763,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -796,7 +801,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -940,7 +950,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1057,7 +1067,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1093,7 +1103,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1237,7 +1247,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1383,7 +1393,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1527,7 +1537,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1646,7 +1656,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/incremental/outFile/different-options.js
+++ b/tests/baselines/reference/tsc/incremental/outFile/different-options.js
@@ -62,7 +62,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -223,7 +228,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -372,7 +377,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -518,7 +523,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -553,7 +558,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -590,7 +595,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -726,7 +731,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -858,7 +863,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -893,7 +898,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -931,7 +936,12 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/a.ts
+/src/project/b.ts
+/src/project/c.ts
+/src/project/d.ts
 
 No shapes updated in the builder::
 
@@ -1077,7 +1087,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1113,7 +1123,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1260,7 +1270,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1420,7 +1430,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -1584,7 +1594,7 @@ Program files::
 /src/project/c.ts
 /src/project/d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-composite-discrepancies.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-composite-discrepancies.js
@@ -1,0 +1,1764 @@
+0:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+1:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+2:: Introduce error but still noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+5:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+6:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+10:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+11:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+13:: Fix error and no emit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+15:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}
+16:: No Change run with noEmit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-composite.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-composite.js
@@ -137,7 +137,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -230,11 +230,26 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2052
+  "size": 2267
 }
 
 
@@ -298,8 +313,172 @@ Found 2 errors in 2 files.
 Errors  Files
      1  src/project/src/directUse.ts[90m:2[0m
      1  src/project/src/indirectUse.ts[90m:2[0m
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 2865
+}
 
 
 
@@ -324,6 +503,123 @@ Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.js] file written with same contents
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "./outFile.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 2267
+}
 
 
 
@@ -504,7 +800,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -597,11 +893,70 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2056
+  "size": 2847
 }
 
 
@@ -780,97 +1135,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "src/class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "src/indirectClass" {
-    import { classC } from "src/class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "src/directUse" { }
-declare module "src/indirectUse" { }
-declare module "src/noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("src/class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("src/noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -963,11 +1229,235 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 2289
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "src/class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "src/indirectClass" {
+    import { classC } from "src/class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "src/directUse" { }
+declare module "src/indirectUse" { }
+declare module "src/noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("src/class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("src/noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2052
+  "size": 2267
 }
 
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-incremental-declaration.js
@@ -138,7 +138,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -230,10 +230,25 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1503
+  "size": 1718
 }
 
 
@@ -297,8 +312,170 @@ Found 2 errors in 2 files.
 Errors  Files
      1  src/project/src/directUse.ts[90m:2[0m
      1  src/project/src/indirectUse.ts[90m:2[0m
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 2316
+}
 
 
 
@@ -323,6 +500,122 @@ Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.d.ts] file written with same contents
+//// [/src/outFile.js] file written with same contents
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1718
+}
 
 
 
@@ -503,7 +796,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -595,10 +888,69 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1505
+  "size": 2296
 }
 
 
@@ -777,97 +1129,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "indirectClass" {
-    import { classC } from "class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "directUse" { }
-declare module "indirectUse" { }
-declare module "noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -959,10 +1222,232 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1503
+  "size": 1738
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "indirectClass" {
+    import { classC } from "class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "directUse" { }
+declare module "indirectUse" { }
+declare module "noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1718
 }
 
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-incremental.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-incremental.js
@@ -117,7 +117,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -208,10 +208,25 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1484
+  "size": 1699
 }
 
 
@@ -275,8 +290,169 @@ Found 2 errors in 2 files.
 Errors  Files
      1  src/project/src/directUse.ts[90m:2[0m
      1  src/project/src/indirectUse.ts[90m:2[0m
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "1786859709-export class classC {\n    prop1 = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 2297
+}
 
 
 
@@ -301,6 +477,120 @@ Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
+
+//// [/src/outFile.js] file written with same contents
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1699
+}
 
 
 
@@ -461,7 +751,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -552,10 +842,69 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1486
+  "size": 2277
 }
 
 
@@ -734,77 +1083,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -895,10 +1175,211 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1484
+  "size": 1719
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1699
 }
 
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-composite-discrepancies.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-composite-discrepancies.js
@@ -1,0 +1,150 @@
+2:: Fix error and no emit
+Clean build will not have latestChangedDtsFile as there was no emit and emitSignatures as undefined for files
+Incremental will store the past latestChangedDtsFile and emitSignatures
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-composite.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-composite.js
@@ -58,97 +58,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "src/class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "src/indirectClass" {
-    import { classC } from "src/class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "src/directUse" { }
-declare module "src/indirectUse" { }
-declare module "src/noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("src/class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("src/noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -241,11 +152,233 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1736
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "src/class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "src/indirectClass" {
+    import { classC } from "src/class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "src/directUse" { }
+declare module "src/indirectUse" { }
+declare module "src/noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("src/class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("src/noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2052
+  "size": 2267
 }
 
 
@@ -367,7 +500,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -460,11 +593,70 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2056
+  "size": 2847
 }
 
 
@@ -483,97 +675,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "src/class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "src/indirectClass" {
-    import { classC } from "src/class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "src/directUse" { }
-declare module "src/indirectUse" { }
-declare module "src/noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("src/class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("src/noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -666,10 +769,234 @@ function someFunc(arguments) {
       "module": 2,
       "outFile": "./outFile.js"
     },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "outSignature": "-1966987419-declare module \"src/class\" {\n    export class classC {\n        prop1: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 2289
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "src/class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "src/indirectClass" {
+    import { classC } from "src/class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "src/directUse" { }
+declare module "src/indirectUse" { }
+declare module "src/noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("src/class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("src/indirectClass", ["require", "exports", "src/class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("src/directUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("src/indirectUse", ["require", "exports", "src/indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("src/noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"outSignature":"8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
     "outSignature": "8998999540-declare module \"src/class\" {\n    export class classC {\n        prop: number;\n    }\n}\ndeclare module \"src/indirectClass\" {\n    import { classC } from \"src/class\";\n    export class indirectClass {\n        classC: classC;\n    }\n}\ndeclare module \"src/directUse\" { }\ndeclare module \"src/indirectUse\" { }\ndeclare module \"src/noChangeFile\" {\n    export function writeLog(s: string): void;\n}\ndeclare function someFunc(arguments: boolean, ...rest: any[]): void;\n",
     "latestChangedDtsFile": "./outFile.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 2052
+  "size": 2267
 }
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-incremental-declaration.js
@@ -59,97 +59,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "indirectClass" {
-    import { classC } from "class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "directUse" { }
-declare module "indirectUse" { }
-declare module "noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -241,10 +152,232 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1503
+  "size": 1738
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "indirectClass" {
+    import { classC } from "class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "directUse" { }
+declare module "indirectUse" { }
+declare module "noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1718
 }
 
 
@@ -366,7 +499,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -458,10 +591,69 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1505
+  "size": 2296
 }
 
 
@@ -480,97 +672,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.d.ts]
-declare module "class" {
-    export class classC {
-        prop: number;
-    }
-}
-declare module "indirectClass" {
-    import { classC } from "class";
-    export class indirectClass {
-        classC: classC;
-    }
-}
-declare module "directUse" { }
-declare module "indirectUse" { }
-declare module "noChangeFile" {
-    export function writeLog(s: string): void;
-}
-declare function someFunc(arguments: boolean, ...rest: any[]): void;
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -662,9 +765,231 @@ function someFunc(arguments) {
       "declaration": true,
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1503
+  "size": 1738
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.d.ts]
+declare module "class" {
+    export class classC {
+        prop: number;
+    }
+}
+declare module "indirectClass" {
+    import { classC } from "class";
+    export class indirectClass {
+        classC: classC;
+    }
+}
+declare module "directUse" { }
+declare module "indirectUse" { }
+declare module "noChangeFile" {
+    export function writeLog(s: string): void;
+}
+declare function someFunc(arguments: boolean, ...rest: any[]): void;
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"declaration":true,"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1718
 }
 

--- a/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-incremental.js
+++ b/tests/baselines/reference/tsc/noEmit/outFile/changes-with-initial-noEmit-incremental.js
@@ -58,77 +58,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -219,10 +150,211 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1484
+  "size": 1719
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1699
 }
 
 
@@ -324,7 +456,7 @@ function someFunc(arguments) {
 
 
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"1786859709-export class classC {\n    prop1 = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[4,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[5,[{"start":76,"length":4,"code":2551,"category":1,"messageText":"Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?","relatedInformation":[{"file":"./project/src/class.ts","start":26,"length":5,"messageText":"'prop1' is declared here.","category":3,"code":2728}]}]],[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -415,10 +547,69 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/directuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/indirectuse.ts",
+        [
+          {
+            "start": 76,
+            "length": 4,
+            "code": 2551,
+            "category": 1,
+            "messageText": "Property 'prop' does not exist on type 'classC'. Did you mean 'prop1'?",
+            "relatedInformation": [
+              {
+                "file": "./project/src/class.ts",
+                "start": 26,
+                "length": 5,
+                "messageText": "'prop1' is declared here.",
+                "category": 3,
+                "code": 2728
+              }
+            ]
+          }
+        ]
+      ],
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1486
+  "size": 2277
 }
 
 
@@ -437,77 +628,8 @@ Output::
 exitCode:: ExitStatus.Success
 
 
-
-
-Change:: No Change run with emit
-Input::
-
-
-Output::
-/lib/tsc --p src/project
-[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-
-[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
-[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
-
-
-//// [/src/outFile.js]
-define("class", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.classC = void 0;
-    var classC = /** @class */ (function () {
-        function classC() {
-            this.prop = 1;
-        }
-        return classC;
-    }());
-    exports.classC = classC;
-});
-define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.indirectClass = void 0;
-    var indirectClass = /** @class */ (function () {
-        function indirectClass() {
-            this.classC = new class_1.classC();
-        }
-        return indirectClass;
-    }());
-    exports.indirectClass = indirectClass;
-});
-define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_1.indirectClass().classC.prop;
-});
-define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    new indirectClass_2.indirectClass().classC.prop;
-});
-define("noChangeFile", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.writeLog = writeLog;
-    function writeLog(s) {
-    }
-});
-function someFunc(arguments) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-}
-
-
 //// [/src/outFile.tsbuildinfo]
-{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"}},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]],"pendingEmit":false},"version":"FakeTSVersion"}
 
 //// [/src/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -598,9 +720,210 @@ function someFunc(arguments) {
     "options": {
       "module": 2,
       "outFile": "./outFile.js"
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 1484
+  "size": 1719
+}
+
+
+
+Change:: No Change run with emit
+Input::
+
+
+Output::
+/lib/tsc --p src/project
+[96msrc/project/src/noChangeFileWithEmitSpecificError.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2396: [0mDuplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
+
+[7m1[0m function someFunc(arguments: boolean, ...rest: any[]) {
+[7m [0m [91m                  ~~~~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error in src/project/src/noChangeFileWithEmitSpecificError.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/outFile.js]
+define("class", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.classC = void 0;
+    var classC = /** @class */ (function () {
+        function classC() {
+            this.prop = 1;
+        }
+        return classC;
+    }());
+    exports.classC = classC;
+});
+define("indirectClass", ["require", "exports", "class"], function (require, exports, class_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.indirectClass = void 0;
+    var indirectClass = /** @class */ (function () {
+        function indirectClass() {
+            this.classC = new class_1.classC();
+        }
+        return indirectClass;
+    }());
+    exports.indirectClass = indirectClass;
+});
+define("directUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_1.indirectClass().classC.prop;
+});
+define("indirectUse", ["require", "exports", "indirectClass"], function (require, exports, indirectClass_2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    new indirectClass_2.indirectClass().classC.prop;
+});
+define("noChangeFile", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.writeLog = writeLog;
+    function writeLog(s) {
+    }
+});
+function someFunc(arguments) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+}
+
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/src/class.ts","./project/src/indirectclass.ts","./project/src/directuse.ts","./project/src/indirectuse.ts","./project/src/nochangefile.ts","./project/src/nochangefilewithemitspecificerror.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"545032748-export class classC {\n    prop = 1;\n}","impliedFormat":1},{"version":"6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;","impliedFormat":1},{"version":"6714567633-export function writeLog(s: string) {\n}","impliedFormat":1},{"version":"-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}","impliedFormat":1}],"root":[[2,7]],"options":{"module":2,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[7,[{"start":18,"length":18,"messageText":"Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.","category":1,"code":2396,"skippedOn":"noEmit"}]]]},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/src/class.ts",
+      "./project/src/indirectclass.ts",
+      "./project/src/directuse.ts",
+      "./project/src/indirectuse.ts",
+      "./project/src/nochangefile.ts",
+      "./project/src/nochangefilewithemitspecificerror.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/class.ts": {
+        "original": {
+          "version": "545032748-export class classC {\n    prop = 1;\n}",
+          "impliedFormat": 1
+        },
+        "version": "545032748-export class classC {\n    prop = 1;\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectclass.ts": {
+        "original": {
+          "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+          "impliedFormat": 1
+        },
+        "version": "6324910780-import { classC } from './class';\nexport class indirectClass {\n    classC = new classC();\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/directuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/indirectuse.ts": {
+        "original": {
+          "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+          "impliedFormat": 1
+        },
+        "version": "-8953710208-import { indirectClass } from './indirectClass';\nnew indirectClass().classC.prop;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefile.ts": {
+        "original": {
+          "version": "6714567633-export function writeLog(s: string) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "6714567633-export function writeLog(s: string) {\n}",
+        "impliedFormat": "commonjs"
+      },
+      "./project/src/nochangefilewithemitspecificerror.ts": {
+        "original": {
+          "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+          "impliedFormat": 1
+        },
+        "version": "-19339541508-function someFunc(arguments: boolean, ...rest: any[]) {\n}",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          7
+        ],
+        [
+          "./project/src/class.ts",
+          "./project/src/indirectclass.ts",
+          "./project/src/directuse.ts",
+          "./project/src/indirectuse.ts",
+          "./project/src/nochangefile.ts",
+          "./project/src/nochangefilewithemitspecificerror.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/src/nochangefilewithemitspecificerror.ts",
+        [
+          {
+            "start": 18,
+            "length": 18,
+            "messageText": "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.",
+            "category": 1,
+            "code": 2396,
+            "skippedOn": "noEmit"
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1699
 }
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/file-deleted-before-fixing-error-with-noEmitOnError.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/file-deleted-before-fixing-error-with-noEmitOnError.js
@@ -61,10 +61,88 @@ Program files::
 /src/project/file1.ts
 /src/project/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/file1.ts
+/src/project/file2.ts
 
 No shapes updated in the builder::
 
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/file1.ts","./project/file2.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-10927263693-export const x: 30 = \"hello\";","impliedFormat":1},{"version":"-7804761415-export class D { }","impliedFormat":1}],"root":[2,3],"options":{"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type '\"hello\"' is not assignable to type '30'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/file1.ts",
+      "./project/file2.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/file1.ts": {
+        "original": {
+          "version": "-10927263693-export const x: 30 = \"hello\";",
+          "impliedFormat": 1
+        },
+        "version": "-10927263693-export const x: 30 = \"hello\";",
+        "impliedFormat": "commonjs"
+      },
+      "./project/file2.ts": {
+        "original": {
+          "version": "-7804761415-export class D { }",
+          "impliedFormat": 1
+        },
+        "version": "-7804761415-export class D { }",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./project/file1.ts"
+      ],
+      [
+        3,
+        "./project/file2.ts"
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/file1.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '\"hello\"' is not assignable to type '30'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 991
+}
 
 
 
@@ -100,8 +178,72 @@ Program files::
 /lib/lib.d.ts
 /src/project/file1.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/lib/lib.d.ts
+/src/project/file1.ts
 
 No shapes updated in the builder::
 
+
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/file1.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-10927263693-export const x: 30 = \"hello\";","impliedFormat":1}],"root":[2],"options":{"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type '\"hello\"' is not assignable to type '30'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/file1.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/file1.ts": {
+        "original": {
+          "version": "-10927263693-export const x: 30 = \"hello\";",
+          "impliedFormat": 1
+        },
+        "version": "-10927263693-export const x: 30 = \"hello\";",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./project/file1.ts"
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/file1.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '\"hello\"' is not assignable to type '30'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 905
+}
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/semantic-errors-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/semantic-errors-with-declaration-with-incremental.js
@@ -74,10 +74,102 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1216
+}
 
 
 
@@ -116,7 +208,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -154,7 +246,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -287,7 +383,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/semantic-errors-with-incremental.js
@@ -72,10 +72,101 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1197
+}
 
 
 
@@ -113,7 +204,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -150,7 +241,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -269,7 +364,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/syntax-errors-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/syntax-errors-with-declaration-with-incremental.js
@@ -77,10 +77,88 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1080
+}
 
 
 
@@ -119,7 +197,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -159,7 +237,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -294,7 +376,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/syntax-errors-with-incremental.js
@@ -75,10 +75,87 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
+
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1061
+}
 
 
 
@@ -116,7 +193,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -155,7 +232,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -276,7 +357,7 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/when-declarationMap-changes-discrepancies.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/when-declarationMap-changes-discrepancies.js
@@ -1,0 +1,110 @@
+0:: error and enable declarationMap
+Clean build does not emit any file so will not have outSignature
+Incremental build has outSignature from before
+TsBuild info text without affectedFilesPendingEmit:: /src/outfile.tsbuildinfo.readable.baseline.txt::
+CleanBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/a.ts": {
+        "version": "5515933561-const x: 20 = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/b.ts": {
+        "version": "2026006654-const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./project/a.ts"
+      ],
+      [
+        3,
+        "./project/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "declarationMap": true,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/a.ts",
+        [
+          {
+            "start": 6,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '10' is not assignable to type '20'."
+          }
+        ]
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+IncrementalBuild:
+{
+  "program": {
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/a.ts": {
+        "version": "5515933561-const x: 20 = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/b.ts": {
+        "version": "2026006654-const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./project/a.ts"
+      ],
+      [
+        3,
+        "./project/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "declarationMap": true,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/a.ts",
+        [
+          {
+            "start": 6,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '10' is not assignable to type '20'."
+          }
+        ]
+      ]
+    ],
+    "outSignature": [
+      "-2781996726-declare const x = 10;\ndeclare const y = 10;\n"
+    ],
+    "latestChangedDtsFile": "FakeFileName"
+  },
+  "version": "FakeTSVersion"
+}

--- a/tests/baselines/reference/tsc/noEmitOnError/outFile/when-declarationMap-changes.js
+++ b/tests/baselines/reference/tsc/noEmitOnError/outFile/when-declarationMap-changes.js
@@ -130,6 +130,87 @@ Found 1 error in src/project/a.ts[90m:1[0m
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
+//// [/src/outFile.tsbuildinfo]
+{"program":{"fileNames":["../lib/lib.d.ts","./project/a.ts","./project/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"5515933561-const x: 20 = 10;","impliedFormat":1},{"version":"2026006654-const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"declaration":true,"declarationMap":true,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":6,"length":1,"code":2322,"category":1,"messageText":"Type '10' is not assignable to type '20'."}]]],"outSignature":["-2781996726-declare const x = 10;\ndeclare const y = 10;\n"],"latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/src/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../lib/lib.d.ts",
+      "./project/a.ts",
+      "./project/b.ts"
+    ],
+    "fileInfos": {
+      "../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./project/a.ts": {
+        "original": {
+          "version": "5515933561-const x: 20 = 10;",
+          "impliedFormat": 1
+        },
+        "version": "5515933561-const x: 20 = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./project/b.ts": {
+        "original": {
+          "version": "2026006654-const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "2026006654-const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./project/a.ts"
+      ],
+      [
+        3,
+        "./project/b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "declarationMap": true,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./project/a.ts",
+        [
+          {
+            "start": 6,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '10' is not assignable to type '20'."
+          }
+        ]
+      ]
+    ],
+    "outSignature": [
+      "-2781996726-declare const x = 10;\ndeclare const y = 10;\n"
+    ],
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts | DtsMap",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1118
+}
+
 
 
 Change:: fix error declarationMap
@@ -152,6 +233,7 @@ declare const y = 10;
 //// [/src/outFile.d.ts.map]
 {"version":3,"file":"outFile.d.ts","sourceRoot":"","sources":["project/a.ts","project/b.ts"],"names":[],"mappings":"AAAA,QAAA,MAAM,CAAC,KAAK,CAAC;ACAb,QAAA,MAAM,CAAC,KAAK,CAAC"}
 
+//// [/src/outFile.js] file written with same contents
 //// [/src/outFile.tsbuildinfo]
 {"program":{"fileNames":["../lib/lib.d.ts","./project/a.ts","./project/b.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"5029505981-const x = 10;","impliedFormat":1},{"version":"2026006654-const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"declaration":true,"declarationMap":true,"noEmitOnError":true,"outFile":"./outFile.js"},"outSignature":"-2781996726-declare const x = 10;\ndeclare const y = 10;\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
@@ -138,7 +138,13 @@ Program files::
 /a/b/globalFile3.ts
 /a/b/moduleFile2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/moduleFile1.ts
+/a/b/file1Consumer1.ts
+/a/b/file1Consumer2.ts
+/a/b/globalFile3.ts
+/a/b/moduleFile2.ts
 
 No shapes updated in the builder::
 
@@ -241,7 +247,13 @@ Program files::
 /a/b/globalFile3.ts
 /a/b/moduleFile2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/moduleFile1.ts
+/a/b/file1Consumer1.ts
+/a/b/file1Consumer2.ts
+/a/b/globalFile3.ts
+/a/b/moduleFile2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
@@ -73,7 +73,10 @@ Program files::
 /a/b.ts
 /a/lib/lib.d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/a.ts
+/a/b.ts
+/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 
@@ -126,7 +129,10 @@ Program files::
 /a/b.ts
 /a/lib/lib.d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/a.ts
+/a/b.ts
+/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 
@@ -179,7 +185,10 @@ Program files::
 /a/b.ts
 /a/lib/lib.d.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/a.ts
+/a/b.ts
+/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
@@ -110,7 +110,12 @@ Program files::
 /a/b/project/src/main.ts
 /a/b/project/src/main2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/output/AnotherDependency/file1.d.ts
+/a/b/dependencies/file2.d.ts
+/a/b/project/src/main.ts
+/a/b/project/src/main2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
@@ -170,7 +170,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -295,7 +299,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
@@ -170,7 +170,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -295,7 +299,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -178,7 +178,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/xY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -311,7 +315,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/xY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -178,7 +178,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -311,7 +315,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -178,7 +178,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -311,7 +315,11 @@ Program files::
 /user/username/projects/myproject/link/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-incremental.js
@@ -121,7 +121,10 @@ Program files::
 /users/username/projects/project/file1.ts
 /users/username/projects/project/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/file1.ts
+/users/username/projects/project/file2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-watch.js
@@ -151,7 +151,10 @@ Program files::
 /users/username/projects/project/file1.ts
 /users/username/projects/project/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/file1.ts
+/users/username/projects/project/file2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/incremental/with---out-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/with---out-incremental.js
@@ -108,7 +108,10 @@ Program files::
 /users/username/projects/project/file1.ts
 /users/username/projects/project/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/file1.ts
+/users/username/projects/project/file2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
@@ -134,7 +134,10 @@ Program files::
 /users/username/projects/project/file1.ts
 /users/username/projects/project/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/file1.ts
+/users/username/projects/project/file2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration-with-incremental.js
@@ -59,6 +59,80 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1080
+}
+
 
 PolledWatches::
 /user/username/projects/noEmitOnError/node_modules/@types: *new*
@@ -113,7 +187,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -160,37 +238,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = {
-        lastName: 'sdsd'
-    };
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
-
-
-//// [/user/username/projects/dev-build.d.ts]
-declare module "shared/types/db" {
-    export interface A {
-        name: string;
-    }
-}
-declare module "src/main" { }
-declare module "src/other" {
-    export {};
-}
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -263,6 +310,37 @@ declare module "src/other" {
   "size": 1059
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = {
+        lastName: 'sdsd'
+    };
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
+//// [/user/username/projects/dev-build.d.ts]
+declare module "shared/types/db" {
+    export interface A {
+        name: string;
+    }
+}
+declare module "src/main" { }
+declare module "src/other" {
+    export {};
+}
+
+
 
 
 Program root files: [
@@ -286,7 +364,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -321,6 +403,94 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "declaration": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1216
+}
+
 
 
 Program root files: [
@@ -344,7 +514,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -391,24 +565,6 @@ Output::
 
 
 
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = "hello";
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
-
-
-//// [/user/username/projects/dev-build.d.ts] file written with same contents
 //// [/user/username/projects/dev-build.tsbuildinfo]
 {"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-8373351622-import { A } from \"../shared/types/db\";\nconst a: string = \"hello\";","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"declaration":true,"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"}},"version":"FakeTSVersion"}
 
@@ -479,6 +635,24 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1050
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = "hello";
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
+//// [/user/username/projects/dev-build.d.ts] file written with same contents
 
 
 Program root files: [
@@ -502,7 +676,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration.js
@@ -111,7 +111,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -213,7 +217,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -270,7 +278,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -357,7 +369,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-incremental.js
@@ -58,6 +58,79 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+          "impliedFormat": 1
+        },
+        "version": "-2574607723-import { A } from \"../shared/types/db\";\nconst a = {\n    lastName: 'sdsd'\n;\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1061
+}
+
 
 PolledWatches::
 /user/username/projects/noEmitOnError/node_modules/@types: *new*
@@ -111,7 +184,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -158,25 +235,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = {
-        lastName: 'sdsd'
-    };
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -248,6 +306,25 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1040
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = {
+        lastName: 'sdsd'
+    };
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
 
 
 Program root files: [
@@ -270,7 +347,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -305,6 +386,93 @@ Output::
 
 
 
+//// [/user/username/projects/dev-build.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./noemitonerror/shared/types/db.ts","./noemitonerror/src/main.ts","./noemitonerror/src/other.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","impliedFormat":1},{"version":"-5014788164-export interface A {\n    name: string;\n}\n","impliedFormat":1},{"version":"-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;","impliedFormat":1},{"version":"9084524823-console.log(\"hi\");\nexport { }\n","impliedFormat":1}],"root":[[2,4]],"options":{"module":2,"noEmitOnError":true,"outFile":"./dev-build.js"},"semanticDiagnosticsPerFile":[[3,[{"start":46,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/dev-build.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./noemitonerror/shared/types/db.ts",
+      "./noemitonerror/src/main.ts",
+      "./noemitonerror/src/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "impliedFormat": 1
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/shared/types/db.ts": {
+        "original": {
+          "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+          "impliedFormat": 1
+        },
+        "version": "-5014788164-export interface A {\n    name: string;\n}\n",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/main.ts": {
+        "original": {
+          "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-11111345725-import { A } from \"../shared/types/db\";\nconst a: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./noemitonerror/src/other.ts": {
+        "original": {
+          "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+          "impliedFormat": 1
+        },
+        "version": "9084524823-console.log(\"hi\");\nexport { }\n",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        [
+          2,
+          4
+        ],
+        [
+          "./noemitonerror/shared/types/db.ts",
+          "./noemitonerror/src/main.ts",
+          "./noemitonerror/src/other.ts"
+        ]
+      ]
+    ],
+    "options": {
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./dev-build.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./noemitonerror/src/main.ts",
+        [
+          {
+            "start": 46,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1197
+}
+
 
 
 Program root files: [
@@ -327,7 +495,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -372,23 +544,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/dev-build.js]
-define("shared/types/db", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-});
-define("src/main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var a = "hello";
-});
-define("src/other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    console.log("hi");
-});
 
 
 //// [/user/username/projects/dev-build.tsbuildinfo]
@@ -460,6 +615,23 @@ define("src/other", ["require", "exports"], function (require, exports) {
   "size": 1031
 }
 
+//// [/user/username/projects/dev-build.js]
+define("shared/types/db", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+});
+define("src/main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var a = "hello";
+});
+define("src/other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    console.log("hi");
+});
+
+
 
 
 Program root files: [
@@ -482,7 +654,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError.js
@@ -109,7 +109,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -198,7 +202,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -254,7 +262,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 
@@ -339,7 +351,11 @@ Program files::
 /user/username/projects/noEmitOnError/src/main.ts
 /user/username/projects/noEmitOnError/src/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/noEmitOnError/shared/types/db.ts
+/user/username/projects/noEmitOnError/src/main.ts
+/user/username/projects/noEmitOnError/src/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
@@ -138,7 +138,10 @@ Program files::
 /a/b/f1.ts
 /a/b/f2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/f1.ts
+/a/b/f2.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
@@ -98,7 +98,10 @@ Program files::
 /user/username/projects/myproject/file1.ts
 /user/username/projects/myproject/src/file2.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/file1.ts
+/user/username/projects/myproject/src/file2.ts
 
 No shapes updated in the builder::
 
@@ -208,7 +211,11 @@ Program files::
 /user/username/projects/myproject/src/file2.ts
 /user/username/projects/myproject/src/file3.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/file1.ts
+/user/username/projects/myproject/src/file2.ts
+/user/username/projects/myproject/src/file3.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-emit-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-emit-builder.js
@@ -38,6 +38,67 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-10726455937-export const x = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-10726455937-export const x = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-10726455937-export const x = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 759
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -80,7 +141,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -93,30 +157,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
-
-
-//// [/user/username/projects/outFile.d.ts]
-declare module "main" {
-    export const x = 10;
-}
-declare module "other" {
-    export const y = 10;
-}
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -178,6 +218,30 @@ declare module "other" {
   "size": 921
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "main" {
+    export const x = 10;
+}
+declare module "other" {
+    export const y = 10;
+}
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types:
@@ -243,7 +307,7 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -290,6 +354,69 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-14918944530-export const x = 10;\n// SomeComment","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-14918944530-export const x = 10;\n// SomeComment",
+          "impliedFormat": 1
+        },
+        "version": "-14918944530-export const x = 10;\n// SomeComment",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "outSignature": "3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n",
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 957
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -332,7 +459,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -345,22 +475,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-// SomeComment
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -422,6 +536,22 @@ define("other", ["require", "exports"], function (require, exports) {
   "size": 937
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+// SomeComment
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types:
@@ -487,7 +617,7 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -533,23 +663,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-// SomeComment
-// SomeComment
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -611,6 +724,23 @@ define("other", ["require", "exports"], function (require, exports) {
   "size": 953
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+// SomeComment
+// SomeComment
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -652,7 +782,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-semantic-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-semantic-builder.js
@@ -38,6 +38,67 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-10726455937-export const x = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-10726455937-export const x = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-10726455937-export const x = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 759
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -80,7 +141,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -100,30 +164,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
-
-
-//// [/user/username/projects/outFile.d.ts]
-declare module "main" {
-    export const x = 10;
-}
-declare module "other" {
-    export const y = 10;
-}
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -185,6 +225,30 @@ declare module "other" {
   "size": 921
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "main" {
+    export const x = 10;
+}
+declare module "other" {
+    export const y = 10;
+}
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types:
@@ -250,7 +314,7 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -304,6 +368,69 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-14918944530-export const x = 10;\n// SomeComment","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"outFile":"./outFile.js"},"outSignature":"3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-14918944530-export const x = 10;\n// SomeComment",
+          "impliedFormat": 1
+        },
+        "version": "-14918944530-export const x = 10;\n// SomeComment",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "outFile": "./outFile.js"
+    },
+    "outSignature": "3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n",
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 957
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -346,7 +473,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -366,22 +496,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-// SomeComment
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -443,6 +557,22 @@ define("other", ["require", "exports"], function (require, exports) {
   "size": 937
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+// SomeComment
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types:
@@ -508,7 +638,7 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
 
 No shapes updated in the builder::
 
@@ -561,23 +691,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-// SomeComment
-// SomeComment
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -639,6 +752,23 @@ define("other", ["require", "exports"], function (require, exports) {
   "size": 953
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+// SomeComment
+// SomeComment
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -680,7 +810,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-emit-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-emit-builder.js
@@ -44,6 +44,82 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-8089124208-export const x: string = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-8089124208-export const x: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-8089124208-export const x: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./myproject/main.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 939
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -86,7 +162,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -138,6 +217,82 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-5691975201-export const x: string = 10;\n// SomeComment","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-5691975201-export const x: string = 10;\n// SomeComment",
+          "impliedFormat": 1
+        },
+        "version": "-5691975201-export const x: string = 10;\n// SomeComment",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./myproject/main.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 955
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -180,7 +335,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -224,30 +382,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
-
-
-//// [/user/username/projects/outFile.d.ts]
-declare module "main" {
-    export const x = 10;
-}
-declare module "other" {
-    export const y = 10;
-}
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -310,6 +444,30 @@ declare module "other" {
   "size": 942
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "main" {
+    export const x = 10;
+}
+declare module "other" {
+    export const y = 10;
+}
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -352,7 +510,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-semantic-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-semantic-builder.js
@@ -44,6 +44,82 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-8089124208-export const x: string = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-8089124208-export const x: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-8089124208-export const x: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./myproject/main.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 939
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -86,7 +162,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -145,6 +224,82 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-5691975201-export const x: string = 10;\n// SomeComment","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-5691975201-export const x: string = 10;\n// SomeComment",
+          "impliedFormat": 1
+        },
+        "version": "-5691975201-export const x: string = 10;\n// SomeComment",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./myproject/main.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 955
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -187,7 +342,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -238,30 +396,6 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-
-
-//// [/user/username/projects/outFile.js]
-define("main", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.x = void 0;
-    exports.x = 10;
-});
-define("other", ["require", "exports"], function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.y = void 0;
-    exports.y = 10;
-});
-
-
-//// [/user/username/projects/outFile.d.ts]
-declare module "main" {
-    export const x = 10;
-}
-declare module "other" {
-    export const y = 10;
-}
 
 
 //// [/user/username/projects/outFile.tsbuildinfo]
@@ -324,6 +458,30 @@ declare module "other" {
   "size": 942
 }
 
+//// [/user/username/projects/outFile.js]
+define("main", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = void 0;
+    exports.x = 10;
+});
+define("other", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.y = void 0;
+    exports.y = 10;
+});
+
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "main" {
+    export const x = 10;
+}
+declare module "other" {
+    export const y = 10;
+}
+
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -366,7 +524,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/semantic-builder-emitOnlyDts.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/semantic-builder-emitOnlyDts.js
@@ -44,6 +44,82 @@ Output::
 
 
 
+//// [/user/username/projects/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-8089124208-export const x: string = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[2,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type 'number' is not assignable to type 'string'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../a/lib/lib.d.ts",
+      "./myproject/main.ts",
+      "./myproject/other.ts"
+    ],
+    "fileInfos": {
+      "../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/main.ts": {
+        "original": {
+          "version": "-8089124208-export const x: string = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-8089124208-export const x: string = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./myproject/other.ts": {
+        "original": {
+          "version": "-13729955264-export const y = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-13729955264-export const y = 10;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./myproject/main.ts"
+      ],
+      [
+        3,
+        "./myproject/other.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./myproject/main.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type 'number' is not assignable to type 'string'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 939
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -86,7 +162,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -131,17 +210,8 @@ Output::
 
 
 
-//// [/user/username/projects/outFile.d.ts]
-declare module "main" {
-    export const x = 10;
-}
-declare module "other" {
-    export const y = 10;
-}
-
-
 //// [/user/username/projects/outFile.tsbuildinfo]
-{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-10726455937-export const x = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"outSignature":"3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n","latestChangedDtsFile":"./outFile.d.ts"},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../../../a/lib/lib.d.ts","./myproject/main.ts","./myproject/other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-10726455937-export const x = 10;","impliedFormat":1},{"version":"-13729955264-export const y = 10;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"outSignature":"3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n","latestChangedDtsFile":"./outFile.d.ts","pendingEmit":1},"version":"FakeTSVersion"}
 
 //// [/user/username/projects/outFile.tsbuildinfo.readable.baseline.txt]
 {
@@ -194,11 +264,24 @@ declare module "other" {
       "outFile": "./outFile.js"
     },
     "outSignature": "3483479585-declare module \"main\" {\n    export const x = 10;\n}\ndeclare module \"other\" {\n    export const y = 10;\n}\n",
-    "latestChangedDtsFile": "./outFile.d.ts"
+    "latestChangedDtsFile": "./outFile.d.ts",
+    "pendingEmit": [
+      "Js",
+      1
+    ]
   },
   "version": "FakeTSVersion",
-  "size": 942
+  "size": 958
 }
+
+//// [/user/username/projects/outFile.d.ts]
+declare module "main" {
+    export const x = 10;
+}
+declare module "other" {
+    export const y = 10;
+}
+
 
 
 PolledWatches::
@@ -242,7 +325,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/verifies-that-noEmit-is-handled-on-createSemanticDiagnosticsBuilderProgram.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/verifies-that-noEmit-is-handled-on-createSemanticDiagnosticsBuilderProgram.js
@@ -73,7 +73,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 
@@ -121,7 +124,10 @@ Program files::
 /user/username/projects/myproject/main.ts
 /user/username/projects/myproject/other.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/main.ts
+/user/username/projects/myproject/other.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/when-emitting-with-emitOnlyDtsFiles.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/when-emitting-with-emitOnlyDtsFiles.js
@@ -62,6 +62,82 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node
 
 
 
+//// [/user/username/projects/myproject/outFile.tsbuildinfo]
+{"program":{"fileNames":["../../../../a/lib/lib.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","impliedFormat":1},{"version":"-10726455937-export const x = 10;","impliedFormat":1},{"version":"-11268290852-export const y: 10 = 20;","impliedFormat":1}],"root":[2,3],"options":{"composite":true,"module":2,"noEmitOnError":true,"outFile":"./outFile.js"},"semanticDiagnosticsPerFile":[[3,[{"start":13,"length":1,"code":2322,"category":1,"messageText":"Type '20' is not assignable to type '10'."}]]],"pendingEmit":false},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/myproject/outFile.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../a/lib/lib.d.ts",
+      "./a.ts",
+      "./b.ts"
+    ],
+    "fileInfos": {
+      "../../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+          "impliedFormat": 1
+        },
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "impliedFormat": "commonjs"
+      },
+      "./a.ts": {
+        "original": {
+          "version": "-10726455937-export const x = 10;",
+          "impliedFormat": 1
+        },
+        "version": "-10726455937-export const x = 10;",
+        "impliedFormat": "commonjs"
+      },
+      "./b.ts": {
+        "original": {
+          "version": "-11268290852-export const y: 10 = 20;",
+          "impliedFormat": 1
+        },
+        "version": "-11268290852-export const y: 10 = 20;",
+        "impliedFormat": "commonjs"
+      }
+    },
+    "root": [
+      [
+        2,
+        "./a.ts"
+      ],
+      [
+        3,
+        "./b.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "module": 2,
+      "noEmitOnError": true,
+      "outFile": "./outFile.js"
+    },
+    "semanticDiagnosticsPerFile": [
+      [
+        "./b.ts",
+        [
+          {
+            "start": 13,
+            "length": 1,
+            "code": 2322,
+            "category": 1,
+            "messageText": "Type '20' is not assignable to type '10'."
+          }
+        ]
+      ]
+    ],
+    "pendingEmit": [
+      "Js | Dts",
+      false
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 904
+}
+
 
 PolledWatches::
 /user/username/projects/myproject/node_modules/@types: *new*
@@ -101,7 +177,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 
@@ -135,15 +214,6 @@ Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/a.ts","/user/username/projects/myproject/b.ts"]
   options: {"composite":true,"noEmitOnError":true,"module":2,"outFile":"/user/username/projects/myproject/outFile.js","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-
-
-//// [/user/username/projects/myproject/outFile.d.ts]
-declare module "a" {
-    export const x = 10;
-}
-declare module "b" {
-    export const y = 10;
-}
 
 
 //// [/user/username/projects/myproject/outFile.tsbuildinfo]
@@ -210,6 +280,15 @@ declare module "b" {
   "size": 928
 }
 
+//// [/user/username/projects/myproject/outFile.d.ts]
+declare module "a" {
+    export const x = 10;
+}
+declare module "b" {
+    export const y = 10;
+}
+
+
 
 
 Program root files: [
@@ -230,7 +309,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.ts
 
-No cached semantic diagnostics in the builder::
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/a.ts
+/user/username/projects/myproject/b.ts
 
 No shapes updated in the builder::
 


### PR DESCRIPTION
This makes `--outFile` behave similar to not specifying it.
Previously we use to store the bundle section information in the `outFileBuildInfo` which means we could not emit buildInfo without emitting the other output files and had to be always in sync. But now that we are not storing that information with no support for `prepend`, we can write buildInfo even if the other outputs like js or dts were not emitted. This helps with storing semantic diagnostics information and dts errors information in the buildInfo so we can re-use it just like multiFile scenario.
The changes are:
- Cache semantic diagnostics in `--outFile` scenario
- Ensuring all places that checked for outFile not present when emitting buildInfo explicitly to disable that
- Ensuring emitter can emit only outFile's js, dts, map etc without emitting buildInfo so that buildInfo can be synchronized correctly with the builder state for changeFileSet, dts diagnostics etc (this is similar to multiFileScenario where we emit all affected files one by one and then emit build info. In --outFile we have to emit program without emitting buildInfo and then emit buildInfo in later stage)