### PR TITLE
Fixed crash on circular local type arguments when outer ones are present too

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16298,7 +16298,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeArguments(type: TypeReference): readonly Type[] {
         if (!type.resolvedTypeArguments) {
             if (!pushTypeResolution(type, TypeSystemPropertyName.ResolvedTypeArguments)) {
-                return type.target.localTypeParameters?.map(() => errorType) || emptyArray;
+                return concatenate(type.target.outerTypeParameters, type.target.localTypeParameters?.map(() => errorType) || emptyArray);
             }
             const node = type.node;
             const typeArguments = !node ? emptyArray :
@@ -16309,7 +16309,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 type.resolvedTypeArguments ??= type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }
             else {
-                type.resolvedTypeArguments ??= type.target.localTypeParameters?.map(() => errorType) || emptyArray;
+                type.resolvedTypeArguments ??= concatenate(type.target.outerTypeParameters, type.target.localTypeParameters?.map(() => errorType) || emptyArray);
                 error(
                     type.node || currentNode,
                     type.target.symbol ? Diagnostics.Type_arguments_for_0_circularly_reference_themselves : Diagnostics.Tuple_type_arguments_circularly_reference_themselves,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16298,7 +16298,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeArguments(type: TypeReference): readonly Type[] {
         if (!type.resolvedTypeArguments) {
             if (!pushTypeResolution(type, TypeSystemPropertyName.ResolvedTypeArguments)) {
-                return concatenate(type.target.outerTypeParameters, type.target.localTypeParameters?.map(() => errorType) || emptyArray);
+                return concatenate(type.target.outerTypeParameters, type.target.localTypeParameters?.map(() => errorType)) || emptyArray;
             }
             const node = type.node;
             const typeArguments = !node ? emptyArray :

--- a/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.errors.txt
+++ b/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.errors.txt
@@ -1,0 +1,13 @@
+circularTypeArgumentsLocalAndOuterNoCrash1.ts(5,12): error TS4109: Type arguments for 'NumArray' circularly reference themselves.
+
+
+==== circularTypeArgumentsLocalAndOuterNoCrash1.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59062
+    
+    function f<_T, _S>() {
+      interface NumArray<T extends number> extends Array<T> {}
+      type X = NumArray<X extends {} ? number : number>;
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS4109: Type arguments for 'NumArray' circularly reference themselves.
+    }
+    

--- a/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.symbols
+++ b/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts] ////
+
+=== circularTypeArgumentsLocalAndOuterNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59062
+
+function f<_T, _S>() {
+>f : Symbol(f, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 0, 0))
+>_T : Symbol(_T, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 2, 11))
+>_S : Symbol(_S, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 2, 14))
+
+  interface NumArray<T extends number> extends Array<T> {}
+>NumArray : Symbol(NumArray, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 2, 22))
+>T : Symbol(T, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 3, 21))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 3, 21))
+
+  type X = NumArray<X extends {} ? number : number>;
+>X : Symbol(X, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 3, 58))
+>NumArray : Symbol(NumArray, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 2, 22))
+>X : Symbol(X, Decl(circularTypeArgumentsLocalAndOuterNoCrash1.ts, 3, 58))
+}
+

--- a/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.types
+++ b/tests/baselines/reference/circularTypeArgumentsLocalAndOuterNoCrash1.types
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts] ////
+
+=== circularTypeArgumentsLocalAndOuterNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59062
+
+function f<_T, _S>() {
+>f : <_T, _S>() => void
+>  : ^  ^^  ^^^^^^^^^^^
+
+  interface NumArray<T extends number> extends Array<T> {}
+  type X = NumArray<X extends {} ? number : number>;
+>X : NumArray<any>
+>  : ^^^^^^^^^^^^^
+}
+

--- a/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
+++ b/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
@@ -1,0 +1,9 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59062
+
+function f<_T, _S>() {
+  interface NumArray<T extends number> extends Array<T> {}
+  type X = NumArray<X extends {} ? number : number>;
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59062