### PR TITLE
Fix crash in isSourceFileDefaultLibrary for vscode benchmark

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2788,7 +2788,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             return equalityComparer(file.fileName, getDefaultLibraryFileName());
         }
         else {
-            return some(options.lib, libFileName => equalityComparer(file.fileName, resolvedLibReferences!.get(libFileName)!.actual));
+            return some(options.lib, libFileName => resolvedLibReferences!.has(libFileName) && equalityComparer(file.fileName, resolvedLibReferences!.get(libFileName)!.actual));
         }
     }
 


### PR DESCRIPTION
I am not 100% certain how to test this, but the benchmark should show that this fixes things.