### PR TITLE
Fix redundant `export {}` in declaration file

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1718,6 +1718,8 @@ export function transformDeclarations(context: TransformationContext) {
                 ));
             }
         }
+        // Anything left unhandled is an error, so this should be unreachable
+        return Debug.assertNever(input, `Unhandled top-level node in declaration emit: ${Debug.formatSyntaxKind((input as Node).kind)}`);
 
         function cleanup<T extends Node>(node: T | undefined): T | undefined {
             if (isEnclosingDeclaration(input)) {

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -507,7 +507,7 @@ export function transformDeclarations(context: TransformationContext) {
         else {
             const statements = visitNodes(node.statements, visitDeclarationStatements, isStatement);
             combinedStatements = setTextRange(factory.createNodeArray(transformAndReplaceLatePaintedStatements(statements)), node.statements);
-            if (isExternalModule(node) && (!resultHasExternalModuleIndicator || (needsScopeFixMarker && !resultHasScopeMarker))) {
+            if (isExternalModule(node) && !resultHasExternalModuleIndicator) {
                 combinedStatements = setTextRange(factory.createNodeArray([...combinedStatements, createEmptyExports(factory)]), combinedStatements);
             }
         }
@@ -1529,8 +1529,6 @@ export function transformDeclarations(context: TransformationContext) {
                 needsDeclare = false;
                 const inner = input.body;
                 if (inner && inner.kind === SyntaxKind.ModuleBlock) {
-                    const oldNeedsScopeFix = needsScopeFixMarker;
-                    const oldHasScopeFix = resultHasScopeMarker;
                     resultHasScopeMarker = false;
                     needsScopeFixMarker = false;
                     const statements = visitNodes(inner.statements, visitDeclarationStatements, isStatement);
@@ -1552,8 +1550,6 @@ export function transformDeclarations(context: TransformationContext) {
                     }
                     const body = factory.updateModuleBlock(inner, lateStatements);
                     needsDeclare = previousNeedsDeclare;
-                    needsScopeFixMarker = oldNeedsScopeFix;
-                    resultHasScopeMarker = oldHasScopeFix;
                     const mods = ensureModifiers(input);
 
                     return cleanup(updateModuleDeclarationAndKeyword(
@@ -1722,8 +1718,6 @@ export function transformDeclarations(context: TransformationContext) {
                 ));
             }
         }
-        // Anything left unhandled is an error, so this should be unreachable
-        return Debug.assertNever(input, `Unhandled top-level node in declaration emit: ${Debug.formatSyntaxKind((input as Node).kind)}`);
 
         function cleanup<T extends Node>(node: T | undefined): T | undefined {
             if (isEnclosingDeclaration(input)) {

--- a/tests/baselines/reference/DeclarationErrorsNoEmitOnError.js
+++ b/tests/baselines/reference/DeclarationErrorsNoEmitOnError.js
@@ -18,4 +18,3 @@ type T = {
 export interface I {
     f: T;
 }
-export {};

--- a/tests/baselines/reference/classReferencedInContextualParameterWithinItsOwnBaseExpression.js
+++ b/tests/baselines/reference/classReferencedInContextualParameterWithinItsOwnBaseExpression.js
@@ -65,4 +65,3 @@ declare const A_base: Class<OutputFrom<{
 }>>;
 export declare class A extends A_base {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitAliasInlineing.js
+++ b/tests/baselines/reference/declarationEmitAliasInlineing.js
@@ -61,7 +61,6 @@ type I = {
     prop: string;
 };
 export declare const fn: (v: O["prop"], p: Omit<O, "prop">, key: keyof O, p2: Omit<O, keyof I>) => void;
-export {};
 //// [aExp.d.ts]
 export type O = {
     prop: string;

--- a/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.js
@@ -47,4 +47,3 @@ export interface GetLocalesOptions<T extends LocaleData> {
     name?: string;
 }
 export declare const getLocales: <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config: userLocalesConfig, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>;
-export {};

--- a/tests/baselines/reference/declarationEmitCastReusesTypeNode5(strictnullchecks=false).js
+++ b/tests/baselines/reference/declarationEmitCastReusesTypeNode5(strictnullchecks=false).js
@@ -47,4 +47,3 @@ export declare class C {
     reuseType8?: `${string}-ok` | `${string}-ok`;
     reuseType9?: this | this;
 }
-export {};

--- a/tests/baselines/reference/declarationEmitCastReusesTypeNode5(strictnullchecks=true).js
+++ b/tests/baselines/reference/declarationEmitCastReusesTypeNode5(strictnullchecks=true).js
@@ -47,4 +47,3 @@ export declare class C {
     reuseType8?: `${string}-ok` | `${string}-ok`;
     reuseType9?: this | this;
 }
-export {};

--- a/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.js
+++ b/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.js
@@ -87,4 +87,3 @@ export declare const t9: number;
 export declare const t10: number;
 export declare const t11: number;
 export declare const t12: number;
-export {};

--- a/tests/baselines/reference/declarationEmitClassMixinLocalClassDeclaration.js
+++ b/tests/baselines/reference/declarationEmitClassMixinLocalClassDeclaration.js
@@ -87,4 +87,3 @@ declare const XmlElement2_base: {
 };
 export declare class XmlElement2 extends XmlElement2_base {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitClassPrivateConstructor2.js
+++ b/tests/baselines/reference/declarationEmitClassPrivateConstructor2.js
@@ -42,4 +42,3 @@ export declare class ExportedClass1 {
 export declare class ExportedClass2 {
     protected constructor(data: PrivateInterface);
 }
-export {};

--- a/tests/baselines/reference/declarationEmitComputedPropertyNameSymbol2.js
+++ b/tests/baselines/reference/declarationEmitComputedPropertyNameSymbol2.js
@@ -23,4 +23,3 @@ export type Type = {
         [Foo.sym]: 0;
     };
 };
-export {};

--- a/tests/baselines/reference/declarationEmitExpandoPropertyPrivateName.js
+++ b/tests/baselines/reference/declarationEmitExpandoPropertyPrivateName.js
@@ -28,4 +28,3 @@ q.val = (0, a_1.f)();
 interface I {
 }
 export declare function f(): I;
-export {};

--- a/tests/baselines/reference/declarationEmitExpressionInExtends3.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends3.js
@@ -140,4 +140,3 @@ export declare class MyClass3 extends MyClass3_base<LocalInterface> {
 declare const MyClass4_base: typeof ExportedClass;
 export declare class MyClass4 extends MyClass4_base<ExportedInterface> {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitExpressionInExtends6.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends6.js
@@ -60,4 +60,3 @@ import * as A from "./a";
 declare const Foo: typeof A.Foo;
 export default class extends Foo {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.js
+++ b/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.js
@@ -25,4 +25,3 @@ type AX = {
     readonly A: unique symbol;
 };
 export declare const A: AX;
-export {};

--- a/tests/baselines/reference/declarationEmitForDefaultExportClassExtendingExpression01.js
+++ b/tests/baselines/reference/declarationEmitForDefaultExportClassExtendingExpression01.js
@@ -69,4 +69,3 @@ interface GreeterConstructor {
 declare const default_base: GreeterConstructor;
 export default class extends default_base {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitIdentifierPredicatesWithPrivateName01.js
+++ b/tests/baselines/reference/declarationEmitIdentifierPredicatesWithPrivateName01.js
@@ -23,4 +23,3 @@ interface I {
     a: number;
 }
 export declare function f(x: any): x is I;
-export {};

--- a/tests/baselines/reference/declarationEmitInferredTypeAlias9.js
+++ b/tests/baselines/reference/declarationEmitInferredTypeAlias9.js
@@ -23,4 +23,3 @@ type Foo<T> = T | {
     x: Foo<T>;
 };
 export declare function returnSomeGlobalValue(): Foo<number[]>;
-export {};

--- a/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.js
+++ b/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.js
@@ -49,7 +49,6 @@ export declare function excludePrivateKeys2<Obj>(obj: Obj): {
 };
 export type PublicKeys1<T> = T extends `_${string}` ? never : T;
 type PublicKeys2<T> = T extends `_${string}` ? never : T;
-export {};
 //// [api.d.ts]
 export declare const dropPrivateProps1: <Obj>(obj: Obj) => { [K in import("./internal").PublicKeys1<keyof Obj>]: Obj[K]; };
 export declare const dropPrivateProps2: <Obj>(obj: Obj) => { [K in keyof Obj extends infer T ? T extends keyof Obj ? T extends `_${string}` ? never : T : never : never]: Obj[K]; };

--- a/tests/baselines/reference/declarationEmitLocalClassDeclarationMixin.js
+++ b/tests/baselines/reference/declarationEmitLocalClassDeclarationMixin.js
@@ -113,4 +113,3 @@ declare const FilteredThing_base: (abstract new (...args: any[]) => {
 export declare class FilteredThing extends FilteredThing_base {
     match(path: string): boolean;
 }
-export {};

--- a/tests/baselines/reference/declarationEmitLocalClassHasRequiredDeclare.js
+++ b/tests/baselines/reference/declarationEmitLocalClassHasRequiredDeclare.js
@@ -54,4 +54,3 @@ export declare namespace Y {
 }
 export declare class Y {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.js
+++ b/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.js
@@ -37,4 +37,3 @@ interface Bar {
 declare namespace Bar {
     function biz(): number;
 }
-export {};

--- a/tests/baselines/reference/declarationEmitNonExportedBindingPattern.js
+++ b/tests/baselines/reference/declarationEmitNonExportedBindingPattern.js
@@ -47,4 +47,3 @@ declare const renamed: {
 export type AliasType2 = typeof renamed;
 declare const c: string;
 export type AliasType3 = typeof c;
-export {};

--- a/tests/baselines/reference/declarationEmitPartialNodeReuseTypeOf.js
+++ b/tests/baselines/reference/declarationEmitPartialNodeReuseTypeOf.js
@@ -39,7 +39,6 @@ export declare const o: (p1: typeof nImported, p2: typeof nNotImported, p3: type
     bar: typeof nPrivate;
     baz: typeof nNotImported;
 };
-export {};
 //// [b.d.ts]
 import { nImported } from "./a";
 export declare const g: (p1: typeof nImported, p2: typeof import("./a").nNotImported, p3: "private") => {

--- a/tests/baselines/reference/declarationEmitPartialNodeReuseTypeReferences.js
+++ b/tests/baselines/reference/declarationEmitPartialNodeReuseTypeReferences.js
@@ -38,7 +38,6 @@ export declare const o: (p1: SpecialString, p2: PrivateSpecialString, p3: N.Spec
     bar: PrivateSpecialString;
     baz: N.SpecialString;
 };
-export {};
 //// [b.d.ts]
 import * as a from "./a";
 export declare const g: (p1: a.SpecialString, p2: string, p3: a.N.SpecialString) => {

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.js
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.js
@@ -56,4 +56,3 @@ export declare function ignoreExtraVariables<CtorT extends {
         [IGNORE_EXTRA_VARIABLES]: boolean;
     };
 } & CtorT;
-export {};

--- a/tests/baselines/reference/declarationEmitPrivatePromiseLikeInterface.js
+++ b/tests/baselines/reference/declarationEmitPrivatePromiseLikeInterface.js
@@ -74,4 +74,3 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown> ex
 export declare class HttpClient<SecurityDataType = unknown> {
     request: <T = any, E = any>() => TPromise<HttpResponse<T, E>>;
 }
-export {};

--- a/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.js
+++ b/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.js
@@ -27,4 +27,3 @@ declare const _data: unique symbol;
 export declare class User {
     private [_data];
 }
-export {};

--- a/tests/baselines/reference/declarationEmitResolveTypesIfNotReusable.js
+++ b/tests/baselines/reference/declarationEmitResolveTypesIfNotReusable.js
@@ -46,7 +46,6 @@ export declare const o1: (o: A["a"]["b"]) => void;
 export declare const o2: (o: (typeof a)["a"]) => void;
 export declare const o3: (o: (typeof a)["a"]) => void;
 export declare const o4: (o: keyof A["a"]) => void;
-export {};
 //// [main.d.ts]
 export declare const f: {
     o1: (o: "value of b") => void;

--- a/tests/baselines/reference/declarationEmitShadowingInferNotRenamed.js
+++ b/tests/baselines/reference/declarationEmitShadowingInferNotRenamed.js
@@ -39,4 +39,3 @@ type UpdatedClient<C> = C & {
     foo: number;
 };
 export declare const createClient: <D extends (new (...args: any[]) => Client) | Record<string, new (...args: any[]) => Client>>(clientDef: D) => D extends new (...args: any[]) => infer C ? UpdatedClient<C> : { [K in keyof D]: D[K] extends new (...args: any[]) => infer C ? UpdatedClient<C> : never; };
-export {};

--- a/tests/baselines/reference/declarationEmitSpreadStringlyKeyedEnum.js
+++ b/tests/baselines/reference/declarationEmitSpreadStringlyKeyedEnum.js
@@ -52,4 +52,3 @@ export declare const SpotifyAgeGroupEnum: {
     "45-59": (typeof AgeGroups)["45-59"];
     "60-150": (typeof AgeGroups)["60-150"];
 };
-export {};

--- a/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName01.js
+++ b/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName01.js
@@ -53,4 +53,3 @@ export declare class C {
 }
 declare class D extends C {
 }
-export {};

--- a/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName02.js
+++ b/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName02.js
@@ -35,4 +35,3 @@ interface Foo {
 export declare const obj: {
     m(): this is Foo;
 };
-export {};

--- a/tests/baselines/reference/declarationEmitTypeAliasWithTypeParameters5.js
+++ b/tests/baselines/reference/declarationEmitTypeAliasWithTypeParameters5.js
@@ -24,4 +24,3 @@ type Foo<T, Y> = {
     foo<U, J>(): Foo<U, J>;
 };
 export type SubFoo<R> = Foo<string, R>;
-export {};

--- a/tests/baselines/reference/declarationEmitUsingAlternativeContainingModules1.js
+++ b/tests/baselines/reference/declarationEmitUsingAlternativeContainingModules1.js
@@ -270,4 +270,3 @@ interface IEntry {
     Category: string;
 }
 export declare const useEntries: () => import("@tanstack/vue-query").UseQueryReturnType<IEntry[], Error>;
-export {};

--- a/tests/baselines/reference/declarationEmitUsingAlternativeContainingModules2.js
+++ b/tests/baselines/reference/declarationEmitUsingAlternativeContainingModules2.js
@@ -270,4 +270,3 @@ interface IEntry {
     Category: string;
 }
 export declare const useEntries: () => import("@tanstack/vue-query").UseQueryReturnType<IEntry[], Error>;
-export {};

--- a/tests/baselines/reference/declarationNoDanglingGenerics.js
+++ b/tests/baselines/reference/declarationNoDanglingGenerics.js
@@ -131,4 +131,3 @@ declare const CKind_base: {
 };
 export declare class CKind extends CKind_base {
 }
-export {};

--- a/tests/baselines/reference/declarationsForFileShadowingGlobalNoError.js
+++ b/tests/baselines/reference/declarationsForFileShadowingGlobalNoError.js
@@ -67,4 +67,3 @@ export declare const mixin: (Base: Constructor) => {
         get(domNode: DOMNode): void;
     };
 };
-export {};

--- a/tests/baselines/reference/dynamicNamesErrors.js
+++ b/tests/baselines/reference/dynamicNamesErrors.js
@@ -121,4 +121,3 @@ export declare const ObjectLiteralVisibility: {
     readonly [z]: number;
     [w]: number;
 };
-export {};

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile.js
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile.js
@@ -138,4 +138,3 @@ declare const Test_base: {
 } & typeof FooItem;
 export declare class Test extends Test_base {
 }
-export {};

--- a/tests/baselines/reference/expandoFunctionNullishProperty.js
+++ b/tests/baselines/reference/expandoFunctionNullishProperty.js
@@ -72,4 +72,3 @@ interface TestUndefined {
     readonly prop: undefined;
 }
 export declare function testUndefined(): TestUndefined;
-export {};

--- a/tests/baselines/reference/expandoFunctionSymbolProperty.js
+++ b/tests/baselines/reference/expandoFunctionSymbolProperty.js
@@ -34,4 +34,3 @@ interface TestSymb {
     readonly [symb]: boolean;
 }
 export declare function test(): TestSymb;
-export {};

--- a/tests/baselines/reference/exportClassExtendingIntersection.js
+++ b/tests/baselines/reference/exportClassExtendingIntersection.js
@@ -130,6 +130,5 @@ declare const MyExtendedClass_base: typeof MyBaseClass & import("./BaseClass").C
 export declare class MyExtendedClass extends MyExtendedClass_base<string> {
     extendedClassProperty: number;
 }
-export {};
 //// [Main.d.ts]
 export {};

--- a/tests/baselines/reference/getEmitOutputWithEmitterErrors2.baseline
+++ b/tests/baselines/reference/getEmitOutputWithEmitterErrors2.baseline
@@ -23,5 +23,4 @@ declare class C {
 export declare namespace M {
     var foo: C;
 }
-export {};
 

--- a/tests/baselines/reference/giant.js
+++ b/tests/baselines/reference/giant.js
@@ -1413,4 +1413,3 @@ export declare namespace eaM {
         namespace eM { }
     }
 }
-export {};

--- a/tests/baselines/reference/importTypeGenericArrowTypeParenthesized.js
+++ b/tests/baselines/reference/importTypeGenericArrowTypeParenthesized.js
@@ -38,4 +38,3 @@ export declare const fail2: import("module").Modifier<(<T>(x: T) => T)>;
 export declare const works1: import("module").Modifier<(x: number) => number>;
 type MakeItWork = <T>(x: T) => T;
 export declare const works2: import("module").Modifier<MakeItWork>;
-export {};

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.js
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.js
@@ -333,4 +333,3 @@ interface OK<T> {
     value: T;
 }
 export declare function ok<T>(value: T): OK<T>;
-export {};

--- a/tests/baselines/reference/inlineMappedTypeModifierDeclarationEmit.js
+++ b/tests/baselines/reference/inlineMappedTypeModifierDeclarationEmit.js
@@ -69,7 +69,6 @@ type OmitUnveiled<T, K extends string | number | symbol> = {
 };
 export declare function test1<T, K extends string>(obj: T, k: K): OmitReal<T, K>;
 export declare function test2<T, K extends string>(obj: T, k: K): OmitUnveiled<T, K>;
-export {};
 //// [index.d.ts]
 export declare function wrappedTest1<T, K extends string>(obj: T, k: K): Exclude<keyof T, K> extends infer T_1 extends keyof T ? { [P in T_1]: T[P]; } : never;
 export declare function wrappedTest2<T, K extends string>(obj: T, k: K): { [P in Exclude<keyof T, K>]: T[P]; };

--- a/tests/baselines/reference/isolatedDeclarationsAddUndefined.js
+++ b/tests/baselines/reference/isolatedDeclarationsAddUndefined.js
@@ -67,4 +67,3 @@ export declare class Bar {
     readonly r = 1;
     f: number;
 }
-export {};

--- a/tests/baselines/reference/leaveOptionalParameterAsWritten.js
+++ b/tests/baselines/reference/leaveOptionalParameterAsWritten.js
@@ -34,4 +34,3 @@ declare global {
 //// [c.d.ts]
 type Foo = teams.calling.Foo;
 export declare const bar: (p?: Foo) => void;
-export {};

--- a/tests/baselines/reference/mappedTypeGenericInstantiationPreservesHomomorphism.js
+++ b/tests/baselines/reference/mappedTypeGenericInstantiationPreservesHomomorphism.js
@@ -33,6 +33,5 @@ export declare function usePrivateType<T extends unknown[]>(...args: T): Private
 type PrivateMapped<Obj> = {
     [K in keyof Obj]: Obj[K];
 };
-export {};
 //// [api.d.ts]
 export declare const mappedUnionWithPrivateType: <T extends unknown[]>(...args: T) => T[any] extends infer T_1 ? { [K in keyof T_1]: T[any][K]; } : never;

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports2.js
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports2.js
@@ -98,6 +98,5 @@ declare module "./f1" {
         baz(): C;
     }
 }
-export {};
 //// [f4.d.ts]
 import "./f3";

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports3.js
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports3.js
@@ -95,6 +95,5 @@ declare module "./f1" {
         baz(): C;
     }
 }
-export {};
 //// [f4.d.ts]
 import "./f3";

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports5.js
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports5.js
@@ -99,6 +99,5 @@ declare module "./f1" {
         baz(): C;
     }
 }
-export {};
 //// [f4.d.ts]
 import "./f3";

--- a/tests/baselines/reference/omitTypeTestErrors01.js
+++ b/tests/baselines/reference/omitTypeTestErrors01.js
@@ -43,4 +43,3 @@ export type Bar = Omit<Foo, "c">;
 export type Baz = Omit<Foo, "b" | "c">;
 export declare function getBarC(bar: Bar): any;
 export declare function getBazB(baz: Baz): any;
-export {};

--- a/tests/baselines/reference/omitTypeTests01.js
+++ b/tests/baselines/reference/omitTypeTests01.js
@@ -43,4 +43,3 @@ export type Bar = Omit<Foo, "c">;
 export type Baz = Omit<Foo, "b" | "c">;
 export declare function getBarA(bar: Bar): string;
 export declare function getBazA(baz: Baz): string;
-export {};

--- a/tests/baselines/reference/privacyAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyAccessorDeclFile.js
@@ -3702,7 +3702,6 @@ declare namespace privateModule {
     }
     export {};
 }
-export {};
 //// [privacyAccessorDeclFile_GlobalFile.d.ts]
 declare class publicClassInGlobal {
 }

--- a/tests/baselines/reference/privacyCheckTypeOfFunction.js
+++ b/tests/baselines/reference/privacyCheckTypeOfFunction.js
@@ -20,4 +20,3 @@ exports.b = foo;
 declare function foo(): void;
 export declare var x: typeof foo;
 export declare var b: typeof foo;
-export {};

--- a/tests/baselines/reference/privacyClassExtendsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyClassExtendsClauseDeclFile.js
@@ -411,7 +411,6 @@ export declare class publicClassExtendingPrivateClass extends privateClass {
 }
 export declare class publicClassExtendingFromPrivateModuleClass extends privateModule.publicClassInPrivateModule {
 }
-export {};
 //// [privacyClassExtendsClauseDeclFile_GlobalFile.d.ts]
 declare namespace publicModuleInGlobal {
     export class publicClassInPublicModule {

--- a/tests/baselines/reference/privacyClassImplementsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyClassImplementsClauseDeclFile.js
@@ -280,7 +280,6 @@ export declare class publicClassImplementingPrivateInterface implements privateI
 }
 export declare class publicClassImplementingFromPrivateModuleInterface implements privateModule.publicInterfaceInPrivateModule {
 }
-export {};
 //// [privacyClassImplementsClauseDeclFile_GlobalFile.d.ts]
 declare namespace publicModuleInGlobal {
     export interface publicInterfaceInPublicModule {

--- a/tests/baselines/reference/privacyFunctionParameterDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionParameterDeclFile.js
@@ -1438,7 +1438,6 @@ declare namespace privateModule {
     export function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
     export {};
 }
-export {};
 //// [privacyFunctionParameterDeclFile_GlobalFile.d.ts]
 declare class publicClassInGlobal {
 }

--- a/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
@@ -2459,7 +2459,6 @@ declare namespace privateModule {
     export function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
     export {};
 }
-export {};
 //// [privacyFunctionReturnTypeDeclFile_GlobalFile.d.ts]
 declare class publicClassInGlobal {
 }

--- a/tests/baselines/reference/privacyInterfaceExtendsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyInterfaceExtendsClauseDeclFile.js
@@ -138,7 +138,6 @@ export interface publicInterfaceImplementingPrivateInterface extends privateInte
 }
 export interface publicInterfaceImplementingFromPrivateModuleInterface extends privateModule.publicInterfaceInPrivateModule {
 }
-export {};
 //// [privacyInterfaceExtendsClauseDeclFile_GlobalFile.d.ts]
 declare namespace publicModuleInGlobal {
     export interface publicInterfaceInPublicModule {

--- a/tests/baselines/reference/privacyLocalInternalReferenceImportWithExport.js
+++ b/tests/baselines/reference/privacyLocalInternalReferenceImportWithExport.js
@@ -371,4 +371,3 @@ export declare namespace import_public {
     var publicUse_im_public_mi_public: im_public_mi_public.c;
     var publicUse_im_public_mu_public: im_public_mu_public.i;
 }
-export {};

--- a/tests/baselines/reference/privacyLocalInternalReferenceImportWithoutExport.js
+++ b/tests/baselines/reference/privacyLocalInternalReferenceImportWithoutExport.js
@@ -369,4 +369,3 @@ export declare namespace import_public {
     var publicUse_im_private_mi_public: im_private_mi_public.c;
     var publicUse_im_private_mu_public: im_private_mu_public.i;
 }
-export {};

--- a/tests/baselines/reference/privacyTopLevelInternalReferenceImportWithExport.js
+++ b/tests/baselines/reference/privacyTopLevelInternalReferenceImportWithExport.js
@@ -274,4 +274,3 @@ export declare var publicUse_im_public_v_public: number;
 export declare var publicUse_im_public_i_public: im_public_i_public;
 export declare var publicUse_im_public_mi_public: im_public_mi_public.c;
 export declare var publicUse_im_public_mu_public: im_public_mu_public.i;
-export {};

--- a/tests/baselines/reference/privacyTopLevelInternalReferenceImportWithoutExport.js
+++ b/tests/baselines/reference/privacyTopLevelInternalReferenceImportWithoutExport.js
@@ -270,4 +270,3 @@ export declare var publicUse_im_private_v_public: number;
 export declare var publicUse_im_private_i_public: im_private_i_public;
 export declare var publicUse_im_private_mi_public: im_private_mi_public.c;
 export declare var publicUse_im_private_mu_public: im_private_mu_public.i;
-export {};

--- a/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
@@ -968,4 +968,3 @@ declare namespace privateModule {
     export function publicFunctionWithPublicTypeParametersWithoutExtends<T>(): void;
     export {};
 }
-export {};

--- a/tests/baselines/reference/privacyTypeParametersOfClassDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParametersOfClassDeclFile.js
@@ -440,4 +440,3 @@ declare namespace privateModule {
     }
     export {};
 }
-export {};

--- a/tests/baselines/reference/privacyTypeParametersOfInterfaceDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParametersOfInterfaceDeclFile.js
@@ -365,4 +365,3 @@ declare namespace privateModule {
     }
     export {};
 }
-export {};

--- a/tests/baselines/reference/privacyVarDeclFile.js
+++ b/tests/baselines/reference/privacyVarDeclFile.js
@@ -801,7 +801,6 @@ declare namespace privateModule {
     export var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
     export {};
 }
-export {};
 //// [privacyVarDeclFile_GlobalFile.d.ts]
 declare class publicClassInGlobal {
 }

--- a/tests/baselines/reference/recursiveMappedTypes.js
+++ b/tests/baselines/reference/recursiveMappedTypes.js
@@ -128,4 +128,3 @@ export type ThemeValue<K extends keyof ThemeType, ThemeType, TVal = any> = Theme
 export type Foo<T> = T extends {
     [P in infer E]: any;
 } ? E : never;
-export {};

--- a/tests/baselines/reference/symbolProperty61.js
+++ b/tests/baselines/reference/symbolProperty61.js
@@ -64,4 +64,3 @@ export declare class MyObservable<T> {
     subscribe(next: (val: T) => void): void;
     [observable](): this;
 }
-export {};

--- a/tests/baselines/reference/transpile/declarationComputedPropertyNames.d.ts
+++ b/tests/baselines/reference/transpile/declarationComputedPropertyNames.d.ts
@@ -99,7 +99,6 @@ export declare const D: {
     1: number;
     "2": number;
 };
-export {};
 
 
 //// [Diagnostics reported]

--- a/tests/baselines/reference/transpile/declarationEmitPartialNodeReuse.d.ts
+++ b/tests/baselines/reference/transpile/declarationEmitPartialNodeReuse.d.ts
@@ -23,7 +23,6 @@ export declare const o: (p1: SpecialString, p2: PrivateSpecialString, p3: N.Spec
     bar: PrivateSpecialString;
     baz: N.SpecialString;
 };
-export {};
 //// [b.d.ts] ////
 export declare const g: any;
 

--- a/tests/baselines/reference/transpile/declarationFunctionDeclarations.d.ts
+++ b/tests/baselines/reference/transpile/declarationFunctionDeclarations.d.ts
@@ -121,7 +121,6 @@ export declare class InClassMethodOk2 {
 export declare class InClassMethodBad {
     o(array: T | undefined, rParam: string): void;
 }
-export {};
 
 
 //// [Diagnostics reported]

--- a/tests/baselines/reference/transpile/declarationNotInScopeTypes.d.ts
+++ b/tests/baselines/reference/transpile/declarationNotInScopeTypes.d.ts
@@ -18,7 +18,6 @@ declare const x = "";
 export declare function one(): typeof x;
 export declare function two(): "";
 export declare function three(): string;
-export {};
 
 
 //// [Diagnostics reported]

--- a/tests/baselines/reference/transpile/declarationPartialNodeReuseTypeOf.d.ts
+++ b/tests/baselines/reference/transpile/declarationPartialNodeReuseTypeOf.d.ts
@@ -19,7 +19,6 @@ export declare const o: (p1: typeof nImported, p2: typeof nNotImported, p3: type
     bar: typeof nPrivate;
     baz: typeof nNotImported;
 };
-export {};
 //// [b.d.ts] ////
 export declare const g: any;
 

--- a/tests/baselines/reference/tsbuild/declarationEmit/when-declaration-file-is-referenced-through-triple-slash-but-uses-no-references.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/when-declaration-file-is-referenced-through-triple-slash-but-uses-no-references.js
@@ -156,7 +156,6 @@ declare const variable: {
     key: MyNominal;
 };
 export declare function getVar(): keyof typeof variable;
-export {};
 
 
 //// [/src/solution/lib/src/subProject2/index.js]
@@ -172,7 +171,7 @@ function getVar() {
 
 
 //// [/src/solution/lib/tsconfig.tsbuildinfo]
-{"fileNames":["../../../lib/lib.d.ts","../src/common/types.d.ts","../src/common/nominal.ts","../src/subproject/index.ts","../src/subproject2/index.ts"],"fileIdsList":[[2],[3],[4]],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"23815050294-declare type MyNominal<T, Name extends string> = T & {\n    specialKey: Name;\n};","affectsGlobalScope":true},{"version":"-8103970050-/// <reference path=\"./types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;","signature":"-29966695877-/// <reference path=\"../../../src/common/types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;\n"},{"version":"-25117049605-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;","signature":"-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n"},{"version":"2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}","signature":"-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"}],"root":[[2,5]],"options":{"composite":true,"outDir":"./","rootDir":".."},"referencedMap":[[3,1],[4,2],[5,3]],"latestChangedDtsFile":"./src/subProject2/index.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../lib/lib.d.ts","../src/common/types.d.ts","../src/common/nominal.ts","../src/subproject/index.ts","../src/subproject2/index.ts"],"fileIdsList":[[2],[3],[4]],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"23815050294-declare type MyNominal<T, Name extends string> = T & {\n    specialKey: Name;\n};","affectsGlobalScope":true},{"version":"-8103970050-/// <reference path=\"./types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;","signature":"-29966695877-/// <reference path=\"../../../src/common/types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;\n"},{"version":"-25117049605-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;","signature":"-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n"},{"version":"2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}","signature":"-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"}],"root":[[2,5]],"options":{"composite":true,"outDir":"./","rootDir":".."},"referencedMap":[[3,1],[4,2],[5,3]],"latestChangedDtsFile":"./src/subProject2/index.d.ts","version":"FakeTSVersion"}
 
 //// [/src/solution/lib/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -232,10 +231,10 @@ function getVar() {
     "../src/subproject2/index.ts": {
       "original": {
         "version": "2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}",
-        "signature": "-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+        "signature": "-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
       },
       "version": "2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}",
-      "signature": "-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+      "signature": "-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
     }
   },
   "root": [
@@ -270,6 +269,6 @@ function getVar() {
   },
   "latestChangedDtsFile": "./src/subProject2/index.d.ts",
   "version": "FakeTSVersion",
-  "size": 1994
+  "size": 1982
 }
 

--- a/tests/baselines/reference/tsbuild/declarationEmit/when-declaration-file-is-referenced-through-triple-slash.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/when-declaration-file-is-referenced-through-triple-slash.js
@@ -309,7 +309,6 @@ declare const variable: {
     key: MyNominal;
 };
 export declare function getVar(): keyof typeof variable;
-export {};
 
 
 //// [/src/solution/lib/src/subProject2/index.js]
@@ -325,7 +324,7 @@ function getVar() {
 
 
 //// [/src/solution/lib/src/subProject2/tsconfig.tsbuildinfo]
-{"fileNames":["../../../../../lib/lib.d.ts","../../../src/common/types.d.ts","../common/nominal.d.ts","../subproject/index.d.ts","../../../src/subproject2/index.ts"],"fileIdsList":[[2],[3],[4]],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"23815050294-declare type MyNominal<T, Name extends string> = T & {\n    specialKey: Name;\n};","affectsGlobalScope":true},"-29966695877-/// <reference path=\"../../../src/common/types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;\n","-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n",{"version":"2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}","signature":"-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"}],"root":[5],"options":{"composite":true,"outDir":"../..","rootDir":"../../.."},"referencedMap":[[3,1],[4,2],[5,3]],"latestChangedDtsFile":"./index.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../../../lib/lib.d.ts","../../../src/common/types.d.ts","../common/nominal.d.ts","../subproject/index.d.ts","../../../src/subproject2/index.ts"],"fileIdsList":[[2],[3],[4]],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"23815050294-declare type MyNominal<T, Name extends string> = T & {\n    specialKey: Name;\n};","affectsGlobalScope":true},"-29966695877-/// <reference path=\"../../../src/common/types.d.ts\" preserve=\"true\" />\nexport declare type Nominal<T, Name extends string> = MyNominal<T, Name>;\n","-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n",{"version":"2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}","signature":"-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"}],"root":[5],"options":{"composite":true,"outDir":"../..","rootDir":"../../.."},"referencedMap":[[3,1],[4,2],[5,3]],"latestChangedDtsFile":"./index.d.ts","version":"FakeTSVersion"}
 
 //// [/src/solution/lib/src/subProject2/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -377,10 +376,10 @@ function getVar() {
     "../../../src/subproject2/index.ts": {
       "original": {
         "version": "2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}",
-        "signature": "-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+        "signature": "-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
       },
       "version": "2747033208-import { MyNominal } from '../subProject/index';\nconst variable = {\n    key: 'value' as MyNominal,\n};\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}",
-      "signature": "-29417180885-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+      "signature": "-28260965492-import { MyNominal } from '../subProject/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
     }
   },
   "root": [
@@ -407,6 +406,6 @@ function getVar() {
   },
   "latestChangedDtsFile": "./index.d.ts",
   "version": "FakeTSVersion",
-  "size": 1687
+  "size": 1675
 }
 

--- a/tests/baselines/reference/tsbuild/moduleSpecifiers/synthesized-module-specifiers-resolve-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleSpecifiers/synthesized-module-specifiers-resolve-correctly.js
@@ -267,7 +267,6 @@ declare const variable: {
     key: MyNominal;
 };
 export declare function getVar(): keyof typeof variable;
-export {};
 
 
 //// [/src/lib/solution/sub-project-2/index.js]
@@ -283,7 +282,7 @@ function getVar() {
 
 
 //// [/src/lib/solution/sub-project-2/tsconfig.tsbuildinfo]
-{"fileNames":["../../../../lib/lib.d.ts","../common/nominal.d.ts","../sub-project/index.d.ts","../../../solution/sub-project-2/index.ts"],"fileIdsList":[[2],[3]],"fileInfos":[{"version":"-32082413277-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };\ninterface SymbolConstructor {\n    readonly species: symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\n","affectsGlobalScope":true},"-24498031910-export declare type Nominal<T, Name extends string> = T & {\n    [Symbol.species]: Name;\n};\n","-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n",{"version":"-13939373533-import { MyNominal } from '../sub-project/index';\n\nconst variable = {\n    key: 'value' as MyNominal,\n};\n\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}\n","signature":"-20490736360-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"}],"root":[4],"options":{"composite":true,"outDir":"../..","rootDir":"../../..","skipLibCheck":true},"referencedMap":[[3,1],[4,2]],"latestChangedDtsFile":"./index.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../../lib/lib.d.ts","../common/nominal.d.ts","../sub-project/index.d.ts","../../../solution/sub-project-2/index.ts"],"fileIdsList":[[2],[3]],"fileInfos":[{"version":"-32082413277-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };\ninterface SymbolConstructor {\n    readonly species: symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\n","affectsGlobalScope":true},"-24498031910-export declare type Nominal<T, Name extends string> = T & {\n    [Symbol.species]: Name;\n};\n","-25703752603-import { Nominal } from '../common/nominal';\nexport type MyNominal = Nominal<string, 'MyNominal'>;\n",{"version":"-13939373533-import { MyNominal } from '../sub-project/index';\n\nconst variable = {\n    key: 'value' as MyNominal,\n};\n\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}\n","signature":"-21457428071-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"}],"root":[4],"options":{"composite":true,"outDir":"../..","rootDir":"../../..","skipLibCheck":true},"referencedMap":[[3,1],[4,2]],"latestChangedDtsFile":"./index.d.ts","version":"FakeTSVersion"}
 
 //// [/src/lib/solution/sub-project-2/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -322,10 +321,10 @@ function getVar() {
     "../../../solution/sub-project-2/index.ts": {
       "original": {
         "version": "-13939373533-import { MyNominal } from '../sub-project/index';\n\nconst variable = {\n    key: 'value' as MyNominal,\n};\n\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}\n",
-        "signature": "-20490736360-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+        "signature": "-21457428071-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
       },
       "version": "-13939373533-import { MyNominal } from '../sub-project/index';\n\nconst variable = {\n    key: 'value' as MyNominal,\n};\n\nexport function getVar(): keyof typeof variable {\n    return 'key';\n}\n",
-      "signature": "-20490736360-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\nexport {};\n"
+      "signature": "-21457428071-import { MyNominal } from '../sub-project/index';\ndeclare const variable: {\n    key: MyNominal;\n};\nexport declare function getVar(): keyof typeof variable;\n"
     }
   },
   "root": [
@@ -350,6 +349,6 @@ function getVar() {
   },
   "latestChangedDtsFile": "./index.d.ts",
   "version": "FakeTSVersion",
-  "size": 1698
+  "size": 1686
 }
 

--- a/tests/baselines/reference/tsbuildWatch/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
+++ b/tests/baselines/reference/tsbuildWatch/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
@@ -73,11 +73,10 @@ interface SomeObject {
     message: string;
 }
 export declare function createSomeObject(): SomeObject;
-export {};
 
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo]
-{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}","signature":"-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}","signature":"-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -98,10 +97,10 @@ export {};
     "./library.ts": {
       "original": {
         "version": "5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}",
-        "signature": "-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+        "signature": "-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
       },
       "version": "5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}",
-      "signature": "-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+      "signature": "-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
     }
   },
   "root": [
@@ -115,7 +114,7 @@ export {};
   },
   "latestChangedDtsFile": "./library.d.ts",
   "version": "FakeTSVersion",
-  "size": 914
+  "size": 902
 }
 
 //// [/user/username/projects/sample1/App/app.js]
@@ -250,11 +249,10 @@ interface SomeObject {
     message2: string;
 }
 export declare function createSomeObject(): SomeObject;
-export {};
 
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo]
-{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"-9741349880-\ninterface SomeObject\n{\n    message2: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message2: \"new Object\"\n    };\n}","signature":"1956297931-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"-9741349880-\ninterface SomeObject\n{\n    message2: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message2: \"new Object\"\n    };\n}","signature":"4720309036-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -275,10 +273,10 @@ export {};
     "./library.ts": {
       "original": {
         "version": "-9741349880-\ninterface SomeObject\n{\n    message2: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message2: \"new Object\"\n    };\n}",
-        "signature": "1956297931-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+        "signature": "4720309036-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
       },
       "version": "-9741349880-\ninterface SomeObject\n{\n    message2: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message2: \"new Object\"\n    };\n}",
-      "signature": "1956297931-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+      "signature": "4720309036-interface SomeObject {\n    message2: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
     }
   },
   "root": [
@@ -292,7 +290,7 @@ export {};
   },
   "latestChangedDtsFile": "./library.d.ts",
   "version": "FakeTSVersion",
-  "size": 916
+  "size": 904
 }
 
 
@@ -427,11 +425,10 @@ interface SomeObject {
     message: string;
 }
 export declare function createSomeObject(): SomeObject;
-export {};
 
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo]
-{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}","signature":"-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
+{"fileNames":["../../../../../a/lib/lib.d.ts","./library.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}","signature":"-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"}],"root":[2],"options":{"composite":true},"latestChangedDtsFile":"./library.d.ts","version":"FakeTSVersion"}
 
 //// [/user/username/projects/sample1/Library/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -452,10 +449,10 @@ export {};
     "./library.ts": {
       "original": {
         "version": "5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}",
-        "signature": "-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+        "signature": "-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
       },
       "version": "5256469508-\ninterface SomeObject\n{\n    message: string;\n}\n\nexport function createSomeObject(): SomeObject\n{\n    return {\n        message: \"new Object\"\n    };\n}",
-      "signature": "-18933614215-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\nexport {};\n"
+      "signature": "-18802708326-interface SomeObject {\n    message: string;\n}\nexport declare function createSomeObject(): SomeObject;\n"
     }
   },
   "root": [
@@ -469,7 +466,7 @@ export {};
   },
   "latestChangedDtsFile": "./library.d.ts",
   "version": "FakeTSVersion",
-  "size": 914
+  "size": 902
 }
 
 

--- a/tests/baselines/reference/tsc/declarationEmit/when-using-Windows-paths-and-uppercase-letters.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-using-Windows-paths-and-uppercase-letters.js
@@ -189,7 +189,6 @@ declare const Sub_base: import("./utils/type-helpers").MyReturnType;
 export declare class Sub extends Sub_base {
     id: string;
 }
-export {};
 
 
 

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.js
@@ -150,4 +150,3 @@ export declare class ClassWithPrivateNamedAccessors {
     static get [s](): any;
     static set [s](v: any);
 }
-export {};

--- a/tests/baselines/reference/usingDeclarationsDeclarationEmit.2.js
+++ b/tests/baselines/reference/usingDeclarationsDeclarationEmit.2.js
@@ -23,4 +23,3 @@ declare const r2: {
     [Symbol.asyncDispose](): Promise<void>;
 };
 export type R2 = typeof r2;
-export {};

--- a/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
+++ b/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
@@ -28,4 +28,3 @@ declare const key: unique symbol;
 export declare class Foo {
     [key]: number;
 }
-export {};

--- a/tests/baselines/reference/verbatim-declarations-parameters.js
+++ b/tests/baselines/reference/verbatim-declarations-parameters.js
@@ -65,4 +65,3 @@ export declare class Foo {
     constructor(reuseTypeNode?: Map | undefined, reuseTypeNode2?: Exclude<MapOrUndefined, "dummy">, resolveType?: Map | undefined);
 }
 export declare function foo1(reuseTypeNode: Map | undefined, reuseTypeNode2: Exclude<MapOrUndefined, "dummy">, resolveType: Map | undefined, requiredParam: number): void;
-export {};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #51338 
