### PR TITLE
fix: allow BindableStaticNameExpression as late-bindable name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13216,17 +13216,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     /**
      * Indicates whether a declaration name is definitely late-bindable.
      * A declaration name is only late-bindable if:
-     * - It is a `ComputedPropertyName`.
-     * - Its expression is an `Identifier` or either a `PropertyAccessExpression` an
-     * `ElementAccessExpression` consisting only of these same three types of nodes.
-     * - The type of its expression is a string or numeric literal type, or is a `unique symbol` type.
+     * - It is a `ComputedPropertyName` or a `ElementAccessExpression` and
+     * - Its (argument) expression is a bindable name expression and
+     * - The type of its (argument) expression is a string or numeric literal type, or a `unique symbol` type.
      */
     function isLateBindableName(node: DeclarationName): node is LateBoundName {
         if (!isComputedPropertyName(node) && !isElementAccessExpression(node)) {
             return false;
         }
         const expr = isComputedPropertyName(node) ? node.expression : node.argumentExpression;
-        return isEntityNameExpression(expr)
+        return isBindableStaticNameExpression(expr)
             && isTypeUsableAsPropertyName(isComputedPropertyName(node) ? checkComputedPropertyName(node) : checkExpressionCached(expr));
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3951,7 +3951,7 @@ export function isBindableStaticElementAccessExpression(node: Node, excludeThisK
 
 /** @internal */
 export function isBindableStaticNameExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticNameExpression {
-    return isEntityNameExpression(node) || isBindableStaticAccessExpression(node, excludeThisKeyword);
+    return isEntityNameExpression(node) || isBindableStaticElementAccessExpression(node, excludeThisKeyword);
 }
 
 /** @internal */

--- a/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.js
+++ b/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/computedPropertyNameWithElementAccessExpression.ts] ////
+
+//// [computedPropertyNameWithElementAccessExpression.ts]
+// https://github.com/microsoft/TypeScript/issues/25083
+
+enum Type {
+  Foo = "foo",
+}
+
+type TypeMap = {
+  [Type.Foo]: any;
+  [Type["Foo"]]: any;
+};
+
+
+//// [computedPropertyNameWithElementAccessExpression.js]
+// https://github.com/microsoft/TypeScript/issues/25083
+var Type;
+(function (Type) {
+    Type["Foo"] = "foo";
+})(Type || (Type = {}));

--- a/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.symbols
+++ b/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/computedPropertyNameWithElementAccessExpression.ts] ////
+
+=== computedPropertyNameWithElementAccessExpression.ts ===
+// https://github.com/microsoft/TypeScript/issues/25083
+
+enum Type {
+>Type : Symbol(Type, Decl(computedPropertyNameWithElementAccessExpression.ts, 0, 0))
+
+  Foo = "foo",
+>Foo : Symbol(Type.Foo, Decl(computedPropertyNameWithElementAccessExpression.ts, 2, 11))
+}
+
+type TypeMap = {
+>TypeMap : Symbol(TypeMap, Decl(computedPropertyNameWithElementAccessExpression.ts, 4, 1))
+
+  [Type.Foo]: any;
+>[Type.Foo] : Symbol([Type.Foo], Decl(computedPropertyNameWithElementAccessExpression.ts, 6, 16), Decl(computedPropertyNameWithElementAccessExpression.ts, 7, 18))
+>Type.Foo : Symbol(Type.Foo, Decl(computedPropertyNameWithElementAccessExpression.ts, 2, 11))
+>Type : Symbol(Type, Decl(computedPropertyNameWithElementAccessExpression.ts, 0, 0))
+>Foo : Symbol(Type.Foo, Decl(computedPropertyNameWithElementAccessExpression.ts, 2, 11))
+
+  [Type["Foo"]]: any;
+>[Type["Foo"]] : Symbol([Type.Foo], Decl(computedPropertyNameWithElementAccessExpression.ts, 6, 16), Decl(computedPropertyNameWithElementAccessExpression.ts, 7, 18))
+>Type : Symbol(Type, Decl(computedPropertyNameWithElementAccessExpression.ts, 0, 0))
+>"Foo" : Symbol(Type.Foo, Decl(computedPropertyNameWithElementAccessExpression.ts, 2, 11))
+
+};
+

--- a/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.types
+++ b/tests/baselines/reference/computedPropertyNameWithElementAccessExpression.types
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/computedPropertyNameWithElementAccessExpression.ts] ////
+
+=== computedPropertyNameWithElementAccessExpression.ts ===
+// https://github.com/microsoft/TypeScript/issues/25083
+
+enum Type {
+>Type : Type
+>     : ^^^^
+
+  Foo = "foo",
+>Foo : Type.Foo
+>    : ^^^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+}
+
+type TypeMap = {
+>TypeMap : TypeMap
+>        : ^^^^^^^
+
+  [Type.Foo]: any;
+>[Type.Foo] : any
+>Type.Foo : Type
+>         : ^^^^
+>Type : typeof Type
+>     : ^^^^^^^^^^^
+>Foo : Type
+>    : ^^^^
+
+  [Type["Foo"]]: any;
+>[Type["Foo"]] : any
+>Type["Foo"] : Type
+>            : ^^^^
+>Type : typeof Type
+>     : ^^^^^^^^^^^
+>"Foo" : "Foo"
+>      : ^^^^^
+
+};
+

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.errors.txt
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.errors.txt
@@ -1,6 +1,6 @@
 isolatedDeclarationLazySymbols.ts(1,17): error TS9007: Function must have an explicit return type annotation with --isolatedDeclarations.
+isolatedDeclarationLazySymbols.ts(12,1): error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
 isolatedDeclarationLazySymbols.ts(13,1): error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
-isolatedDeclarationLazySymbols.ts(16,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 isolatedDeclarationLazySymbols.ts(16,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
 isolatedDeclarationLazySymbols.ts(21,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
 isolatedDeclarationLazySymbols.ts(22,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
@@ -21,22 +21,22 @@ isolatedDeclarationLazySymbols.ts(22,5): error TS9038: Computed property names o
         }
     } as const
     
-    foo[o["prop.inner"]] ="A";
+    foo[o["prop.inner"]] = "A";
+    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
     foo[o.prop.inner] = "B";
     ~~~~~~~~~~~~~~~~~
 !!! error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
     
     export class Foo {
-        [o["prop.inner"]] ="A"
-        ~~~~~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+        [o["prop.inner"]] = "A"
         ~~~~~~~~~~~~~~~~~
 !!! error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
         [o.prop.inner] = "B"
     }
     
     export let oo = {
-        [o['prop.inner']]:"A",
+        [o['prop.inner']]: "A",
         ~~~~~~~~~~~~~~~~~
 !!! error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
 !!! related TS9027 isolatedDeclarationLazySymbols.ts:20:12: Add a type annotation to the variable oo.

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.js
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.js
@@ -12,16 +12,16 @@ const o = {
     }
 } as const
 
-foo[o["prop.inner"]] ="A";
+foo[o["prop.inner"]] = "A";
 foo[o.prop.inner] = "B";
 
 export class Foo {
-    [o["prop.inner"]] ="A"
+    [o["prop.inner"]] = "A"
     [o.prop.inner] = "B"
 }
 
 export let oo = {
-    [o['prop.inner']]:"A",
+    [o['prop.inner']]: "A",
     [o.prop.inner]: "B",
 }
 

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.symbols
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.symbols
@@ -2,7 +2,7 @@
 
 === isolatedDeclarationLazySymbols.ts ===
 export function foo() {
->foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 26))
+>foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 27))
 
 }
 
@@ -22,13 +22,13 @@ const o = {
 } as const
 >const : Symbol(const)
 
-foo[o["prop.inner"]] ="A";
->foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 26))
+foo[o["prop.inner"]] = "A";
+>foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 27))
 >o : Symbol(o, Decl(isolatedDeclarationLazySymbols.ts, 4, 5))
 >"prop.inner" : Symbol(["prop.inner"], Decl(isolatedDeclarationLazySymbols.ts, 4, 11))
 
 foo[o.prop.inner] = "B";
->foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 26))
+>foo : Symbol(foo, Decl(isolatedDeclarationLazySymbols.ts, 0, 0), Decl(isolatedDeclarationLazySymbols.ts, 9, 10), Decl(isolatedDeclarationLazySymbols.ts, 11, 27))
 >o.prop.inner : Symbol(inner, Decl(isolatedDeclarationLazySymbols.ts, 6, 11))
 >o.prop : Symbol(prop, Decl(isolatedDeclarationLazySymbols.ts, 5, 24))
 >o : Symbol(o, Decl(isolatedDeclarationLazySymbols.ts, 4, 5))
@@ -38,7 +38,7 @@ foo[o.prop.inner] = "B";
 export class Foo {
 >Foo : Symbol(Foo, Decl(isolatedDeclarationLazySymbols.ts, 12, 24))
 
-    [o["prop.inner"]] ="A"
+    [o["prop.inner"]] = "A"
 >[o["prop.inner"]] : Symbol(Foo[o["prop.inner"]], Decl(isolatedDeclarationLazySymbols.ts, 14, 18))
 >o : Symbol(o, Decl(isolatedDeclarationLazySymbols.ts, 4, 5))
 >"prop.inner" : Symbol(["prop.inner"], Decl(isolatedDeclarationLazySymbols.ts, 4, 11))
@@ -54,13 +54,13 @@ export class Foo {
 export let oo = {
 >oo : Symbol(oo, Decl(isolatedDeclarationLazySymbols.ts, 19, 10))
 
-    [o['prop.inner']]:"A",
+    [o['prop.inner']]: "A",
 >[o['prop.inner']] : Symbol([o['prop.inner']], Decl(isolatedDeclarationLazySymbols.ts, 19, 17))
 >o : Symbol(o, Decl(isolatedDeclarationLazySymbols.ts, 4, 5))
 >'prop.inner' : Symbol(["prop.inner"], Decl(isolatedDeclarationLazySymbols.ts, 4, 11))
 
     [o.prop.inner]: "B",
->[o.prop.inner] : Symbol([o.prop.inner], Decl(isolatedDeclarationLazySymbols.ts, 20, 26))
+>[o.prop.inner] : Symbol([o.prop.inner], Decl(isolatedDeclarationLazySymbols.ts, 20, 27))
 >o.prop.inner : Symbol(inner, Decl(isolatedDeclarationLazySymbols.ts, 6, 11))
 >o.prop : Symbol(prop, Decl(isolatedDeclarationLazySymbols.ts, 5, 24))
 >o : Symbol(o, Decl(isolatedDeclarationLazySymbols.ts, 4, 5))

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.types
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.types
@@ -37,11 +37,11 @@ const o = {
     }
 } as const
 
-foo[o["prop.inner"]] ="A";
->foo[o["prop.inner"]] ="A" : "A"
->                          : ^^^
->foo[o["prop.inner"]] : any
->                     : ^^^
+foo[o["prop.inner"]] = "A";
+>foo[o["prop.inner"]] = "A" : "A"
+>                           : ^^^
+>foo[o["prop.inner"]] : string
+>                     : ^^^^^^
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >o["prop.inner"] : "a"
@@ -77,7 +77,7 @@ export class Foo {
 >Foo : Foo
 >    : ^^^
 
-    [o["prop.inner"]] ="A"
+    [o["prop.inner"]] = "A"
 >[o["prop.inner"]] : string
 >                  : ^^^^^^
 >o["prop.inner"] : "a"
@@ -111,10 +111,10 @@ export class Foo {
 export let oo = {
 >oo : { a: string; b: string; }
 >   : ^^^^^^^^^^^^^^^^^^^^^^^^^
->{    [o['prop.inner']]:"A",    [o.prop.inner]: "B",} : { a: string; b: string; }
->                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    [o['prop.inner']]: "A",    [o.prop.inner]: "B",} : { a: string; b: string; }
+>                                                      : ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    [o['prop.inner']]:"A",
+    [o['prop.inner']]: "A",
 >[o['prop.inner']] : string
 >                  : ^^^^^^
 >o['prop.inner'] : "a"

--- a/tests/cases/compiler/computedPropertyNameWithElementAccessExpression.ts
+++ b/tests/cases/compiler/computedPropertyNameWithElementAccessExpression.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// https://github.com/microsoft/TypeScript/issues/25083
+
+enum Type {
+  Foo = "foo",
+}
+
+type TypeMap = {
+  [Type.Foo]: any;
+  [Type["Foo"]]: any;
+};

--- a/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
+++ b/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
@@ -14,15 +14,15 @@ const o = {
     }
 } as const
 
-foo[o["prop.inner"]] ="A";
+foo[o["prop.inner"]] = "A";
 foo[o.prop.inner] = "B";
 
 export class Foo {
-    [o["prop.inner"]] ="A"
+    [o["prop.inner"]] = "A"
     [o.prop.inner] = "B"
 }
 
 export let oo = {
-    [o['prop.inner']]:"A",
+    [o['prop.inner']]: "A",
     [o.prop.inner]: "B",
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #25083

Most of the stuff was already in place, and I mostly aligned the functions with the types.