### PR TITLE
Skip ID inference errors on nodes collected from other files

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -308,6 +308,7 @@ export function transformDeclarations(context: TransformationContext) {
     }
     function reportInferenceFallback(node: Node) {
         if (!isolatedDeclarations || isSourceFileJS(currentSourceFile)) return;
+        if (getSourceFileOfNode(node) !== currentSourceFile) return; // Nested error on a declaration in another file - ignore, will be reemitted if file is in the output file set
         if (isVariableDeclaration(node) && resolver.isExpandoFunctionDeclaration(node)) {
             reportExpandoFunctionErrors(node);
         }

--- a/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.errors.txt
+++ b/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.errors.txt
@@ -1,0 +1,69 @@
+index.ts(5,14): error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+index.ts(6,14): error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+index.ts(7,14): error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+
+
+==== node_modules/@trpc/server/internals/config.d.ts (0 errors) ====
+    export interface RootConfig<T> {
+        prop: T;
+    }
+==== node_modules/@trpc/server/internals/utils.d.ts (0 errors) ====
+    export interface ErrorFormatterShape<T={}> {
+        prop: T;
+    }
+    export type PickFirstDefined<TType, TPick> = undefined extends TType
+      ? undefined extends TPick
+        ? never
+        : TPick
+      : TType;
+    export interface ErrorFormatter<T={},U={}> {
+        prop: [T, U];
+    }
+    export interface DefaultErrorShape<T={}> {
+        prop: T;
+    }
+==== node_modules/@trpc/server/middleware.d.ts (0 errors) ====
+    export interface MiddlewareFunction<T={},U={}> {
+        prop: [T, U];
+    }
+    export interface MiddlewareBuilder<T={},U={}> {
+        prop: [T, U];
+    }
+==== node_modules/@trpc/server/index.d.ts (0 errors) ====
+    import { RootConfig } from './internals/config';
+    import { ErrorFormatterShape, PickFirstDefined, ErrorFormatter, DefaultErrorShape } from './internals/utils';
+    declare class TRPCBuilder<TParams> {
+        create<TOptions extends Record<string, any>>(): {
+            procedure: {};
+            middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{
+                _config: RootConfig<{
+                    errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+                }>;
+            }, TNewParams>) => import("./middleware").MiddlewareBuilder<{
+                _config: RootConfig<{
+                    errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+                }>;
+            }, TNewParams>;
+            router: {};
+        };
+    } 
+    
+    export declare const initTRPC: TRPCBuilder<object>;
+    export {};
+==== index.ts (3 errors) ====
+    import { initTRPC } from "@trpc/server";
+    
+    const trpc = initTRPC.create();
+    
+    export const middleware = trpc.middleware;
+                 ~~~~~~~~~~
+!!! error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+!!! related TS9027 index.ts:5:14: Add a type annotation to the variable middleware.
+    export const router = trpc.router;
+                 ~~~~~~
+!!! error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+!!! related TS9027 index.ts:6:14: Add a type annotation to the variable router.
+    export const publicProcedure = trpc.procedure;
+                 ~~~~~~~~~~~~~~~
+!!! error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
+!!! related TS9027 index.ts:7:14: Add a type annotation to the variable publicProcedure.

--- a/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.js
+++ b/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.js
@@ -1,0 +1,67 @@
+//// [tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts] ////
+
+//// [config.d.ts]
+export interface RootConfig<T> {
+    prop: T;
+}
+//// [utils.d.ts]
+export interface ErrorFormatterShape<T={}> {
+    prop: T;
+}
+export type PickFirstDefined<TType, TPick> = undefined extends TType
+  ? undefined extends TPick
+    ? never
+    : TPick
+  : TType;
+export interface ErrorFormatter<T={},U={}> {
+    prop: [T, U];
+}
+export interface DefaultErrorShape<T={}> {
+    prop: T;
+}
+//// [middleware.d.ts]
+export interface MiddlewareFunction<T={},U={}> {
+    prop: [T, U];
+}
+export interface MiddlewareBuilder<T={},U={}> {
+    prop: [T, U];
+}
+//// [index.d.ts]
+import { RootConfig } from './internals/config';
+import { ErrorFormatterShape, PickFirstDefined, ErrorFormatter, DefaultErrorShape } from './internals/utils';
+declare class TRPCBuilder<TParams> {
+    create<TOptions extends Record<string, any>>(): {
+        procedure: {};
+        middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{
+            _config: RootConfig<{
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+            }>;
+        }, TNewParams>) => import("./middleware").MiddlewareBuilder<{
+            _config: RootConfig<{
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+            }>;
+        }, TNewParams>;
+        router: {};
+    };
+} 
+
+export declare const initTRPC: TRPCBuilder<object>;
+export {};
+//// [index.ts]
+import { initTRPC } from "@trpc/server";
+
+const trpc = initTRPC.create();
+
+export const middleware = trpc.middleware;
+export const router = trpc.router;
+export const publicProcedure = trpc.procedure;
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.publicProcedure = exports.router = exports.middleware = void 0;
+var server_1 = require("@trpc/server");
+var trpc = server_1.initTRPC.create();
+exports.middleware = trpc.middleware;
+exports.router = trpc.router;
+exports.publicProcedure = trpc.procedure;

--- a/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.symbols
+++ b/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.symbols
@@ -1,0 +1,180 @@
+//// [tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts] ////
+
+=== node_modules/@trpc/server/internals/config.d.ts ===
+export interface RootConfig<T> {
+>RootConfig : Symbol(RootConfig, Decl(config.d.ts, 0, 0))
+>T : Symbol(T, Decl(config.d.ts, 0, 28))
+
+    prop: T;
+>prop : Symbol(RootConfig.prop, Decl(config.d.ts, 0, 32))
+>T : Symbol(T, Decl(config.d.ts, 0, 28))
+}
+=== node_modules/@trpc/server/internals/utils.d.ts ===
+export interface ErrorFormatterShape<T={}> {
+>ErrorFormatterShape : Symbol(ErrorFormatterShape, Decl(utils.d.ts, 0, 0))
+>T : Symbol(T, Decl(utils.d.ts, 0, 37))
+
+    prop: T;
+>prop : Symbol(ErrorFormatterShape.prop, Decl(utils.d.ts, 0, 44))
+>T : Symbol(T, Decl(utils.d.ts, 0, 37))
+}
+export type PickFirstDefined<TType, TPick> = undefined extends TType
+>PickFirstDefined : Symbol(PickFirstDefined, Decl(utils.d.ts, 2, 1))
+>TType : Symbol(TType, Decl(utils.d.ts, 3, 29))
+>TPick : Symbol(TPick, Decl(utils.d.ts, 3, 35))
+>TType : Symbol(TType, Decl(utils.d.ts, 3, 29))
+
+  ? undefined extends TPick
+>TPick : Symbol(TPick, Decl(utils.d.ts, 3, 35))
+
+    ? never
+    : TPick
+>TPick : Symbol(TPick, Decl(utils.d.ts, 3, 35))
+
+  : TType;
+>TType : Symbol(TType, Decl(utils.d.ts, 3, 29))
+
+export interface ErrorFormatter<T={},U={}> {
+>ErrorFormatter : Symbol(ErrorFormatter, Decl(utils.d.ts, 7, 10))
+>T : Symbol(T, Decl(utils.d.ts, 8, 32))
+>U : Symbol(U, Decl(utils.d.ts, 8, 37))
+
+    prop: [T, U];
+>prop : Symbol(ErrorFormatter.prop, Decl(utils.d.ts, 8, 44))
+>T : Symbol(T, Decl(utils.d.ts, 8, 32))
+>U : Symbol(U, Decl(utils.d.ts, 8, 37))
+}
+export interface DefaultErrorShape<T={}> {
+>DefaultErrorShape : Symbol(DefaultErrorShape, Decl(utils.d.ts, 10, 1))
+>T : Symbol(T, Decl(utils.d.ts, 11, 35))
+
+    prop: T;
+>prop : Symbol(DefaultErrorShape.prop, Decl(utils.d.ts, 11, 42))
+>T : Symbol(T, Decl(utils.d.ts, 11, 35))
+}
+=== node_modules/@trpc/server/middleware.d.ts ===
+export interface MiddlewareFunction<T={},U={}> {
+>MiddlewareFunction : Symbol(MiddlewareFunction, Decl(middleware.d.ts, 0, 0))
+>T : Symbol(T, Decl(middleware.d.ts, 0, 36))
+>U : Symbol(U, Decl(middleware.d.ts, 0, 41))
+
+    prop: [T, U];
+>prop : Symbol(MiddlewareFunction.prop, Decl(middleware.d.ts, 0, 48))
+>T : Symbol(T, Decl(middleware.d.ts, 0, 36))
+>U : Symbol(U, Decl(middleware.d.ts, 0, 41))
+}
+export interface MiddlewareBuilder<T={},U={}> {
+>MiddlewareBuilder : Symbol(MiddlewareBuilder, Decl(middleware.d.ts, 2, 1))
+>T : Symbol(T, Decl(middleware.d.ts, 3, 35))
+>U : Symbol(U, Decl(middleware.d.ts, 3, 40))
+
+    prop: [T, U];
+>prop : Symbol(MiddlewareBuilder.prop, Decl(middleware.d.ts, 3, 47))
+>T : Symbol(T, Decl(middleware.d.ts, 3, 35))
+>U : Symbol(U, Decl(middleware.d.ts, 3, 40))
+}
+=== node_modules/@trpc/server/index.d.ts ===
+import { RootConfig } from './internals/config';
+>RootConfig : Symbol(RootConfig, Decl(index.d.ts, 0, 8))
+
+import { ErrorFormatterShape, PickFirstDefined, ErrorFormatter, DefaultErrorShape } from './internals/utils';
+>ErrorFormatterShape : Symbol(ErrorFormatterShape, Decl(index.d.ts, 1, 8))
+>PickFirstDefined : Symbol(PickFirstDefined, Decl(index.d.ts, 1, 29))
+>ErrorFormatter : Symbol(ErrorFormatter, Decl(index.d.ts, 1, 47))
+>DefaultErrorShape : Symbol(DefaultErrorShape, Decl(index.d.ts, 1, 63))
+
+declare class TRPCBuilder<TParams> {
+>TRPCBuilder : Symbol(TRPCBuilder, Decl(index.d.ts, 1, 109))
+>TParams : Symbol(TParams, Decl(index.d.ts, 2, 26))
+
+    create<TOptions extends Record<string, any>>(): {
+>create : Symbol(TRPCBuilder.create, Decl(index.d.ts, 2, 36))
+>TOptions : Symbol(TOptions, Decl(index.d.ts, 3, 11))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+        procedure: {};
+>procedure : Symbol(procedure, Decl(index.d.ts, 3, 53))
+
+        middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{
+>middleware : Symbol(middleware, Decl(index.d.ts, 4, 22))
+>TNewParams : Symbol(TNewParams, Decl(index.d.ts, 5, 21))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>fn : Symbol(fn, Decl(index.d.ts, 5, 61))
+>MiddlewareFunction : Symbol(MiddlewareFunction, Decl(middleware.d.ts, 0, 0))
+
+            _config: RootConfig<{
+>_config : Symbol(_config, Decl(index.d.ts, 5, 108))
+>RootConfig : Symbol(RootConfig, Decl(index.d.ts, 0, 8))
+
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+>errorShape : Symbol(errorShape, Decl(index.d.ts, 6, 33))
+>ErrorFormatterShape : Symbol(ErrorFormatterShape, Decl(index.d.ts, 1, 8))
+>PickFirstDefined : Symbol(PickFirstDefined, Decl(index.d.ts, 1, 29))
+>TOptions : Symbol(TOptions, Decl(index.d.ts, 3, 11))
+>ErrorFormatter : Symbol(ErrorFormatter, Decl(index.d.ts, 1, 47))
+>TParams : Symbol(TParams, Decl(index.d.ts, 2, 26))
+>TParams : Symbol(TParams, Decl(index.d.ts, 2, 26))
+>DefaultErrorShape : Symbol(DefaultErrorShape, Decl(index.d.ts, 1, 63))
+
+            }>;
+        }, TNewParams>) => import("./middleware").MiddlewareBuilder<{
+>TNewParams : Symbol(TNewParams, Decl(index.d.ts, 5, 21))
+>MiddlewareBuilder : Symbol(MiddlewareBuilder, Decl(middleware.d.ts, 2, 1))
+
+            _config: RootConfig<{
+>_config : Symbol(_config, Decl(index.d.ts, 9, 69))
+>RootConfig : Symbol(RootConfig, Decl(index.d.ts, 0, 8))
+
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+>errorShape : Symbol(errorShape, Decl(index.d.ts, 10, 33))
+>ErrorFormatterShape : Symbol(ErrorFormatterShape, Decl(index.d.ts, 1, 8))
+>PickFirstDefined : Symbol(PickFirstDefined, Decl(index.d.ts, 1, 29))
+>TOptions : Symbol(TOptions, Decl(index.d.ts, 3, 11))
+>ErrorFormatter : Symbol(ErrorFormatter, Decl(index.d.ts, 1, 47))
+>TParams : Symbol(TParams, Decl(index.d.ts, 2, 26))
+>TParams : Symbol(TParams, Decl(index.d.ts, 2, 26))
+>DefaultErrorShape : Symbol(DefaultErrorShape, Decl(index.d.ts, 1, 63))
+
+            }>;
+        }, TNewParams>;
+>TNewParams : Symbol(TNewParams, Decl(index.d.ts, 5, 21))
+
+        router: {};
+>router : Symbol(router, Decl(index.d.ts, 13, 23))
+
+    };
+} 
+
+export declare const initTRPC: TRPCBuilder<object>;
+>initTRPC : Symbol(initTRPC, Decl(index.d.ts, 18, 20))
+>TRPCBuilder : Symbol(TRPCBuilder, Decl(index.d.ts, 1, 109))
+
+export {};
+=== index.ts ===
+import { initTRPC } from "@trpc/server";
+>initTRPC : Symbol(initTRPC, Decl(index.ts, 0, 8))
+
+const trpc = initTRPC.create();
+>trpc : Symbol(trpc, Decl(index.ts, 2, 5))
+>initTRPC.create : Symbol(TRPCBuilder.create, Decl(index.d.ts, 2, 36))
+>initTRPC : Symbol(initTRPC, Decl(index.ts, 0, 8))
+>create : Symbol(TRPCBuilder.create, Decl(index.d.ts, 2, 36))
+
+export const middleware = trpc.middleware;
+>middleware : Symbol(middleware, Decl(index.ts, 4, 12))
+>trpc.middleware : Symbol(middleware, Decl(index.d.ts, 4, 22))
+>trpc : Symbol(trpc, Decl(index.ts, 2, 5))
+>middleware : Symbol(middleware, Decl(index.d.ts, 4, 22))
+
+export const router = trpc.router;
+>router : Symbol(router, Decl(index.ts, 5, 12))
+>trpc.router : Symbol(router, Decl(index.d.ts, 13, 23))
+>trpc : Symbol(trpc, Decl(index.ts, 2, 5))
+>router : Symbol(router, Decl(index.d.ts, 13, 23))
+
+export const publicProcedure = trpc.procedure;
+>publicProcedure : Symbol(publicProcedure, Decl(index.ts, 6, 12))
+>trpc.procedure : Symbol(procedure, Decl(index.d.ts, 3, 53))
+>trpc : Symbol(trpc, Decl(index.ts, 2, 5))
+>procedure : Symbol(procedure, Decl(index.d.ts, 3, 53))
+

--- a/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.types
+++ b/tests/baselines/reference/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.types
@@ -1,0 +1,155 @@
+//// [tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts] ////
+
+=== node_modules/@trpc/server/internals/config.d.ts ===
+export interface RootConfig<T> {
+    prop: T;
+>prop : T
+>     : ^
+}
+=== node_modules/@trpc/server/internals/utils.d.ts ===
+export interface ErrorFormatterShape<T={}> {
+    prop: T;
+>prop : T
+>     : ^
+}
+export type PickFirstDefined<TType, TPick> = undefined extends TType
+>PickFirstDefined : PickFirstDefined<TType, TPick>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  ? undefined extends TPick
+    ? never
+    : TPick
+  : TType;
+export interface ErrorFormatter<T={},U={}> {
+    prop: [T, U];
+>prop : [T, U]
+>     : ^^^^^^
+}
+export interface DefaultErrorShape<T={}> {
+    prop: T;
+>prop : T
+>     : ^
+}
+=== node_modules/@trpc/server/middleware.d.ts ===
+export interface MiddlewareFunction<T={},U={}> {
+    prop: [T, U];
+>prop : [T, U]
+>     : ^^^^^^
+}
+export interface MiddlewareBuilder<T={},U={}> {
+    prop: [T, U];
+>prop : [T, U]
+>     : ^^^^^^
+}
+=== node_modules/@trpc/server/index.d.ts ===
+import { RootConfig } from './internals/config';
+>RootConfig : any
+>           : ^^^
+
+import { ErrorFormatterShape, PickFirstDefined, ErrorFormatter, DefaultErrorShape } from './internals/utils';
+>ErrorFormatterShape : any
+>                    : ^^^
+>PickFirstDefined : any
+>                 : ^^^
+>ErrorFormatter : any
+>               : ^^^
+>DefaultErrorShape : any
+>                  : ^^^
+
+declare class TRPCBuilder<TParams> {
+>TRPCBuilder : TRPCBuilder<TParams>
+>            : ^^^^^^^^^^^^^^^^^^^^
+
+    create<TOptions extends Record<string, any>>(): {
+>create : <TOptions extends Record<string, any>>() => { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{ _config: RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>; }, TNewParams>) => import("./middleware").MiddlewareBuilder<{ _config: RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>       : ^        ^^^^^^^^^                   ^^^^^^^                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+
+        procedure: {};
+>procedure : {}
+>          : ^^
+
+        middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{
+>middleware : <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{ _config: RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>; }, TNewParams>) => import("./middleware").MiddlewareBuilder<{ _config: RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>; }, TNewParams>
+>           : ^          ^^^^^^^^^                   ^^  ^^                                                                                                                                                                                                                                                               ^^^^^                                                                                                                                                                                                                                                              
+>fn : import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>; }, TNewParams>
+>   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                          ^^^^^^^^^^^^^^^^
+
+            _config: RootConfig<{
+>_config : RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                             ^^^^
+
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+>errorShape : ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape<{}>>>>
+>           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+            }>;
+        }, TNewParams>) => import("./middleware").MiddlewareBuilder<{
+            _config: RootConfig<{
+>_config : RootConfig<{ errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>; }>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                             ^^^^
+
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+>errorShape : ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape<{}>>>>
+>           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+            }>;
+        }, TNewParams>;
+        router: {};
+>router : {}
+>       : ^^
+
+    };
+} 
+
+export declare const initTRPC: TRPCBuilder<object>;
+>initTRPC : TRPCBuilder<object>
+>         : ^^^^^^^^^^^^^^^^^^^
+
+export {};
+=== index.ts ===
+import { initTRPC } from "@trpc/server";
+>initTRPC : TRPCBuilder<object>
+>         : ^^^^^^^^^^^^^^^^^^^
+
+const trpc = initTRPC.create();
+>trpc : { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>     : ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^^^^^^^^^  ^^^
+>initTRPC.create() : { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>                  : ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^^^^^^^^^  ^^^
+>initTRPC.create : <TOptions extends Record<string, any>>() => { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<TOptions["errorFormatter"], import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<TOptions["errorFormatter"], import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>                : ^        ^^^^^^^^^                   ^^^^^^^                                                                                                                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^                                                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^                                      
+>initTRPC : TRPCBuilder<object>
+>         : ^^^^^^^^^^^^^^^^^^^
+>create : <TOptions extends Record<string, any>>() => { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<TOptions["errorFormatter"], import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<TOptions["errorFormatter"], import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>       : ^        ^^^^^^^^^                   ^^^^^^^                                                                                                                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^                                                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^                                      
+
+export const middleware = trpc.middleware;
+>middleware : <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>
+>           : ^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ 
+>trpc.middleware : <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>
+>                : ^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ 
+>trpc : { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>     : ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^^^^^^^^^  ^^^
+>middleware : <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>
+>           : ^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ 
+
+export const router = trpc.router;
+>router : {}
+>       : ^^
+>trpc.router : {}
+>            : ^^
+>trpc : { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>     : ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^^^^^^^^^  ^^^
+>router : {}
+>       : ^^
+
+export const publicProcedure = trpc.procedure;
+>publicProcedure : {}
+>                : ^^
+>trpc.procedure : {}
+>               : ^^
+>trpc : { procedure: {}; middleware: <TNewParams extends Record<string, any>>(fn: import("node_modules/@trpc/server/middleware").MiddlewareFunction<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<never>; }>; }, TNewParams>) => import("node_modules/@trpc/server/middleware").MiddlewareBuilder<{ _config: import("node_modules/@trpc/server/internals/config").RootConfig<{ errorShape: import("node_modules/@trpc/server/internals/utils").ErrorFormatterShape<import("node_modules/@trpc/server/internals/utils").PickFirstDefined<any, import("node_modules/@trpc/server/internals/utils").ErrorFormatter<unknown extends object ? object : object, import("node_modules/@trpc/server/internals/utils").DefaultErrorShape>>>; }>; }, TNewParams>; router: {}; }
+>     : ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^          ^^^^^^^^^                   ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ ^^^^^^^                  ^^^^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^^^^^^^^^  ^^^
+>procedure : {}
+>          : ^^
+

--- a/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
+++ b/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
@@ -1,0 +1,57 @@
+// @declaration: true
+// @isolatedDeclarations: true
+// @filename: node_modules/@trpc/server/internals/config.d.ts
+export interface RootConfig<T> {
+    prop: T;
+}
+// @filename: node_modules/@trpc/server/internals/utils.d.ts
+export interface ErrorFormatterShape<T={}> {
+    prop: T;
+}
+export type PickFirstDefined<TType, TPick> = undefined extends TType
+  ? undefined extends TPick
+    ? never
+    : TPick
+  : TType;
+export interface ErrorFormatter<T={},U={}> {
+    prop: [T, U];
+}
+export interface DefaultErrorShape<T={}> {
+    prop: T;
+}
+// @filename: node_modules/@trpc/server/middleware.d.ts
+export interface MiddlewareFunction<T={},U={}> {
+    prop: [T, U];
+}
+export interface MiddlewareBuilder<T={},U={}> {
+    prop: [T, U];
+}
+// @filename: node_modules/@trpc/server/index.d.ts
+import { RootConfig } from './internals/config';
+import { ErrorFormatterShape, PickFirstDefined, ErrorFormatter, DefaultErrorShape } from './internals/utils';
+declare class TRPCBuilder<TParams> {
+    create<TOptions extends Record<string, any>>(): {
+        procedure: {};
+        middleware: <TNewParams extends Record<string, any>>(fn: import("./middleware").MiddlewareFunction<{
+            _config: RootConfig<{
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+            }>;
+        }, TNewParams>) => import("./middleware").MiddlewareBuilder<{
+            _config: RootConfig<{
+                errorShape: ErrorFormatterShape<PickFirstDefined<TOptions["errorFormatter"], ErrorFormatter<TParams["ctx"] extends object ? TParams["ctx"] : object, DefaultErrorShape>>>;
+            }>;
+        }, TNewParams>;
+        router: {};
+    };
+} 
+
+export declare const initTRPC: TRPCBuilder<object>;
+export {};
+// @filename: index.ts
+import { initTRPC } from "@trpc/server";
+
+const trpc = initTRPC.create();
+
+export const middleware = trpc.middleware;
+export const router = trpc.router;
+export const publicProcedure = trpc.procedure;


### PR DESCRIPTION
Fixes #58909


I considered skipping the error at the callsite issuing the error if the node isn't from the `context.enclosingFile`, but remembering that at *every* callsite is much more cumbersome than just filtering the node's applicability for the output file under consideration within the error reporter itself.