### PR TITLE
Suggest editor.foldingImportsByDefault in settings.template.json

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -21,6 +21,9 @@
     "javascript.preferences.importModuleSpecifierEnding": "js",
     "typescript.preferences.importModuleSpecifierEnding": "js",
 
+    // Auto-fold imports.
+    // "editor.foldingImportsByDefault": true,
+
     // Match dprint in organize/auto-imports.
     "typescript.unstable": {
         "organizeImportsCollation": "unicode",


### PR DESCRIPTION
Since nobody knew this existed or worked.

I can uncomment it instead too.