### PR TITLE
Derive tuple labels for rest elements from array binding patterns

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13587,8 +13587,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function getUniqAssociatedNamesFromTupleType(type: TupleTypeReference, restSymbol: Symbol) {
-            const names = map(type.target.labeledElementDeclarations, (labeledElement, i) =>
-                getTupleElementLabel(labeledElement, i, type.target.elementFlags[i], restSymbol));
+            const names = map(type.target.labeledElementDeclarations, (labeledElement, i) => getTupleElementLabel(labeledElement, i, type.target.elementFlags[i], restSymbol));
             if (names) {
                 const duplicates: number[] = [];
                 const uniqueNames = new Set<__String>();
@@ -37321,7 +37320,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const restParameter = signature.parameters[paramCount] || unknownSymbol;
         const restType = overrideRestType || getTypeOfSymbol(restParameter);
         if (isTupleType(restType)) {
-            const tupleType = ((restType as TypeReference).target as TupleType);
+            const tupleType = (restType as TypeReference).target as TupleType;
             const index = pos - paramCount;
             const associatedName = tupleType.labeledElementDeclarations?.[index];
             const elementFlags = tupleType.elementFlags[index];

--- a/tests/baselines/reference/argumentsSpreadRestIterables(target=es5).types
+++ b/tests/baselines/reference/argumentsSpreadRestIterables(target=es5).types
@@ -40,10 +40,10 @@ declare const itNum: Iterable<number>
 ;(function(a, ...rest) {})('', true, ...itNum)
 >(function(a, ...rest) {})('', true, ...itNum) : void
 >                                              : ^^^^
->(function(a, ...rest) {}) : (a: string, rest_0: boolean, ...rest_1: Iterable<number>[]) => void
->                          : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function(a, ...rest) {} : (a: string, rest_0: boolean, ...rest_1: Iterable<number>[]) => void
->                        : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function(a, ...rest) {}) : (a: string, rest_0: boolean, ...rest: Iterable<number>[]) => void
+>                          : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function(a, ...rest) {} : (a: string, rest_0: boolean, ...rest: Iterable<number>[]) => void
+>                        : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : string
 >  : ^^^^^^
 >rest : [boolean, ...Iterable<number>[]]

--- a/tests/baselines/reference/argumentsSpreadRestIterables(target=esnext).types
+++ b/tests/baselines/reference/argumentsSpreadRestIterables(target=esnext).types
@@ -40,10 +40,10 @@ declare const itNum: Iterable<number>
 ;(function(a, ...rest) {})('', true, ...itNum)
 >(function(a, ...rest) {})('', true, ...itNum) : void
 >                                              : ^^^^
->(function(a, ...rest) {}) : (a: string, rest_0: boolean, ...rest_1: number[]) => void
->                          : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function(a, ...rest) {} : (a: string, rest_0: boolean, ...rest_1: number[]) => void
->                        : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function(a, ...rest) {}) : (a: string, rest_0: boolean, ...rest: number[]) => void
+>                          : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function(a, ...rest) {} : (a: string, rest_0: boolean, ...rest: number[]) => void
+>                        : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : string
 >  : ^^^^^^
 >rest : [boolean, ...number[]]

--- a/tests/baselines/reference/genericRestParameters2.types
+++ b/tests/baselines/reference/genericRestParameters2.types
@@ -64,14 +64,14 @@ declare let f04: (a: number, b: string, c: boolean, ...x: []) => void;
 >  : ^^
 
 declare let f10: (...x: [number, string, ...boolean[]]) => void;
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >x : [number, string, ...boolean[]]
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 declare let f11: (a: number, ...x: [string, ...boolean[]]) => void;
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >a : number
 >  : ^^^^^^
 >x : [string, ...boolean[]]
@@ -108,8 +108,8 @@ declare const sn: [string, number];
 f10(42, "hello");
 >f10(42, "hello") : void
 >                 : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -118,8 +118,8 @@ f10(42, "hello");
 f10(42, "hello", true);
 >f10(42, "hello", true) : void
 >                       : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -130,8 +130,8 @@ f10(42, "hello", true);
 f10(42, "hello", true, false);
 >f10(42, "hello", true, false) : void
 >                              : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -144,8 +144,8 @@ f10(42, "hello", true, false);
 f10(t1[0], t1[1], t1[2], t1[3]);
 >f10(t1[0], t1[1], t1[2], t1[3]) : void
 >                                : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >t1[0] : number
 >      : ^^^^^^
 >t1 : [number, string, ...boolean[]]
@@ -174,8 +174,8 @@ f10(t1[0], t1[1], t1[2], t1[3]);
 f10(...t1);
 >f10(...t1) : void
 >           : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >...t1 : string | number | boolean
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^
 >t1 : [number, string, ...boolean[]]
@@ -184,8 +184,8 @@ f10(...t1);
 f10(42, ...t2);
 >f10(42, ...t2) : void
 >               : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >...t2 : string | boolean
@@ -196,8 +196,8 @@ f10(42, ...t2);
 f10(42, "hello", ...t3);
 >f10(42, "hello", ...t3) : void
 >                        : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -210,8 +210,8 @@ f10(42, "hello", ...t3);
 f10(42, "hello", true, ...t4);
 >f10(42, "hello", true, ...t4) : void
 >                              : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -226,8 +226,8 @@ f10(42, "hello", true, ...t4);
 f10(42, "hello", true, ...t4, false, ...t3);
 >f10(42, "hello", true, ...t4, false, ...t3) : void
 >                                            : ^^^^
->f10 : (x_0: number, x_1: string, ...x_2: boolean[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f10 : (x_0: number, x_1: string, ...x: boolean[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -248,8 +248,8 @@ f10(42, "hello", true, ...t4, false, ...t3);
 f11(42, "hello");
 >f11(42, "hello") : void
 >                 : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -258,8 +258,8 @@ f11(42, "hello");
 f11(42, "hello", true);
 >f11(42, "hello", true) : void
 >                       : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -270,8 +270,8 @@ f11(42, "hello", true);
 f11(42, "hello", true, false);
 >f11(42, "hello", true, false) : void
 >                              : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -284,8 +284,8 @@ f11(42, "hello", true, false);
 f11(t1[0], t1[1], t1[2], t1[3]);
 >f11(t1[0], t1[1], t1[2], t1[3]) : void
 >                                : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >t1[0] : number
 >      : ^^^^^^
 >t1 : [number, string, ...boolean[]]
@@ -314,8 +314,8 @@ f11(t1[0], t1[1], t1[2], t1[3]);
 f11(...t1);
 >f11(...t1) : void
 >           : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >...t1 : string | number | boolean
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^
 >t1 : [number, string, ...boolean[]]
@@ -324,8 +324,8 @@ f11(...t1);
 f11(42, ...t2);
 >f11(42, ...t2) : void
 >               : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >...t2 : string | boolean
@@ -336,8 +336,8 @@ f11(42, ...t2);
 f11(42, "hello", ...t3);
 >f11(42, "hello", ...t3) : void
 >                        : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -350,8 +350,8 @@ f11(42, "hello", ...t3);
 f11(42, "hello", true, ...t4);
 >f11(42, "hello", true, ...t4) : void
 >                              : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"
@@ -366,8 +366,8 @@ f11(42, "hello", true, ...t4);
 f11(42, "hello", true, ...t4, false, ...t3);
 >f11(42, "hello", true, ...t4, false, ...t3) : void
 >                                            : ^^^^
->f11 : (a: number, x_0: string, ...x_1: boolean[]) => void
->    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>f11 : (a: number, x_0: string, ...x: boolean[]) => void
+>    : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >42 : 42
 >   : ^^
 >"hello" : "hello"

--- a/tests/baselines/reference/iterableArrayPattern14.types
+++ b/tests/baselines/reference/iterableArrayPattern14.types
@@ -59,8 +59,8 @@ class FooIterator {
 }
 
 function fun(...[a, ...b]) { }
->fun : (__0_0: any, ...__0_1: any[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fun : (a: any, ...b_0: any[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : any
 >  : ^^^
 >b : any[]
@@ -69,8 +69,8 @@ function fun(...[a, ...b]) { }
 fun(new FooIterator);
 >fun(new FooIterator) : void
 >                     : ^^^^
->fun : (__0_0: any, ...__0_1: any[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fun : (a: any, ...b_0: any[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new FooIterator : FooIterator
 >                : ^^^^^^^^^^^
 >FooIterator : typeof FooIterator

--- a/tests/baselines/reference/iterableArrayPattern14.types
+++ b/tests/baselines/reference/iterableArrayPattern14.types
@@ -59,8 +59,8 @@ class FooIterator {
 }
 
 function fun(...[a, ...b]) { }
->fun : (a: any, ...b_0: any[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fun : (a: any, ...b: any[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : any
 >  : ^^^
 >b : any[]
@@ -69,8 +69,8 @@ function fun(...[a, ...b]) { }
 fun(new FooIterator);
 >fun(new FooIterator) : void
 >                     : ^^^^
->fun : (a: any, ...b_0: any[]) => void
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fun : (a: any, ...b: any[]) => void
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new FooIterator : FooIterator
 >                : ^^^^^^^^^^^
 >FooIterator : typeof FooIterator

--- a/tests/baselines/reference/iterableArrayPattern25.types
+++ b/tests/baselines/reference/iterableArrayPattern25.types
@@ -2,7 +2,7 @@
 
 === iterableArrayPattern25.ts ===
 function takeFirstTwoEntries(...[[k1, v1], [k2, v2]]) { }
->takeFirstTwoEntries : (__0_0: [any, any], __0_1: [any, any]) => void
+>takeFirstTwoEntries : (arg_0: [any, any], arg_1: [any, any]) => void
 >                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >k1 : any
 >   : ^^^
@@ -16,7 +16,7 @@ function takeFirstTwoEntries(...[[k1, v1], [k2, v2]]) { }
 takeFirstTwoEntries(new Map([["", 0], ["hello", 1]]));
 >takeFirstTwoEntries(new Map([["", 0], ["hello", 1]])) : void
 >                                                      : ^^^^
->takeFirstTwoEntries : (__0_0: [any, any], __0_1: [any, any]) => void
+>takeFirstTwoEntries : (arg_0: [any, any], arg_1: [any, any]) => void
 >                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Map([["", 0], ["hello", 1]]) : Map<string, number>
 >                                 : ^^^^^^^^^^^^^^^^^^^

--- a/tests/baselines/reference/restParameterWithBindingPattern2.types
+++ b/tests/baselines/reference/restParameterWithBindingPattern2.types
@@ -2,8 +2,8 @@
 
 === restParameterWithBindingPattern2.ts ===
 function a(...[a, b]) { }
->a : (__0_0: any, __0_1: any) => void
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : (a: any, b: any) => void
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^
 >a : any
 >  : ^^^
 >b : any

--- a/tests/baselines/reference/restParameterWithBindingPattern3.types
+++ b/tests/baselines/reference/restParameterWithBindingPattern3.types
@@ -32,8 +32,8 @@ function c(...{0: a, length, 3: d}: [boolean, string, number]) { }
 >  : ^^^^^^^^^
 
 function d(...[a, , , d]: [boolean, string, number]) { }
->d : (__0_0: boolean, __0_1: string, __0_2: number) => void
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d : (a: boolean, __0_1: string, __0_2: number) => void
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : boolean
 >  : ^^^^^^^
 > : undefined

--- a/tests/baselines/reference/restParameterWithBindingPattern3.types
+++ b/tests/baselines/reference/restParameterWithBindingPattern3.types
@@ -22,7 +22,7 @@ function b(...[...foo = []]: string[]) { }
 >   : ^^^^^^^^^^^
 
 function c(...{0: a, length, 3: d}: [boolean, string, number]) { }
->c : (__0_0: boolean, __0_1: string, __0_2: number) => void
+>c : (arg_0: boolean, arg_1: string, arg_2: number) => void
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : boolean
 >  : ^^^^^^^
@@ -32,7 +32,7 @@ function c(...{0: a, length, 3: d}: [boolean, string, number]) { }
 >  : ^^^^^^^^^
 
 function d(...[a, , , d]: [boolean, string, number]) { }
->d : (a: boolean, __0_1: string, __0_2: number) => void
+>d : (a: boolean, arg_1: string, arg_2: number) => void
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : boolean
 >  : ^^^^^^^
@@ -44,7 +44,7 @@ function d(...[a, , , d]: [boolean, string, number]) { }
 >  : ^^^^^^^^^
 
 function e(...{0: a = 1, 1: b = true, ...rest: rest}: [boolean, string, number]) { }
->e : (__0_0: boolean, __0_1: string, __0_2: number) => void
+>e : (arg_0: boolean, arg_1: string, arg_2: number) => void
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : boolean
 >  : ^^^^^^^

--- a/tests/baselines/reference/restTupleElements1.types
+++ b/tests/baselines/reference/restTupleElements1.types
@@ -302,8 +302,8 @@ declare function f1(a: [(x: number) => number, ...((x: string) => number)[]]): v
 >  : ^^^^^^
 
 declare function f2(...a: [(x: number) => number, ...((x: string) => number)[]]): void;
->f2 : (a_0: (x: number) => number, ...a_1: ((x: string) => number)[]) => void
->   : ^^^^^^^ ^^      ^^^^^      ^^^^^^^^^^^^ ^^      ^^^^^      ^^^^^^^^    
+>f2 : (a_0: (x: number) => number, ...a: ((x: string) => number)[]) => void
+>   : ^^^^^^^ ^^      ^^^^^      ^^^^^^^^^^ ^^      ^^^^^      ^^^^^^^^    
 >a : [(x: number) => number, ...((x: string) => number)[]]
 >  : ^^ ^^      ^^^^^      ^^^^^^^ ^^      ^^^^^      ^^^^
 >x : number
@@ -356,8 +356,8 @@ f1([x => x * 2, x => x.length, x => x.charCodeAt(0)]);
 f2(x => x * 2, x => x.length, x => x.charCodeAt(0));
 >f2(x => x * 2, x => x.length, x => x.charCodeAt(0)) : void
 >                                                    : ^^^^
->f2 : (a_0: (x: number) => number, ...a_1: ((x: string) => number)[]) => void
->   : ^^^^^^^ ^^      ^^^^^      ^^^^^^^^^^^^ ^^      ^^^^^      ^^^^^^^^    
+>f2 : (a_0: (x: number) => number, ...a: ((x: string) => number)[]) => void
+>   : ^^^^^^^ ^^      ^^^^^      ^^^^^^^^^^ ^^      ^^^^^      ^^^^^^^^    
 >x => x * 2 : (x: number) => number
 >           : ^ ^^^^^^^^^^^^^^^^^^^
 >x : number

--- a/tests/baselines/reference/restTuplesFromContextualTypes.types
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.types
@@ -192,10 +192,10 @@ declare const t2: [number, boolean, ...string[]];
 (function (...x){})(...t2);
 >(function (...x){})(...t2) : void
 >                           : ^^^^
->(function (...x){}) : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function (...x){} : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function (...x){}) : (x_0: number, x_1: boolean, ...x: string[]) => void
+>                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function (...x){} : (x_0: number, x_1: boolean, ...x: string[]) => void
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >x : [number, boolean, ...string[]]
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >...t2 : string | number | boolean
@@ -206,10 +206,10 @@ declare const t2: [number, boolean, ...string[]];
 (function (a, ...x){})(...t2);
 >(function (a, ...x){})(...t2) : void
 >                              : ^^^^
->(function (a, ...x){}) : (a: number, x_0: boolean, ...x_1: string[]) => void
->                       : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function (a, ...x){} : (a: number, x_0: boolean, ...x_1: string[]) => void
->                     : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function (a, ...x){}) : (a: number, x_0: boolean, ...x: string[]) => void
+>                       : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function (a, ...x){} : (a: number, x_0: boolean, ...x: string[]) => void
+>                     : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : number
 >  : ^^^^^^
 >x : [boolean, ...string[]]
@@ -260,8 +260,8 @@ declare const t2: [number, boolean, ...string[]];
 declare function f2(cb: (...args: typeof t2) => void): void;
 >f2 : (cb: (...args: typeof t2) => void) => void
 >   : ^  ^^                            ^^^^^    
->cb : (args_0: number, args_1: boolean, ...args_2: string[]) => void
->   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>cb : (args_0: number, args_1: boolean, ...args: string[]) => void
+>   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >args : [number, boolean, ...string[]]
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >t2 : [number, boolean, ...string[]]
@@ -286,8 +286,8 @@ f2((...x) => {})
 >                 : ^^^^
 >f2 : (cb: (...args: typeof t2) => void) => void
 >   : ^  ^^                            ^^^^^    
->(...x) => {} : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(...x) => {} : (x_0: number, x_1: boolean, ...x: string[]) => void
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >x : [number, boolean, ...string[]]
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -296,8 +296,8 @@ f2((a, ...x) => {})
 >                    : ^^^^
 >f2 : (cb: (...args: typeof t2) => void) => void
 >   : ^  ^^                            ^^^^^    
->(a, ...x) => {} : (a: number, x_0: boolean, ...x_1: string[]) => void
->                : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(a, ...x) => {} : (a: number, x_0: boolean, ...x: string[]) => void
+>                : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : number
 >  : ^^^^^^
 >x : [boolean, ...string[]]
@@ -360,10 +360,10 @@ declare const t3: [boolean, ...string[]];
 (function (...x){})(1, ...t3);
 >(function (...x){})(1, ...t3) : void
 >                              : ^^^^
->(function (...x){}) : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function (...x){} : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function (...x){}) : (x_0: number, x_1: boolean, ...x: string[]) => void
+>                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function (...x){} : (x_0: number, x_1: boolean, ...x: string[]) => void
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >x : [number, boolean, ...string[]]
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >1 : 1
@@ -376,10 +376,10 @@ declare const t3: [boolean, ...string[]];
 (function (a, ...x){})(1, ...t3);
 >(function (a, ...x){})(1, ...t3) : void
 >                                 : ^^^^
->(function (a, ...x){}) : (a: number, x_0: boolean, ...x_1: string[]) => void
->                       : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function (a, ...x){} : (a: number, x_0: boolean, ...x_1: string[]) => void
->                     : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function (a, ...x){}) : (a: number, x_0: boolean, ...x: string[]) => void
+>                       : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function (a, ...x){} : (a: number, x_0: boolean, ...x: string[]) => void
+>                     : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : number
 >  : ^^^^^^
 >x : [boolean, ...string[]]
@@ -436,8 +436,8 @@ declare const t3: [boolean, ...string[]];
 declare function f3(cb: (x: number, ...args: typeof t3) => void): void;
 >f3 : (cb: (x: number, ...args: typeof t3) => void) => void
 >   : ^  ^^                                       ^^^^^    
->cb : (x: number, args_0: boolean, ...args_1: string[]) => void
->   : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
+>cb : (x: number, args_0: boolean, ...args: string[]) => void
+>   : ^ ^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
 >x : number
 >  : ^^^^^^
 >args : [boolean, ...string[]]
@@ -474,8 +474,8 @@ f3((a, ...x) => {})
 >                    : ^^^^
 >f3 : (cb: (x: number, ...args: typeof t3) => void) => void
 >   : ^  ^^                                       ^^^^^    
->(a, ...x) => {} : (a: number, x_0: boolean, ...x_1: string[]) => void
->                : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(a, ...x) => {} : (a: number, x_0: boolean, ...x: string[]) => void
+>                : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : number
 >  : ^^^^^^
 >x : [boolean, ...string[]]
@@ -552,10 +552,10 @@ function f4<T extends any[]>(t: T) {
     (function(a, ...x){})(1, 2, ...t);
 >(function(a, ...x){})(1, 2, ...t) : void
 >                                  : ^^^^
->(function(a, ...x){}) : (a: number, x_0: number, ...x_1: T) => void
->                      : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->function(a, ...x){} : (a: number, x_0: number, ...x_1: T) => void
->                    : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(function(a, ...x){}) : (a: number, x_0: number, ...x: T) => void
+>                      : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function(a, ...x){} : (a: number, x_0: number, ...x: T) => void
+>                    : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >a : number
 >  : ^^^^^^
 >x : [number, ...T]

--- a/tests/baselines/reference/signatureHelpExpandedRestTuplesLocalLabels1.baseline
+++ b/tests/baselines/reference/signatureHelpExpandedRestTuplesLocalLabels1.baseline
@@ -1,0 +1,6882 @@
+// === SignatureHelp ===
+=== /tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts ===
+// interface AppleInfo {
+//   color: "green" | "red";
+// }
+// 
+// interface BananaInfo {
+//   curvature: number;
+// }
+// 
+// type FruitAndInfo1 = ["apple", AppleInfo] | ["banana", BananaInfo];
+// 
+// function logFruitTuple1(...[fruit, info]: FruitAndInfo1) {}
+// logFruitTuple1();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple1(**fruit: "apple"**, info: AppleInfo): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple2(...[, info]: FruitAndInfo1) {}
+// logFruitTuple2();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple2(**arg_0: "apple"**, info: AppleInfo): void
+// | ----------------------------------------------------------------------
+// logFruitTuple2("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple2(arg_0: "apple", **info: AppleInfo**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple3(...[fruit, ...rest]: FruitAndInfo1) {}
+// logFruitTuple3();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple3(**fruit: "apple"**, rest_0: AppleInfo): void
+// | ----------------------------------------------------------------------
+// logFruitTuple3("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple3(fruit: "apple", **rest_0: AppleInfo**): void
+// | ----------------------------------------------------------------------
+// function logFruitTuple4(...[fruit, ...[info]]: FruitAndInfo1) {}
+// logFruitTuple4();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple4(**fruit: "apple"**, info: AppleInfo): void
+// | ----------------------------------------------------------------------
+// logFruitTuple4("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple4(fruit: "apple", **info: AppleInfo**): void
+// | ----------------------------------------------------------------------
+// 
+// type FruitAndInfo2 = ["apple", ...AppleInfo[]] | ["banana", ...BananaInfo[]];
+// 
+// function logFruitTuple5(...[fruit, firstInfo]: FruitAndInfo2) {}
+// logFruitTuple5();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple5(**fruit: "apple"**, ...firstInfo_n: AppleInfo[]): void
+// | ----------------------------------------------------------------------
+// logFruitTuple5("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple5(fruit: "apple", **...firstInfo_n: AppleInfo[]**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple6(...[fruit, ...fruitInfo]: FruitAndInfo2) {}
+// logFruitTuple6();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple6(**fruit: "apple"**, ...fruitInfo: AppleInfo[]): void
+// | ----------------------------------------------------------------------
+// logFruitTuple6("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple6(fruit: "apple", **...fruitInfo: AppleInfo[]**): void
+// | ----------------------------------------------------------------------
+// 
+// type FruitAndInfo3 = ["apple", ...AppleInfo[], number] | ["banana", ...BananaInfo[], number];
+// 
+// function logFruitTuple7(...[fruit, fruitInfoOrNumber, secondFruitInfoOrNumber]: FruitAndInfo3) {}
+// logFruitTuple7();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple7(**fruit: "apple"**, ...fruitInfoOrNumber_n: AppleInfo[], secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple7("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple7(fruit: "apple", **...fruitInfoOrNumber_n: AppleInfo[]**, secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple7("apple", { color: "red" }, );
+//                                           ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple7(fruit: "apple", ...fruitInfoOrNumber_n: AppleInfo[], **secondFruitInfoOrNumber: number**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple8(...[fruit, , secondFruitInfoOrNumber]: FruitAndInfo3) {}
+// logFruitTuple8();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple8(**fruit: "apple"**, ...arg_1: AppleInfo[], secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple8("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple8(fruit: "apple", **...arg_1: AppleInfo[]**, secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple8("apple", { color: "red" }, );
+//                                           ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple8(fruit: "apple", ...arg_1: AppleInfo[], **secondFruitInfoOrNumber: number**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple9(...[...[fruit, fruitInfoOrNumber, secondFruitInfoOrNumber]]: FruitAndInfo3) {}
+// logFruitTuple9();
+//                ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple9(**fruit: "apple"**, ...fruitInfoOrNumber_n: AppleInfo[], secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple9("apple", );
+//                         ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple9(fruit: "apple", **...fruitInfoOrNumber_n: AppleInfo[]**, secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple9("apple", { color: "red" }, );
+//                                           ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple9(fruit: "apple", ...fruitInfoOrNumber_n: AppleInfo[], **secondFruitInfoOrNumber: number**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple10(...[fruit, {}, secondFruitInfoOrNumber]: FruitAndInfo3) {}
+// logFruitTuple10();
+//                 ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple10(**fruit: "apple"**, ...arg_1: AppleInfo[], secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple10("apple", );
+//                          ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple10(fruit: "apple", **...arg_1: AppleInfo[]**, secondFruitInfoOrNumber: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple10("apple", { color: "red" }, );
+//                                            ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple10(fruit: "apple", ...arg_1: AppleInfo[], **secondFruitInfoOrNumber: number**): void
+// | ----------------------------------------------------------------------
+// 
+// function logFruitTuple11(...{}: FruitAndInfo3) {}
+// logFruitTuple11();
+//                 ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple11(**arg_0: "apple"**, ...arg_1: AppleInfo[], arg_2: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple11("apple", );
+//                          ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple11(arg_0: "apple", **...arg_1: AppleInfo[]**, arg_2: number): void
+// | ----------------------------------------------------------------------
+// logFruitTuple11("apple", { color: "red" }, );
+//                                            ^
+// | ----------------------------------------------------------------------
+// | logFruitTuple11(arg_0: "apple", ...arg_1: AppleInfo[], **arg_2: number**): void
+// | ----------------------------------------------------------------------
+// function withPair(...[first, second]: [number, named: string]) {}
+// withPair();
+//          ^
+// | ----------------------------------------------------------------------
+// | withPair(**first: number**, named: string): void
+// | ----------------------------------------------------------------------
+// withPair(101, );
+//               ^
+// | ----------------------------------------------------------------------
+// | withPair(first: number, **named: string**): void
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 242,
+      "name": "1"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple1",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple1",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 242,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 316,
+      "name": "2"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple2",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple2",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 316,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 343,
+      "name": "3"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple2",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple2",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 334,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 425,
+      "name": "4"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple3",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "rest_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "rest_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple3",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "rest_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "rest_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 425,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 452,
+      "name": "5"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple3",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "rest_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "rest_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple3",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "rest_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "rest_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 443,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 535,
+      "name": "6"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple4",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple4",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 535,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 562,
+      "name": "7"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple4",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple4",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "info",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "info",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 553,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 725,
+      "name": "8"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple5",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "firstInfo_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "firstInfo_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple5",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "firstInfo_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "firstInfo_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 725,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 752,
+      "name": "9"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple5",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "firstInfo_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "firstInfo_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple5",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "firstInfo_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "firstInfo_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 743,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 839,
+      "name": "10"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple6",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfo",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfo",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple6",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfo",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfo",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 839,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 866,
+      "name": "11"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple6",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfo",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfo",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": true,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple6",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfo",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfo",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 857,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1078,
+      "name": "12"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1078,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1105,
+      "name": "13"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1096,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1150,
+      "name": "14"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple7",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1123,
+        "length": 27
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1250,
+      "name": "15"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1250,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1277,
+      "name": "16"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1268,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1322,
+      "name": "17"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple8",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1295,
+        "length": 27
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1444,
+      "name": "18"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1444,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1471,
+      "name": "19"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1462,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1516,
+      "name": "20"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple9",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "fruitInfoOrNumber_n",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "fruitInfoOrNumber_n",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1489,
+        "length": 27
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1620,
+      "name": "21"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1620,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1648,
+      "name": "22"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1639,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1694,
+      "name": "23"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple10",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "fruit",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "fruit",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "secondFruitInfoOrNumber",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "secondFruitInfoOrNumber",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1667,
+        "length": 27
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1764,
+      "name": "24"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1764,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1792,
+      "name": "25"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1783,
+        "length": 9
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1838,
+      "name": "26"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"apple\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "AppleInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        },
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "logFruitTuple11",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "arg_0",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "\"banana\"",
+                  "kind": "stringLiteral"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg_1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "...",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "arg_1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "BananaInfo",
+                  "kind": "interfaceName"
+                },
+                {
+                  "text": "[",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": "]",
+                  "kind": "punctuation"
+                }
+              ],
+              "isOptional": false,
+              "isRest": true
+            },
+            {
+              "name": "arg_2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg_2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1811,
+        "length": 27
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1916,
+      "name": "27"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "withPair",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "first",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "first",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "named",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "named",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1916,
+        "length": 0
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 0
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts",
+      "position": 1933,
+      "name": "28"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "withPair",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "first",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "first",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "named",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "named",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 1928,
+        "length": 5
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 2
+    }
+  }
+]

--- a/tests/baselines/reference/variadicTuples1.js
+++ b/tests/baselines/reference/variadicTuples1.js
@@ -823,7 +823,7 @@ declare function getOrgUser(id: string, orgId: number, options?: {
     y?: number;
     z?: boolean;
 }): void;
-declare function callApi<T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U): (...args_0: T) => U;
+declare function callApi<T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U): (...args: T) => U;
 type Numbers = number[];
 type Unbounded = [...Numbers, boolean];
 declare const data: Unbounded;

--- a/tests/baselines/reference/variadicTuples1.types
+++ b/tests/baselines/reference/variadicTuples1.types
@@ -2218,16 +2218,16 @@ declare function getOrgUser(id: string, orgId: number, options?: { y?: number, z
 >  : ^^^^^^^^^^^^^^^^^^^
 
 function callApi<T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) {
->callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args_0: T) => U
->        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^^^
+>callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args: T) => U
+>        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^
 >method : (...args: [...T, object]) => U
 >       : ^^^^    ^^              ^^^^^ 
 >args : [...T, object]
 >     : ^^^^^^^^^^^^^^
 
     return (...args: [...T]) => method(...args, {});
->(...args: [...T]) => method(...args, {}) : (...args_0: T) => U
->                                         : ^^^^^^^^^^^^^^^^^^^
+>(...args: [...T]) => method(...args, {}) : (...args: T) => U
+>                                         : ^^^^^^^^^^^^^^^^^
 >args : [...T]
 >     : ^^^^^^
 >method(...args, {}) : U
@@ -2245,16 +2245,16 @@ function callApi<T extends unknown[] = [], U = void>(method: (...args: [...T, ob
 callApi(getUser);
 >callApi(getUser) : (id: string) => string
 >                 : ^^^^^^^^^^^^^^^^^^^^^^
->callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args_0: T) => U
->        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^^^
+>callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args: T) => U
+>        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^
 >getUser : (id: string, options?: { x?: string; }) => string
 >        : ^  ^^      ^^       ^^^               ^^^^^      
 
 callApi(getOrgUser);
 >callApi(getOrgUser) : (id: string, orgId: number) => void
 >                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args_0: T) => U
->        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^^^
+>callApi : <T extends unknown[] = [], U = void>(method: (...args: [...T, object]) => U) => (...args: T) => U
+>        : ^ ^^^^^^^^^         ^^^^^^^ ^^^^^^^^^      ^^                              ^^^^^^^^^^^^^^^^^^^^^^
 >getOrgUser : (id: string, orgId: number, options?: { y?: number; z?: boolean; }) => void
 >           : ^  ^^      ^^     ^^      ^^       ^^^                            ^^^^^    
 

--- a/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts
+++ b/tests/cases/fourslash/signatureHelpExpandedRestTuplesLocalLabels1.ts
@@ -1,0 +1,70 @@
+/// <reference path='fourslash.ts' />
+// from: https://github.com/microsoft/TypeScript/pull/57619
+
+//// interface AppleInfo {
+////   color: "green" | "red";
+//// }
+////
+//// interface BananaInfo {
+////   curvature: number;
+//// }
+////
+//// type FruitAndInfo1 = ["apple", AppleInfo] | ["banana", BananaInfo];
+////
+//// function logFruitTuple1(...[fruit, info]: FruitAndInfo1) {}
+//// logFruitTuple1(/*1*/);
+////
+//// function logFruitTuple2(...[, info]: FruitAndInfo1) {}
+//// logFruitTuple2(/*2*/);
+//// logFruitTuple2("apple", /*3*/);
+////
+//// function logFruitTuple3(...[fruit, ...rest]: FruitAndInfo1) {}
+//// logFruitTuple3(/*4*/);
+//// logFruitTuple3("apple", /*5*/);
+
+//// function logFruitTuple4(...[fruit, ...[info]]: FruitAndInfo1) {}
+//// logFruitTuple4(/*6*/);
+//// logFruitTuple4("apple", /*7*/);
+////
+//// type FruitAndInfo2 = ["apple", ...AppleInfo[]] | ["banana", ...BananaInfo[]];
+////
+//// function logFruitTuple5(...[fruit, firstInfo]: FruitAndInfo2) {}
+//// logFruitTuple5(/*8*/);
+//// logFruitTuple5("apple", /*9*/);
+////
+//// function logFruitTuple6(...[fruit, ...fruitInfo]: FruitAndInfo2) {}
+//// logFruitTuple6(/*10*/);
+//// logFruitTuple6("apple", /*11*/);
+////
+//// type FruitAndInfo3 = ["apple", ...AppleInfo[], number] | ["banana", ...BananaInfo[], number];
+////
+//// function logFruitTuple7(...[fruit, fruitInfoOrNumber, secondFruitInfoOrNumber]: FruitAndInfo3) {}
+//// logFruitTuple7(/*12*/);
+//// logFruitTuple7("apple", /*13*/);
+//// logFruitTuple7("apple", { color: "red" }, /*14*/);
+////
+//// function logFruitTuple8(...[fruit, , secondFruitInfoOrNumber]: FruitAndInfo3) {}
+//// logFruitTuple8(/*15*/);
+//// logFruitTuple8("apple", /*16*/);
+//// logFruitTuple8("apple", { color: "red" }, /*17*/);
+////
+//// function logFruitTuple9(...[...[fruit, fruitInfoOrNumber, secondFruitInfoOrNumber]]: FruitAndInfo3) {}
+//// logFruitTuple9(/*18*/);
+//// logFruitTuple9("apple", /*19*/);
+//// logFruitTuple9("apple", { color: "red" }, /*20*/);
+////
+//// function logFruitTuple10(...[fruit, {}, secondFruitInfoOrNumber]: FruitAndInfo3) {}
+//// logFruitTuple10(/*21*/);
+//// logFruitTuple10("apple", /*22*/);
+//// logFruitTuple10("apple", { color: "red" }, /*23*/);
+////
+//// function logFruitTuple11(...{}: FruitAndInfo3) {}
+//// logFruitTuple11(/*24*/);
+//// logFruitTuple11("apple", /*25*/);
+//// logFruitTuple11("apple", { color: "red" }, /*26*/);
+
+//// function withPair(...[first, second]: [number, named: string]) {}
+//// withPair(/*27*/);
+//// withPair(101, /*28*/);
+
+verify.baselineSignatureHelp();

--- a/tests/cases/fourslash/signatureHelpExpandedRestUnlabeledTuples.ts
+++ b/tests/cases/fourslash/signatureHelpExpandedRestUnlabeledTuples.ts
@@ -29,7 +29,7 @@ verify.signatureHelp(
     },
     {
         marker: "3",
-        text: "complex(item: string, another: string, rest_0: (err: Error) => void, ...rest_1: object[]): void",
+        text: "complex(item: string, another: string, rest_0: (err: Error) => void, ...rest: object[]): void",
         overloadsCount: 3,
         isVariadic: true,
     },


### PR DESCRIPTION
While working on #58243, a community member asked if we could label the tuple we use to properly type arguments to the `next()` methods of iterators and generators. A brief experiment showed that directly labeling the tuple element resulted in the creation of thousands of new types in some tests since iterator/generator instantiations would produce new named tuple elements since named tuple elements are cached far less frequently.

An alternative to that approach would be to use an additional source for the label when the label comes from a rest parameter whose name is actually an `ArrayBindingPattern`:

```ts
declare function a(...args: [] | [number]): void;
a(1); // quickinfo shows `(args_0: number)`

declare function b(...[value] : [] | [number]): void;
b(1); // quickinfo now shows `(value: number)`
      // quickinfo previously showed `(__0_0: number)`
```

Since this is merely treated as an additional labeling source, there is no need to synthesize additional types for named tuple elements.

This also improves label inference in other cases such as elision and object assignment pattern elements:

```ts
declare function a(...[x, , z]: [number, number, number]): void;
a(1, 2, 3); // quickinfo shows `(x: number, arg_1: number, z: number)`
            // previously showed `(__0_0: number, __0_1: number, __0_2: number)`
```

Related https://github.com/microsoft/TypeScript/pull/58243#discussion_r1586225461

Fixes #56289
Closes #57619
