### PR TITLE
Defer creation of barebonesLibSourceFile

### DIFF
--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -26,6 +26,7 @@ import {
     optionDeclarations,
     parseCustomTypeOption,
     ScriptTarget,
+    SourceFile,
     toPath,
     transpileOptionValueCompilerOptions,
 } from "./_namespaces/ts.js";
@@ -109,9 +110,11 @@ interface Symbol {
     readonly [Symbol.toStringTag]: string;
 }`;
 const barebonesLibName = "lib.d.ts";
-const barebonesLibSourceFile = createSourceFile(barebonesLibName, barebonesLibContent, { languageVersion: ScriptTarget.Latest });
+let barebonesLibSourceFile: SourceFile | undefined;
 
 function transpileWorker(input: string, transpileOptions: TranspileOptions, declaration?: boolean): TranspileOutput {
+    barebonesLibSourceFile ??= createSourceFile(barebonesLibName, barebonesLibContent, { languageVersion: ScriptTarget.Latest });
+
     const diagnostics: Diagnostic[] = [];
 
     const options: CompilerOptions = transpileOptions.compilerOptions ? fixupCompilerOptions(transpileOptions.compilerOptions, diagnostics) : {};


### PR DESCRIPTION
Pulled out of #58928.

Locally, this looks like a big win for typescript.js startup:

```
Benchmark 1 (695 runs): node ./built/local-old/typescript.js
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           144ms ± 1.76ms     140ms …  152ms         15 ( 2%)        0%
  peak_rss           89.6MB ±  541KB    88.3MB … 94.3MB          7 ( 1%)        0%
  cpu_cycles          638M  ± 5.60M      629M  …  675M          18 ( 3%)        0%
  instructions       1.07G  ±  453K     1.07G  … 1.07G           2 ( 0%)        0%
  cache_references   16.8M  ±  362K     15.7M  … 18.0M          13 ( 2%)        0%
  cache_misses       2.31M  ±  201K     2.06M  … 3.33M          34 ( 5%)        0%
  branch_misses      4.74M  ± 14.8K     4.70M  … 4.79M           6 ( 1%)        0%
Benchmark 2 (726 runs): node ./built/local/typescript.js
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           138ms ± 1.86ms     134ms …  154ms         21 ( 3%)        ⚡-  4.3% ±  0.1%
  peak_rss           89.4MB ±  661KB    88.0MB … 95.1MB         38 ( 5%)          -  0.2% ±  0.1%
  cpu_cycles          607M  ± 6.24M      598M  …  669M          24 ( 3%)        ⚡-  4.8% ±  0.1%
  instructions       1.03G  ±  457K     1.03G  … 1.04G           3 ( 0%)        ⚡-  3.4% ±  0.0%
  cache_references   15.1M  ±  334K     14.2M  … 16.0M          16 ( 2%)        ⚡- 10.1% ±  0.2%
  cache_misses       2.29M  ±  206K     1.99M  … 3.85M          28 ( 4%)          -  1.2% ±  0.9%
  branch_misses      4.48M  ± 14.4K     4.44M  … 4.54M          18 ( 2%)        ⚡-  5.5% ±  0.0%
```

Also, this apparently runs before services swaps out the object allocators, so it causes a decrease in monomorphism.