### PR TITLE
`visitNodesWithoutCopyingPositions` always makes a new `NodeArray`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8980,7 +8980,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (result) {
                         if (result.pos !== -1 || result.end !== -1) {
                             if (result === nodes) {
-                                result = factory.createNodeArray([...nodes], nodes.hasTrailingComma);
+                                result = factory.createNodeArray(nodes.slice(), nodes.hasTrailingComma);
                             }
                             setTextRangePosEnd(result, -1, -1);
                         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8980,7 +8980,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (result) {
                         if (result.pos !== -1 || result.end !== -1) {
                             if (result === nodes) {
-                                result = factory.createNodeArray(nodes, nodes.hasTrailingComma);
+                                result = factory.createNodeArray([...nodes], nodes.hasTrailingComma);
                             }
                             setTextRangePosEnd(result, -1, -1);
                         }

--- a/tests/cases/fourslash/nodeArrayCloneCrash.ts
+++ b/tests/cases/fourslash/nodeArrayCloneCrash.ts
@@ -1,0 +1,38 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+
+// @Filename: /TLLineShape.ts
+//// import { createShapePropsMigrationIds } from "./TLShape";
+//// createShapePropsMigrationIds/**/
+
+// @Filename: /TLShape.ts
+//// import { T } from "@tldraw/validate";
+////
+//// /**
+////  * @public
+////  */
+//// export function createShapePropsMigrationIds<T>(): { [k in keyof T]: any } {
+////     return;
+//// }
+
+verify.completions({
+    marker: "",
+    includes: [
+        {
+            name: "createShapePropsMigrationIds",
+            text: "(alias) function createShapePropsMigrationIds<T>(): { [k in keyof T]: any; }\nimport createShapePropsMigrationIds",
+            tags: [{ name: "public", text: undefined }]
+        }
+    ]
+});
+    
+goTo.file("/TLShape.ts");
+verify.organizeImports(
+`
+/**
+ * @public
+ */
+export function createShapePropsMigrationIds<T>(): { [k in keyof T]: any } {
+    return;
+}`);


### PR DESCRIPTION
fixes #59115

The original call assumed `createNodeArray` always makes a _new_ `NodeArray`, however, in some instances (when there are no changes to the `NodeArray`), the original array returns. Unpacking the array makes sure that a new `NodeArray` is always created.

(Side note: As a lot of nodeFactory functions make a distinction between when it is always new node vs it is possible to return the old one, ie `createT` vs `updateT`, `createNodeArray` doesn't currently follow that convention. A bigger version of this PR would be to change the behavior of `createNodeArray` (such as #59135, but it could/would have other side effects), or to make two `___NodeArray` functions that makes this distinction)
