### PR TITLE
Enable typed linting for scripts dir

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,15 @@ export default tseslint.config(
         },
     },
     {
+        files: ["scripts/**"],
+        languageOptions: {
+            parserOptions: {
+                tsconfigRootDir: __dirname,
+                project: "./scripts/tsconfig.json",
+            },
+        },
+    },
+    {
         files: ["src/**"],
         rules: {
             "@typescript-eslint/no-unnecessary-type-assertion": "error",

--- a/scripts/configurePrerelease.mjs
+++ b/scripts/configurePrerelease.mjs
@@ -57,7 +57,7 @@ function main() {
     // Finally write the changes to disk.
     // Modify the package.json structure
     packageJsonValue.version = `${majorMinor}.${prereleasePatch}`;
-    writeFileSync(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4));
+    writeFileSync(packageJsonFilePath, JSON.stringify(packageJsonValue, undefined, 4));
     writeFileSync(tsFilePath, modifiedTsFileContents);
 }
 


### PR DESCRIPTION
This leaves only files in the repo root without types, which will eventually be fixed in ts-eslint v8 with the ProjectService.