### PR TITLE
Send updated sourceFile to getLiteralText

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5188,7 +5188,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             | (printerOptions.terminateUnterminatedLiterals ? GetLiteralTextFlags.TerminateUnterminatedLiterals : 0)
             | (printerOptions.target && printerOptions.target >= ScriptTarget.ES2021 ? GetLiteralTextFlags.AllowNumericSeparator : 0);
 
-        return getLiteralText(node, currentSourceFile, flags);
+        return getLiteralText(node, getSourceFileOfNode(node), flags);
     }
 
     /**

--- a/tests/baselines/reference/extractFunction/extractFunction_VariableDeclaration_Writes_Let_LiteralType1.ts
+++ b/tests/baselines/reference/extractFunction/extractFunction_VariableDeclaration_Writes_Let_LiteralType1.ts
@@ -10,7 +10,7 @@ function f() {
 
 function f() {
     let a = 1;
-    let x: 0o10 | 10 | 0b10 = /*RENAME*/newFunction();
+    let x: 8 | 10 | 2 = /*RENAME*/newFunction();
     a; x;
 
     function newFunction() {
@@ -23,7 +23,7 @@ function f() {
 
 function f() {
     let a = 1;
-    let x: (0o10 | 10 | 0b10) | undefined;
+    let x: (8 | 10 | 2) | undefined;
     ({ x, a } = /*RENAME*/newFunction(a));
     a; x;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/59085#issuecomment-2198774412

When the node's sourceFile is not the same as the `currentSourceFile` the method returns an incorrect position. In example, in the code below, the position will hit the comment text in `foo.ts` instead of `bar.ts`.
```typescript
// @Filename: foo.ts
// Some comment that is going to be used instead on the correct ['constructor'] text.
import { Bar } from "./bar";

export class Foo extends Bar {
    // | <-- trigger completions here should show ['constructor'] from bar.ts. Instead, crashes.
}

// @Filename: bar.ts
export class ElementNode {
    ['constructor']!: any;
}
```

Note that I unsuccessfully tried creating the repro as a fourslash test but for some reason the completions api treats the whole thing as a single file avoiding the issue. Also, I don't know how to avoid the test that changed.