### PR TITLE
feat(transformers): Add beforeDeclarations transformers

### DIFF
--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -183,7 +183,11 @@ function getScriptTransformers(compilerOptions: CompilerOptions, customTransform
 
 function getDeclarationTransformers(customTransformers?: CustomTransformers) {
     const transformers: TransformerFactory<SourceFile | Bundle>[] = [];
+
+    addRange(transformers, customTransformers && map(customTransformers.beforeDeclarations, wrapDeclarationTransformerFactory));
+
     transformers.push(transformDeclarations);
+
     addRange(transformers, customTransformers && map(customTransformers.afterDeclarations, wrapDeclarationTransformerFactory));
     return transformers;
 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4867,6 +4867,8 @@ export interface CustomTransformers {
     before?: (TransformerFactory<SourceFile> | CustomTransformerFactory)[];
     /** Custom transformers to evaluate after built-in .js transformations. */
     after?: (TransformerFactory<SourceFile> | CustomTransformerFactory)[];
+    /** Custom transformers to evaluate before built-in .d.ts transformations. */
+    beforeDeclarations?: (TransformerFactory<Bundle | SourceFile> | CustomTransformerFactory)[];
     /** Custom transformers to evaluate after built-in .d.ts transformations. */
     afterDeclarations?: (TransformerFactory<Bundle | SourceFile> | CustomTransformerFactory)[];
 }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6058,6 +6058,8 @@ declare namespace ts {
         before?: (TransformerFactory<SourceFile> | CustomTransformerFactory)[];
         /** Custom transformers to evaluate after built-in .js transformations. */
         after?: (TransformerFactory<SourceFile> | CustomTransformerFactory)[];
+        /** Custom transformers to evaluate before built-in .d.ts transformations. */
+        beforeDeclarations?: (TransformerFactory<Bundle | SourceFile> | CustomTransformerFactory)[];
         /** Custom transformers to evaluate after built-in .d.ts transformations. */
         afterDeclarations?: (TransformerFactory<Bundle | SourceFile> | CustomTransformerFactory)[];
     }

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformDeclarationFileBefore.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformDeclarationFileBefore.js
@@ -1,0 +1,4 @@
+export declare class Test {
+    /** @default `"bar"`*/
+    foo: string;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Relates to #17146 and #41486 (not fully fixes them)

The custom transformers were lacking a `beforeDeclarations` allowing devs to do a AST transformation before the built-in transformers. If you wanted to use information from erased AST nodes (visibility, initializers, etc.) you were lost. With this change devs can improve their JSDoc comments or use other transformations specific for declarations. 

Sorry for the PR without `Backlog` milestone issue. I still hope this makes it through. 