### PR TITLE
`createNodeArray` always makes a new `nodeArray` when given a `nodeArray`

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1174,8 +1174,6 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
                 if (elements.transformFlags === undefined) {
                     aggregateChildrenFlags(elements as MutableNodeArray<T>);
                 }
-                Debug.attachNodeArrayDebugInfo(elements);
-                return elements;
             }
 
             // This *was* a `NodeArray`, but the `hasTrailingComma` option differs. Recreate the
@@ -1184,7 +1182,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             const array = elements.slice() as MutableNodeArray<T>;
             array.pos = elements.pos;
             array.end = elements.end;
-            array.hasTrailingComma = hasTrailingComma;
+            array.hasTrailingComma = hasTrailingComma || elements.hasTrailingComma;
             array.transformFlags = elements.transformFlags;
             Debug.attachNodeArrayDebugInfo(array);
             return array;

--- a/tests/cases/fourslash/nodeArrayCloneCrash.ts
+++ b/tests/cases/fourslash/nodeArrayCloneCrash.ts
@@ -1,0 +1,38 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+
+// @Filename: /TLLineShape.ts
+//// import { createShapePropsMigrationIds } from "./TLShape";
+//// createShapePropsMigrationIds/**/
+
+// @Filename: /TLShape.ts
+//// import { T } from "@tldraw/validate";
+////
+//// /**
+////  * @public
+////  */
+//// export function createShapePropsMigrationIds<T>(): { [k in keyof T]: any } {
+////     return;
+//// }
+
+verify.completions({
+    marker: "",
+    includes: [
+        {
+            name: "createShapePropsMigrationIds",
+            text: "(alias) function createShapePropsMigrationIds<T>(): { [k in keyof T]: any; }\nimport createShapePropsMigrationIds",
+            tags: [{ name: "public", text: undefined }]
+        }
+    ]
+});
+    
+goTo.file("/TLShape.ts");
+verify.organizeImports(
+`
+/**
+ * @public
+ */
+export function createShapePropsMigrationIds<T>(): { [k in keyof T]: any } {
+    return;
+}`);


### PR DESCRIPTION
fixes #59115