### PR TITLE
Don't avoid caching variable types resolved using `CheckMode.TypeOnly`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11985,7 +11985,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return false;
     }
 
-    function getTypeOfVariableOrParameterOrProperty(symbol: Symbol, checkMode?: CheckMode): Type {
+    function getTypeOfVariableOrParameterOrProperty(symbol: Symbol, checkMode = CheckMode.Normal): Type {
         const links = getSymbolLinks(symbol);
         if (!links.type) {
             const type = getTypeOfVariableOrParameterOrPropertyWorker(symbol, checkMode);
@@ -11994,7 +11994,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // to preserve this type. In fact, we need to _prefer_ that type, but it won't
             // be assigned until contextual typing is complete, so we need to defer in
             // cases where contextual typing may take place.
-            if (!links.type && !isParameterOfContextSensitiveSignature(symbol) && !checkMode) {
+            if (!links.type && !isParameterOfContextSensitiveSignature(symbol) && !(checkMode & ~CheckMode.TypeOnly)) {
                 links.type = type;
             }
             return type;

--- a/tests/cases/fourslash/quickInfoCircularityInLoop1.ts
+++ b/tests/cases/fourslash/quickInfoCircularityInLoop1.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+// @Filename: user.ts
+//// declare const line: string;
+//// let test: string | null = null;
+////
+//// for (let i = 0; i < line.length; i++) {
+////   const char = line[i];
+////   if (test === char) {}
+////   const [|alsoChar/*1*/|] = char;
+////   test = alsoChar;
+//// }
+
+// if this circularity error ever goes awayt a different input code should be used here
+verify.getSemanticDiagnostics([{
+  code: 7022,
+  message: "'alsoChar' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.",
+}]);
+verify.quickInfoAt("1", "const alsoChar: any");


### PR DESCRIPTION
Fixes the weird behavior observed in https://github.com/microsoft/TypeScript/issues/59074
