### PR TITLE
Report updateGraph time in async requests (that is getErr) as well as part of request completed event

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2491,6 +2491,7 @@ export interface RequestCompletedEvent extends Event {
 
 export interface RequestCompletedEventBody {
     request_seq: number;
+    performanceData?: PerformanceData;
 }
 
 /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1065,7 +1065,7 @@ export class Session<TMessage = string> implements EventSender {
     }
 
     private sendRequestCompletedEvent(requestId: number): void {
-        this.event<protocol.RequestCompletedEventBody>({ request_seq: requestId }, "requestCompleted");
+        this.event<protocol.RequestCompletedEventBody>({ request_seq: requestId, performanceData: this.performanceData }, "requestCompleted");
     }
 
     private addPerformanceData(key: keyof protocol.PerformanceData, value: number) {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1897,6 +1897,7 @@ declare namespace ts {
             }
             export interface RequestCompletedEventBody {
                 request_seq: number;
+                performanceData?: PerformanceData;
             }
             /**
              * Item of diagnostic information found in a DiagnosticEvent message.

--- a/tests/baselines/reference/tsserver/cancellationT/Geterr-is-cancellable.js
+++ b/tests/baselines/reference/tsserver/cancellationT/Geterr-is-cancellable.js
@@ -234,7 +234,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 2 is as expected
@@ -301,7 +304,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 3 is as expected
@@ -364,7 +370,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 5 is as expected
@@ -455,7 +464,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 6 is as expected
@@ -527,7 +539,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 7
+        "request_seq": 7,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 8 is as expected

--- a/tests/baselines/reference/tsserver/cancellationT/is-attached-to-request.js
+++ b/tests/baselines/reference/tsserver/cancellationT/is-attached-to-request.js
@@ -192,7 +192,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 TestServerCancellationToken:: resetRequest:: 2 is as expected

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -490,7 +490,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -466,7 +466,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -490,7 +490,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -466,7 +466,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -490,7 +490,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -610,7 +610,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -490,7 +490,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -610,7 +610,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
@@ -620,7 +620,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-link-open.js
@@ -384,7 +384,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -546,7 +549,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-target-and-link-open.js
@@ -459,7 +459,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -604,7 +607,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk-with-target-open.js
@@ -384,7 +384,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -529,7 +532,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
@@ -309,7 +309,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -477,7 +480,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-link-open.js
@@ -375,7 +375,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -537,7 +540,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-target-and-link-open.js
@@ -448,7 +448,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -593,7 +596,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk-with-target-open.js
@@ -375,7 +375,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -520,7 +523,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk.js
@@ -302,7 +302,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -470,7 +473,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
@@ -284,7 +284,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -451,7 +454,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-link-open.js
@@ -384,7 +384,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -546,7 +549,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-target-and-link-open.js
@@ -459,7 +459,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -604,7 +607,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not-with-target-open.js
@@ -384,7 +384,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -529,7 +532,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
@@ -309,7 +309,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -477,7 +480,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
@@ -595,7 +595,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1146,7 +1149,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1536,7 +1542,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 10
+        "request_seq": 10,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-link-open.js
@@ -375,7 +375,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -537,7 +540,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-target-and-link-open.js
@@ -448,7 +448,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -593,7 +596,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not-with-target-open.js
@@ -375,7 +375,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -520,7 +523,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not.js
@@ -302,7 +302,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -470,7 +473,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-link-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -574,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
@@ -473,7 +473,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -632,7 +635,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different-with-target-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -557,7 +560,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -323,7 +323,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -505,7 +508,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-link-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -565,7 +568,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-and-link-open.js
@@ -462,7 +462,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -621,7 +624,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different-with-target-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -548,7 +551,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
@@ -316,7 +316,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -498,7 +501,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-link-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -574,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
@@ -473,7 +473,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -632,7 +635,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk-with-target-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -557,7 +560,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -323,7 +323,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -505,7 +508,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-link-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -565,7 +568,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-and-link-open.js
@@ -462,7 +462,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -621,7 +624,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk-with-target-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -548,7 +551,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
@@ -316,7 +316,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -498,7 +501,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-link-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -574,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-and-link-open.js
@@ -473,7 +473,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -632,7 +635,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not-with-target-open.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -557,7 +560,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -323,7 +323,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -505,7 +508,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-link-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -565,7 +568,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-and-link-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-and-link-open.js
@@ -462,7 +462,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -621,7 +624,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-open.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not-with-target-open.js
@@ -389,7 +389,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -548,7 +551,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
@@ -316,7 +316,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -498,7 +501,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
@@ -284,7 +284,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -719,7 +722,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 7
+        "request_seq": 7,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/inconsistentErrorInEditor/should-not-error.js
+++ b/tests/baselines/reference/tsserver/inconsistentErrorInEditor/should-not-error.js
@@ -212,7 +212,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
+++ b/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
@@ -182,7 +182,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/moduleResolution/alternateResult.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/alternateResult.js
@@ -710,7 +710,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1053,7 +1056,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1376,7 +1382,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1709,7 +1718,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -2021,7 +2033,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -2345,7 +2360,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 7
+        "request_seq": 7,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -2688,7 +2706,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 8
+        "request_seq": 8,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -3091,7 +3112,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 9
+        "request_seq": 9,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -3448,7 +3472,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 10
+        "request_seq": 10,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -3817,7 +3844,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 11
+        "request_seq": 11,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -4168,7 +4198,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 12
+        "request_seq": 12,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -4529,7 +4562,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 13
+        "request_seq": 13,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -4868,7 +4904,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 14
+        "request_seq": 14,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
@@ -436,7 +436,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -621,7 +624,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -850,7 +856,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1069,7 +1078,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1289,7 +1301,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited.js
@@ -422,7 +422,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -620,7 +623,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -843,7 +849,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1055,7 +1064,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1281,7 +1293,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/moduleResolution/using-referenced-project-built.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/using-referenced-project-built.js
@@ -780,7 +780,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1102,7 +1105,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1414,7 +1420,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/moduleResolution/using-referenced-project.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/using-referenced-project.js
@@ -577,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -899,7 +902,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1211,7 +1217,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
+++ b/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
@@ -181,7 +181,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -343,7 +346,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -491,7 +497,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/partialSemanticServer/syntactic-diagnostics-are-returned-with-no-error.js
+++ b/tests/baselines/reference/tsserver/partialSemanticServer/syntactic-diagnostics-are-returned-with-no-error.js
@@ -197,7 +197,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Timeout callback:: count: 0

--- a/tests/baselines/reference/tsserver/pasteEdits/adds-paste-edits.js
+++ b/tests/baselines/reference/tsserver/pasteEdits/adds-paste-edits.js
@@ -338,7 +338,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/plugins/when-scriptKind-changes-for-the-external-file.js
+++ b/tests/baselines/reference/tsserver/plugins/when-scriptKind-changes-for-the-external-file.js
@@ -384,7 +384,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
+++ b/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
@@ -340,7 +340,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -514,7 +517,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
@@ -320,7 +320,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -545,7 +548,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
@@ -291,7 +291,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -491,7 +494,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -634,7 +640,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -739,7 +748,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1026,7 +1038,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
@@ -291,7 +291,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -529,7 +532,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -675,7 +681,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -783,7 +792,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1068,7 +1080,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
+++ b/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
@@ -644,7 +644,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1254,7 +1257,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 6
+        "request_seq": 6,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
@@ -303,7 +303,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
@@ -314,7 +314,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
@@ -202,7 +202,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
@@ -193,7 +193,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
@@ -270,7 +270,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
@@ -268,7 +268,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/when-options-for-dependency-project-are-different-from-usage-project.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/when-options-for-dependency-project-are-different-from-usage-project.js
@@ -434,7 +434,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
@@ -359,7 +359,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
@@ -411,7 +411,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -560,7 +563,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
@@ -622,7 +622,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
@@ -605,7 +605,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -700,7 +703,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
@@ -341,7 +341,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
@@ -393,7 +393,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -542,7 +545,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
@@ -591,7 +591,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
@@ -574,7 +574,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -669,7 +672,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
@@ -581,7 +581,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -739,7 +742,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
@@ -576,7 +576,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -734,7 +737,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
@@ -403,7 +403,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -561,7 +564,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -556,7 +559,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -581,7 +581,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -739,7 +742,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
@@ -576,7 +576,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -734,7 +737,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -403,7 +403,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -561,7 +564,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
@@ -398,7 +398,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -556,7 +559,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
@@ -577,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -735,7 +738,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
@@ -572,7 +572,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -730,7 +733,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
@@ -399,7 +399,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -557,7 +560,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
@@ -394,7 +394,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -552,7 +555,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -577,7 +577,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -735,7 +738,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
@@ -572,7 +572,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -730,7 +733,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -399,7 +399,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -557,7 +560,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
@@ -394,7 +394,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -552,7 +555,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
@@ -467,7 +467,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
@@ -558,7 +558,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/referencing-const-enum-from-referenced-project-with-preserveConstEnums.js
+++ b/tests/baselines/reference/tsserver/projectReferences/referencing-const-enum-from-referenced-project-with-preserveConstEnums.js
@@ -345,7 +345,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
@@ -516,7 +516,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
@@ -619,7 +619,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/when-file-is-not-part-of-first-config-tree-found-finds-default-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-file-is-not-part-of-first-config-tree-found-finds-default-project.js
@@ -409,7 +409,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
@@ -413,7 +413,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
+++ b/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
@@ -981,7 +981,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 7
+        "request_seq": 7,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
@@ -284,7 +284,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
@@ -200,7 +200,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
@@ -277,7 +277,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
@@ -76,7 +76,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 Info seq  [hh:mm:ss:mss] response:
@@ -103,7 +106,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 Info seq  [hh:mm:ss:mss] response:

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
@@ -338,7 +338,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -649,7 +652,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -346,7 +346,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -608,7 +611,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
@@ -331,7 +331,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -589,7 +592,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -868,7 +874,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
@@ -370,7 +370,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -710,7 +713,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -375,7 +375,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -656,7 +659,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
@@ -350,7 +350,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -618,7 +621,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -916,7 +922,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-Linux.js
+++ b/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-Linux.js
@@ -499,7 +499,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -867,7 +870,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1418,7 +1424,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1845,7 +1854,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-package1-built-Linux.js
+++ b/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-package1-built-Linux.js
@@ -470,7 +470,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1024,7 +1027,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1451,7 +1457,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-package1-built.js
+++ b/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked-package1-built.js
@@ -466,7 +466,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -828,7 +831,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1158,7 +1164,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked.js
+++ b/tests/baselines/reference/tsserver/symLinks/monorepo-style-sibling-packages-symlinked.js
@@ -497,7 +497,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -823,7 +826,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1185,7 +1191,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -1515,7 +1524,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 5
+        "request_seq": 5,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0

--- a/tests/baselines/reference/tsserver/watchEnvironment/watching-npm-install-in-codespaces-where-workspaces-folder-is-hosted-at-root.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/watching-npm-install-in-codespaces-where-workspaces-folder-is-hosted-at-root.js
@@ -292,7 +292,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 2
+        "request_seq": 2,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -551,7 +554,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 3
+        "request_seq": 3,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0
@@ -835,7 +841,10 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "requestCompleted",
       "body": {
-        "request_seq": 4
+        "request_seq": 4,
+        "performanceData": {
+          "updateGraphDurationMs": *
+        }
       }
     }
 After running Immedidate callback:: count: 0


### PR DESCRIPTION
I think this was over site when we added this to Respose and forgot about "getErr" being async request