### PR TITLE
feat(58561): Allow leading underscore for types to bypass noUnusedLocals warning

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43174,6 +43174,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
     }
+
     function isTypeParameterUnused(typeParameter: TypeParameterDeclaration): boolean {
         return !(getMergedSymbol(typeParameter.symbol).isReferenced! & SymbolFlags.TypeParameter) && !isIdentifierThatStartsWithUnderscore(typeParameter.name);
     }
@@ -43194,6 +43195,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isValidUnusedLocalDeclaration(declaration: Declaration): boolean {
+        if (isTypeAliasDeclaration(declaration)) {
+            /**
+             * ignore starts with underscore names _
+             * type _T = number;
+             */
+            return isIdentifierThatStartsWithUnderscore(declaration.name);
+        }
         if (isBindingElement(declaration)) {
             if (isObjectBindingPattern(declaration.parent)) {
                 /**

--- a/tests/baselines/reference/unusedTypeDeclarations.errors.txt
+++ b/tests/baselines/reference/unusedTypeDeclarations.errors.txt
@@ -1,0 +1,11 @@
+unusedTypeDeclarations.ts(1,6): error TS6196: 'T1' is declared but never used.
+
+
+==== unusedTypeDeclarations.ts (1 errors) ====
+    type T1 = number;  // error
+         ~~
+!!! error TS6196: 'T1' is declared but never used.
+    type _T2 = number; // ok
+    
+    export {};
+    

--- a/tests/baselines/reference/unusedTypeDeclarations.js
+++ b/tests/baselines/reference/unusedTypeDeclarations.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/unusedTypeDeclarations.ts] ////
+
+//// [unusedTypeDeclarations.ts]
+type T1 = number;  // error
+type _T2 = number; // ok
+
+export {};
+
+
+//// [unusedTypeDeclarations.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/unusedTypeDeclarations.symbols
+++ b/tests/baselines/reference/unusedTypeDeclarations.symbols
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/unusedTypeDeclarations.ts] ////
+
+=== unusedTypeDeclarations.ts ===
+type T1 = number;  // error
+>T1 : Symbol(T1, Decl(unusedTypeDeclarations.ts, 0, 0))
+
+type _T2 = number; // ok
+>_T2 : Symbol(_T2, Decl(unusedTypeDeclarations.ts, 0, 17))
+
+export {};
+

--- a/tests/baselines/reference/unusedTypeDeclarations.types
+++ b/tests/baselines/reference/unusedTypeDeclarations.types
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/unusedTypeDeclarations.ts] ////
+
+=== unusedTypeDeclarations.ts ===
+type T1 = number;  // error
+>T1 : number
+>   : ^^^^^^
+
+type _T2 = number; // ok
+>_T2 : number
+>    : ^^^^^^
+
+export {};
+

--- a/tests/cases/compiler/unusedTypeDeclarations.ts
+++ b/tests/cases/compiler/unusedTypeDeclarations.ts
@@ -1,0 +1,6 @@
+// @noUnusedLocals: true
+
+type T1 = number;  // error
+type _T2 = number; // ok
+
+export {};


### PR DESCRIPTION
Fixes #58561