### PR TITLE
`organizeImports` makes no changes if there are parse errors in the sourceFile

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2508,8 +2508,9 @@ export function createLanguageService(
         synchronizeHostData();
         Debug.assert(args.type === "file");
         const sourceFile = getValidSourceFile(args.fileName);
-        const formatContext = formatting.getFormatContext(formatOptions, host);
+        if (containsParseError(sourceFile)) return [];
 
+        const formatContext = formatting.getFormatContext(formatOptions, host);
         const mode = args.mode ?? (args.skipDestructiveCodeActions ? OrganizeImportsMode.SortAndCombine : OrganizeImportsMode.All);
         return OrganizeImports.organizeImports(sourceFile, formatContext, host, program, preferences, mode);
     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2508,7 +2508,7 @@ export function createLanguageService(
         synchronizeHostData();
         Debug.assert(args.type === "file");
         const sourceFile = getValidSourceFile(args.fileName);
-        if (containsParseError(sourceFile)) return [];
+        if (containsParseError(sourceFile)) return emptyArray;
 
         const formatContext = formatting.getFormatContext(formatOptions, host);
         const mode = args.mode ?? (args.skipDestructiveCodeActions ? OrganizeImportsMode.SortAndCombine : OrganizeImportsMode.All);

--- a/tests/baselines/reference/organizeImports/JsxFactoryUsedTs.ts
+++ b/tests/baselines/reference/organizeImports/JsxFactoryUsedTs.ts
@@ -1,10 +1,6 @@
 // ==ORIGINAL==
+// ==NO CHANGES==
 
 import { React, Other } from "react";
-
-<div/>;
-
-// ==ORGANIZED==
-
 
 <div/>;

--- a/tests/baselines/reference/organizeImports/Syntax_Error_Body.ts
+++ b/tests/baselines/reference/organizeImports/Syntax_Error_Body.ts
@@ -1,14 +1,8 @@
 // ==ORIGINAL==
+// ==NO CHANGES==
 
 import { F1, F2 } from "lib";
 import * as NS from "lib";
-import D from "lib";
-
-class class class;
-D;
-
-// ==ORGANIZED==
-
 import D from "lib";
 
 class class class;

--- a/tests/baselines/reference/organizeImports/Syntax_Error_Body_skipDestructiveCodeActions.ts
+++ b/tests/baselines/reference/organizeImports/Syntax_Error_Body_skipDestructiveCodeActions.ts
@@ -1,16 +1,9 @@
 // ==ORIGINAL==
+// ==NO CHANGES==
 
 import { F1, F2 } from "lib";
 import * as NS from "lib";
 import D from "lib";
-
-class class class;
-D;
-
-// ==ORGANIZED==
-
-import * as NS from "lib";
-import D, { F1, F2 } from "lib";
 
 class class class;
 D;

--- a/tests/baselines/reference/organizeImports/Syntax_Error_Imports.ts
+++ b/tests/baselines/reference/organizeImports/Syntax_Error_Imports.ts
@@ -1,15 +1,9 @@
 // ==ORIGINAL==
+// ==NO CHANGES==
 
 import { F1, F2 class class class; } from "lib";
 import * as NS from "lib";
 class class class;
 import D from "lib";
-
-D;
-
-// ==ORGANIZED==
-
-import D from "lib";
-class class class;
 
 D;

--- a/tests/baselines/reference/organizeImports/Syntax_Error_Imports_skipDestructiveCodeActions.ts
+++ b/tests/baselines/reference/organizeImports/Syntax_Error_Imports_skipDestructiveCodeActions.ts
@@ -1,16 +1,9 @@
 // ==ORIGINAL==
+// ==NO CHANGES==
 
 import { F1, F2 class class class; } from "lib";
 import * as NS from "lib";
 class class class;
 import D from "lib";
-
-D;
-
-// ==ORGANIZED==
-
-import * as NS from "lib";
-import D, { F1, F2, class, class, class } from "lib";
-class class class;
 
 D;

--- a/tests/baselines/reference/organizeImports/parseErrors.ts
+++ b/tests/baselines/reference/organizeImports/parseErrors.ts
@@ -1,0 +1,20 @@
+// ==ORIGINAL==
+// ==NO CHANGES==
+declare module 'mod1' {
+    declare export type P = {|
+    |};
+    declare export type F = {|
+        ...$Exact<Node>,
+        await?: Span,
+    |};
+    declare export type S = {|
+    |};
+    declare export type C = {|
+    |};
+}
+
+declare module 'mod2' {
+    import type {
+        U,
+    } from 'mod1';
+}

--- a/tests/cases/fourslash/organizeImports17.ts
+++ b/tests/cases/fourslash/organizeImports17.ts
@@ -1,10 +1,10 @@
 /// <reference path="fourslash.ts" />
 
 //// import { Both } from "module-specifiers-unsorted";
-//// import { case, Insensitively, sorted } from "aardvark";
+//// import { aa, CaseInsensitively, sorted } from "aardvark";
 
 verify.organizeImports(
-`import { case, Insensitively, sorted } from "aardvark";
+`import { aa, CaseInsensitively, sorted } from "aardvark";
 import { Both } from "module-specifiers-unsorted";
 `,
     ts.OrganizeImportsMode.SortAndCombine,


### PR DESCRIPTION
When called from our services, `organizeImports` returns no changes if there are parse errors in the `sourceFile`.

fixes https://github.com/microsoft/TypeScript/issues/56252 / https://github.com/microsoft/TypeScript/issues/56252#issuecomment-1784231506

The original crash happened because the parser was unable to parse a .js file, and as a result, the failed parse generated two duplicate/overlapping modules. Organize imports then tried to remove the same imports twice, leading to a change tracker crash. 