### PR TITLE
Fix global when typescript.js loaded as script

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -216,7 +216,7 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             // Monaco bundles us as ESM by wrapping our code with something that defines module.exports
             // but then does not use it, instead using the `ts` variable. Ensure that if we think we're CJS
             // that we still set `ts` to the module.exports object.
-            options.footer = { js: `})(typeof module !== "undefined" && module.exports ? module : { exports: ts });\nif (typeof module !== "undefined" && module.exports) { ts = module.exports; }` };
+            options.footer = { js: `})({ get exports() { return ts }, set exports(v) { ts = v; if (typeof module !== "undefined" && module.exports) { module.exports = v } } })` };
 
             // esbuild converts calls to "require" to "__require"; this function
             // calls the real require if it exists, or throws if it does not (rather than

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -216,7 +216,7 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             // Monaco bundles us as ESM by wrapping our code with something that defines module.exports
             // but then does not use it, instead using the `ts` variable. Ensure that if we think we're CJS
             // that we still set `ts` to the module.exports object.
-            options.footer = { js: `})({ get exports() { return ts }, set exports(v) { ts = v; if (typeof module !== "undefined" && module.exports) { module.exports = v } } })` };
+            options.footer = { js: `})({ get exports() { return ts; }, set exports(v) { ts = v; if (typeof module !== "undefined" && module.exports) { module.exports = v; } } })` };
 
             // esbuild converts calls to "require" to "__require"; this function
             // calls the real require if it exists, or throws if it does not (rather than

--- a/scripts/browserIntegrationTest.mjs
+++ b/scripts/browserIntegrationTest.mjs
@@ -29,6 +29,7 @@ for (const browserType of browsers) {
     await page.setContent(`
     <html>
     <script>${readFileSync(join("built", "local", "typescript.js"), "utf8")}</script>
+    <script>if (typeof ts.version !== "string") throw new Error("ts.version not set")</script>
     </html>
     `);
 


### PR DESCRIPTION
Fixes #58893

Not sure why I thought this worked, but I probably just assumed that the tests passed therefore it was okay. The tests didn't actually test anything. Oops.

getters/setters have been supported ~forever, so this method is fine. We have tests which verify everything now.