### PR TITLE
Remove unwrapParenthesizedType, use skipTypeParentheses

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1088,7 +1088,6 @@ import {
     UnionType,
     UnionTypeNode,
     UniqueESSymbolType,
-    unwrapParenthesizedType,
     usingSingleLineStringWriter,
     VariableDeclaration,
     VariableDeclarationList,
@@ -8603,7 +8602,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             function tryVisitSimpleTypeNode(node: TypeNode): TypeNode | undefined {
-                const innerNode = unwrapParenthesizedType(node);
+                const innerNode = skipTypeParentheses(node);
                 switch (innerNode.kind) {
                     case SyntaxKind.TypeReference:
                         return tryVisitTypeReference(innerNode as TypeReferenceNode);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -11645,14 +11645,6 @@ export function unwrapParenthesizedExpression(o: Expression) {
 }
 
 /** @internal */
-export function unwrapParenthesizedType(o: TypeNode) {
-    while (o.kind === SyntaxKind.ParenthesizedType) {
-        o = (o as ParenthesizedTypeNode).type;
-    }
-    return o;
-}
-
-/** @internal */
 export function hasInferredType(node: Node): node is HasInferredType {
     Debug.type<HasInferredType>(node);
     switch (node.kind) {


### PR DESCRIPTION
Follow-up to #58758