### PR TITLE
Mark `jsxFactorySymbol` as referenced for noUnusedLocals even in verbatimModuleSyntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33371,7 +33371,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         checkJsxPreconditions(node);
 
-        markLinkedReferences(node, ReferenceHint.Jsx);
+        markJsxAliasReferenced(node);
 
         if (isNodeOpeningLikeElement) {
             const jsxOpeningLikeNode = node;

--- a/tests/cases/compiler/verbatimModuleSyntaxReactReference.ts
+++ b/tests/cases/compiler/verbatimModuleSyntaxReactReference.ts
@@ -1,0 +1,14 @@
+// @module: preserve
+// @verbatimModuleSyntax: true
+// @jsx: react
+// @noEmit: true
+// @noUnusedLocals: true
+// @noTypesAndSymbols: true
+
+// @Filename: react.d.ts
+declare module 'react';
+
+// @Filename: index.tsx
+import React from 'react';
+
+export const build = <div>hello </div>;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #59117 

`markJsxAliasReferenced` itself checks `canCollectSymbolAccessibilityInfo` before marking the symbol as `referenced` for _elision_ purposes (which is not necessary in `verbatimModuleSyntax`), but marks the symbol as `isReferenced` for _unused locals checking_ purposes beforehand. That needs to happen unconditionally, but `markLinkedReferences` bails immediately if `canCollectSymbolAccessibilityInfo` is false.

I re-read all the changes in https://github.com/microsoft/TypeScript/pull/58366 and tried and failed to break other features in combination with `verbatimModuleSyntax`.
