### PR TITLE
Fixed an issue with top-level for-await loops not being allowed with `--module preserve`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -51097,6 +51097,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 // fallthrough
                             case ModuleKind.ES2022:
                             case ModuleKind.ESNext:
+                            case ModuleKind.Preserve:
                             case ModuleKind.System:
                                 if (languageVersion >= ScriptTarget.ES2017) {
                                     break;

--- a/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).errors.txt
+++ b/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).errors.txt
@@ -1,0 +1,14 @@
+modulePreserveTopLevelAwait1.ts(1,5): error TS1432: Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+modulePreserveTopLevelAwait1.ts(2,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+
+
+==== modulePreserveTopLevelAwait1.ts (2 errors) ====
+    for await (const x of []) {}
+        ~~~~~
+!!! error TS1432: Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    await Promise.resolve();
+    ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    
+    export {};
+    

--- a/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).symbols
+++ b/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/modulePreserveTopLevelAwait1.ts] ////
+
+=== modulePreserveTopLevelAwait1.ts ===
+for await (const x of []) {}
+>x : Symbol(x, Decl(modulePreserveTopLevelAwait1.ts, 0, 16))
+
+await Promise.resolve();
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+export {};
+

--- a/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).types
+++ b/tests/baselines/reference/modulePreserveTopLevelAwait1(target=es2016).types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/modulePreserveTopLevelAwait1.ts] ////
+
+=== modulePreserveTopLevelAwait1.ts ===
+for await (const x of []) {}
+>x : any
+>  : ^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+await Promise.resolve();
+>await Promise.resolve() : void
+>                        : ^^^^
+>Promise.resolve() : Promise<void>
+>                  : ^^^^^^^^^^^^^
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>                : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+
+export {};
+

--- a/tests/baselines/reference/modulePreserveTopLevelAwait1(target=esnext).symbols
+++ b/tests/baselines/reference/modulePreserveTopLevelAwait1(target=esnext).symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/modulePreserveTopLevelAwait1.ts] ////
+
+=== modulePreserveTopLevelAwait1.ts ===
+for await (const x of []) {}
+>x : Symbol(x, Decl(modulePreserveTopLevelAwait1.ts, 0, 16))
+
+await Promise.resolve();
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+export {};
+

--- a/tests/baselines/reference/modulePreserveTopLevelAwait1(target=esnext).types
+++ b/tests/baselines/reference/modulePreserveTopLevelAwait1(target=esnext).types
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/modulePreserveTopLevelAwait1.ts] ////
+
+=== modulePreserveTopLevelAwait1.ts ===
+for await (const x of []) {}
+>x : any
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+await Promise.resolve();
+>await Promise.resolve() : void
+>                        : ^^^^
+>Promise.resolve() : Promise<void>
+>                  : ^^^^^^^^^^^^^
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>                : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+
+export {};
+

--- a/tests/cases/compiler/modulePreserveTopLevelAwait1.ts
+++ b/tests/cases/compiler/modulePreserveTopLevelAwait1.ts
@@ -1,0 +1,8 @@
+// @module: preserve
+// @target: es2016, esnext
+// @noEmit: true
+
+for await (const x of []) {}
+await Promise.resolve();
+
+export {};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59030
this was missed in https://github.com/microsoft/TypeScript/pull/56785 , cc @andrewbranch 