### PR TITLE
Refactor resolving module or type reference name

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -30,6 +30,8 @@ import {
     getOptionsForLibraryResolution,
     getPathComponents,
     getPathFromPathComponents,
+    getResolvedModuleFromResolution,
+    getResolvedTypeReferenceDirectiveFromResolution,
     HasInvalidatedLibResolutions,
     HasInvalidatedResolutions,
     hasTrailingDirectorySeparator,
@@ -51,7 +53,6 @@ import {
     mutateMap,
     noopFileWatcher,
     normalizePath,
-    PackageId,
     packageIdToString,
     PackageJsonInfoCacheEntry,
     parseNodeModuleFromPath,
@@ -63,6 +64,7 @@ import {
     resolutionExtensionIsTSOrJson,
     ResolutionLoader,
     ResolutionMode,
+    ResolutionWithResolvedFileName,
     ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
     ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
@@ -171,12 +173,6 @@ export interface ResolutionWithFailedLookupLocations {
     // Files that have this resolution using
     files?: Set<Path>;
     alternateResult?: string;
-}
-
-/** @internal */
-export interface ResolutionWithResolvedFileName {
-    resolvedFileName: string | undefined;
-    packageId?: PackageId;
 }
 
 /** @internal */
@@ -670,14 +666,6 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         onChangesAffectModuleResolution,
     };
 
-    function getResolvedModule(resolution: CachedResolvedModuleWithFailedLookupLocations) {
-        return resolution.resolvedModule;
-    }
-
-    function getResolvedTypeReferenceDirective(resolution: CachedResolvedTypeReferenceDirectiveWithFailedLookupLocations) {
-        return resolution.resolvedTypeReferenceDirective;
-    }
-
     function clear() {
         clearMap(directoryWatchesOfFailedLookups, closeFileWatcherOf);
         clearMap(fileWatchesOfAffectingLocations, closeFileWatcherOf);
@@ -776,7 +764,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 stopWatchFailedLookupLocationOfResolution(
                     resolution,
                     resolutionHost.toPath(getInferredLibraryNameResolveFrom(resolutionHost.getCompilationSettings(), getCurrentDirectory(), libFileName)),
-                    getResolvedModule,
+                    getResolvedModuleFromResolution,
                 );
                 resolvedLibraries.delete(libFileName);
             }
@@ -1003,7 +991,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 getModuleResolutionHost(resolutionHost),
                 typeReferenceDirectiveResolutionCache,
             ),
-            getResolutionWithResolvedFileName: getResolvedTypeReferenceDirective,
+            getResolutionWithResolvedFileName: getResolvedTypeReferenceDirectiveFromResolution,
             shouldRetryResolution: resolution => resolution.resolvedTypeReferenceDirective === undefined,
             deferWatchingNonRelativeResolution: false,
         });
@@ -1032,7 +1020,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 resolutionHost,
                 moduleResolutionCache,
             ),
-            getResolutionWithResolvedFileName: getResolvedModule,
+            getResolutionWithResolvedFileName: getResolvedModuleFromResolution,
             shouldRetryResolution: resolution => !resolution.resolvedModule || !resolutionExtensionIsTSOrJson(resolution.resolvedModule.extension),
             logChanges: logChangesWhenResolvingModule,
             deferWatchingNonRelativeResolution: true, // Defer non relative resolution watch because we could be using ambient modules
@@ -1051,15 +1039,15 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
             const existingResolution = resolution;
             resolution = ts_resolveLibrary(libraryName, resolveFrom, options, host, libraryResolutionCache);
             const path = resolutionHost.toPath(resolveFrom);
-            watchFailedLookupLocationsOfExternalModuleResolutions(libraryName, resolution, path, getResolvedModule, /*deferWatchingNonRelativeResolution*/ false);
+            watchFailedLookupLocationsOfExternalModuleResolutions(libraryName, resolution, path, getResolvedModuleFromResolution, /*deferWatchingNonRelativeResolution*/ false);
             resolvedLibraries.set(libFileName, resolution);
             if (existingResolution) {
-                stopWatchFailedLookupLocationOfResolution(existingResolution, path, getResolvedModule);
+                stopWatchFailedLookupLocationOfResolution(existingResolution, path, getResolvedModuleFromResolution);
             }
         }
         else {
             if (isTraceEnabled(options, host)) {
-                const resolved = getResolvedModule(resolution);
+                const resolved = getResolvedModuleFromResolution(resolution);
                 trace(
                     host,
                     resolved?.resolvedFileName ?
@@ -1483,8 +1471,8 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
     }
 
     function removeResolutionsOfFile(filePath: Path, syncDirWatcherRemove?: boolean) {
-        removeResolutionsOfFileFromCache(resolvedModuleNames, filePath, getResolvedModule, syncDirWatcherRemove);
-        removeResolutionsOfFileFromCache(resolvedTypeReferenceDirectives, filePath, getResolvedTypeReferenceDirective, syncDirWatcherRemove);
+        removeResolutionsOfFileFromCache(resolvedModuleNames, filePath, getResolvedModuleFromResolution, syncDirWatcherRemove);
+        removeResolutionsOfFileFromCache(resolvedTypeReferenceDirectives, filePath, getResolvedTypeReferenceDirectiveFromResolution, syncDirWatcherRemove);
     }
 
     function invalidateResolutions(resolutions: Set<ResolutionWithFailedLookupLocations> | Map<string, ResolutionWithFailedLookupLocations> | undefined, canInvalidate: (resolution: ResolutionWithFailedLookupLocations) => boolean | undefined) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -799,6 +799,16 @@ export function moduleResolutionIsEqualTo(oldResolution: ResolvedModuleWithFaile
 }
 
 /** @internal */
+export function getResolvedModuleFromResolution(resolution: ResolvedModuleWithFailedLookupLocations) {
+    return resolution.resolvedModule;
+}
+
+/** @internal */
+export function getResolvedTypeReferenceDirectiveFromResolution(resolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations) {
+    return resolution.resolvedTypeReferenceDirective;
+}
+
+/** @internal */
 export function createModuleNotFoundChain(sourceFile: SourceFile, host: TypeCheckerHost, moduleReference: string, mode: ResolutionMode, packageName: string) {
     const alternateResult = host.getResolvedModule(sourceFile, moduleReference, mode)?.alternateResult;
     const alternateResultMessage = alternateResult && (getEmitModuleResolutionKind(host.getCompilerOptions()) === ModuleResolutionKind.Node10


### PR DESCRIPTION
Picking unrelated change from #55968 
We resolve module and type ref similarly so pulled it out into a function that can be used by both instead.
Will help later as we add more functionality