### PR TITLE
Optimize `scan` with a lookup table to reduce branching

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2104,7 +2104,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 return token = scanNumber();
             }
 
-            Debug.assert(tokenInfo & TokenInfo.RecognizedMisc);
+            if (!(tokenInfo & TokenInfo.RecognizedMisc)) Debug.fail(`Unhandled token category ${tokenInfo}`);
             switch (ch) {
                 case CharacterCodes.exclamation:
                     if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -333,11 +333,12 @@ for (
         [CharacterCodes.paragraphSeparator, TokenCategory.LineBreak],
 
         // Single Line Whitespace
+        [CharacterCodes.space, TokenCategory.Whitespace],
         [CharacterCodes.tab, TokenCategory.Whitespace],
         [CharacterCodes.verticalTab, TokenCategory.Whitespace],
         [CharacterCodes.formFeed, TokenCategory.Whitespace],
-        [CharacterCodes.space, TokenCategory.Whitespace],
         [CharacterCodes.nonBreakingSpace, TokenCategory.Whitespace],
+        [CharacterCodes.nextLine, TokenCategory.Whitespace],
         [CharacterCodes.ogham, TokenCategory.Whitespace],
         [CharacterCodes.enQuad, TokenCategory.Whitespace],
         [CharacterCodes.emQuad, TokenCategory.Whitespace],
@@ -2033,15 +2034,6 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 if (identifierKind) {
                     return token = identifierKind;
                 }
-                else if (isWhiteSpaceSingleLine(ch)) {
-                    pos += charSize(ch);
-                    continue;
-                }
-                else if (isLineBreak(ch)) {
-                    tokenFlags |= TokenFlags.PrecedingLineBreak;
-                    pos += charSize(ch);
-                    continue;
-                }
                 const size = charSize(ch);
                 error(Diagnostics.Invalid_character, pos, size);
                 pos += size;
@@ -2059,6 +2051,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                     }
                     return token = SyntaxKind.WhitespaceTrivia;
                 }
+            }
+
+            if (tokenCategory & TokenCategory.LineBreak) {
+                tokenFlags |= TokenFlags.PrecedingLineBreak;
+                pos += charSize(ch);
+                continue;
             }
 
             if (tokenCategory & TokenCategory.SimpleToken) {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -302,9 +302,12 @@ const regExpFlagToFirstAvailableLanguageVersion = new Map<RegularExpressionFlags
 ]);
 
 const enum TokenCategory {
-    None = 0,
+    IdentifierOrUnknown = 0,
 
-    /** Single-width tokens whose contents fit in the lower masked bits. */
+    /**
+     * Single-width tokens whose SyntaxKind value fits
+     * in the lower masked bits of the current value.
+     */
     SimpleToken = 1 << 8, // must come first
     Whitespace = 1 << 9,
     LineBreak = 1 << 10,
@@ -321,7 +324,7 @@ const enum TokenCategory {
 const tokenCategoryLookup: TokenCategory[] = [];
 const tokenCategoryLookupUncommon = new Map<CharacterCodes, TokenCategory>();
 for (let i = 0; i < CharacterCodes.maxAsciiCharacter; i++) {
-    tokenCategoryLookup.push(TokenCategory.None);
+    tokenCategoryLookup.push(TokenCategory.IdentifierOrUnknown);
 }
 
 for (
@@ -2027,9 +2030,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
             const tokenCategory = ch < tokenCategoryLookup.length ?
                 tokenCategoryLookup[ch] :
-                tokenCategoryLookupUncommon.get(ch) ?? TokenCategory.None;
+                tokenCategoryLookupUncommon.get(ch) ?? TokenCategory.IdentifierOrUnknown;
 
-            if (tokenCategory === TokenCategory.None) {
+            if (tokenCategory === TokenCategory.IdentifierOrUnknown) {
                 const identifierKind = scanIdentifier(ch, languageVersion);
                 if (identifierKind) {
                     return token = identifierKind;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1991,28 +1991,41 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
             const ch = codePointUnchecked(pos);
 
+            if (ch === CharacterCodes.tab || ch === CharacterCodes.space) {
+                if (skipTrivia) {
+                    pos++;
+                    continue;
+                }
+                else {
+                    while (pos < end && isWhiteSpaceSingleLine(charCodeUnchecked(pos))) {
+                        pos++;
+                    }
+                    return token = SyntaxKind.WhitespaceTrivia;
+                }
+            }
+
+            if (ch === CharacterCodes.lineFeed || ch === CharacterCodes.carriageReturn) {
+                tokenFlags |= TokenFlags.PrecedingLineBreak;
+                if (skipTrivia) {
+                    pos++;
+                    continue;
+                }
+                else {
+                    if (ch === CharacterCodes.carriageReturn && pos + 1 < end && charCodeUnchecked(pos + 1) === CharacterCodes.lineFeed) {
+                        // consume both CR and LF
+                        pos += 2;
+                    }
+                    else {
+                        pos++;
+                    }
+                    return token = SyntaxKind.NewLineTrivia;
+                }
+            }
+
             const tokenInfo = ch < charcodeToTokenInfoCommon.length ?
                 charcodeToTokenInfoCommon[ch] :
                 charcodeToTokenInfoUncommon.get(ch) ?? TokenInfo.None;
             if (tokenInfo !== TokenInfo.None) {
-                if (tokenInfo & TokenInfo.LineBreak) {
-                    tokenFlags |= TokenFlags.PrecedingLineBreak;
-                    if (skipTrivia) {
-                        pos++;
-                        continue;
-                    }
-                    else {
-                        if (ch === CharacterCodes.carriageReturn && pos + 1 < end && charCodeUnchecked(pos + 1) === CharacterCodes.lineFeed) {
-                            // consume both CR and LF
-                            pos += 2;
-                        }
-                        else {
-                            pos++;
-                        }
-                        return token = SyntaxKind.NewLineTrivia;
-                    }
-                }
-
                 if (tokenInfo & TokenInfo.Whitespace) {
                     if (skipTrivia) {
                         pos++;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -305,10 +305,10 @@ const enum TokenInfo {
     None = 0,
 
     /** Single-width tokens whose contents fit in the lower masked bits. */
-    SimpleToken = 1 << 8,
-    Whitespace,
-    LineBreak,
-    Digit,
+    SimpleToken = 1 << 8, // must come first
+    Whitespace = 1 << 9,
+    LineBreak = 1 << 10,
+    Digit = 1 << 11,
 
     SimpleTokenMask = SimpleToken - 1,
 }
@@ -2007,7 +2007,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
 
                 if (tokenInfo & TokenInfo.Digit) {
-                    if (ch === 0) {
+                    if (ch === CharacterCodes._0) {
                         if (pos + 2 < end && (charCodeUnchecked(pos + 1) === CharacterCodes.X || charCodeUnchecked(pos + 1) === CharacterCodes.x)) {
                             pos += 2;
                             tokenValue = scanMinimumNumberOfHexDigits(1, /*canHaveSeparators*/ true);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -309,6 +309,11 @@ const enum TokenInfo {
     Whitespace = 1 << 9,
     LineBreak = 1 << 10,
     Digit = 1 << 11,
+    /**
+     * Not a character that can be generically handled,
+     * but needs to be handled in some well-understood way.
+     */
+    RecognizedMisc = 1 << 12,
 
     SimpleTokenMask = SimpleToken - 1,
 }
@@ -374,6 +379,26 @@ for (
         [CharacterCodes._8, TokenInfo.Digit],
         [CharacterCodes._9, TokenInfo.Digit],
 
+        [CharacterCodes.exclamation, TokenInfo.RecognizedMisc],
+        [CharacterCodes.doubleQuote, TokenInfo.RecognizedMisc],
+        [CharacterCodes.singleQuote, TokenInfo.RecognizedMisc],
+        [CharacterCodes.backtick, TokenInfo.RecognizedMisc],
+        [CharacterCodes.percent, TokenInfo.RecognizedMisc],
+        [CharacterCodes.ampersand, TokenInfo.RecognizedMisc],
+        [CharacterCodes.asterisk, TokenInfo.RecognizedMisc],
+        [CharacterCodes.plus, TokenInfo.RecognizedMisc],
+        [CharacterCodes.minus, TokenInfo.RecognizedMisc],
+        [CharacterCodes.dot, TokenInfo.RecognizedMisc],
+        [CharacterCodes.slash, TokenInfo.RecognizedMisc],
+        [CharacterCodes.lessThan, TokenInfo.RecognizedMisc],
+        [CharacterCodes.equals, TokenInfo.RecognizedMisc],
+        [CharacterCodes.greaterThan, TokenInfo.RecognizedMisc],
+        [CharacterCodes.question, TokenInfo.RecognizedMisc],
+        [CharacterCodes.caret, TokenInfo.RecognizedMisc],
+        [CharacterCodes.bar, TokenInfo.RecognizedMisc],
+        [CharacterCodes.backslash, TokenInfo.RecognizedMisc],
+        [CharacterCodes.hash, TokenInfo.RecognizedMisc],
+        [CharacterCodes.replacementCharacter, TokenInfo.RecognizedMisc],
     ]
 ) {
     if (key < charcodeToTokenInfoCommon.length) {
@@ -2045,363 +2070,363 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
 
                     return token = scanNumber();
                 }
-            }
 
-            switch (ch) {
-                case CharacterCodes.exclamation:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.ExclamationEqualsEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.ExclamationEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.ExclamationToken;
-                case CharacterCodes.doubleQuote:
-                case CharacterCodes.singleQuote:
-                    tokenValue = scanString();
-                    return token = SyntaxKind.StringLiteral;
-                case CharacterCodes.backtick:
-                    return token = scanTemplateAndSetTokenValue(/*shouldEmitInvalidEscapeError*/ false);
-                case CharacterCodes.percent:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.PercentEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.PercentToken;
-                case CharacterCodes.ampersand:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.ampersand) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.AmpersandAmpersandEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.AmpersandAmpersandToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.AmpersandEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.AmpersandToken;
-                case CharacterCodes.asterisk:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.AsteriskEqualsToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.asterisk) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.AsteriskAsteriskEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.AsteriskAsteriskToken;
-                    }
-                    pos++;
-                    if (skipJsDocLeadingAsterisks && !asteriskSeen && (tokenFlags & TokenFlags.PrecedingLineBreak)) {
-                        // decoration at the start of a JSDoc comment line
-                        asteriskSeen = true;
-                        continue;
-                    }
-                    return token = SyntaxKind.AsteriskToken;
-                case CharacterCodes.plus:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.plus) {
-                        return pos += 2, token = SyntaxKind.PlusPlusToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.PlusEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.PlusToken;
-                case CharacterCodes.minus:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.minus) {
-                        return pos += 2, token = SyntaxKind.MinusMinusToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.MinusEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.MinusToken;
-                case CharacterCodes.dot:
-                    if (isDigit(charCodeUnchecked(pos + 1))) {
-                        scanNumber();
-                        return token = SyntaxKind.NumericLiteral;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.dot && charCodeUnchecked(pos + 2) === CharacterCodes.dot) {
-                        return pos += 3, token = SyntaxKind.DotDotDotToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.DotToken;
-                case CharacterCodes.slash:
-                    // Single-line comment
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.slash) {
-                        pos += 2;
-
-                        while (pos < end) {
-                            if (isLineBreak(charCodeUnchecked(pos))) {
-                                break;
+                Debug.assert(tokenInfo & TokenInfo.RecognizedMisc);
+                switch (ch) {
+                    case CharacterCodes.exclamation:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.ExclamationEqualsEqualsToken;
                             }
-                            pos++;
+                            return pos += 2, token = SyntaxKind.ExclamationEqualsToken;
                         }
-
-                        commentDirectives = appendIfCommentDirective(
-                            commentDirectives,
-                            text.slice(tokenStart, pos),
-                            commentDirectiveRegExSingleLine,
-                            tokenStart,
-                        );
-
-                        if (skipTrivia) {
+                        pos++;
+                        return token = SyntaxKind.ExclamationToken;
+                    case CharacterCodes.doubleQuote:
+                    case CharacterCodes.singleQuote:
+                        tokenValue = scanString();
+                        return token = SyntaxKind.StringLiteral;
+                    case CharacterCodes.backtick:
+                        return token = scanTemplateAndSetTokenValue(/*shouldEmitInvalidEscapeError*/ false);
+                    case CharacterCodes.percent:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.PercentEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.PercentToken;
+                    case CharacterCodes.ampersand:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.ampersand) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.AmpersandAmpersandEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.AmpersandAmpersandToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.AmpersandEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.AmpersandToken;
+                    case CharacterCodes.asterisk:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.AsteriskEqualsToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.asterisk) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.AsteriskAsteriskEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.AsteriskAsteriskToken;
+                        }
+                        pos++;
+                        if (skipJsDocLeadingAsterisks && !asteriskSeen && (tokenFlags & TokenFlags.PrecedingLineBreak)) {
+                            // decoration at the start of a JSDoc comment line
+                            asteriskSeen = true;
                             continue;
                         }
-                        else {
-                            return token = SyntaxKind.SingleLineCommentTrivia;
+                        return token = SyntaxKind.AsteriskToken;
+                    case CharacterCodes.plus:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.plus) {
+                            return pos += 2, token = SyntaxKind.PlusPlusToken;
                         }
-                    }
-                    // Multi-line comment
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.asterisk) {
-                        pos += 2;
-                        const isJSDoc = charCodeUnchecked(pos) === CharacterCodes.asterisk && charCodeUnchecked(pos + 1) !== CharacterCodes.slash;
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.PlusEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.PlusToken;
+                    case CharacterCodes.minus:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.minus) {
+                            return pos += 2, token = SyntaxKind.MinusMinusToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.MinusEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.MinusToken;
+                    case CharacterCodes.dot:
+                        if (isDigit(charCodeUnchecked(pos + 1))) {
+                            scanNumber();
+                            return token = SyntaxKind.NumericLiteral;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.dot && charCodeUnchecked(pos + 2) === CharacterCodes.dot) {
+                            return pos += 3, token = SyntaxKind.DotDotDotToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.DotToken;
+                    case CharacterCodes.slash:
+                        // Single-line comment
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.slash) {
+                            pos += 2;
 
-                        let commentClosed = false;
-                        let lastLineStart = tokenStart;
-                        while (pos < end) {
-                            const ch = charCodeUnchecked(pos);
-
-                            if (ch === CharacterCodes.asterisk && charCodeUnchecked(pos + 1) === CharacterCodes.slash) {
-                                pos += 2;
-                                commentClosed = true;
-                                break;
+                            while (pos < end) {
+                                if (isLineBreak(charCodeUnchecked(pos))) {
+                                    break;
+                                }
+                                pos++;
                             }
 
-                            pos++;
+                            commentDirectives = appendIfCommentDirective(
+                                commentDirectives,
+                                text.slice(tokenStart, pos),
+                                commentDirectiveRegExSingleLine,
+                                tokenStart,
+                            );
 
-                            if (isLineBreak(ch)) {
-                                lastLineStart = pos;
-                                tokenFlags |= TokenFlags.PrecedingLineBreak;
-                            }
-                        }
-
-                        if (isJSDoc && shouldParseJSDoc()) {
-                            tokenFlags |= TokenFlags.PrecedingJSDocComment;
-                        }
-
-                        commentDirectives = appendIfCommentDirective(commentDirectives, text.slice(lastLineStart, pos), commentDirectiveRegExMultiLine, lastLineStart);
-
-                        if (!commentClosed) {
-                            error(Diagnostics.Asterisk_Slash_expected);
-                        }
-
-                        if (skipTrivia) {
-                            continue;
-                        }
-                        else {
-                            if (!commentClosed) {
-                                tokenFlags |= TokenFlags.Unterminated;
-                            }
-                            return token = SyntaxKind.MultiLineCommentTrivia;
-                        }
-                    }
-
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.SlashEqualsToken;
-                    }
-
-                    pos++;
-                    return token = SyntaxKind.SlashToken;
-
-                
-                case CharacterCodes.lessThan:
-                    if (isConflictMarkerTrivia(text, pos)) {
-                        pos = scanConflictMarkerTrivia(text, pos, error);
-                        if (skipTrivia) {
-                            continue;
-                        }
-                        else {
-                            return token = SyntaxKind.ConflictMarkerTrivia;
-                        }
-                    }
-
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.lessThan) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.LessThanLessThanEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.LessThanLessThanToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.LessThanEqualsToken;
-                    }
-                    if (
-                        languageVariant === LanguageVariant.JSX &&
-                        charCodeUnchecked(pos + 1) === CharacterCodes.slash &&
-                        charCodeUnchecked(pos + 2) !== CharacterCodes.asterisk
-                    ) {
-                        return pos += 2, token = SyntaxKind.LessThanSlashToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.LessThanToken;
-                case CharacterCodes.equals:
-                    if (isConflictMarkerTrivia(text, pos)) {
-                        pos = scanConflictMarkerTrivia(text, pos, error);
-                        if (skipTrivia) {
-                            continue;
-                        }
-                        else {
-                            return token = SyntaxKind.ConflictMarkerTrivia;
-                        }
-                    }
-
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.EqualsEqualsEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.EqualsEqualsToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.greaterThan) {
-                        return pos += 2, token = SyntaxKind.EqualsGreaterThanToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.EqualsToken;
-                case CharacterCodes.greaterThan:
-                    if (isConflictMarkerTrivia(text, pos)) {
-                        pos = scanConflictMarkerTrivia(text, pos, error);
-                        if (skipTrivia) {
-                            continue;
-                        }
-                        else {
-                            return token = SyntaxKind.ConflictMarkerTrivia;
-                        }
-                    }
-
-                    pos++;
-                    return token = SyntaxKind.GreaterThanToken;
-                case CharacterCodes.question:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.dot && !isDigit(charCodeUnchecked(pos + 2))) {
-                        return pos += 2, token = SyntaxKind.QuestionDotToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.question) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.QuestionQuestionEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.QuestionQuestionToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.QuestionToken;
-                case CharacterCodes.caret:
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.CaretEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.CaretToken;
-                case CharacterCodes.bar:
-                    if (isConflictMarkerTrivia(text, pos)) {
-                        pos = scanConflictMarkerTrivia(text, pos, error);
-                        if (skipTrivia) {
-                            continue;
-                        }
-                        else {
-                            return token = SyntaxKind.ConflictMarkerTrivia;
-                        }
-                    }
-
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.bar) {
-                        if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
-                            return pos += 3, token = SyntaxKind.BarBarEqualsToken;
-                        }
-                        return pos += 2, token = SyntaxKind.BarBarToken;
-                    }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
-                        return pos += 2, token = SyntaxKind.BarEqualsToken;
-                    }
-                    pos++;
-                    return token = SyntaxKind.BarToken;
-                case CharacterCodes.backslash:
-                    const extendedCookedChar = peekExtendedUnicodeEscape();
-                    if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
-                        tokenValue = scanExtendedUnicodeEscape(/*shouldEmitInvalidEscapeError*/ true) + scanIdentifierParts();
-                        return token = getIdentifierToken();
-                    }
-
-                    const cookedChar = peekUnicodeEscape();
-                    if (cookedChar >= 0 && isIdentifierStart(cookedChar, languageVersion)) {
-                        pos += 6;
-                        tokenFlags |= TokenFlags.UnicodeEscape;
-                        tokenValue = String.fromCharCode(cookedChar) + scanIdentifierParts();
-                        return token = getIdentifierToken();
-                    }
-
-                    error(Diagnostics.Invalid_character);
-                    pos++;
-                    return token = SyntaxKind.Unknown;
-                case CharacterCodes.hash:
-                    const charAfterHash = codePointUnchecked(pos + 1);
-
-                    if (charAfterHash === CharacterCodes.exclamation) {
-                        if (pos === 0) {
-                            pos = scanShebangTrivia(text, pos);
                             if (skipTrivia) {
                                 continue;
                             }
                             else {
-                                return token = SyntaxKind.ShebangTrivia;
+                                return token = SyntaxKind.SingleLineCommentTrivia;
                             }
                         }
-                        else if (pos !== 0) {
-                            error(Diagnostics.can_only_be_used_at_the_start_of_a_file, pos, 2);
-                            pos++;
-                            return token = SyntaxKind.Unknown;
-                        }
-                    }
+                        // Multi-line comment
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.asterisk) {
+                            pos += 2;
+                            const isJSDoc = charCodeUnchecked(pos) === CharacterCodes.asterisk && charCodeUnchecked(pos + 1) !== CharacterCodes.slash;
 
-                    if (charAfterHash === CharacterCodes.backslash) {
+                            let commentClosed = false;
+                            let lastLineStart = tokenStart;
+                            while (pos < end) {
+                                const ch = charCodeUnchecked(pos);
+
+                                if (ch === CharacterCodes.asterisk && charCodeUnchecked(pos + 1) === CharacterCodes.slash) {
+                                    pos += 2;
+                                    commentClosed = true;
+                                    break;
+                                }
+
+                                pos++;
+
+                                if (isLineBreak(ch)) {
+                                    lastLineStart = pos;
+                                    tokenFlags |= TokenFlags.PrecedingLineBreak;
+                                }
+                            }
+
+                            if (isJSDoc && shouldParseJSDoc()) {
+                                tokenFlags |= TokenFlags.PrecedingJSDocComment;
+                            }
+
+                            commentDirectives = appendIfCommentDirective(commentDirectives, text.slice(lastLineStart, pos), commentDirectiveRegExMultiLine, lastLineStart);
+
+                            if (!commentClosed) {
+                                error(Diagnostics.Asterisk_Slash_expected);
+                            }
+
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                if (!commentClosed) {
+                                    tokenFlags |= TokenFlags.Unterminated;
+                                }
+                                return token = SyntaxKind.MultiLineCommentTrivia;
+                            }
+                        }
+
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.SlashEqualsToken;
+                        }
+
                         pos++;
+                        return token = SyntaxKind.SlashToken;
+
+                    case CharacterCodes.lessThan:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.lessThan) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.LessThanLessThanEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.LessThanLessThanToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.LessThanEqualsToken;
+                        }
+                        if (
+                            languageVariant === LanguageVariant.JSX &&
+                            charCodeUnchecked(pos + 1) === CharacterCodes.slash &&
+                            charCodeUnchecked(pos + 2) !== CharacterCodes.asterisk
+                        ) {
+                            return pos += 2, token = SyntaxKind.LessThanSlashToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.LessThanToken;
+                    case CharacterCodes.equals:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.EqualsEqualsEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.EqualsEqualsToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.greaterThan) {
+                            return pos += 2, token = SyntaxKind.EqualsGreaterThanToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.EqualsToken;
+                    case CharacterCodes.greaterThan:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
+                        pos++;
+                        return token = SyntaxKind.GreaterThanToken;
+                    case CharacterCodes.question:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.dot && !isDigit(charCodeUnchecked(pos + 2))) {
+                            return pos += 2, token = SyntaxKind.QuestionDotToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.question) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.QuestionQuestionEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.QuestionQuestionToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.QuestionToken;
+                    case CharacterCodes.caret:
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.CaretEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.CaretToken;
+                    case CharacterCodes.bar:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.bar) {
+                            if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.BarBarEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.BarBarToken;
+                        }
+                        if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.BarEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.BarToken;
+                    case CharacterCodes.backslash:
                         const extendedCookedChar = peekExtendedUnicodeEscape();
                         if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
-                            tokenValue = "#" + scanExtendedUnicodeEscape(/*shouldEmitInvalidEscapeError*/ true) + scanIdentifierParts();
-                            return token = SyntaxKind.PrivateIdentifier;
+                            tokenValue = scanExtendedUnicodeEscape(/*shouldEmitInvalidEscapeError*/ true) + scanIdentifierParts();
+                            return token = getIdentifierToken();
                         }
 
                         const cookedChar = peekUnicodeEscape();
                         if (cookedChar >= 0 && isIdentifierStart(cookedChar, languageVersion)) {
                             pos += 6;
                             tokenFlags |= TokenFlags.UnicodeEscape;
-                            tokenValue = "#" + String.fromCharCode(cookedChar) + scanIdentifierParts();
-                            return token = SyntaxKind.PrivateIdentifier;
+                            tokenValue = String.fromCharCode(cookedChar) + scanIdentifierParts();
+                            return token = getIdentifierToken();
                         }
-                        pos--;
-                    }
 
-                    if (isIdentifierStart(charAfterHash, languageVersion)) {
+                        error(Diagnostics.Invalid_character);
                         pos++;
-                        // We're relying on scanIdentifier's behavior and adjusting the token kind after the fact.
-                        // Notably absent from this block is the fact that calling a function named "scanIdentifier",
-                        // but identifiers don't include '#', and that function doesn't deal with it at all.
-                        // This works because 'scanIdentifier' tries to reuse source characters and builds up substrings;
-                        // however, it starts at the 'tokenPos' which includes the '#', and will "accidentally" prepend the '#' for us.
-                        scanIdentifier(charAfterHash, languageVersion);
-                    }
-                    else {
-                        tokenValue = "#";
-                        error(Diagnostics.Invalid_character, pos++, charSize(ch));
-                    }
-                    return token = SyntaxKind.PrivateIdentifier;
-                case CharacterCodes.replacementCharacter:
-                    error(Diagnostics.File_appears_to_be_binary, 0, 0);
-                    pos = end;
-                    return token = SyntaxKind.NonTextFileMarkerTrivia;
-                default:
-                    const identifierKind = scanIdentifier(ch, languageVersion);
-                    if (identifierKind) {
-                        return token = identifierKind;
-                    }
-                    else if (isWhiteSpaceSingleLine(ch)) {
-                        pos += charSize(ch);
-                        continue;
-                    }
-                    else if (isLineBreak(ch)) {
-                        tokenFlags |= TokenFlags.PrecedingLineBreak;
-                        pos += charSize(ch);
-                        continue;
-                    }
-                    const size = charSize(ch);
-                    error(Diagnostics.Invalid_character, pos, size);
-                    pos += size;
-                    return token = SyntaxKind.Unknown;
+                        return token = SyntaxKind.Unknown;
+                    case CharacterCodes.hash:
+                        const charAfterHash = codePointUnchecked(pos + 1);
+
+                        if (charAfterHash === CharacterCodes.exclamation) {
+                            if (pos === 0) {
+                                pos = scanShebangTrivia(text, pos);
+                                if (skipTrivia) {
+                                    continue;
+                                }
+                                else {
+                                    return token = SyntaxKind.ShebangTrivia;
+                                }
+                            }
+                            else if (pos !== 0) {
+                                error(Diagnostics.can_only_be_used_at_the_start_of_a_file, pos, 2);
+                                pos++;
+                                return token = SyntaxKind.Unknown;
+                            }
+                        }
+
+                        if (charAfterHash === CharacterCodes.backslash) {
+                            pos++;
+                            const extendedCookedChar = peekExtendedUnicodeEscape();
+                            if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
+                                tokenValue = "#" + scanExtendedUnicodeEscape(/*shouldEmitInvalidEscapeError*/ true) + scanIdentifierParts();
+                                return token = SyntaxKind.PrivateIdentifier;
+                            }
+
+                            const cookedChar = peekUnicodeEscape();
+                            if (cookedChar >= 0 && isIdentifierStart(cookedChar, languageVersion)) {
+                                pos += 6;
+                                tokenFlags |= TokenFlags.UnicodeEscape;
+                                tokenValue = "#" + String.fromCharCode(cookedChar) + scanIdentifierParts();
+                                return token = SyntaxKind.PrivateIdentifier;
+                            }
+                            pos--;
+                        }
+
+                        if (isIdentifierStart(charAfterHash, languageVersion)) {
+                            pos++;
+                            // We're relying on scanIdentifier's behavior and adjusting the token kind after the fact.
+                            // Notably absent from this block is the fact that calling a function named "scanIdentifier",
+                            // but identifiers don't include '#', and that function doesn't deal with it at all.
+                            // This works because 'scanIdentifier' tries to reuse source characters and builds up substrings;
+                            // however, it starts at the 'tokenPos' which includes the '#', and will "accidentally" prepend the '#' for us.
+                            scanIdentifier(charAfterHash, languageVersion);
+                        }
+                        else {
+                            tokenValue = "#";
+                            error(Diagnostics.Invalid_character, pos++, charSize(ch));
+                        }
+                        return token = SyntaxKind.PrivateIdentifier;
+                    case CharacterCodes.replacementCharacter:
+                        error(Diagnostics.File_appears_to_be_binary, 0, 0);
+                        pos = end;
+                        return token = SyntaxKind.NonTextFileMarkerTrivia;
+                }
             }
+
+            const identifierKind = scanIdentifier(ch, languageVersion);
+            if (identifierKind) {
+                return token = identifierKind;
+            }
+            else if (isWhiteSpaceSingleLine(ch)) {
+                pos += charSize(ch);
+                continue;
+            }
+            else if (isLineBreak(ch)) {
+                tokenFlags |= TokenFlags.PrecedingLineBreak;
+                pos += charSize(ch);
+                continue;
+            }
+            const size = charSize(ch);
+            error(Diagnostics.Invalid_character, pos, size);
+            pos += size;
+            return token = SyntaxKind.Unknown;
         }
     }
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -329,6 +329,8 @@ for (
         // Line Break Whitespace
         [CharacterCodes.lineFeed, TokenCategory.LineBreak],
         [CharacterCodes.carriageReturn, TokenCategory.LineBreak],
+        [CharacterCodes.lineSeparator, TokenCategory.LineBreak],
+        [CharacterCodes.paragraphSeparator, TokenCategory.LineBreak],
 
         // Single Line Whitespace
         [CharacterCodes.tab, TokenCategory.Whitespace],
@@ -2022,11 +2024,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
             }
 
-            const tokenInfo = ch < tokenCategoryLookup.length ?
+            const tokenCategory = ch < tokenCategoryLookup.length ?
                 tokenCategoryLookup[ch] :
                 tokenCategoryLookupUncommon.get(ch) ?? TokenCategory.None;
 
-            if (tokenInfo === TokenCategory.None) {
+            if (tokenCategory === TokenCategory.None) {
                 const identifierKind = scanIdentifier(ch, languageVersion);
                 if (identifierKind) {
                     return token = identifierKind;
@@ -2046,7 +2048,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 return token = SyntaxKind.Unknown;
             }
 
-            if (tokenInfo & TokenCategory.Whitespace) {
+            if (tokenCategory & TokenCategory.Whitespace) {
                 if (skipTrivia) {
                     pos++;
                     continue;
@@ -2059,12 +2061,12 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 }
             }
 
-            if (tokenInfo & TokenCategory.SimpleToken) {
+            if (tokenCategory & TokenCategory.SimpleToken) {
                 pos++;
-                return token = tokenInfo & TokenCategory.SimpleTokenMask;
+                return token = tokenCategory & TokenCategory.SimpleTokenMask;
             }
 
-            if (tokenInfo & TokenCategory.Digit) {
+            if (tokenCategory & TokenCategory.Digit) {
                 if (ch === CharacterCodes._0) {
                     if (pos + 2 < end && (charCodeUnchecked(pos + 1) === CharacterCodes.X || charCodeUnchecked(pos + 1) === CharacterCodes.x)) {
                         pos += 2;
@@ -2104,7 +2106,7 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 return token = scanNumber();
             }
 
-            if (!(tokenInfo & TokenCategory.RecognizedMisc)) Debug.fail(`Unhandled token category ${tokenInfo}`);
+            if (!(tokenCategory & TokenCategory.RecognizedMisc)) Debug.fail(`Unhandled token category ${tokenCategory}`);
             switch (ch) {
                 case CharacterCodes.exclamation:
                     if (charCodeUnchecked(pos + 1) === CharacterCodes.equals) {


### PR DESCRIPTION
This change introduces two lookup tables to the lexical scanner/tokenizer. One is a simple array-based lookup for entities in the ASCII range, and the other is a `Map` for wider codepoints.

These tables assign categories to codepoints to indicate how they should be handled. For example, all line breaks, single-line whitespace, and single-character tokens can be handled generically in their own respective fashion. Doing so allows us to perform fewer individual checks to jump into or skip over a given branch.

One additional optimization is the way in which simple single-character tokens are handled is that the token itself is encoded in the lower 8 bits the category value. This allows us to avoid any branching for such cases.

This all comes at the expense of some memory overhead, along with some overhead from fetching from the table. To avoid hitting the table too often, spaces, tabs, and carriage returns, and line feeds are currently handled separately.