### PR TITLE
Improve `@implements` error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42919,7 +42919,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const name = getIdentifierFromEntityNameExpression(node.class.expression);
         const extend = getClassExtendsHeritageElement(classLike);
-        if (extend) {
+        if (name && extend) {
             const className = getIdentifierFromEntityNameExpression(extend.expression);
             if (className && name.escapedText !== className.escapedText) {
                 error(name, Diagnostics.JSDoc_0_1_does_not_match_the_extends_2_clause, idText(node.tagName), idText(name), idText(className));

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9474,12 +9474,12 @@ namespace Parser {
             }
 
             function parseImplementsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocImplementsTag {
-                const className = parseExpressionWithTypeArgumentsForAugments();
+                const className = parseExpressionWithTypeArgumentsForJSDoc();
                 return finishNode(factory.createJSDocImplementsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
             }
 
             function parseAugmentsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocAugmentsTag {
-                const className = parseExpressionWithTypeArgumentsForAugments();
+                const className = parseExpressionWithTypeArgumentsForJSDoc();
                 return finishNode(factory.createJSDocAugmentsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
             }
 
@@ -9505,14 +9505,22 @@ namespace Parser {
                 return finishNode(factory.createJSDocImportTag(tagName, importClause, moduleSpecifier, attributes, comments), start);
             }
 
-            function parseExpressionWithTypeArgumentsForAugments(): ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression; } {
+            function parseExpressionWithTypeArgumentsForJSDoc(): ExpressionWithTypeArguments {
                 const usedBrace = parseOptional(SyntaxKind.OpenBraceToken);
                 const pos = getNodePos();
-                const expression = parsePropertyAccessEntityNameExpression();
+                // const expression = parsePropertyAccessEntityNameExpression();
+        const saveParsingContext = parsingContext;
+        parsingContext |= 1 << ParsingContext.HeritageClauseElement;
+        const expression = parseLeftHandSideExpressionOrHigher();
+        parsingContext = saveParsingContext;
+        if (expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
+            parseExpected(SyntaxKind.CloseBraceToken);
+            return expression as ExpressionWithTypeArguments;
+        }
                 scanner.setSkipJsDocLeadingAsterisks(true);
                 const typeArguments = tryParseTypeArguments();
                 scanner.setSkipJsDocLeadingAsterisks(false);
-                const node = factory.createExpressionWithTypeArguments(expression, typeArguments) as ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression; };
+                const node = factory.createExpressionWithTypeArguments(expression, typeArguments);
                 const res = finishNode(node, pos);
                 if (usedBrace) {
                     parseExpected(SyntaxKind.CloseBraceToken);
@@ -9520,15 +9528,15 @@ namespace Parser {
                 return res;
             }
 
-            function parsePropertyAccessEntityNameExpression() {
-                const pos = getNodePos();
-                let node: Identifier | PropertyAccessEntityNameExpression = parseJSDocIdentifierName();
-                while (parseOptional(SyntaxKind.DotToken)) {
-                    const name = parseJSDocIdentifierName();
-                    node = finishNode(factoryCreatePropertyAccessExpression(node, name), pos) as PropertyAccessEntityNameExpression;
-                }
-                return node;
-            }
+            // function parsePropertyAccessEntityNameExpression() {
+            //     const pos = getNodePos();
+            //     let node: Identifier | PropertyAccessEntityNameExpression = parseJSDocIdentifierName();
+            //     while (parseOptional(SyntaxKind.DotToken)) {
+            //         const name = parseJSDocIdentifierName();
+            //         node = finishNode(factoryCreatePropertyAccessExpression(node, name), pos) as PropertyAccessEntityNameExpression;
+            //     }
+            //     return node;
+            // }
 
             function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocComment>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
                 return finishNode(createTag(tagName, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9508,15 +9508,14 @@ namespace Parser {
             function parseExpressionWithTypeArgumentsForJSDoc(): ExpressionWithTypeArguments {
                 const usedBrace = parseOptional(SyntaxKind.OpenBraceToken);
                 const pos = getNodePos();
-                // const expression = parsePropertyAccessEntityNameExpression();
-        const saveParsingContext = parsingContext;
-        parsingContext |= 1 << ParsingContext.HeritageClauseElement;
-        const expression = parseLeftHandSideExpressionOrHigher();
-        parsingContext = saveParsingContext;
-        if (expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
-            parseExpected(SyntaxKind.CloseBraceToken);
-            return expression as ExpressionWithTypeArguments;
-        }
+                const saveParsingContext = parsingContext;
+                parsingContext |= 1 << ParsingContext.HeritageClauseElement;
+                const expression = parseLeftHandSideExpressionOrHigher();
+                parsingContext = saveParsingContext;
+                if (expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
+                    parseExpected(SyntaxKind.CloseBraceToken);
+                    return expression as ExpressionWithTypeArguments;
+                }
                 scanner.setSkipJsDocLeadingAsterisks(true);
                 const typeArguments = tryParseTypeArguments();
                 scanner.setSkipJsDocLeadingAsterisks(false);
@@ -9527,16 +9526,6 @@ namespace Parser {
                 }
                 return res;
             }
-
-            // function parsePropertyAccessEntityNameExpression() {
-            //     const pos = getNodePos();
-            //     let node: Identifier | PropertyAccessEntityNameExpression = parseJSDocIdentifierName();
-            //     while (parseOptional(SyntaxKind.DotToken)) {
-            //         const name = parseJSDocIdentifierName();
-            //         node = finishNode(factoryCreatePropertyAccessExpression(node, name), pos) as PropertyAccessEntityNameExpression;
-            //     }
-            //     return node;
-            // }
 
             function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocComment>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
                 return finishNode(createTag(tagName, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3949,12 +3949,12 @@ export interface JSDocUnknownTag extends JSDocTag {
  */
 export interface JSDocAugmentsTag extends JSDocTag {
     readonly kind: SyntaxKind.JSDocAugmentsTag;
-    readonly class: ExpressionWithTypeArguments & { readonly expression: Identifier | PropertyAccessEntityNameExpression; };
+    readonly class: ExpressionWithTypeArguments;
 }
 
 export interface JSDocImplementsTag extends JSDocTag {
     readonly kind: SyntaxKind.JSDocImplementsTag;
-    readonly class: ExpressionWithTypeArguments & { readonly expression: Identifier | PropertyAccessEntityNameExpression; };
+    readonly class: ExpressionWithTypeArguments;
 }
 
 export interface JSDocAuthorTag extends JSDocTag {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5737,15 +5737,11 @@ declare namespace ts {
      */
     interface JSDocAugmentsTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocAugmentsTag;
-        readonly class: ExpressionWithTypeArguments & {
-            readonly expression: Identifier | PropertyAccessEntityNameExpression;
-        };
+        readonly class: ExpressionWithTypeArguments;
     }
     interface JSDocImplementsTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocImplementsTag;
-        readonly class: ExpressionWithTypeArguments & {
-            readonly expression: Identifier | PropertyAccessEntityNameExpression;
-        };
+        readonly class: ExpressionWithTypeArguments;
     }
     interface JSDocAuthorTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocAuthorTag;

--- a/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
+++ b/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
@@ -1,5 +1,5 @@
-/a.js(2,14): error TS1003: Identifier expected.
 /a.js(2,14): error TS8023: JSDoc '@augments ' does not match the 'extends A' clause.
+/a.js(2,14): error TS1109: Expression expected.
 /a.js(5,14): error TS2339: Property 'x' does not exist on type 'B'.
 
 
@@ -7,9 +7,9 @@
     class A { constructor() { this.x = 0; } }
     /** @augments */
                  
-!!! error TS1003: Identifier expected.
-                 
 !!! error TS8023: JSDoc '@augments ' does not match the 'extends A' clause.
+                 ~
+!!! error TS1109: Expression expected.
     class B extends A {
         m() {
             this.x

--- a/tests/baselines/reference/jsdocImplements_importType.errors.txt
+++ b/tests/baselines/reference/jsdocImplements_importType.errors.txt
@@ -1,0 +1,16 @@
+/a.js(1,18): error TS2500: A class can only implement an identifier/qualified-name with optional type arguments.
+
+
+==== /a.js (1 errors) ====
+    /** @implements {import('./b').B} */
+                     ~~~~~~~~~~~~~~~
+!!! error TS2500: A class can only implement an identifier/qualified-name with optional type arguments.
+    class A {
+        /** @return {number} */
+        method() { throw new Error(); }
+    }
+==== /b.ts (0 errors) ====
+    export interface B  {
+        method(): number
+    }
+    

--- a/tests/baselines/reference/jsdocImplements_importType.js
+++ b/tests/baselines/reference/jsdocImplements_importType.js
@@ -1,0 +1,26 @@
+//// [tests/cases/conformance/jsdoc/jsdocImplements_importType.ts] ////
+
+//// [a.js]
+/** @implements {import('./b').B} */
+class A {
+    /** @return {number} */
+    method() { throw new Error(); }
+}
+//// [b.ts]
+export interface B  {
+    method(): number
+}
+
+
+
+
+//// [b.d.ts]
+export interface B {
+    method(): number;
+}
+//// [a.d.ts]
+/** @implements {import('./b').B} */
+declare class A implements import('./b').B {
+    /** @return {number} */
+    method(): number;
+}

--- a/tests/baselines/reference/jsdocImplements_importType.symbols
+++ b/tests/baselines/reference/jsdocImplements_importType.symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/jsdoc/jsdocImplements_importType.ts] ////
+
+=== /a.js ===
+/** @implements {import('./b').B} */
+class A {
+>A : Symbol(A, Decl(a.js, 0, 0))
+
+    /** @return {number} */
+    method() { throw new Error(); }
+>method : Symbol(A.method, Decl(a.js, 1, 9))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+}
+=== /b.ts ===
+export interface B  {
+>B : Symbol(B, Decl(b.ts, 0, 0))
+
+    method(): number
+>method : Symbol(B.method, Decl(b.ts, 0, 21))
+}
+

--- a/tests/baselines/reference/jsdocImplements_importType.types
+++ b/tests/baselines/reference/jsdocImplements_importType.types
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/jsdoc/jsdocImplements_importType.ts] ////
+
+=== /a.js ===
+/** @implements {import('./b').B} */
+class A {
+>A : A
+>  : ^
+
+    /** @return {number} */
+    method() { throw new Error(); }
+>method : () => number
+>       : ^^^^^^      
+>new Error() : Error
+>            : ^^^^^
+>Error : ErrorConstructor
+>      : ^^^^^^^^^^^^^^^^
+}
+=== /b.ts ===
+export interface B  {
+    method(): number
+>method : () => number
+>       : ^^^^^^      
+}
+

--- a/tests/baselines/reference/jsdocImplements_missingType.errors.txt
+++ b/tests/baselines/reference/jsdocImplements_missingType.errors.txt
@@ -1,11 +1,11 @@
-/a.js(2,16): error TS1003: Identifier expected.
+/a.js(2,16): error TS1109: Expression expected.
 
 
 ==== /a.js (1 errors) ====
     class A { constructor() { this.x = 0; } }
     /** @implements */
-                   
-!!! error TS1003: Identifier expected.
+                   ~
+!!! error TS1109: Expression expected.
     class B  {
     }
     

--- a/tests/cases/conformance/jsdoc/jsdocImplements_importType.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImplements_importType.ts
@@ -1,0 +1,16 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @outDir: ./out
+
+// @Filename: /a.js
+/** @implements {import('./b').B} */
+class A {
+    /** @return {number} */
+    method() { throw new Error(); }
+}
+// @Filename: /b.ts
+export interface B  {
+    method(): number
+}


### PR DESCRIPTION
Make `@implements/@extends` parse its expression with `parseLeftHandSideExpressionOrHigher` instead of `parsePropertyAccessEntityNameExpression`. This turns many more parse errors into grammar errors, just like in TS. I kept `parseExpressionWithTypeArgumentsForJSDoc` as a separate function in order to keep parsing asterisks -- and `@implements` still only supports a single interface, unlike TS which supports a list of them.

This changes the public API, making the `expression` property a supertype of what it used to be. The one change it required in our codebase is in checker.ts

Fixes https://github.com/microsoft/TypeScript/issues/58542
