### PR TITLE
Expose getBigIntLiteralType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1811,6 +1811,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getNumberType: () => numberType,
         getNumberLiteralType,
         getBigIntType: () => bigintType,
+        getBigIntLiteralType,
         createPromiseType,
         createArrayType,
         getElementTypeOfArrayType,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5132,7 +5132,7 @@ export interface TypeChecker {
     getNumberType(): Type;
     getNumberLiteralType(value: number): NumberLiteralType;
     getBigIntType(): Type;
-    getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType
+    getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType;
     getBooleanType(): Type;
     /* eslint-disable @typescript-eslint/unified-signatures */
     /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5132,6 +5132,7 @@ export interface TypeChecker {
     getNumberType(): Type;
     getNumberLiteralType(value: number): NumberLiteralType;
     getBigIntType(): Type;
+    getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType
     getBooleanType(): Type;
     /* eslint-disable @typescript-eslint/unified-signatures */
     /** @internal */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6196,6 +6196,7 @@ declare namespace ts {
         getNumberType(): Type;
         getNumberLiteralType(value: number): NumberLiteralType;
         getBigIntType(): Type;
+        getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType;
         getBooleanType(): Type;
         getFalseType(): Type;
         getTrueType(): Type;


### PR DESCRIPTION
Fixes #58563

We added `getBigIntType` to #52473 after noticing the omission in a design meeting, but forgot to add `getBigIntLiteralType` too.