### PR TITLE
Enable Build Provenance for Nightly Builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 # Ensure scripts are run with pipefail. See:
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
@@ -60,6 +61,6 @@ jobs:
           npx hereby configure-nightly
           npx hereby LKG
           node ./scripts/addPackageJsonGitHead.mjs package.json
-          npm publish --tag next
+          npm publish --provenance --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -61,6 +61,10 @@ jobs:
           npx hereby configure-nightly
           npx hereby LKG
           node ./scripts/addPackageJsonGitHead.mjs package.json
+          npm --version
+          # update npm to latest for build provenance feature on publish
+          npm install -g npm
+          npm --version
           npm publish --provenance --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Maybe. This is pretty difficult (impossible?) to test outside of the CI environment itself. Ostensibly, this is all we should need for github actions, though.

cc @DanielRosenwasser who wanted to know what it'd take to enable this. For nightlies, at least, it's in theory not bad. For actual releases, it's likely a bit more complex, given our publishing and releasing pipeline.
