### PR TITLE
unconstrained type parameters consistently check for `{} | null | undefined` in `strictNullChecks`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27330,7 +27330,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFactsWorker(type: Type, callerOnlyNeeds: TypeFacts): TypeFacts {
         if (type.flags & (TypeFlags.Intersection | TypeFlags.Instantiable)) {
             const constraintType = getBaseConstraintOfType(type) || unknownType;
-            if (type.flags & TypeFlags.Instantiable && constraintType === unknownType) return callerOnlyNeeds;
+            if (strictNullChecks && type.flags & TypeFlags.Instantiable && constraintType === unknownType) return callerOnlyNeeds;
 
             type = constraintType
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27329,7 +27329,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getTypeFactsWorker(type: Type, callerOnlyNeeds: TypeFacts): TypeFacts {
         if (type.flags & (TypeFlags.Intersection | TypeFlags.Instantiable)) {
-            type = getBaseConstraintOfType(type) || unknownType;
+            const constraintType = getBaseConstraintOfType(type) || unknownType;
+            if (type.flags & TypeFlags.Instantiable && constraintType === unknownType) return callerOnlyNeeds;
+
+            type = constraintType
         }
         const flags = type.flags;
         if (flags & (TypeFlags.String | TypeFlags.StringMapping)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27330,9 +27330,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFactsWorker(type: Type, callerOnlyNeeds: TypeFacts): TypeFacts {
         if (type.flags & (TypeFlags.Intersection | TypeFlags.Instantiable)) {
             const constraintType = getBaseConstraintOfType(type) || unknownType;
-            if (strictNullChecks && type.flags & TypeFlags.Instantiable && constraintType === unknownType) return callerOnlyNeeds;
-
-            type = constraintType
+            if (strictNullChecks && type.flags & TypeFlags.Instantiable && constraintType === unknownType) {
+                return callerOnlyNeeds;
+            }
+            type = constraintType;
         }
         const flags = type.flags;
         if (flags & (TypeFlags.String | TypeFlags.StringMapping)) {
@@ -27466,7 +27467,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // For each constituent type that can compare equal to the target nullable, intersect with the above union
         // if the type doesn't already include the opppsite nullable and the constituent can compare equal to the
         // opposite nullable; otherwise, just intersect with {}.
-        return mapType(type, t => hasTypeFacts(t, targetFacts) ? getIntersectionType([t, !(facts & otherIncludesFacts) && hasTypeFacts(t, otherFacts) ? emptyAndOtherUnion : emptyObjectType]) : t);
+        return mapType(type, t => hasTypeFacts(t, targetFacts) ? getIntersectionType([t, (strictNullChecks || !(facts & otherIncludesFacts)) && hasTypeFacts(t, otherFacts) ? emptyAndOtherUnion : emptyObjectType]) : t);
     }
 
     function recombineUnknownType(type: Type) {

--- a/tests/baselines/reference/controlFlowGenericTypes.errors.txt
+++ b/tests/baselines/reference/controlFlowGenericTypes.errors.txt
@@ -5,12 +5,13 @@ controlFlowGenericTypes.ts(81,11): error TS2339: Property 'foo' does not exist o
 controlFlowGenericTypes.ts(90,44): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 controlFlowGenericTypes.ts(91,11): error TS2339: Property 'foo' does not exist on type 'MyUnion'.
   Property 'foo' does not exist on type 'AA'.
+controlFlowGenericTypes.ts(146,16): error TS18049: 'obj' is possibly 'null' or 'undefined'.
 controlFlowGenericTypes.ts(156,16): error TS18048: 'obj' is possibly 'undefined'.
 controlFlowGenericTypes.ts(167,9): error TS18048: 'iSpec' is possibly 'undefined'.
 controlFlowGenericTypes.ts(168,9): error TS18048: 'iSpec' is possibly 'undefined'.
 
 
-==== controlFlowGenericTypes.ts (8 errors) ====
+==== controlFlowGenericTypes.ts (9 errors) ====
     function f1<T extends string | undefined>(x: T, y: { a: T }, z: [T]): string {
         if (x) {
             x;
@@ -169,6 +170,8 @@ controlFlowGenericTypes.ts(168,9): error TS18048: 'iSpec' is possibly 'undefined
     
     function fx1<T, K extends keyof T>(obj: T, key: K) {
         const x1 = obj[key];
+                   ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
         const x2 = obj && obj[key];
     }
     

--- a/tests/baselines/reference/controlFlowGenericTypes.types
+++ b/tests/baselines/reference/controlFlowGenericTypes.types
@@ -596,10 +596,10 @@ function fx1<T, K extends keyof T>(obj: T, key: K) {
 >    : ^
 
     const x1 = obj[key];
->x1 : T[K]
->   : ^^^^
->obj[key] : T[K]
->         : ^^^^
+>x1 : NonNullable<T>[K]
+>   : ^^^^^^^^^^^^^^^^^
+>obj[key] : NonNullable<T>[K]
+>         : ^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.errors.txt
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.errors.txt
@@ -1,14 +1,14 @@
-genericUnboundedTypeParamAssignability.ts(2,5): error TS2339: Property 'toString' does not exist on type 'T'.
+genericUnboundedTypeParamAssignability.ts(2,3): error TS18049: 'o' is possibly 'null' or 'undefined'.
 genericUnboundedTypeParamAssignability.ts(15,6): error TS2345: Argument of type 'T' is not assignable to parameter of type '{}'.
 genericUnboundedTypeParamAssignability.ts(16,6): error TS2345: Argument of type 'T' is not assignable to parameter of type 'Record<string, any>'.
-genericUnboundedTypeParamAssignability.ts(17,5): error TS2339: Property 'toString' does not exist on type 'T'.
+genericUnboundedTypeParamAssignability.ts(17,3): error TS18049: 't' is possibly 'null' or 'undefined'.
 
 
 ==== genericUnboundedTypeParamAssignability.ts (4 errors) ====
     function f1<T>(o: T) {
       o.toString(); // error
-        ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'T'.
+      ~
+!!! error TS18049: 'o' is possibly 'null' or 'undefined'.
     }
     
     function f2<T extends {}>(o: T) {
@@ -30,7 +30,7 @@ genericUnboundedTypeParamAssignability.ts(17,5): error TS2339: Property 'toStrin
 !!! error TS2345: Argument of type 'T' is not assignable to parameter of type 'Record<string, any>'.
 !!! related TS2208 genericUnboundedTypeParamAssignability.ts:13:15: This type parameter might need an `extends Record<string, any>` constraint.
       t.toString();  // error, for the same reason as f1()
-        ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'T'.
+      ~
+!!! error TS18049: 't' is possibly 'null' or 'undefined'.
     }
     

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.symbols
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.symbols
@@ -8,7 +8,9 @@ function f1<T>(o: T) {
 >T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 0, 12))
 
   o.toString(); // error
+>o.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 0, 15))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
 }
 
 function f2<T extends {}>(o: T) {
@@ -55,6 +57,8 @@ function user<T>(t: T) {
 >t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
 
   t.toString();  // error, for the same reason as f1()
+>t.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
 >t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
 }
 

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.types
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.types
@@ -8,14 +8,14 @@ function f1<T>(o: T) {
 >  : ^
 
   o.toString(); // error
->o.toString() : any
->             : ^^^
->o.toString : any
->           : ^^^
+>o.toString() : string
+>             : ^^^^^^
+>o.toString : () => string
+>           : ^^^^^^      
 >o : T
 >  : ^
->toString : any
->         : ^^^
+>toString : () => string
+>         : ^^^^^^      
 }
 
 function f2<T extends {}>(o: T) {
@@ -83,13 +83,13 @@ function user<T>(t: T) {
 >  : ^
 
   t.toString();  // error, for the same reason as f1()
->t.toString() : any
->             : ^^^
->t.toString : any
->           : ^^^
+>t.toString() : string
+>             : ^^^^^^
+>t.toString : () => string
+>           : ^^^^^^      
 >t : T
 >  : ^
->toString : any
->         : ^^^
+>toString : () => string
+>         : ^^^^^^      
 }
 

--- a/tests/baselines/reference/inKeywordTypeguard(strict=true).errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard(strict=true).errors.txt
@@ -30,7 +30,7 @@ inKeywordTypeguard.ts(90,5): error TS2564: Property 'a' has no initializer and i
 inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' does not exist on type 'never'.
 inKeywordTypeguard.ts(155,16): error TS18046: 'x' is of type 'unknown'.
 inKeywordTypeguard.ts(158,21): error TS2638: Type '{}' may represent a primitive value, which is not permitted as the right operand of the 'in' operator.
-inKeywordTypeguard.ts(183,16): error TS2322: Type 'T' is not assignable to type 'object'.
+inKeywordTypeguard.ts(183,16): error TS18049: 'x' is possibly 'null' or 'undefined'.
 inKeywordTypeguard.ts(186,21): error TS2638: Type 'NonNullable<T>' may represent a primitive value, which is not permitted as the right operand of the 'in' operator.
 
 
@@ -277,8 +277,7 @@ inKeywordTypeguard.ts(186,21): error TS2638: Type 'NonNullable<T>' may represent
     function f3<T>(x: T) {
         if ("a" in x) {
                    ~
-!!! error TS2322: Type 'T' is not assignable to type 'object'.
-!!! related TS2208 inKeywordTypeguard.ts:182:13: This type parameter might need an `extends object` constraint.
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
             x.a;
         }
         if (x && "a" in x) {

--- a/tests/baselines/reference/isomorphicMappedTypeInference.errors.txt
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.errors.txt
@@ -1,0 +1,188 @@
+isomorphicMappedTypeInference.ts(20,9): error TS2536: Type 'Extract<keyof NonNullable<T>, string>' cannot be used to index type 'Boxified<T>'.
+isomorphicMappedTypeInference.ts(35,9): error TS2536: Type 'Extract<keyof NonNullable<T>, string>' cannot be used to index type 'Boxified<T>'.
+
+
+==== isomorphicMappedTypeInference.ts (2 errors) ====
+    type Box<T> = {
+        value: T;
+    }
+    
+    type Boxified<T> = {
+        [P in keyof T]: Box<T[P]>;
+    }
+    
+    function box<T>(x: T): Box<T> {
+        return { value: x };
+    }
+    
+    function unbox<T>(x: Box<T>): T {
+        return x.value;
+    }
+    
+    function boxify<T>(obj: T): Boxified<T> {
+        let result = {} as Boxified<T>;
+        for (let k in obj) {
+            result[k] = box(obj[k]);
+            ~~~~~~~~~
+!!! error TS2536: Type 'Extract<keyof NonNullable<T>, string>' cannot be used to index type 'Boxified<T>'.
+        }
+        return result;
+    }
+    
+    function unboxify<T extends object>(obj: Boxified<T>): T {
+        let result = {} as T;
+        for (let k in obj) {
+            result[k] = unbox(obj[k]);
+        }
+        return result;
+    }
+    
+    function assignBoxified<T>(obj: Boxified<T>, values: T) {
+        for (let k in values) {
+            obj[k].value = values[k];
+            ~~~~~~
+!!! error TS2536: Type 'Extract<keyof NonNullable<T>, string>' cannot be used to index type 'Boxified<T>'.
+        }
+    }
+    
+    function f1() {
+        let v = {
+            a: 42,
+            b: "hello",
+            c: true
+        };
+        let b = boxify(v);
+        let x: number = b.a.value;
+    }
+    
+    function f2() {
+        let b = {
+            a: box(42),
+            b: box("hello"),
+            c: box(true)
+        };
+        let v = unboxify(b);
+        let x: number = v.a;
+    }
+    
+    function f3() {
+        let b = {
+            a: box(42),
+            b: box("hello"),
+            c: box(true)
+        };
+        assignBoxified(b, { c: false });
+    }
+    
+    function f4() {
+        let b = {
+            a: box(42),
+            b: box("hello"),
+            c: box(true)
+        };
+        b = boxify(unboxify(b));
+        b = unboxify(boxify(b));
+    }
+    
+    function makeRecord<T, K extends string>(obj: { [P in K]: T }) {
+        return obj;
+    }
+    
+    function f5(s: string) {
+        let b = makeRecord({
+            a: box(42),
+            b: box("hello"),
+            c: box(true)
+        });
+        let v = unboxify(b);
+        let x: string | number | boolean = v.a;
+    }
+    
+    function makeDictionary<T>(obj: { [x: string]: T }) {
+        return obj;
+    }
+    
+    function f6(s: string) {
+        let b = makeDictionary({
+            a: box(42),
+            b: box("hello"),
+            c: box(true)
+        });
+        let v = unboxify(b);
+        let x: string | number | boolean = v[s];
+    }
+    
+    declare function validate<T>(obj: { [P in keyof T]?: T[P] }): T;
+    declare function clone<T>(obj: { readonly [P in keyof T]: T[P] }): T;
+    declare function validateAndClone<T>(obj: { readonly [P in keyof T]?: T[P] }): T;
+    
+    type Foo = {
+        a?: number;
+        readonly b: string;
+    }
+    
+    function f10(foo: Foo) {
+        let x = validate(foo);  // { a: number, readonly b: string }
+        let y = clone(foo);  // { a?: number, b: string }
+        let z = validateAndClone(foo);  // { a: number, b: string }
+    }
+    
+    // Repro from #12606
+    
+    type Func<T> = (...args: any[]) => T;
+    type Spec<T> = {
+        [P in keyof T]: Func<T[P]> | Spec<T[P]> ;
+    };
+    
+    /**
+     * Given a spec object recursively mapping properties to functions, creates a function
+     * producing an object of the same structure, by mapping each property to the result
+     * of calling its associated function with the supplied arguments.
+     */
+    declare function applySpec<T>(obj: Spec<T>): (...args: any[]) => T;
+    
+    // Infers g1: (...args: any[]) => { sum: number, nested: { mul: string } }
+    var g1 = applySpec({
+        sum: (a: any) => 3,
+        nested: {
+            mul: (b: any) => "n"
+        }
+    });
+    
+    // Infers g2: (...args: any[]) => { foo: { bar: { baz: boolean } } }
+    var g2 = applySpec({ foo: { bar: { baz: (x: any) => true } } });
+    
+    // Repro from #12633
+    
+    const foo = <T>(object: T, partial: Partial<T>) => object;
+    let o = {a: 5, b: 7};
+    foo(o, {b: 9});
+    o = foo(o, {b: 9});
+    
+    // Inferring to { [P in K]: X }, where K extends keyof T, produces same inferences as
+    // inferring to { [P in keyof T]: X }.
+    
+    declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+    declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+    declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+    declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+    declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
+    
+    let x0 = f20({ foo: 42, bar: "hello" });
+    let x1 = f21({ foo: 42, bar: "hello" });
+    let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+    let x3 = f23({ foo: 42, bar: "hello" });
+    let x4 = f24({ foo: 42, bar: "hello" });
+    
+    // Repro from #29765
+    
+    function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+        return {} as any;
+    }
+    
+    const myAny: any = {};
+    
+    const o1 = getProps(myAny, ['foo', 'bar']);
+    
+    const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
+    

--- a/tests/baselines/reference/isomorphicMappedTypeInference.symbols
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.symbols
@@ -118,10 +118,8 @@ function assignBoxified<T>(obj: Boxified<T>, values: T) {
 >values : Symbol(values, Decl(isomorphicMappedTypeInference.ts, 32, 44))
 
         obj[k].value = values[k];
->obj[k].value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 0, 15))
 >obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 32, 27))
 >k : Symbol(k, Decl(isomorphicMappedTypeInference.ts, 33, 12))
->value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 0, 15))
 >values : Symbol(values, Decl(isomorphicMappedTypeInference.ts, 32, 44))
 >k : Symbol(k, Decl(isomorphicMappedTypeInference.ts, 33, 12))
     }

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -65,30 +65,30 @@ function boxify<T>(obj: T): Boxified<T> {
 >   : ^^
 
     for (let k in obj) {
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 
         result[k] = box(obj[k]);
->result[k] = box(obj[k]) : Box<T[Extract<keyof T, string>]>
->                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->result[k] : Boxified<T>[Extract<keyof T, string>]
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>result[k] = box(obj[k]) : Box<NonNullable<T>[Extract<keyof NonNullable<T>, string>]>
+>                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>result[k] : any
+>          : ^^^
 >result : Boxified<T>
 >       : ^^^^^^^^^^^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
->box(obj[k]) : Box<T[Extract<keyof T, string>]>
->            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>box(obj[k]) : Box<NonNullable<T>[Extract<keyof NonNullable<T>, string>]>
+>            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >box : <T_1>(x: T_1) => Box<T_1>
 >    : ^^^^^^ ^^   ^^^^^        
->obj[k] : T[Extract<keyof T, string>]
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj : T
->    : ^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>obj[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj : NonNullable<T>
+>    : ^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
     return result;
 >result : Boxified<T>
@@ -149,30 +149,30 @@ function assignBoxified<T>(obj: Boxified<T>, values: T) {
 >       : ^
 
     for (let k in values) {
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >values : T
 >       : ^
 
         obj[k].value = values[k];
->obj[k].value = values[k] : T[Extract<keyof T, string>]
->                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj[k].value : T[Extract<keyof T, string>]
->             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj[k] : Boxified<T>[Extract<keyof T, string>]
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj[k].value = values[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj[k].value : any
+>             : ^^^
+>obj[k] : any
+>       : ^^^
 >obj : Boxified<T>
 >    : ^^^^^^^^^^^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
->value : T[Extract<keyof T, string>]
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->values[k] : T[Extract<keyof T, string>]
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->values : T
->       : ^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>value : any
+>      : ^^^
+>values[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>values : NonNullable<T>
+>       : ^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
 }
 
@@ -695,6 +695,7 @@ var g1 = applySpec({
 >(a: any) => 3 : (a: any) => number
 >              : ^ ^^   ^^^^^^^^^^^
 >a : any
+>  : ^^^
 >3 : 3
 >  : ^
 
@@ -710,6 +711,7 @@ var g1 = applySpec({
 >(b: any) => "n" : (b: any) => string
 >                : ^ ^^   ^^^^^^^^^^^
 >b : any
+>  : ^^^
 >"n" : "n"
 >    : ^^^
     }
@@ -738,6 +740,7 @@ var g2 = applySpec({ foo: { bar: { baz: (x: any) => true } } });
 >(x: any) => true : (x: any) => boolean
 >                 : ^ ^^   ^^^^^^^^^^^^
 >x : any
+>  : ^^^
 >true : true
 >     : ^^^^
 
@@ -944,12 +947,14 @@ function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
 
     return {} as any;
 >{} as any : any
+>          : ^^^
 >{} : {}
 >   : ^^
 }
 
 const myAny: any = {};
 >myAny : any
+>      : ^^^
 >{} : {}
 >   : ^^
 
@@ -961,6 +966,7 @@ const o1 = getProps(myAny, ['foo', 'bar']);
 >getProps : <T, K extends keyof T>(obj: T, list: K[]) => Pick<T, K>
 >         : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^    ^^   ^^^^^          
 >myAny : any
+>      : ^^^
 >['foo', 'bar'] : ("foo" | "bar")[]
 >               : ^^^^^^^^^^^^^^^^^
 >'foo' : "foo"
@@ -972,12 +978,15 @@ const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
 >o2 : { foo: any; bar: any; }
 >   : ^^^^^^^   ^^^^^^^   ^^^
 >foo : any
+>    : ^^^
 >bar : any
+>    : ^^^
 >getProps(myAny, ['foo', 'bar']) : Pick<any, "foo" | "bar">
 >                                : ^^^^^^^^^^^^^^^^^^^^^^^^
 >getProps : <T, K extends keyof T>(obj: T, list: K[]) => Pick<T, K>
 >         : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^    ^^   ^^^^^          
 >myAny : any
+>      : ^^^
 >['foo', 'bar'] : ("foo" | "bar")[]
 >               : ^^^^^^^^^^^^^^^^^
 >'foo' : "foo"

--- a/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
@@ -1,19 +1,47 @@
-keyofAndIndexedAccess.ts(205,24): error TS2322: Type 'T[keyof T]' is not assignable to type 'object'.
-  Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
-    Type 'T[string]' is not assignable to type 'object'.
-keyofAndIndexedAccess.ts(211,24): error TS2322: Type 'T[K]' is not assignable to type 'object'.
-  Type 'T[keyof T]' is not assignable to type 'object'.
-    Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
-      Type 'T[string]' is not assignable to type 'object'.
+keyofAndIndexedAccess.ts(80,12): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(84,5): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(84,5): error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[K]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
+keyofAndIndexedAccess.ts(116,16): error TS2533: Object is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(119,9): error TS2533: Object is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(119,9): error TS2322: Type 'PropType[K]' is not assignable to type 'NonNullable<PropType>[K]'.
+  Type 'PropType' is not assignable to type 'NonNullable<PropType>'.
+    Type 'PropType' is not assignable to type '{}'.
+keyofAndIndexedAccess.ts(133,27): error TS18049: 'x' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(203,19): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(205,24): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(205,24): error TS2533: Object is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(209,19): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(211,24): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(211,24): error TS2533: Object is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(216,9): error TS18049: 'target' is possibly 'null' or 'undefined'.
 keyofAndIndexedAccess.ts(316,5): error TS2322: Type 'T' is not assignable to type '{}'.
 keyofAndIndexedAccess.ts(317,5): error TS2322: Type 'T[keyof T]' is not assignable to type '{}'.
   Type 'T[string] | T[number] | T[symbol]' is not assignable to type '{}'.
     Type 'T[string]' is not assignable to type '{}'.
 keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to type '{}'.
   Type 'T[keyof T]' is not assignable to type '{}'.
+keyofAndIndexedAccess.ts(390,27): error TS18049: 'object' is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(390,27): error TS2533: Object is possibly 'null' or 'undefined'.
+keyofAndIndexedAccess.ts(390,27): error TS2322: Type 'T[K1][K2]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>[K2]'.
+  Type 'T[K1]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+    Type 'T[keyof T]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+      Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+        Type 'T[string]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+          Type 'T[string]' is not assignable to type 'NonNullable<T>[K1]'.
+            Type 'T' is not assignable to type 'NonNullable<T>'.
+              Type 'T[keyof T]' is not assignable to type 'NonNullable<T>[K1]'.
+                Type 'T' is not assignable to type 'NonNullable<T>'.
+                  Type 'T[K1]' is not assignable to type 'NonNullable<T>[K1]'.
+                    Type 'T' is not assignable to type 'NonNullable<T>'.
+                      Type 'T' is not assignable to type '{}'.
+keyofAndIndexedAccess.ts(566,9): error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[Extract<keyof NonNullable<T>, string>]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
 
 
-==== keyofAndIndexedAccess.ts (5 errors) ====
+==== keyofAndIndexedAccess.ts (21 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -94,10 +122,20 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
     
     function getProperty<T, K extends keyof T>(obj: T, key: K) {
         return obj[key];
+               ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
     }
     
     function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
         obj[key] = value;
+        ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
+        ~~~~~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[K]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 keyofAndIndexedAccess.ts:83:22: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:83:22: This type parameter might need an `extends NonNullable<T>` constraint.
     }
     
     function f10(shape: Shape) {
@@ -130,9 +168,19 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
         props: PropType;
         getProperty<K extends keyof PropType>(key: K) {
             return this.props[key];
+                   ~~~~~~~~~~
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
         }
         setProperty<K extends keyof PropType>(key: K, value: PropType[K]) {
             this.props[key] = value;
+            ~~~~~~~~~~
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
+            ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'PropType[K]' is not assignable to type 'NonNullable<PropType>[K]'.
+!!! error TS2322:   Type 'PropType' is not assignable to type 'NonNullable<PropType>'.
+!!! error TS2322:     Type 'PropType' is not assignable to type '{}'.
+!!! related TS2208 keyofAndIndexedAccess.ts:113:17: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:113:17: This type parameter might need an `extends NonNullable<PropType>` constraint.
         }
     }
     
@@ -147,6 +195,8 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
     
     function pluck<T, K extends keyof T>(array: T[], key: K) {
         return array.map(x => x[key]);
+                              ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f30(shapes: Shape[]) {
@@ -217,28 +267,33 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
     
     function f54<T>(obj: T, key: keyof T) {
         for (let s in obj[key]) {
+                      ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
         }
         const b = "foo" in obj[key];
+                           ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
                            ~~~~~~~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'object'.
-!!! error TS2322:   Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
-!!! error TS2322:     Type 'T[string]' is not assignable to type 'object'.
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
     }
     
     function f55<T, K extends keyof T>(obj: T, key: K) {
         for (let s in obj[key]) {
+                      ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
         }
         const b = "foo" in obj[key];
+                           ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
                            ~~~~~~~~
-!!! error TS2322: Type 'T[K]' is not assignable to type 'object'.
-!!! error TS2322:   Type 'T[keyof T]' is not assignable to type 'object'.
-!!! error TS2322:     Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
-!!! error TS2322:       Type 'T[string]' is not assignable to type 'object'.
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
     }
     
     function f60<T>(source: T, target: T) {
         for (let k in source) {
             target[k] = source[k];
+            ~~~~~~
+!!! error TS18049: 'target' is possibly 'null' or 'undefined'.
         }
     }
     
@@ -423,6 +478,27 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
     
     const assignTo2 = <T, K1 extends keyof T, K2 extends keyof T[K1]>(object: T, key1: K1, key2: K2) =>
         (value: T[K1][K2]) => object[key1][key2] = value;
+                              ~~~~~~
+!!! error TS18049: 'object' is possibly 'null' or 'undefined'.
+                              ~~~~~~~~~~~~
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
+                              ~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'T[K1][K2]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>[K2]'.
+!!! error TS2322:   Type 'T[K1]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+!!! error TS2322:     Type 'T[keyof T]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+!!! error TS2322:       Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+!!! error TS2322:         Type 'T[string]' is not assignable to type 'NonNullable<NonNullable<T>[K1]>'.
+!!! error TS2322:           Type 'T[string]' is not assignable to type 'NonNullable<T>[K1]'.
+!!! error TS2322:             Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:               Type 'T[keyof T]' is not assignable to type 'NonNullable<T>[K1]'.
+!!! error TS2322:                 Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:                   Type 'T[K1]' is not assignable to type 'NonNullable<T>[K1]'.
+!!! error TS2322:                     Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:                       Type 'T' is not assignable to type '{}'.
+!!! related TS2208 keyofAndIndexedAccess.ts:389:20: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:389:20: This type parameter might need an `extends NonNullable<T>` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:389:20: This type parameter might need an `extends NonNullable<T>` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:389:20: This type parameter might need an `extends NonNullable<T>` constraint.
     
     // Modified repro from #12573
     
@@ -599,6 +675,12 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
         for (let key in t) {
             key = k // ok, K ==> keyof T
             t[key] = tk; // ok, T[K] ==> T[keyof T]
+            ~~~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[Extract<keyof NonNullable<T>, string>]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 keyofAndIndexedAccess.ts:563:13: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 keyofAndIndexedAccess.ts:563:13: This type parameter might need an `extends NonNullable<T>` constraint.
         }
     }
     

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -1170,7 +1170,7 @@ type Q50 = Dictionary<Shape>["howdy"];
 type Q51 = Dictionary<Shape>[123];
 type Q52 = Dictionary<Shape>[E.B];
 declare let cond: boolean;
-declare function getProperty<T, K extends keyof T>(obj: T, key: K): T[K];
+declare function getProperty<T, K extends keyof T>(obj: T, key: K): NonNullable<T>[K];
 declare function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]): void;
 declare function f10(shape: Shape): void;
 declare function f11(a: Shape[]): void;
@@ -1178,15 +1178,15 @@ declare function f12(t: [Shape, boolean]): void;
 declare function f13(foo: any, bar: any): void;
 declare class Component<PropType> {
     props: PropType;
-    getProperty<K extends keyof PropType>(key: K): PropType[K];
+    getProperty<K extends keyof PropType>(key: K): NonNullable<PropType>[K];
     setProperty<K extends keyof PropType>(key: K, value: PropType[K]): void;
 }
 declare function f20(component: Component<Shape>): void;
-declare function pluck<T, K extends keyof T>(array: T[], key: K): T[K][];
+declare function pluck<T, K extends keyof T>(array: T[], key: K): NonNullable<T>[K][];
 declare function f30(shapes: Shape[]): void;
 declare function f31<K extends keyof Shape>(key: K): Shape[K];
 declare function f32<K extends "width" | "height">(key: K): Shape[K];
-declare function f33<S extends Shape, K extends keyof S>(shape: S, key: K): S[K];
+declare function f33<S extends Shape, K extends keyof S>(shape: S, key: K): NonNullable<S>[K];
 declare function f34(ts: TaggedShape): void;
 declare class C {
     x: string;
@@ -1252,7 +1252,7 @@ declare class Person extends Base {
 declare class OtherPerson {
     parts: number;
     constructor(parts: number);
-    getParts(): this["parts"];
+    getParts(): NonNullable<this>["parts"];
 }
 declare function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
 declare function path<T, K1 extends keyof T, K2 extends keyof T[K1]>(obj: T, key1: K1, key2: K2): T[K1][K2];

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -2,6 +2,7 @@
 
 === Performance Stats ===
 Type Count: 1,000
+Instantiation count: 1,000
 
 === keyofAndIndexedAccess.ts ===
 class Shape {
@@ -255,16 +256,16 @@ declare let cond: boolean;
 >     : ^^^^^^^
 
 function getProperty<T, K extends keyof T>(obj: T, key: K) {
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K
 >    : ^
 
     return obj[key];
->obj[key] : T[K]
->         : ^^^^
+>obj[key] : NonNullable<T>[K]
+>         : ^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K
@@ -284,8 +285,8 @@ function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
     obj[key] = value;
 >obj[key] = value : T[K]
 >                 : ^^^^
->obj[key] : T[K]
->         : ^^^^
+>obj[key] : NonNullable<T>[K]
+>         : ^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K
@@ -305,8 +306,8 @@ function f10(shape: Shape) {
 >     : ^^^^^^
 >getProperty(shape, "name") : string
 >                           : ^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >shape : Shape
 >      : ^^^^^
 >"name" : "name"
@@ -317,8 +318,8 @@ function f10(shape: Shape) {
 >              : ^^^^^^
 >getProperty(shape, cond ? "width" : "height") : number
 >                                              : ^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >shape : Shape
 >      : ^^^^^
 >cond ? "width" : "height" : "width" | "height"
@@ -335,8 +336,8 @@ function f10(shape: Shape) {
 >              : ^^^^^^^^^^^^^^^^
 >getProperty(shape, cond ? "name" : "visible") : string | boolean
 >                                              : ^^^^^^^^^^^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >shape : Shape
 >      : ^^^^^
 >cond ? "name" : "visible" : "name" | "visible"
@@ -408,8 +409,8 @@ function f11(a: Shape[]) {
 >    : ^^^^^^
 >getProperty(a, "length") : number
 >                         : ^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >a : Shape[]
 >  : ^^^^^^^
 >"length" : "length"
@@ -439,8 +440,8 @@ function f12(t: [Shape, boolean]) {
 >    : ^
 >getProperty(t, "length") : 2
 >                         : ^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >t : [Shape, boolean]
 >  : ^^^^^^^^^^^^^^^^
 >"length" : "length"
@@ -451,8 +452,8 @@ function f12(t: [Shape, boolean]) {
 >   : ^^^^^
 >getProperty(t, "0") : Shape
 >                    : ^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >t : [Shape, boolean]
 >  : ^^^^^^^^^^^^^^^^
 >"0" : "0"
@@ -463,8 +464,8 @@ function f12(t: [Shape, boolean]) {
 >   : ^^^^^^^
 >getProperty(t, "1") : boolean
 >                    : ^^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >t : [Shape, boolean]
 >  : ^^^^^^^^^^^^^^^^
 >"1" : "1"
@@ -484,8 +485,8 @@ function f13(foo: any, bar: any) {
 >  : ^^^
 >getProperty(foo, "x") : any
 >                      : ^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >foo : any
 >    : ^^^
 >"x" : "x"
@@ -496,8 +497,8 @@ function f13(foo: any, bar: any) {
 >  : ^^^
 >getProperty(foo, "100") : any
 >                        : ^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >foo : any
 >    : ^^^
 >"100" : "100"
@@ -508,8 +509,8 @@ function f13(foo: any, bar: any) {
 >  : ^^^
 >getProperty(foo, bar) : any
 >                      : ^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >foo : any
 >    : ^^^
 >bar : any
@@ -525,14 +526,14 @@ class Component<PropType> {
 >      : ^^^^^^^^
 
     getProperty<K extends keyof PropType>(key: K) {
->getProperty : <K extends keyof PropType>(key: K) => PropType[K]
->            : ^ ^^^^^^^^^              ^^   ^^ ^^^^^^^^^^^^^^^^
+>getProperty : <K extends keyof PropType>(key: K) => NonNullable<PropType>[K]
+>            : ^ ^^^^^^^^^              ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key : K
 >    : ^
 
         return this.props[key];
->this.props[key] : PropType[K]
->                : ^^^^^^^^^^^
+>this.props[key] : NonNullable<PropType>[K]
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^
 >this.props : PropType
 >           : ^^^^^^^^
 >this : this
@@ -553,8 +554,8 @@ class Component<PropType> {
         this.props[key] = value;
 >this.props[key] = value : PropType[K]
 >                        : ^^^^^^^^^^^
->this.props[key] : PropType[K]
->                : ^^^^^^^^^^^
+>this.props[key] : NonNullable<PropType>[K]
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^
 >this.props : PropType
 >           : ^^^^^^^^
 >this : this
@@ -684,28 +685,28 @@ function f20(component: Component<Shape>) {
 }
 
 function pluck<T, K extends keyof T>(array: T[], key: K) {
->pluck : <T, K extends keyof T>(array: T[], key: K) => T[K][]
->      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^
+>pluck : <T, K extends keyof T>(array: T[], key: K) => NonNullable<T>[K][]
+>      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >array : T[]
 >      : ^^^
 >key : K
 >    : ^
 
     return array.map(x => x[key]);
->array.map(x => x[key]) : T[K][]
->                       : ^^^^^^
+>array.map(x => x[key]) : NonNullable<T>[K][]
+>                       : ^^^^^^^^^^^^^^^^^^^
 >array.map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
 >          : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^  
 >array : T[]
 >      : ^^^
 >map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
 >    : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^  
->x => x[key] : (x: T) => T[K]
->            : ^ ^^^^^^^^^^^^
+>x => x[key] : (x: T) => NonNullable<T>[K]
+>            : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
->x[key] : T[K]
->       : ^^^^
+>x[key] : NonNullable<T>[K]
+>       : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >key : K
@@ -723,8 +724,8 @@ function f30(shapes: Shape[]) {
 >      : ^^^^^^^^
 >pluck(shapes, "name") : string[]
 >                      : ^^^^^^^^
->pluck : <T, K extends keyof T>(array: T[], key: K) => T[K][]
->      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^
+>pluck : <T, K extends keyof T>(array: T[], key: K) => NonNullable<T>[K][]
+>      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >shapes : Shape[]
 >       : ^^^^^^^
 >"name" : "name"
@@ -735,8 +736,8 @@ function f30(shapes: Shape[]) {
 >       : ^^^^^^^^
 >pluck(shapes, "width") : number[]
 >                       : ^^^^^^^^
->pluck : <T, K extends keyof T>(array: T[], key: K) => T[K][]
->      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^
+>pluck : <T, K extends keyof T>(array: T[], key: K) => NonNullable<T>[K][]
+>      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >shapes : Shape[]
 >       : ^^^^^^^
 >"width" : "width"
@@ -747,8 +748,8 @@ function f30(shapes: Shape[]) {
 >               : ^^^^^^^^^^^^^^^^^^^^
 >pluck(shapes, cond ? "name" : "visible") : (string | boolean)[]
 >                                         : ^^^^^^^^^^^^^^^^^^^^
->pluck : <T, K extends keyof T>(array: T[], key: K) => T[K][]
->      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^
+>pluck : <T, K extends keyof T>(array: T[], key: K) => NonNullable<T>[K][]
+>      : ^ ^^ ^^^^^^^^^       ^^     ^^   ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >shapes : Shape[]
 >       : ^^^^^^^
 >cond ? "name" : "visible" : "name" | "visible"
@@ -836,40 +837,40 @@ function f32<K extends "width" | "height">(key: K) {
 }
 
 function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
->f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => S[K]
->    : ^ ^^^^^^^^^     ^^ ^^^^^^^^^       ^^     ^^ ^^   ^^ ^^^^^^^^^
+>f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => NonNullable<S>[K]
+>    : ^ ^^^^^^^^^     ^^ ^^^^^^^^^       ^^     ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >shape : S
 >      : ^
 >key : K
 >    : ^
 
     let name = getProperty(shape, "name");
->name : S["name"]
->     : ^^^^^^^^^
->getProperty(shape, "name") : S["name"]
->                           : ^^^^^^^^^
->getProperty : <T, K_1 extends keyof T>(obj: T, key: K_1) => T[K_1]
->            : ^ ^^^^^^^^^^^^^^       ^^   ^^ ^^   ^^   ^^^^^^^^^^^
+>name : NonNullable<S>["name"]
+>     : ^^^^^^^^^^^^^^^^^^^^^^
+>getProperty(shape, "name") : NonNullable<S>["name"]
+>                           : ^^^^^^^^^^^^^^^^^^^^^^
+>getProperty : <T, K_1 extends keyof T>(obj: T, key: K_1) => NonNullable<T>[K_1]
+>            : ^ ^^^^^^^^^^^^^^       ^^   ^^ ^^   ^^   ^^^^^^^^^^^^^^^^^^^^^^^^
 >shape : S
 >      : ^
 >"name" : "name"
 >       : ^^^^^^
 
     let prop = getProperty(shape, key);
->prop : S[K]
->     : ^^^^
->getProperty(shape, key) : S[K]
->                        : ^^^^
->getProperty : <T, K_1 extends keyof T>(obj: T, key: K_1) => T[K_1]
->            : ^ ^^^^^^^^^^^^^^       ^^   ^^ ^^   ^^   ^^^^^^^^^^^
+>prop : NonNullable<S>[K]
+>     : ^^^^^^^^^^^^^^^^^
+>getProperty(shape, key) : NonNullable<S>[K]
+>                        : ^^^^^^^^^^^^^^^^^
+>getProperty : <T, K_1 extends keyof T>(obj: T, key: K_1) => NonNullable<T>[K_1]
+>            : ^ ^^^^^^^^^^^^^^       ^^   ^^ ^^   ^^   ^^^^^^^^^^^^^^^^^^^^^^^^
 >shape : S
 >      : ^
 >key : K
 >    : ^
 
     return prop;
->prop : S[K]
->     : ^^^^
+>prop : NonNullable<S>[K]
+>     : ^^^^^^^^^^^^^^^^^
 }
 
 function f34(ts: TaggedShape) {
@@ -883,8 +884,8 @@ function f34(ts: TaggedShape) {
 >     : ^^^^^^
 >f33(ts, "tag") : string
 >               : ^^^^^^
->f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => S[K]
->    : ^ ^^^^^^^^^     ^^ ^^^^^^^^^       ^^     ^^ ^^   ^^ ^^^^^^^^^
+>f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => NonNullable<S>[K]
+>    : ^ ^^^^^^^^^     ^^ ^^^^^^^^^       ^^     ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >ts : TaggedShape
 >   : ^^^^^^^^^^^
 >"tag" : "tag"
@@ -895,8 +896,8 @@ function f34(ts: TaggedShape) {
 >     : ^^^^^^
 >getProperty(ts, "tag") : string
 >                       : ^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >ts : TaggedShape
 >   : ^^^^^^^^^^^
 >"tag" : "tag"
@@ -1120,10 +1121,10 @@ function f54<T>(obj: T, key: keyof T) {
 >    : ^^^^^^^
 
     for (let s in obj[key]) {
->s : Extract<keyof T[keyof T], string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj[key] : T[keyof T]
->         : ^^^^^^^^^^
+>s : Extract<keyof NonNullable<NonNullable<T>[keyof T]>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj[key] : NonNullable<T>[keyof T]
+>         : ^^^^^^^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : keyof T
@@ -1136,8 +1137,8 @@ function f54<T>(obj: T, key: keyof T) {
 >                  : ^^^^^^^
 >"foo" : "foo"
 >      : ^^^^^
->obj[key] : T[keyof T]
->         : ^^^^^^^^^^
+>obj[key] : NonNullable<T>[keyof T]
+>         : ^^^^^^^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : keyof T
@@ -1153,10 +1154,10 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
 >    : ^
 
     for (let s in obj[key]) {
->s : Extract<keyof T[K], string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj[key] : T[K]
->         : ^^^^
+>s : Extract<keyof NonNullable<NonNullable<T>[K]>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj[key] : NonNullable<T>[K]
+>         : ^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K
@@ -1169,8 +1170,8 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
 >                  : ^^^^^^^
 >"foo" : "foo"
 >      : ^^^^^
->obj[key] : T[K]
->         : ^^^^
+>obj[key] : NonNullable<T>[K]
+>         : ^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >key : K
@@ -1186,26 +1187,26 @@ function f60<T>(source: T, target: T) {
 >       : ^
 
     for (let k in source) {
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >source : T
 >       : ^
 
         target[k] = source[k];
->target[k] = source[k] : T[Extract<keyof T, string>]
->                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->target[k] : T[Extract<keyof T, string>]
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>target[k] = source[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>target[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >target : T
 >       : ^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
->source[k] : T[Extract<keyof T, string>]
->          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->source : T
->       : ^
->k : Extract<keyof T, string>
->  : ^^^^^^^^^^^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>source[k] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>source : NonNullable<T>
+>       : ^^^^^^^^^^^^^^
+>k : Extract<keyof NonNullable<T>, string>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
 }
 
@@ -1894,12 +1895,12 @@ class C1 {
 >    : ^^^
 
         let x4 = getProperty(this, "x"); // this["x"]
->x4 : this["x"]
->   : ^^^^^^^^^
->getProperty(this, "x") : this["x"]
->                       : ^^^^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>x4 : NonNullable<this>["x"]
+>   : ^^^^^^^^^^^^^^^^^^^^^^
+>getProperty(this, "x") : NonNullable<this>["x"]
+>                       : ^^^^^^^^^^^^^^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >this : this
 >     : ^^^^
 >"x" : "x"
@@ -2251,14 +2252,14 @@ class OtherPerson {
 >      : ^^^^^^
     }
     getParts() {
->getParts : () => this["parts"]
->         : ^^^^^^^^^^^^^^^^^^^
+>getParts : () => NonNullable<this>["parts"]
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         return getProperty(this, "parts")
->getProperty(this, "parts") : this["parts"]
->                           : ^^^^^^^^^^^^^
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^
+>getProperty(this, "parts") : NonNullable<this>["parts"]
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => NonNullable<T>[K]
+>            : ^ ^^ ^^^^^^^^^       ^^   ^^ ^^   ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >this : this
 >     : ^^^^
 >"parts" : "parts"
@@ -2446,10 +2447,10 @@ const assignTo2 = <T, K1 extends keyof T, K2 extends keyof T[K1]>(object: T, key
 >      : ^^^^^^^^^
 >object[key1][key2] = value : T[K1][K2]
 >                           : ^^^^^^^^^
->object[key1][key2] : T[K1][K2]
->                   : ^^^^^^^^^
->object[key1] : T[K1]
->             : ^^^^^
+>object[key1][key2] : NonNullable<NonNullable<T>[K1]>[K2]
+>                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>object[key1] : NonNullable<T>[K1]
+>             : ^^^^^^^^^^^^^^^^^^
 >object : T
 >       : ^
 >key1 : K1
@@ -3082,28 +3083,28 @@ function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
 >   : ^^^^
 
     for (let key in t) {
->key : Extract<keyof T, string>
->    : ^^^^^^^^^^^^^^^^^^^^^^^^
+>key : Extract<keyof NonNullable<T>, string>
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >t : T
 >  : ^
 
         key = k // ok, K ==> keyof T
 >key = k : K
 >        : ^
->key : Extract<keyof T, string>
->    : ^^^^^^^^^^^^^^^^^^^^^^^^
+>key : Extract<keyof NonNullable<T>, string>
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >k : K
 >  : ^
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
 >t[key] = tk : T[K]
 >            : ^^^^
->t[key] : T[Extract<keyof T, string>]
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->t : T
->  : ^
->key : Extract<keyof T, string>
->    : ^^^^^^^^^^^^^^^^^^^^^^^^
+>t[key] : NonNullable<T>[Extract<keyof NonNullable<T>, string>]
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>t : NonNullable<T>
+>  : ^^^^^^^^^^^^^^
+>key : Extract<keyof NonNullable<T>, string>
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >tk : T[K]
 >   : ^^^^
     }

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -19,8 +19,16 @@ mappedTypeErrors.ts(75,45): error TS2345: Argument of type '{ x: number; }' is n
   Property 'y' is missing in type '{ x: number; }' but required in type 'Readonly<{ x: number; y: number; }>'.
 mappedTypeErrors.ts(77,59): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
 mappedTypeErrors.ts(83,58): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
+mappedTypeErrors.ts(95,9): error TS18049: 'obj' is possibly 'null' or 'undefined'.
+mappedTypeErrors.ts(95,9): error TS2322: Type 'T[Extract<K, string>]' is not assignable to type 'NonNullable<T>[Extract<K, string>]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
 mappedTypeErrors.ts(105,17): error TS2322: Type 'undefined' is not assignable to type 'string'.
 mappedTypeErrors.ts(106,17): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, keyof Foo>'.
+mappedTypeErrors.ts(112,13): error TS2533: Object is possibly 'null' or 'undefined'.
+mappedTypeErrors.ts(112,13): error TS2322: Type 'T[Extract<K, string>]' is not assignable to type 'NonNullable<T>[Extract<K, string>]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
 mappedTypeErrors.ts(123,14): error TS2322: Type 'undefined' is not assignable to type 'string'.
 mappedTypeErrors.ts(124,14): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, keyof Foo>'.
 mappedTypeErrors.ts(128,16): error TS2322: Type 'string' is not assignable to type 'number'.
@@ -32,7 +40,7 @@ mappedTypeErrors.ts(148,17): error TS2339: Property 'foo' does not exist on type
 mappedTypeErrors.ts(152,17): error TS2339: Property 'foo' does not exist on type 'Record<K, number>'.
 
 
-==== mappedTypeErrors.ts (27 errors) ====
+==== mappedTypeErrors.ts (31 errors) ====
     interface Shape {
         name: string;
         width: number;
@@ -171,6 +179,14 @@ mappedTypeErrors.ts(152,17): error TS2339: Property 'foo' does not exist on type
     function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
         for (let k in props) {
             obj[k] = props[k];
+            ~~~
+!!! error TS18049: 'obj' is possibly 'null' or 'undefined'.
+            ~~~~~~
+!!! error TS2322: Type 'T[Extract<K, string>]' is not assignable to type 'NonNullable<T>[Extract<K, string>]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeErrors.ts:93:19: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeErrors.ts:93:19: This type parameter might need an `extends NonNullable<T>` constraint.
         }
     }
     
@@ -193,6 +209,14 @@ mappedTypeErrors.ts(152,17): error TS2339: Property 'foo' does not exist on type
         setState<K extends keyof T>(props: Pick<T, K>) {
             for (let k in props) {
                 this.state[k] = props[k];
+                ~~~~~~~~~~
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
+                ~~~~~~~~~~~~~
+!!! error TS2322: Type 'T[Extract<K, string>]' is not assignable to type 'NonNullable<T>[Extract<K, string>]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeErrors.ts:108:9: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeErrors.ts:108:9: This type parameter might need an `extends NonNullable<T>` constraint.
             }
         }
     }

--- a/tests/baselines/reference/mappedTypeErrors.types
+++ b/tests/baselines/reference/mappedTypeErrors.types
@@ -407,8 +407,8 @@ function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
         obj[k] = props[k];
 >obj[k] = props[k] : Pick<T, K>[Extract<K, string>]
 >                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->obj[k] : T[Extract<K, string>]
->       : ^^^^^^^^^^^^^^^^^^^^^
+>obj[k] : NonNullable<T>[Extract<K, string>]
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >obj : T
 >    : ^
 >k : Extract<K, string>
@@ -553,8 +553,8 @@ class C<T> {
             this.state[k] = props[k];
 >this.state[k] = props[k] : Pick<T, K>[Extract<K, string>]
 >                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->this.state[k] : T[Extract<K, string>]
->              : ^^^^^^^^^^^^^^^^^^^^^
+>this.state[k] : NonNullable<T>[Extract<K, string>]
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >this.state : T
 >           : ^
 >this : this

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -1,38 +1,92 @@
-mappedTypeRelationships.ts(11,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-  Type 'T' is not assignable to type 'U'.
-    'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-mappedTypeRelationships.ts(16,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
-  Type 'T' is not assignable to type 'U'.
-    'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-mappedTypeRelationships.ts(20,5): error TS2536: Type 'keyof U' cannot be used to index type 'T'.
-mappedTypeRelationships.ts(21,12): error TS2536: Type 'keyof U' cannot be used to index type 'T'.
-mappedTypeRelationships.ts(25,5): error TS2536: Type 'K' cannot be used to index type 'T'.
-mappedTypeRelationships.ts(26,12): error TS2536: Type 'K' cannot be used to index type 'T'.
-mappedTypeRelationships.ts(30,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-  'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'T[keyof T] | undefined'.
-mappedTypeRelationships.ts(35,5): error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
-  'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'T[K] | undefined'.
-mappedTypeRelationships.ts(40,5): error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-  'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'U[keyof T] | undefined'.
-mappedTypeRelationships.ts(41,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
-  Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[keyof T] | undefined'.
-    Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
-mappedTypeRelationships.ts(45,5): error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
-  'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'U[K] | undefined'.
-mappedTypeRelationships.ts(46,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
-  Type 'T[keyof T]' is not assignable to type 'U[K] | undefined'.
-    Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[K] | undefined'.
-      Type 'T[string]' is not assignable to type 'U[K] | undefined'.
+mappedTypeRelationships.ts(2,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(6,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(10,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(10,12): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(11,5): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(11,5): error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'NonNullable<U>[keyof T]'.
+  Type 'NonNullable<T>' is not assignable to type 'NonNullable<U>'.
+    Type 'NonNullable<T>' is not assignable to type 'U'.
+      'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
+mappedTypeRelationships.ts(11,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(15,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(15,12): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(16,5): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(16,5): error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'NonNullable<U>[K]'.
+  Type 'NonNullable<T>' is not assignable to type 'NonNullable<U>'.
+    Type 'NonNullable<T>' is not assignable to type 'U'.
+      'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
+mappedTypeRelationships.ts(16,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(20,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(20,5): error TS2536: Type 'keyof U' cannot be used to index type 'NonNullable<T>'.
+mappedTypeRelationships.ts(20,12): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(21,5): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(21,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(21,12): error TS2536: Type 'keyof U' cannot be used to index type 'NonNullable<T>'.
+mappedTypeRelationships.ts(25,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(25,5): error TS2536: Type 'K' cannot be used to index type 'NonNullable<T>'.
+mappedTypeRelationships.ts(25,12): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(26,5): error TS18049: 'y' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(26,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(26,12): error TS2536: Type 'K' cannot be used to index type 'NonNullable<T>'.
+mappedTypeRelationships.ts(30,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(30,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+  Type 'undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+mappedTypeRelationships.ts(31,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(35,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(35,5): error TS2322: Type 'T[K] | undefined' is not assignable to type 'NonNullable<T>[K]'.
+  Type 'undefined' is not assignable to type 'NonNullable<T>[K]'.
+mappedTypeRelationships.ts(36,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(40,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(40,5): error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+  Type 'undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+mappedTypeRelationships.ts(41,5): error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+  Type 'NonNullable<T>[string] | NonNullable<T>[number] | NonNullable<T>[symbol]' is not assignable to type 'U[keyof T] | undefined'.
+    Type 'NonNullable<T>[string]' is not assignable to type 'U[keyof T] | undefined'.
+mappedTypeRelationships.ts(41,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(45,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(45,5): error TS2322: Type 'U[K] | undefined' is not assignable to type 'NonNullable<T>[K]'.
+  Type 'undefined' is not assignable to type 'NonNullable<T>[K]'.
+mappedTypeRelationships.ts(46,5): error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'U[K] | undefined'.
+  Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[K] | undefined'.
+    Type 'NonNullable<T>[string] | NonNullable<T>[number] | NonNullable<T>[symbol]' is not assignable to type 'U[K] | undefined'.
+      Type 'NonNullable<T>[string]' is not assignable to type 'U[K] | undefined'.
+mappedTypeRelationships.ts(46,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(50,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(50,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'NonNullable<T>[keyof T]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
 mappedTypeRelationships.ts(51,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+mappedTypeRelationships.ts(51,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(55,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(55,5): error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[K]'.
+  Type 'T' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type '{}'.
 mappedTypeRelationships.ts(56,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
-mappedTypeRelationships.ts(61,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-  Type 'T' is not assignable to type 'U'.
-    'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
+mappedTypeRelationships.ts(56,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(60,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(60,5): error TS2322: Type 'U[keyof T]' is not assignable to type 'NonNullable<T>[keyof T]'.
+  Type 'U' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type 'NonNullable<T>'.
+      Type 'T' is not assignable to type '{}'.
+        Type 'U' is not assignable to type '{}'.
+          Type 'T' is not assignable to type '{}'.
+mappedTypeRelationships.ts(61,5): error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[keyof T]'.
+  Type 'NonNullable<T>' is not assignable to type 'U'.
+    'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
 mappedTypeRelationships.ts(61,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
-mappedTypeRelationships.ts(66,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
-  Type 'T' is not assignable to type 'U'.
-    'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
+mappedTypeRelationships.ts(61,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(65,5): error TS18049: 'x' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(65,5): error TS2322: Type 'U[K]' is not assignable to type 'NonNullable<T>[K]'.
+  Type 'U' is not assignable to type 'NonNullable<T>'.
+    Type 'T' is not assignable to type 'NonNullable<T>'.
+      Type 'T' is not assignable to type '{}'.
+        Type 'U' is not assignable to type '{}'.
+          Type 'T' is not assignable to type '{}'.
+mappedTypeRelationships.ts(66,5): error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'U[K]'.
+  Type 'NonNullable<T>' is not assignable to type 'U'.
+    'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
 mappedTypeRelationships.ts(66,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+mappedTypeRelationships.ts(66,12): error TS18049: 'x' is possibly 'null' or 'undefined'.
 mappedTypeRelationships.ts(72,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'Partial<T>'.
 mappedTypeRelationships.ts(78,5): error TS2322: Type 'Partial<Thing>' is not assignable to type 'Partial<T>'.
@@ -71,132 +125,233 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
   Type 'T[P]' is not assignable to type 'U[P]'.
     Type 'T' is not assignable to type 'U'.
       'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
+mappedTypeRelationships.ts(176,12): error TS18049: 't' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(180,12): error TS18049: 't' is possibly 'null' or 'undefined'.
+mappedTypeRelationships.ts(180,12): error TS2533: Object is possibly 'null' or 'undefined'.
 
 
-==== mappedTypeRelationships.ts (28 errors) ====
+==== mappedTypeRelationships.ts (69 errors) ====
     function f1<T>(x: T, k: keyof T) {
         return x[k];
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f2<T, K extends keyof T>(x: T, k: K) {
         return x[k];
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f3<T, U extends T>(x: T, y: U, k: keyof T) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+               ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         y[k] = x[k];  // Error
+        ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'U'.
-!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-!!! related TS2208 mappedTypeRelationships.ts:9:13: This type parameter might need an `extends U` constraint.
+!!! error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'NonNullable<U>[keyof T]'.
+!!! error TS2322:   Type 'NonNullable<T>' is not assignable to type 'NonNullable<U>'.
+!!! error TS2322:     Type 'NonNullable<T>' is not assignable to type 'U'.
+!!! error TS2322:       'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+               ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         y[k] = x[k];  // Error
+        ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'U'.
-!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-!!! related TS2208 mappedTypeRelationships.ts:14:13: This type parameter might need an `extends U` constraint.
+!!! error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'NonNullable<U>[K]'.
+!!! error TS2322:   Type 'NonNullable<T>' is not assignable to type 'NonNullable<U>'.
+!!! error TS2322:     Type 'NonNullable<T>' is not assignable to type 'U'.
+!!! error TS2322:       'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f5<T, U extends T>(x: T, y: U, k: keyof U) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+!!! error TS2536: Type 'keyof U' cannot be used to index type 'NonNullable<T>'.
+               ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         y[k] = x[k];  // Error
+        ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
                ~~~~
-!!! error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+!!! error TS2536: Type 'keyof U' cannot be used to index type 'NonNullable<T>'.
     }
     
     function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2536: Type 'K' cannot be used to index type 'T'.
+!!! error TS2536: Type 'K' cannot be used to index type 'NonNullable<T>'.
+               ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
         y[k] = x[k];  // Error
+        ~
+!!! error TS18049: 'y' is possibly 'null' or 'undefined'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
                ~~~~
-!!! error TS2536: Type 'K' cannot be used to index type 'T'.
+!!! error TS2536: Type 'K' cannot be used to index type 'NonNullable<T>'.
     }
     
     function f10<T>(x: T, y: Partial<T>, k: keyof T) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'T[keyof T] | undefined'.
+!!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
         y[k] = x[k];
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
-!!! error TS2322:   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'T[K] | undefined'.
+!!! error TS2322: Type 'T[K] | undefined' is not assignable to type 'NonNullable<T>[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'NonNullable<T>[K]'.
         y[k] = x[k];
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'U[keyof T] | undefined'.
+!!! error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'NonNullable<T>[keyof T]'.
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
-!!! error TS2322:   Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[keyof T] | undefined'.
-!!! error TS2322:     Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:   Type 'NonNullable<T>[string] | NonNullable<T>[number] | NonNullable<T>[symbol]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:     Type 'NonNullable<T>[string]' is not assignable to type 'U[keyof T] | undefined'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
         x[k] = y[k];  // Error
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
         ~~~~
-!!! error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
-!!! error TS2322:   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'U[K] | undefined'.
+!!! error TS2322: Type 'U[K] | undefined' is not assignable to type 'NonNullable<T>[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'NonNullable<T>[K]'.
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:   Type 'T[keyof T]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:     Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:       Type 'T[string]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:   Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:     Type 'NonNullable<T>[string] | NonNullable<T>[number] | NonNullable<T>[symbol]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:       Type 'NonNullable<T>[string]' is not assignable to type 'U[K] | undefined'.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+        ~~~~
+!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'NonNullable<T>[keyof T]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeRelationships.ts:49:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:49:14: This type parameter might need an `extends NonNullable<T>` constraint.
         y[k] = x[k];  // Error
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+        ~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'NonNullable<T>[K]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeRelationships.ts:54:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:54:14: This type parameter might need an `extends NonNullable<T>` constraint.
         y[k] = x[k];  // Error
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+        ~~~~
+!!! error TS2322: Type 'U[keyof T]' is not assignable to type 'NonNullable<T>[keyof T]'.
+!!! error TS2322:   Type 'U' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:       Type 'T' is not assignable to type '{}'.
+!!! error TS2322:         Type 'U' is not assignable to type '{}'.
+!!! error TS2322:           Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeRelationships.ts:59:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:59:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:59:14: This type parameter might need an `extends NonNullable<T>` constraint.
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'U'.
-!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-!!! related TS2208 mappedTypeRelationships.ts:59:14: This type parameter might need an `extends U` constraint.
+!!! error TS2322: Type 'NonNullable<T>[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:   Type 'NonNullable<T>' is not assignable to type 'U'.
+!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
         x[k] = y[k];
+        ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
+        ~~~~
+!!! error TS2322: Type 'U[K]' is not assignable to type 'NonNullable<T>[K]'.
+!!! error TS2322:   Type 'U' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:       Type 'T' is not assignable to type '{}'.
+!!! error TS2322:         Type 'U' is not assignable to type '{}'.
+!!! error TS2322:           Type 'T' is not assignable to type '{}'.
+!!! related TS2208 mappedTypeRelationships.ts:64:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:64:14: This type parameter might need an `extends {}` constraint.
+!!! related TS2208 mappedTypeRelationships.ts:64:14: This type parameter might need an `extends NonNullable<T>` constraint.
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'U'.
-!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
-!!! related TS2208 mappedTypeRelationships.ts:64:14: This type parameter might need an `extends U` constraint.
+!!! error TS2322: Type 'NonNullable<T>[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:   Type 'NonNullable<T>' is not assignable to type 'U'.
+!!! error TS2322:     'U' could be instantiated with an arbitrary type which could be unrelated to 'NonNullable<T>'.
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+               ~
+!!! error TS18049: 'x' is possibly 'null' or 'undefined'.
     }
     
     type Thing = { a: string, b: string };
@@ -357,10 +512,16 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
     
     function f81<T, K extends keyof T>(t: T, k: K): Partial<T[K]> {
         return t[k];
+               ~
+!!! error TS18049: 't' is possibly 'null' or 'undefined'.
     }
     
     function f82<T, K1 extends keyof T, K2 extends keyof T[K1]>(t: T, k1: K1, k2: K2): Partial<T[K1][K2]> {
         return t[k1][k2];
+               ~
+!!! error TS18049: 't' is possibly 'null' or 'undefined'.
+               ~~~~~
+!!! error TS2533: Object is possibly 'null' or 'undefined'.
     }
     
     // #31070

--- a/tests/baselines/reference/mappedTypeRelationships.js
+++ b/tests/baselines/reference/mappedTypeRelationships.js
@@ -348,8 +348,8 @@ function f() {
 
 
 //// [mappedTypeRelationships.d.ts]
-declare function f1<T>(x: T, k: keyof T): T[keyof T];
-declare function f2<T, K extends keyof T>(x: T, k: K): T[K];
+declare function f1<T>(x: T, k: keyof T): NonNullable<T>[keyof T];
+declare function f2<T, K extends keyof T>(x: T, k: K): NonNullable<T>[K];
 declare function f3<T, U extends T>(x: T, y: U, k: keyof T): void;
 declare function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K): void;
 declare function f5<T, U extends T>(x: T, y: U, k: keyof U): void;

--- a/tests/baselines/reference/mappedTypeRelationships.types
+++ b/tests/baselines/reference/mappedTypeRelationships.types
@@ -2,16 +2,16 @@
 
 === mappedTypeRelationships.ts ===
 function f1<T>(x: T, k: keyof T) {
->f1 : <T>(x: T, k: keyof T) => T[keyof T]
->   : ^ ^^ ^^ ^^ ^^       ^^^^^^^^^^^^^^^
+>f1 : <T>(x: T, k: keyof T) => NonNullable<T>[keyof T]
+>   : ^ ^^ ^^ ^^ ^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
 >  : ^^^^^^^
 
     return x[k];
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -19,16 +19,16 @@ function f1<T>(x: T, k: keyof T) {
 }
 
 function f2<T, K extends keyof T>(x: T, k: K) {
->f2 : <T, K extends keyof T>(x: T, k: K) => T[K]
->   : ^ ^^ ^^^^^^^^^       ^^ ^^ ^^ ^^ ^^^^^^^^^
+>f2 : <T, K extends keyof T>(x: T, k: K) => NonNullable<T>[K]
+>   : ^ ^^ ^^^^^^^^^       ^^ ^^ ^^ ^^ ^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
 >  : ^
 
     return x[k];
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -46,32 +46,32 @@ function f3<T, U extends T>(x: T, y: U, k: keyof T) {
 >  : ^^^^^^^
 
     x[k] = y[k];
->x[k] = y[k] : U[keyof T]
->            : ^^^^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] = y[k] : NonNullable<U>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
 >  : ^^^^^^^
->y[k] : U[keyof T]
->     : ^^^^^^^^^^
+>y[k] : NonNullable<U>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : keyof T
 >  : ^^^^^^^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[keyof T]
->            : ^^^^^^^^^^
->y[k] : U[keyof T]
->     : ^^^^^^^^^^
+>y[k] = x[k] : NonNullable<T>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
+>y[k] : NonNullable<U>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : keyof T
 >  : ^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -89,32 +89,32 @@ function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K) {
 >  : ^
 
     x[k] = y[k];
->x[k] = y[k] : U[K]
->            : ^^^^
->x[k] : T[K]
->     : ^^^^
+>x[k] = y[k] : NonNullable<U>[K]
+>            : ^^^^^^^^^^^^^^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
 >  : ^
->y[k] : U[K]
->     : ^^^^
+>y[k] : NonNullable<U>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : K
 >  : ^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[K]
->            : ^^^^
->y[k] : U[K]
->     : ^^^^
+>y[k] = x[k] : NonNullable<T>[K]
+>            : ^^^^^^^^^^^^^^^^^
+>y[k] : NonNullable<U>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : K
 >  : ^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -132,16 +132,16 @@ function f5<T, U extends T>(x: T, y: U, k: keyof U) {
 >  : ^^^^^^^
 
     x[k] = y[k];  // Error
->x[k] = y[k] : U[keyof U]
->            : ^^^^^^^^^^
+>x[k] = y[k] : NonNullable<U>[keyof U]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
 >x[k] : any
 >     : ^^^
 >x : T
 >  : ^
 >k : keyof U
 >  : ^^^^^^^
->y[k] : U[keyof U]
->     : ^^^^^^^^^^
+>y[k] : NonNullable<U>[keyof U]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : keyof U
@@ -150,8 +150,8 @@ function f5<T, U extends T>(x: T, y: U, k: keyof U) {
     y[k] = x[k];  // Error
 >y[k] = x[k] : any
 >            : ^^^
->y[k] : U[keyof U]
->     : ^^^^^^^^^^
+>y[k] : NonNullable<U>[keyof U]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : keyof U
@@ -175,16 +175,16 @@ function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
 >  : ^
 
     x[k] = y[k];  // Error
->x[k] = y[k] : U[K]
->            : ^^^^
+>x[k] = y[k] : NonNullable<U>[K]
+>            : ^^^^^^^^^^^^^^^^^
 >x[k] : any
 >     : ^^^
 >x : T
 >  : ^
 >k : K
 >  : ^
->y[k] : U[K]
->     : ^^^^
+>y[k] : NonNullable<U>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : K
@@ -193,8 +193,8 @@ function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
     y[k] = x[k];  // Error
 >y[k] = x[k] : any
 >            : ^^^
->y[k] : U[K]
->     : ^^^^
+>y[k] : NonNullable<U>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >y : U
 >  : ^
 >k : K
@@ -220,8 +220,8 @@ function f10<T>(x: T, y: Partial<T>, k: keyof T) {
     x[k] = y[k];  // Error
 >x[k] = y[k] : Partial<T>[keyof T]
 >            : ^^^^^^^^^^^^^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -234,16 +234,16 @@ function f10<T>(x: T, y: Partial<T>, k: keyof T) {
 >  : ^^^^^^^
 
     y[k] = x[k];
->y[k] = x[k] : T[keyof T]
->            : ^^^^^^^^^^
+>y[k] = x[k] : NonNullable<T>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
 >y[k] : Partial<T>[keyof T]
 >     : ^^^^^^^^^^^^^^^^^^^
 >y : Partial<T>
 >  : ^^^^^^^^^^
 >k : keyof T
 >  : ^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -263,8 +263,8 @@ function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
     x[k] = y[k];  // Error
 >x[k] = y[k] : Partial<T>[K]
 >            : ^^^^^^^^^^^^^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -277,16 +277,16 @@ function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
 >  : ^
 
     y[k] = x[k];
->y[k] = x[k] : T[K]
->            : ^^^^
+>y[k] = x[k] : NonNullable<T>[K]
+>            : ^^^^^^^^^^^^^^^^^
 >y[k] : Partial<T>[K]
 >     : ^^^^^^^^^^^^^
 >y : Partial<T>
 >  : ^^^^^^^^^^
 >k : K
 >  : ^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -306,8 +306,8 @@ function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
     x[k] = y[k];  // Error
 >x[k] = y[k] : Partial<U>[keyof T]
 >            : ^^^^^^^^^^^^^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -320,16 +320,16 @@ function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
 >  : ^^^^^^^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[keyof T]
->            : ^^^^^^^^^^
+>y[k] = x[k] : NonNullable<T>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
 >y[k] : Partial<U>[keyof T]
 >     : ^^^^^^^^^^^^^^^^^^^
 >y : Partial<U>
 >  : ^^^^^^^^^^
 >k : keyof T
 >  : ^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -349,8 +349,8 @@ function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
     x[k] = y[k];  // Error
 >x[k] = y[k] : Partial<U>[K]
 >            : ^^^^^^^^^^^^^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -363,16 +363,16 @@ function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
 >  : ^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[K]
->            : ^^^^
+>y[k] = x[k] : NonNullable<T>[K]
+>            : ^^^^^^^^^^^^^^^^^
 >y[k] : Partial<U>[K]
 >     : ^^^^^^^^^^^^^
 >y : Partial<U>
 >  : ^^^^^^^^^^
 >k : K
 >  : ^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -392,8 +392,8 @@ function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
     x[k] = y[k];
 >x[k] = y[k] : Readonly<T>[keyof T]
 >            : ^^^^^^^^^^^^^^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -406,16 +406,16 @@ function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
 >  : ^^^^^^^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[keyof T]
->            : ^^^^^^^^^^
+>y[k] = x[k] : NonNullable<T>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
 >y[k] : Readonly<T>[keyof T]
 >     : ^^^^^^^^^^^^^^^^^^^^
 >y : Readonly<T>
 >  : ^^^^^^^^^^^
 >k : keyof T
 >  : ^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -435,8 +435,8 @@ function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
     x[k] = y[k];
 >x[k] = y[k] : Readonly<T>[K]
 >            : ^^^^^^^^^^^^^^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -449,16 +449,16 @@ function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
 >  : ^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[K]
->            : ^^^^
+>y[k] = x[k] : NonNullable<T>[K]
+>            : ^^^^^^^^^^^^^^^^^
 >y[k] : Readonly<T>[K]
 >     : ^^^^^^^^^^^^^^
 >y : Readonly<T>
 >  : ^^^^^^^^^^^
 >k : K
 >  : ^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -478,8 +478,8 @@ function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
     x[k] = y[k];
 >x[k] = y[k] : Readonly<U>[keyof T]
 >            : ^^^^^^^^^^^^^^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -492,16 +492,16 @@ function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
 >  : ^^^^^^^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[keyof T]
->            : ^^^^^^^^^^
+>y[k] = x[k] : NonNullable<T>[keyof T]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
 >y[k] : Readonly<U>[keyof T]
 >     : ^^^^^^^^^^^^^^^^^^^^
 >y : Readonly<U>
 >  : ^^^^^^^^^^^
 >k : keyof T
 >  : ^^^^^^^
->x[k] : T[keyof T]
->     : ^^^^^^^^^^
+>x[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : keyof T
@@ -521,8 +521,8 @@ function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
     x[k] = y[k];
 >x[k] = y[k] : Readonly<U>[K]
 >            : ^^^^^^^^^^^^^^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -535,16 +535,16 @@ function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
 >  : ^
 
     y[k] = x[k];  // Error
->y[k] = x[k] : T[K]
->            : ^^^^
+>y[k] = x[k] : NonNullable<T>[K]
+>            : ^^^^^^^^^^^^^^^^^
 >y[k] : Readonly<U>[K]
 >     : ^^^^^^^^^^^^^^
 >y : Readonly<U>
 >  : ^^^^^^^^^^^
 >k : K
 >  : ^
->x[k] : T[K]
->     : ^^^^
+>x[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >x : T
 >  : ^
 >k : K
@@ -1030,8 +1030,8 @@ function f81<T, K extends keyof T>(t: T, k: K): Partial<T[K]> {
 >  : ^
 
     return t[k];
->t[k] : T[K]
->     : ^^^^
+>t[k] : NonNullable<T>[K]
+>     : ^^^^^^^^^^^^^^^^^
 >t : T
 >  : ^
 >k : K
@@ -1049,10 +1049,10 @@ function f82<T, K1 extends keyof T, K2 extends keyof T[K1]>(t: T, k1: K1, k2: K2
 >   : ^^
 
     return t[k1][k2];
->t[k1][k2] : T[K1][K2]
->          : ^^^^^^^^^
->t[k1] : T[K1]
->      : ^^^^^
+>t[k1][k2] : NonNullable<NonNullable<T>[K1]>[K2]
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>t[k1] : NonNullable<T>[K1]
+>      : ^^^^^^^^^^^^^^^^^^
 >t : T
 >  : ^
 >k1 : K1

--- a/tests/baselines/reference/unconstrainedTypeComparisons.errors.txt
+++ b/tests/baselines/reference/unconstrainedTypeComparisons.errors.txt
@@ -1,0 +1,12 @@
+unconstrainedTypeComparisons.ts(2,10): error TS18049: 'a' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparisons.ts(2,14): error TS18049: 'b' is possibly 'null' or 'undefined'.
+
+
+==== unconstrainedTypeComparisons.ts (2 errors) ====
+    export function g<T>(a: T, b: T): boolean {
+      return a > b;
+             ~
+!!! error TS18049: 'a' is possibly 'null' or 'undefined'.
+                 ~
+!!! error TS18049: 'b' is possibly 'null' or 'undefined'.
+    }

--- a/tests/baselines/reference/unconstrainedTypeComparisons.js
+++ b/tests/baselines/reference/unconstrainedTypeComparisons.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/unconstrainedTypeComparisons.ts] ////
+
+//// [unconstrainedTypeComparisons.ts]
+export function g<T>(a: T, b: T): boolean {
+  return a > b;
+}
+
+//// [unconstrainedTypeComparisons.js]
+export function g(a, b) {
+    return a > b;
+}

--- a/tests/baselines/reference/unconstrainedTypeComparisons.symbols
+++ b/tests/baselines/reference/unconstrainedTypeComparisons.symbols
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/unconstrainedTypeComparisons.ts] ////
+
+=== unconstrainedTypeComparisons.ts ===
+export function g<T>(a: T, b: T): boolean {
+>g : Symbol(g, Decl(unconstrainedTypeComparisons.ts, 0, 0))
+>T : Symbol(T, Decl(unconstrainedTypeComparisons.ts, 0, 18))
+>a : Symbol(a, Decl(unconstrainedTypeComparisons.ts, 0, 21))
+>T : Symbol(T, Decl(unconstrainedTypeComparisons.ts, 0, 18))
+>b : Symbol(b, Decl(unconstrainedTypeComparisons.ts, 0, 26))
+>T : Symbol(T, Decl(unconstrainedTypeComparisons.ts, 0, 18))
+
+  return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparisons.ts, 0, 21))
+>b : Symbol(b, Decl(unconstrainedTypeComparisons.ts, 0, 26))
+}

--- a/tests/baselines/reference/unconstrainedTypeComparisons.types
+++ b/tests/baselines/reference/unconstrainedTypeComparisons.types
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/unconstrainedTypeComparisons.ts] ////
+
+=== unconstrainedTypeComparisons.ts ===
+export function g<T>(a: T, b: T): boolean {
+>g : <T>(a: T, b: T) => boolean
+>  : ^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+  return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+}

--- a/tests/baselines/reference/unknownControlFlow.errors.txt
+++ b/tests/baselines/reference/unknownControlFlow.errors.txt
@@ -1,5 +1,6 @@
 unknownControlFlow.ts(18,9): error TS2322: Type 'unknown' is not assignable to type '{}'.
-unknownControlFlow.ts(283,5): error TS2536: Type 'keyof (T & {})' cannot be used to index type 'T'.
+unknownControlFlow.ts(275,5): error TS18049: 't' is possibly 'null' or 'undefined'.
+unknownControlFlow.ts(283,5): error TS18049: 't' is possibly 'null' or 'undefined'.
 unknownControlFlow.ts(290,11): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
 unknownControlFlow.ts(291,5): error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
 unknownControlFlow.ts(293,5): error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
@@ -7,7 +8,7 @@ unknownControlFlow.ts(323,9): error TS2367: This comparison appears to be uninte
 unknownControlFlow.ts(341,9): error TS2367: This comparison appears to be unintentional because the types 'T' and 'number' have no overlap.
 
 
-==== unknownControlFlow.ts (7 errors) ====
+==== unknownControlFlow.ts (8 errors) ====
     type T01 = {} & string;  // {} & string
     type T02 = {} & 'a';  // 'a'
     type T03 = {} & object;  // object
@@ -285,6 +286,8 @@ unknownControlFlow.ts(341,9): error TS2367: This comparison appears to be uninte
     
     function ff1<T>(t: T, k: keyof T) {
         t[k];
+        ~
+!!! error TS18049: 't' is possibly 'null' or 'undefined'.
     }
     
     function ff2<T>(t: T & {}, k: keyof T) {
@@ -293,8 +296,8 @@ unknownControlFlow.ts(341,9): error TS2367: This comparison appears to be uninte
     
     function ff3<T>(t: T, k: keyof (T & {})) {
         t[k];  // Error
-        ~~~~
-!!! error TS2536: Type 'keyof (T & {})' cannot be used to index type 'T'.
+        ~
+!!! error TS18049: 't' is possibly 'null' or 'undefined'.
     }
     
     function ff4<T>(t: T & {}, k: keyof (T & {})) {

--- a/tests/baselines/reference/unknownControlFlow.types
+++ b/tests/baselines/reference/unknownControlFlow.types
@@ -481,8 +481,8 @@ function f23<T>(x: T | undefined | null) {
 >          : ^^^^^^^^^
 
         x;  // T & {} | null
->x : (T & {}) | null
->  : ^^^^^^^^^^^^^^^
+>x : (T & ({} | null)) | null
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^
     }
     if (x !== null) {
 >x !== null : boolean
@@ -491,8 +491,8 @@ function f23<T>(x: T | undefined | null) {
 >  : ^^^^^^^^^^^^^^^^^^^^
 
         x;  // T & {} | undefined
->x : (T & {}) | undefined
->  : ^^^^^^^^^^^^^^^^^^^^
+>x : (T & ({} | undefined)) | undefined
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
     if (x != undefined) {
 >x != undefined : boolean
@@ -1062,8 +1062,8 @@ function ff1<T>(t: T, k: keyof T) {
 >  : ^^^^^^^
 
     t[k];
->t[k] : T[keyof T]
->     : ^^^^^^^^^^
+>t[k] : NonNullable<T>[keyof T]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^
 >t : T
 >  : ^
 >k : keyof T
@@ -1096,8 +1096,8 @@ function ff3<T>(t: T, k: keyof (T & {})) {
 >  : ^^^^^^^^^^^^^^
 
     t[k];  // Error
->t[k] : any
->     : ^^^
+>t[k] : NonNullable<T>[keyof (T & {})]
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >t : T
 >  : ^
 >k : keyof (T & {})

--- a/tests/baselines/reference/voidUndefinedReduction.types
+++ b/tests/baselines/reference/voidUndefinedReduction.types
@@ -20,8 +20,8 @@ function isDefined<T>(value: T | undefined | null | void): value is T {
 >          : ^^^^^^^^^
 >value !== null : boolean
 >               : ^^^^^^^
->value : (T & {}) | null
->      : ^^^^^^^^^^^^^^^
+>value : (T & ({} | null)) | null
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^
 }
 
 declare const foo: string | undefined;

--- a/tests/cases/compiler/unconstrainedTypeComparisons.ts
+++ b/tests/cases/compiler/unconstrainedTypeComparisons.ts
@@ -1,0 +1,7 @@
+// @lib: es2015
+// @target: es2015
+// @strict: true
+
+export function g<T>(a: T, b: T): boolean {
+  return a > b;
+}


### PR DESCRIPTION
fixes #50603

todo: this description