### PR TITLE
Update es2017.object.d.ts to indicate that Object.values/entries looks only at own properties

### DIFF
--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -1,24 +1,24 @@
 interface ObjectConstructor {
     /**
-     * Returns an array of values of the enumerable properties of an object
+     * Returns an array of values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
     values<T>(o: { [s: string]: T; } | ArrayLike<T>): T[];
 
     /**
-     * Returns an array of values of the enumerable properties of an object
+     * Returns an array of values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
     values(o: {}): any[];
 
     /**
-     * Returns an array of key/values of the enumerable properties of an object
+     * Returns an array of key/values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
     entries<T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][];
 
     /**
-     * Returns an array of key/values of the enumerable properties of an object
+     * Returns an array of key/values of the enumerable own properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
     entries(o: {}): [string, any][];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Closes #58954

This makes it clear that `Object.values` and `Object.entries` look for _own_ properties only.

An update is also needed for `Object.keys`.