### PR TITLE
Add non-mutating Array methods to es2023 in the lib/target suggestion list

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1336,6 +1336,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Iterator: new Map(Object.entries({
@@ -1613,6 +1617,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Uint8Array: new Map(Object.entries({
@@ -1622,6 +1630,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Uint8ClampedArray: new Map(Object.entries({
@@ -1631,6 +1643,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Int16Array: new Map(Object.entries({
@@ -1640,6 +1656,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Uint16Array: new Map(Object.entries({
@@ -1649,6 +1669,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Int32Array: new Map(Object.entries({
@@ -1658,6 +1682,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Uint32Array: new Map(Object.entries({
@@ -1667,6 +1695,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Float32Array: new Map(Object.entries({
@@ -1676,6 +1708,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Float64Array: new Map(Object.entries({
@@ -1685,6 +1721,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         BigInt64Array: new Map(Object.entries({
@@ -1695,6 +1735,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         BigUint64Array: new Map(Object.entries({
@@ -1705,6 +1749,10 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
             es2023: [
                 "findLastIndex",
                 "findLast",
+                "toReversed",
+                "toSorted",
+                "toSpliced",
+                "with",
             ],
         })),
         Error: new Map(Object.entries({

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).errors.txt
@@ -1,0 +1,64 @@
+doYouNeedToChangeYourTargetLibraryES2023.ts(7,31): error TS2550: Property 'findLastIndex' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(7,45): error TS7006: Parameter 'v' implicitly has an 'any' type.
+doYouNeedToChangeYourTargetLibraryES2023.ts(8,31): error TS2550: Property 'findLastIndex' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(10,26): error TS2550: Property 'findLast' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(11,26): error TS2550: Property 'findLast' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(13,27): error TS2550: Property 'toSorted' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(15,29): error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(16,29): error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(17,29): error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(18,29): error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(19,29): error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(21,34): error TS2550: Property 'with' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+doYouNeedToChangeYourTargetLibraryES2023.ts(22,29): error TS2550: Property 'with' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+
+
+==== doYouNeedToChangeYourTargetLibraryES2023.ts (13 errors) ====
+    export let array = [0, 2, 3, 4];
+    
+    function somePredicate(x: any): boolean {
+        return x === 4;
+    }
+    
+    export let lastIndex1 = array.findLastIndex(v => v === 4);
+                                  ~~~~~~~~~~~~~
+!!! error TS2550: Property 'findLastIndex' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+                                                ~
+!!! error TS7006: Parameter 'v' implicitly has an 'any' type.
+    export let lastIndex2 = array.findLastIndex(somePredicate);
+                                  ~~~~~~~~~~~~~
+!!! error TS2550: Property 'findLastIndex' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    
+    export let last1 = array.findLast(somePredicate);
+                             ~~~~~~~~
+!!! error TS2550: Property 'findLast' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let last2 = array.findLast(somePredicate);
+                             ~~~~~~~~
+!!! error TS2550: Property 'findLast' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    
+    export let sorted = array.toSorted();
+                              ~~~~~~~~
+!!! error TS2550: Property 'toSorted' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    
+    export let spliced1 = array.toSpliced(2);
+                                ~~~~~~~~~
+!!! error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let spliced2 = array.toSpliced(2, 1);
+                                ~~~~~~~~~
+!!! error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+                                ~~~~~~~~~
+!!! error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let spliced4 = array.toSpliced(2, undefined);
+                                ~~~~~~~~~
+!!! error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+                                ~~~~~~~~~
+!!! error TS2550: Property 'toSpliced' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    
+    export let startsWithOne = array.with(0, 1);
+                                     ~~~~
+!!! error TS2550: Property 'with' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
+    export let inTheEnd = array.with(-1, 1);
+                                ~~~~
+!!! error TS2550: Property 'with' does not exist on type 'number[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).symbols
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).symbols
@@ -1,0 +1,69 @@
+//// [tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts] ////
+
+=== doYouNeedToChangeYourTargetLibraryES2023.ts ===
+export let array = [0, 2, 3, 4];
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+function somePredicate(x: any): boolean {
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+>x : Symbol(x, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 2, 23))
+
+    return x === 4;
+>x : Symbol(x, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 2, 23))
+}
+
+export let lastIndex1 = array.findLastIndex(v => v === 4);
+>lastIndex1 : Symbol(lastIndex1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>v : Symbol(v, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 44))
+>v : Symbol(v, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 44))
+
+export let lastIndex2 = array.findLastIndex(somePredicate);
+>lastIndex2 : Symbol(lastIndex2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 7, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let last1 = array.findLast(somePredicate);
+>last1 : Symbol(last1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 9, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let last2 = array.findLast(somePredicate);
+>last2 : Symbol(last2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 10, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let sorted = array.toSorted();
+>sorted : Symbol(sorted, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 12, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+export let spliced1 = array.toSpliced(2);
+>spliced1 : Symbol(spliced1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 14, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+export let spliced2 = array.toSpliced(2, 1);
+>spliced2 : Symbol(spliced2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 15, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+>spliced3 : Symbol(spliced3, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 16, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+export let spliced4 = array.toSpliced(2, undefined);
+>spliced4 : Symbol(spliced4, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 17, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>undefined : Symbol(undefined)
+
+export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+>spliced5 : Symbol(spliced5, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 18, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>undefined : Symbol(undefined)
+
+export let startsWithOne = array.with(0, 1);
+>startsWithOne : Symbol(startsWithOne, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 20, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+export let inTheEnd = array.with(-1, 1);
+>inTheEnd : Symbol(inTheEnd, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 21, 10))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).types
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=es5).types
@@ -1,0 +1,236 @@
+//// [tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts] ////
+
+=== doYouNeedToChangeYourTargetLibraryES2023.ts ===
+export let array = [0, 2, 3, 4];
+>array : number[]
+>      : ^^^^^^^^
+>[0, 2, 3, 4] : number[]
+>             : ^^^^^^^^
+>0 : 0
+>  : ^
+>2 : 2
+>  : ^
+>3 : 3
+>  : ^
+>4 : 4
+>  : ^
+
+function somePredicate(x: any): boolean {
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+>x : any
+>  : ^^^
+
+    return x === 4;
+>x === 4 : boolean
+>        : ^^^^^^^
+>x : any
+>  : ^^^
+>4 : 4
+>  : ^
+}
+
+export let lastIndex1 = array.findLastIndex(v => v === 4);
+>lastIndex1 : any
+>           : ^^^
+>array.findLastIndex(v => v === 4) : any
+>                                  : ^^^
+>array.findLastIndex : any
+>                    : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLastIndex : any
+>              : ^^^
+>v => v === 4 : (v: any) => boolean
+>             : ^ ^^^^^^^^^^^^^^^^^
+>v : any
+>  : ^^^
+>v === 4 : boolean
+>        : ^^^^^^^
+>v : any
+>  : ^^^
+>4 : 4
+>  : ^
+
+export let lastIndex2 = array.findLastIndex(somePredicate);
+>lastIndex2 : any
+>           : ^^^
+>array.findLastIndex(somePredicate) : any
+>                                   : ^^^
+>array.findLastIndex : any
+>                    : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLastIndex : any
+>              : ^^^
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let last1 = array.findLast(somePredicate);
+>last1 : any
+>      : ^^^
+>array.findLast(somePredicate) : any
+>                              : ^^^
+>array.findLast : any
+>               : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLast : any
+>         : ^^^
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let last2 = array.findLast(somePredicate);
+>last2 : any
+>      : ^^^
+>array.findLast(somePredicate) : any
+>                              : ^^^
+>array.findLast : any
+>               : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLast : any
+>         : ^^^
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let sorted = array.toSorted();
+>sorted : any
+>       : ^^^
+>array.toSorted() : any
+>                 : ^^^
+>array.toSorted : any
+>               : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSorted : any
+>         : ^^^
+
+export let spliced1 = array.toSpliced(2);
+>spliced1 : any
+>         : ^^^
+>array.toSpliced(2) : any
+>                   : ^^^
+>array.toSpliced : any
+>                : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : any
+>          : ^^^
+>2 : 2
+>  : ^
+
+export let spliced2 = array.toSpliced(2, 1);
+>spliced2 : any
+>         : ^^^
+>array.toSpliced(2, 1) : any
+>                      : ^^^
+>array.toSpliced : any
+>                : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : any
+>          : ^^^
+>2 : 2
+>  : ^
+>1 : 1
+>  : ^
+
+export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+>spliced3 : any
+>         : ^^^
+>array.toSpliced(2, 1, 4, 5, 6, 7) : any
+>                                  : ^^^
+>array.toSpliced : any
+>                : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : any
+>          : ^^^
+>2 : 2
+>  : ^
+>1 : 1
+>  : ^
+>4 : 4
+>  : ^
+>5 : 5
+>  : ^
+>6 : 6
+>  : ^
+>7 : 7
+>  : ^
+
+export let spliced4 = array.toSpliced(2, undefined);
+>spliced4 : any
+>         : ^^^
+>array.toSpliced(2, undefined) : any
+>                              : ^^^
+>array.toSpliced : any
+>                : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : any
+>          : ^^^
+>2 : 2
+>  : ^
+>undefined : undefined
+>          : ^^^^^^^^^
+
+export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+>spliced5 : any
+>         : ^^^
+>array.toSpliced(2, undefined, 4, 5, 6, 7) : any
+>                                          : ^^^
+>array.toSpliced : any
+>                : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : any
+>          : ^^^
+>2 : 2
+>  : ^
+>undefined : undefined
+>          : ^^^^^^^^^
+>4 : 4
+>  : ^
+>5 : 5
+>  : ^
+>6 : 6
+>  : ^
+>7 : 7
+>  : ^
+
+export let startsWithOne = array.with(0, 1);
+>startsWithOne : any
+>              : ^^^
+>array.with(0, 1) : any
+>                 : ^^^
+>array.with : any
+>           : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>with : any
+>     : ^^^
+>0 : 0
+>  : ^
+>1 : 1
+>  : ^
+
+export let inTheEnd = array.with(-1, 1);
+>inTheEnd : any
+>         : ^^^
+>array.with(-1, 1) : any
+>                  : ^^^
+>array.with : any
+>           : ^^^
+>array : number[]
+>      : ^^^^^^^^
+>with : any
+>     : ^^^
+>-1 : -1
+>   : ^^
+>1 : 1
+>  : ^
+>1 : 1
+>  : ^
+

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).errors.txt
@@ -1,0 +1,28 @@
+doYouNeedToChangeYourTargetLibraryES2023.ts(19,42): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'number'.
+
+
+==== doYouNeedToChangeYourTargetLibraryES2023.ts (1 errors) ====
+    export let array = [0, 2, 3, 4];
+    
+    function somePredicate(x: any): boolean {
+        return x === 4;
+    }
+    
+    export let lastIndex1 = array.findLastIndex(v => v === 4);
+    export let lastIndex2 = array.findLastIndex(somePredicate);
+    
+    export let last1 = array.findLast(somePredicate);
+    export let last2 = array.findLast(somePredicate);
+    
+    export let sorted = array.toSorted();
+    
+    export let spliced1 = array.toSpliced(2);
+    export let spliced2 = array.toSpliced(2, 1);
+    export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+    export let spliced4 = array.toSpliced(2, undefined);
+    export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+                                             ~~~~~~~~~
+!!! error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'number'.
+    
+    export let startsWithOne = array.with(0, 1);
+    export let inTheEnd = array.with(-1, 1);

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).symbols
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).symbols
@@ -1,0 +1,93 @@
+//// [tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts] ////
+
+=== doYouNeedToChangeYourTargetLibraryES2023.ts ===
+export let array = [0, 2, 3, 4];
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+
+function somePredicate(x: any): boolean {
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+>x : Symbol(x, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 2, 23))
+
+    return x === 4;
+>x : Symbol(x, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 2, 23))
+}
+
+export let lastIndex1 = array.findLastIndex(v => v === 4);
+>lastIndex1 : Symbol(lastIndex1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 10))
+>array.findLastIndex : Symbol(Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>findLastIndex : Symbol(Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+>v : Symbol(v, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 44))
+>v : Symbol(v, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 6, 44))
+
+export let lastIndex2 = array.findLastIndex(somePredicate);
+>lastIndex2 : Symbol(lastIndex2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 7, 10))
+>array.findLastIndex : Symbol(Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>findLastIndex : Symbol(Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let last1 = array.findLast(somePredicate);
+>last1 : Symbol(last1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 9, 10))
+>array.findLast : Symbol(Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>findLast : Symbol(Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let last2 = array.findLast(somePredicate);
+>last2 : Symbol(last2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 10, 10))
+>array.findLast : Symbol(Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>findLast : Symbol(Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>somePredicate : Symbol(somePredicate, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 32))
+
+export let sorted = array.toSorted();
+>sorted : Symbol(sorted, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 12, 10))
+>array.toSorted : Symbol(Array.toSorted, Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSorted : Symbol(Array.toSorted, Decl(lib.es2023.array.d.ts, --, --))
+
+export let spliced1 = array.toSpliced(2);
+>spliced1 : Symbol(spliced1, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 14, 10))
+>array.toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+
+export let spliced2 = array.toSpliced(2, 1);
+>spliced2 : Symbol(spliced2, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 15, 10))
+>array.toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+
+export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+>spliced3 : Symbol(spliced3, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 16, 10))
+>array.toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+
+export let spliced4 = array.toSpliced(2, undefined);
+>spliced4 : Symbol(spliced4, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 17, 10))
+>array.toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>undefined : Symbol(undefined)
+
+export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+>spliced5 : Symbol(spliced5, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 18, 10))
+>array.toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>toSpliced : Symbol(Array.toSpliced, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+>undefined : Symbol(undefined)
+
+export let startsWithOne = array.with(0, 1);
+>startsWithOne : Symbol(startsWithOne, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 20, 10))
+>array.with : Symbol(Array.with, Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>with : Symbol(Array.with, Decl(lib.es2023.array.d.ts, --, --))
+
+export let inTheEnd = array.with(-1, 1);
+>inTheEnd : Symbol(inTheEnd, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 21, 10))
+>array.with : Symbol(Array.with, Decl(lib.es2023.array.d.ts, --, --))
+>array : Symbol(array, Decl(doYouNeedToChangeYourTargetLibraryES2023.ts, 0, 10))
+>with : Symbol(Array.with, Decl(lib.es2023.array.d.ts, --, --))
+

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).types
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2023(target=esnext).types
@@ -1,0 +1,236 @@
+//// [tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts] ////
+
+=== doYouNeedToChangeYourTargetLibraryES2023.ts ===
+export let array = [0, 2, 3, 4];
+>array : number[]
+>      : ^^^^^^^^
+>[0, 2, 3, 4] : number[]
+>             : ^^^^^^^^
+>0 : 0
+>  : ^
+>2 : 2
+>  : ^
+>3 : 3
+>  : ^
+>4 : 4
+>  : ^
+
+function somePredicate(x: any): boolean {
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+>x : any
+>  : ^^^
+
+    return x === 4;
+>x === 4 : boolean
+>        : ^^^^^^^
+>x : any
+>  : ^^^
+>4 : 4
+>  : ^
+}
+
+export let lastIndex1 = array.findLastIndex(v => v === 4);
+>lastIndex1 : number
+>           : ^^^^^^
+>array.findLastIndex(v => v === 4) : number
+>                                  : ^^^^^^
+>array.findLastIndex : (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any) => number
+>                    : ^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^      
+>array : number[]
+>      : ^^^^^^^^
+>findLastIndex : (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any) => number
+>              : ^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^      
+>v => v === 4 : (v: number) => v is 4
+>             : ^ ^^^^^^^^^^^^^^^^^^^
+>v : number
+>  : ^^^^^^
+>v === 4 : boolean
+>        : ^^^^^^^
+>v : number
+>  : ^^^^^^
+>4 : 4
+>  : ^
+
+export let lastIndex2 = array.findLastIndex(somePredicate);
+>lastIndex2 : number
+>           : ^^^^^^
+>array.findLastIndex(somePredicate) : number
+>                                   : ^^^^^^
+>array.findLastIndex : (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any) => number
+>                    : ^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^      
+>array : number[]
+>      : ^^^^^^^^
+>findLastIndex : (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any) => number
+>              : ^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^      
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let last1 = array.findLast(somePredicate);
+>last1 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+>array.findLast(somePredicate) : number | undefined
+>                              : ^^^^^^^^^^^^^^^^^^
+>array.findLast : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): number | undefined; }
+>               : ^^^ ^^^^^^^^^^^^^^^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^   ^^^^            ^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^^^^^            ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLast : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): number | undefined; }
+>         : ^^^ ^^^^^^^^^^^^^^^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^   ^^^^            ^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^^^^^            ^^^
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let last2 = array.findLast(somePredicate);
+>last2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+>array.findLast(somePredicate) : number | undefined
+>                              : ^^^^^^^^^^^^^^^^^^
+>array.findLast : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): number | undefined; }
+>               : ^^^ ^^^^^^^^^^^^^^^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^   ^^^^            ^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^^^^^            ^^^
+>array : number[]
+>      : ^^^^^^^^
+>findLast : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): number | undefined; }
+>         : ^^^ ^^^^^^^^^^^^^^^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^   ^^^^            ^^^         ^^^     ^^^^^^^^^^     ^^      ^^     ^^^^^^^^^^^^^^^       ^^       ^^^   ^^^^^^^^^            ^^^
+>somePredicate : (x: any) => boolean
+>              : ^ ^^   ^^^^^       
+
+export let sorted = array.toSorted();
+>sorted : number[]
+>       : ^^^^^^^^
+>array.toSorted() : number[]
+>                 : ^^^^^^^^
+>array.toSorted : (compareFn?: ((a: number, b: number) => number) | undefined) => number[]
+>               : ^         ^^^^^ ^^^^^^^^^^ ^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^  
+>array : number[]
+>      : ^^^^^^^^
+>toSorted : (compareFn?: ((a: number, b: number) => number) | undefined) => number[]
+>         : ^         ^^^^^ ^^^^^^^^^^ ^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^  
+
+export let spliced1 = array.toSpliced(2);
+>spliced1 : number[]
+>         : ^^^^^^^^
+>array.toSpliced(2) : number[]
+>                   : ^^^^^^^^
+>array.toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>                : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>          : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>2 : 2
+>  : ^
+
+export let spliced2 = array.toSpliced(2, 1);
+>spliced2 : number[]
+>         : ^^^^^^^^
+>array.toSpliced(2, 1) : number[]
+>                      : ^^^^^^^^
+>array.toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>                : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>          : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>2 : 2
+>  : ^
+>1 : 1
+>  : ^
+
+export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+>spliced3 : number[]
+>         : ^^^^^^^^
+>array.toSpliced(2, 1, 4, 5, 6, 7) : number[]
+>                                  : ^^^^^^^^
+>array.toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>                : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>          : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>2 : 2
+>  : ^
+>1 : 1
+>  : ^
+>4 : 4
+>  : ^
+>5 : 5
+>  : ^
+>6 : 6
+>  : ^
+>7 : 7
+>  : ^
+
+export let spliced4 = array.toSpliced(2, undefined);
+>spliced4 : number[]
+>         : ^^^^^^^^
+>array.toSpliced(2, undefined) : number[]
+>                              : ^^^^^^^^
+>array.toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>                : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>          : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>2 : 2
+>  : ^
+>undefined : undefined
+>          : ^^^^^^^^^
+
+export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+>spliced5 : number[]
+>         : ^^^^^^^^
+>array.toSpliced(2, undefined, 4, 5, 6, 7) : number[]
+>                                          : ^^^^^^^^
+>array.toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>                : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>array : number[]
+>      : ^^^^^^^^
+>toSpliced : { (start: number, deleteCount: number, ...items: number[]): number[]; (start: number, deleteCount?: number): number[]; }
+>          : ^^^     ^^      ^^           ^^      ^^^^^     ^^^^^^^^^^^^^^^^^^^  ^^^     ^^      ^^           ^^^      ^^^^^^^^^  ^^^
+>2 : 2
+>  : ^
+>undefined : undefined
+>          : ^^^^^^^^^
+>4 : 4
+>  : ^
+>5 : 5
+>  : ^
+>6 : 6
+>  : ^
+>7 : 7
+>  : ^
+
+export let startsWithOne = array.with(0, 1);
+>startsWithOne : number[]
+>              : ^^^^^^^^
+>array.with(0, 1) : number[]
+>                 : ^^^^^^^^
+>array.with : (index: number, value: number) => number[]
+>           : ^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^  
+>array : number[]
+>      : ^^^^^^^^
+>with : (index: number, value: number) => number[]
+>     : ^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^  
+>0 : 0
+>  : ^
+>1 : 1
+>  : ^
+
+export let inTheEnd = array.with(-1, 1);
+>inTheEnd : number[]
+>         : ^^^^^^^^
+>array.with(-1, 1) : number[]
+>                  : ^^^^^^^^
+>array.with : (index: number, value: number) => number[]
+>           : ^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^  
+>array : number[]
+>      : ^^^^^^^^
+>with : (index: number, value: number) => number[]
+>     : ^     ^^      ^^     ^^^^^^^^^^^^^^^^^^^  
+>-1 : -1
+>   : ^^
+>1 : 1
+>  : ^
+>1 : 1
+>  : ^
+

--- a/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts
+++ b/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts
@@ -1,0 +1,27 @@
+
+// @noEmit: true
+// @target: es5, esnext
+// @strict: true
+
+export let array = [0, 2, 3, 4];
+
+function somePredicate(x: any): boolean {
+    return x === 4;
+}
+
+export let lastIndex1 = array.findLastIndex(v => v === 4);
+export let lastIndex2 = array.findLastIndex(somePredicate);
+
+export let last1 = array.findLast(somePredicate);
+export let last2 = array.findLast(somePredicate);
+
+export let sorted = array.toSorted();
+
+export let spliced1 = array.toSpliced(2);
+export let spliced2 = array.toSpliced(2, 1);
+export let spliced3 = array.toSpliced(2, 1, 4, 5, 6, 7);
+export let spliced4 = array.toSpliced(2, undefined);
+export let spliced5 = array.toSpliced(2, undefined, 4, 5, 6, 7);
+
+export let startsWithOne = array.with(0, 1);
+export let inTheEnd = array.with(-1, 1);


### PR DESCRIPTION
[A developer upgraded to TypeScript 5.5](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#comment-444) and was confused when `toSorted` was no longer available when compiling. This was because `toSorted` (along with `toReversed`, `toSpliced`, and `with`) were moved from `esnext.array` to `es2023.array`.

This PR makes it so that we recommend `es2023` appropriately.