### PR TITLE
Disable noEmitOnError

### DIFF
--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -13,7 +13,6 @@
         "declarationMap": true,
         "sourceMap": true,
         "composite": true,
-        "noEmitOnError": true,
         "emitDeclarationOnly": true,
 
         "strict": true,


### PR DESCRIPTION
After #58854, build mode proceeds even if there were errors. However, in our codebase we use `noEmitOnError`.

If I stick a random type error in `src/compiler/types.ts`, then run the build, I end up with 17 thousand errors:

```
src/typingsInstaller/nodeTypingsInstaller.ts:177:22 - error TS2339: Property 'log' does not exist on type 'NodeTypingsInstaller'.

177                 this.log.writeLine(`    Succeeded. stdout:${indent(sys.newLine, stdout)}`);
                         ~~~

src/typingsInstaller/nodeTypingsInstaller.ts:183:18 - error TS2339: Property 'log' does not exist on type 'NodeTypingsInstaller'.

183             this.log.writeLine(`    Failed. stdout:${indent(sys.newLine, stdout)}${sys.newLine}    stderr:${indent(sys.newLine, stderr)}`);
                     ~~~


Found 17418 errors.
```

This really breaks the self check in CI (like https://github.com/microsoft/TypeScript/actions/runs/9868392724/job/27250345885?pr=59217).

Disable the flag in our codebase, netting:

```console
$ node ./built/local/tsc.js -b ./src
src/compiler/types.ts:10277:14 - error TS2322: Type 'string' is not assignable to type 'number'.

10277 export const oops: number = "string";
                   ~~~~

Found 1 error.
```

This does make me wonder if `noEmitOnError` is now just a general hazard when using build mode. Maybe this flag should really enable the old behavior? https://github.com/microsoft/TypeScript/pull/58854#issuecomment-2168694162

Or, detect when a dependency has `noEmitOnError`, had an error, then also refuse to build?