### PR TITLE
Do not reuse ambient module name resolution from other files while determining if resolution can be reused

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1794,11 +1794,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         tryGetMemberInModuleExports: (name, symbol) => tryGetMemberInModuleExports(escapeLeadingUnderscores(name), symbol),
         tryGetMemberInModuleExportsAndProperties: (name, symbol) => tryGetMemberInModuleExportsAndProperties(escapeLeadingUnderscores(name), symbol),
         tryFindAmbientModule: moduleName => tryFindAmbientModule(moduleName, /*withAugmentations*/ true),
-        tryFindAmbientModuleWithoutAugmentations: moduleName => {
-            // we deliberately exclude augmentations
-            // since we are only interested in declarations of the module itself
-            return tryFindAmbientModule(moduleName, /*withAugmentations*/ false);
-        },
         getApparentType,
         getUnionType,
         isTypeAssignableTo,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5113,10 +5113,6 @@
         "category": "Message",
         "code": 6144
     },
-    "Module '{0}' was resolved as ambient module declared in '{1}' since this file was not modified.": {
-        "category": "Message",
-        "code": 6145
-    },
     "Specify the JSX factory function to use when targeting 'react' JSX emit, e.g. 'React.createElement' or 'h'.": {
         "category": "Message",
         "code": 6146

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -6,7 +6,6 @@ import {
     CompilerOptions,
     createModeAwareCache,
     createModuleResolutionCache,
-    createMultiMap,
     createTypeReferenceDirectiveResolutionCache,
     createTypeReferenceResolutionLoader,
     Debug,
@@ -572,7 +571,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
     let filesWithChangedSetOfUnresolvedImports: Path[] | undefined;
     let filesWithInvalidatedResolutions: Set<Path> | undefined;
     let filesWithInvalidatedNonRelativeUnresolvedImports: ReadonlyMap<Path, readonly string[]> | undefined;
-    const nonRelativeExternalModuleResolutions = createMultiMap<string, ResolutionWithFailedLookupLocations>();
+    const nonRelativeExternalModuleResolutions = new Set<ResolutionWithFailedLookupLocations>();
 
     const resolutionsWithFailedLookups = new Set<ResolutionWithFailedLookupLocations>();
     const resolutionsWithOnlyAffectingLocations = new Set<ResolutionWithFailedLookupLocations>();
@@ -755,8 +754,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         libraryResolutionCache.clearAllExceptPackageJsonInfoCache();
         // perDirectoryResolvedModuleNames and perDirectoryResolvedTypeReferenceDirectives could be non empty if there was exception during program update
         // (between startCachingPerDirectoryResolution and finishCachingPerDirectoryResolution)
-        nonRelativeExternalModuleResolutions.forEach(watchFailedLookupLocationOfNonRelativeModuleResolutions);
-        nonRelativeExternalModuleResolutions.clear();
+        watchFailedLookupLocationOfNonRelativeModuleResolutions();
         isSymlinkCache.clear();
     }
 
@@ -776,8 +774,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
     function finishCachingPerDirectoryResolution(newProgram: Program | undefined, oldProgram: Program | undefined) {
         filesWithInvalidatedNonRelativeUnresolvedImports = undefined;
         allModuleAndTypeResolutionsAreInvalidated = false;
-        nonRelativeExternalModuleResolutions.forEach(watchFailedLookupLocationOfNonRelativeModuleResolutions);
-        nonRelativeExternalModuleResolutions.clear();
+        watchFailedLookupLocationOfNonRelativeModuleResolutions();
         // Update file watches
         if (newProgram !== oldProgram) {
             cleanupLibResolutionWatching(newProgram);
@@ -1103,7 +1100,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
             watchFailedLookupLocationOfResolution(resolution);
         }
         else {
-            nonRelativeExternalModuleResolutions.add(name, resolution);
+            nonRelativeExternalModuleResolutions.add(resolution);
         }
         const resolved = getResolutionWithResolvedFileName(resolution);
         if (resolved && resolved.resolvedFileName) {
@@ -1236,14 +1233,9 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         packageJsonMap?.delete(resolutionHost.toPath(path));
     }
 
-    function watchFailedLookupLocationOfNonRelativeModuleResolutions(resolutions: ResolutionWithFailedLookupLocations[], name: string) {
-        const program = resolutionHost.getCurrentProgram();
-        if (!program || !program.getTypeChecker().tryFindAmbientModuleWithoutAugmentations(name)) {
-            resolutions.forEach(watchFailedLookupLocationOfResolution);
-        }
-        else {
-            resolutions.forEach(resolution => watchAffectingLocationsOfResolution(resolution, /*addToResolutionsWithOnlyAffectingLocations*/ true));
-        }
+    function watchFailedLookupLocationOfNonRelativeModuleResolutions() {
+        nonRelativeExternalModuleResolutions.forEach(watchFailedLookupLocationOfResolution);
+        nonRelativeExternalModuleResolutions.clear();
     }
 
     function createDirectoryWatcherForPackageDir(

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5202,7 +5202,6 @@ export interface TypeChecker {
     /** @internal */ createIndexInfo(keyType: Type, type: Type, isReadonly: boolean, declaration?: SignatureDeclaration): IndexInfo;
     /** @internal */ isSymbolAccessible(symbol: Symbol, enclosingDeclaration: Node | undefined, meaning: SymbolFlags, shouldComputeAliasToMarkVisible: boolean): SymbolAccessibilityResult;
     /** @internal */ tryFindAmbientModule(moduleName: string): Symbol | undefined;
-    /** @internal */ tryFindAmbientModuleWithoutAugmentations(moduleName: string): Symbol | undefined;
 
     /** @internal */ getSymbolWalker(accept?: (symbol: Symbol) => boolean): SymbolWalker;
 

--- a/src/testRunner/unittests/helpers/tscWatch.ts
+++ b/src/testRunner/unittests/helpers/tscWatch.ts
@@ -40,8 +40,6 @@ export interface TscWatchCompileChange<T extends ts.BuilderProgram = ts.EmitAndS
         programs: readonly CommandLineProgram[],
         watchOrSolution: WatchOrSolution<T>,
     ) => void;
-    // TODO:: sheetal: Needing these fields are technically issues that need to be fixed later
-    skipStructureCheck?: true;
 }
 export interface TscWatchCheckOptions {
     baselineSourceMap?: boolean;
@@ -214,7 +212,7 @@ export function runWatchBaseline<T extends ts.BuilderProgram = ts.EmitAndSemanti
     });
 
     if (edits) {
-        for (const { caption, edit, timeouts, skipStructureCheck } of edits) {
+        for (const { caption, edit, timeouts } of edits) {
             applyEdit(sys, baseline, edit, caption);
             timeouts(sys, programs, watchOrSolution);
             programs = watchBaseline({
@@ -225,7 +223,7 @@ export function runWatchBaseline<T extends ts.BuilderProgram = ts.EmitAndSemanti
                 baselineSourceMap,
                 baselineDependencies,
                 caption,
-                resolutionCache: !skipStructureCheck ? (watchOrSolution as ts.WatchOfConfigFile<T> | undefined)?.getResolutionCache?.() : undefined,
+                resolutionCache: (watchOrSolution as ts.WatchOfConfigFile<T> | undefined)?.getResolutionCache?.(),
                 useSourceOfProjectReferenceRedirect,
             });
         }

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -367,7 +367,7 @@ describe("unittests:: reuseProgramStructure:: General", () => {
         runBaseline("fetches imports after npm install", baselines);
     });
 
-    it("can reuse ambient module declarations from non-modified files", () => {
+    it("should not reuse ambient module declarations from non-modified files", () => {
         const files = [
             { name: "/a/b/app.ts", text: SourceText.New("", "import * as fs from 'fs'", "") },
             { name: "/a/b/node.d.ts", text: SourceText.New("", "", "declare module 'fs' {}") },
@@ -387,7 +387,7 @@ describe("unittests:: reuseProgramStructure:: General", () => {
             f[1].text = f[1].text.updateProgram("declare var process: any");
         });
         baselineProgram(baselines, program3);
-        runBaseline("can reuse ambient module declarations from non-modified files", baselines);
+        runBaseline("should not reuse ambient module declarations from non-modified files", baselines);
     });
 
     it("can reuse module resolutions from non-modified files", () => {

--- a/src/testRunner/unittests/tscWatch/resolutionCache.ts
+++ b/src/testRunner/unittests/tscWatch/resolutionCache.ts
@@ -302,10 +302,6 @@ declare module "fs" {
 `,
                     ),
                 timeouts: sys => sys.runQueuedTimeoutCallbacks(),
-                // This is currently issue with ambient modules in same file not leading to resolution watching
-                // In this case initially resolution is watched and will continued to be watched but
-                // incremental check will determine that the resolution should not be watched as thats what would have happened if we had started tsc --watch at this state.
-                skipStructureCheck: true,
             },
         ],
     });

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -549,6 +549,8 @@ export const x = 10;`,
                 const host = createServerHost(files);
                 const session = new TestSession(host);
                 openFilesForSession([{ file: srcFile.path, content: srcFile.content, scriptKindName: "TS", projectRootPath: "/user/username/projects/myproject" }], session);
+                host.writeFile("/user/username/projects/myproject/src/somefolder/module1.js", "export const x = 10;");
+                host.runQueuedTimeoutCallbacks();
                 baselineTsserverLogs("resolutionCache", scenario, session);
             });
         }

--- a/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -114,7 +114,34 @@ File: /a/b/node.d.ts
 
 declare module 'fs' {}
 
-Module 'fs' was resolved as ambient module declared in '/a/b/node.d.ts' since this file was not modified.
+======== Resolving module 'fs' from '/a/b/app.ts'. ========
+Module resolution kind is not specified, using 'Classic'.
+File '/a/b/fs.ts' does not exist.
+File '/a/b/fs.tsx' does not exist.
+File '/a/b/fs.d.ts' does not exist.
+File '/a/fs.ts' does not exist.
+File '/a/fs.tsx' does not exist.
+File '/a/fs.d.ts' does not exist.
+File '/fs.ts' does not exist.
+File '/fs.tsx' does not exist.
+File '/fs.d.ts' does not exist.
+Searching all ancestor node_modules directories for preferred extensions: Declaration.
+File '/a/b/node_modules/@types/fs/package.json' does not exist.
+File '/a/b/node_modules/@types/fs.d.ts' does not exist.
+File '/a/b/node_modules/@types/fs/index.d.ts' does not exist.
+File '/a/node_modules/@types/fs/package.json' does not exist.
+File '/a/node_modules/@types/fs.d.ts' does not exist.
+File '/a/node_modules/@types/fs/index.d.ts' does not exist.
+File '/node_modules/@types/fs/package.json' does not exist.
+File '/node_modules/@types/fs.d.ts' does not exist.
+File '/node_modules/@types/fs/index.d.ts' does not exist.
+File '/a/b/fs.js' does not exist.
+File '/a/b/fs.jsx' does not exist.
+File '/a/fs.js' does not exist.
+File '/a/fs.jsx' does not exist.
+File '/fs.js' does not exist.
+File '/fs.jsx' does not exist.
+======== Module name 'fs' was not resolved. ========
 
 MissingPaths:: [
   "lib.d.ts"

--- a/tests/baselines/reference/tscWatch/moduleResolution/ambient-module-names-are-resolved-correctly.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/ambient-module-names-are-resolved-correctly.js
@@ -131,6 +131,12 @@ Resolution for module 'mymoduleutils' was found in cache from location '/home/sr
 ======== Module name 'mymoduleutils' was not resolved. ========
 FileWatcher:: Added:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
+DirectoryWatcher:: Added:: WatchInfo: /home/src/project/witha 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project/witha 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules/@types 1 undefined Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules/@types 1 undefined Type roots
 ../../../a/lib/lib.d.ts
@@ -151,6 +157,8 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project 1 undefine
 
 
 PolledWatches::
+/home/src/project/node_modules: *new*
+  {"pollingInterval":500}
 /home/src/project/node_modules/@types: *new*
   {"pollingInterval":500}
 
@@ -170,6 +178,10 @@ FsWatches::
 
 FsWatchesRecursive::
 /home/src/project: *new*
+  {}
+/home/src/project/witha: *new*
+  {}
+/home/src/project/withb: *new*
   {}
 
 Program root files: [
@@ -228,124 +240,33 @@ Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: Watc
 FileWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts 2:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
 Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts 2:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
 DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
 
 
-Timeout callback:: count: 1
-3: timerToUpdateProgram *new*
+Timeout callback:: count: 2
+3: timerToInvalidateFailedLookupResolutions *new*
+4: timerToUpdateProgram *new*
 
-Before running Timeout callback:: count: 1
-3: timerToUpdateProgram
+Before running Timeout callback:: count: 2
+3: timerToInvalidateFailedLookupResolutions
+4: timerToUpdateProgram
 
 Host is moving to new time
-After running Timeout callback:: count: 0
+After running Timeout callback:: count: 1
 Output::
-Reloading new file names and options
-Synchronizing program
-[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
-
-CreatingProgramWith::
-  roots: ["/home/src/project/witha/a.ts","/home/src/project/withb/b.ts"]
-  options: {"noEmit":true,"traceResolution":true,"watch":true,"extendedDiagnostics":true,"explainFiles":true,"configFilePath":"/home/src/project/tsconfig.json"}
-FileWatcher:: Close:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
-Reusing resolution of module 'mymodule' from '/home/src/project/witha/a.ts' of old program, it was successfully resolved to '/home/src/project/witha/node_modules/mymodule/index.d.ts'.
-Reusing resolution of module 'mymoduleutils' from '/home/src/project/witha/a.ts' of old program, it was not resolved.
-Reusing resolution of module 'mymoduleutils' from '/home/src/project/withb/b.ts' of old program, it was not resolved.
-[96mwitha/a.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
-
-[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
-[7m [0m [91m                    ~~~~~~~~~~[0m
-
-  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
-    [7m5[0m     export function promisify(): void;
-    [7m [0m [96m                    ~~~~~~~~~[0m
-    'promisify' is declared here.
-
-[96mwithb/b.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
-
-[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
-[7m [0m [91m                    ~~~~~~~~~~[0m
-
-  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
-    [7m5[0m     export function promisify(): void;
-    [7m [0m [96m                    ~~~~~~~~~[0m
-    'promisify' is declared here.
-
-[96mwithb/b.ts[0m:[93m3[0m:[93m1[0m - [91merror[0m[90m TS2304: [0mCannot find name 'readFile'.
-
-[7m3[0m readFile();
-[7m [0m [91m~~~~~~~~[0m
-
-../../../a/lib/lib.d.ts
-  Default library for target 'es5'
-witha/node_modules/mymodule/index.d.ts
-  Imported via 'mymodule' from file 'witha/a.ts'
-witha/a.ts
-  Matched by include pattern '**/*.ts' in 'tsconfig.json'
-withb/b.ts
-  Matched by include pattern '**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+Scheduling update
 
 
 
+Timeout callback:: count: 1
+4: timerToUpdateProgram *deleted*
+5: timerToUpdateProgram *new*
 
-PolledWatches::
-/home/src/project/node_modules/@types:
-  {"pollingInterval":500}
-
-FsWatches::
-/a/lib/lib.d.ts:
-  {}
-/home/src/project/tsconfig.json:
-  {}
-/home/src/project/witha/a.ts:
-  {}
-/home/src/project/witha/node_modules/mymodule/index.d.ts:
-  {}
-/home/src/project/withb/b.ts:
-  {}
-
-FsWatches *deleted*::
-/home/src/project/withb/node_modules/mymodule/index.d.ts:
-  {}
-
-FsWatchesRecursive::
-/home/src/project:
-  {}
-
-
-Program root files: [
-  "/home/src/project/witha/a.ts",
-  "/home/src/project/withb/b.ts"
-]
-Program options: {
-  "noEmit": true,
-  "traceResolution": true,
-  "watch": true,
-  "extendedDiagnostics": true,
-  "explainFiles": true,
-  "configFilePath": "/home/src/project/tsconfig.json"
-}
-Program structureReused: Not
-Program files::
-/a/lib/lib.d.ts
-/home/src/project/witha/node_modules/mymodule/index.d.ts
-/home/src/project/witha/a.ts
-/home/src/project/withb/b.ts
-
-Semantic diagnostics in builder refreshed for::
-/a/lib/lib.d.ts
-/home/src/project/witha/node_modules/mymodule/index.d.ts
-/home/src/project/witha/a.ts
-/home/src/project/withb/b.ts
-
-Shape signatures in builder refreshed for::
-/a/lib/lib.d.ts (used version)
-/home/src/project/witha/node_modules/mymodule/index.d.ts (used version)
-/home/src/project/witha/a.ts (computed .d.ts)
-/home/src/project/withb/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined
 
@@ -368,9 +289,15 @@ declare module 'mymoduleutils' {
 
 
 Output::
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
 DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project/withb 1 undefined Failed Lookup Locations
 DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
@@ -379,11 +306,14 @@ Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
 
 
-Timeout callback:: count: 1
-6: timerToUpdateProgram *new*
+Timeout callback:: count: 2
+5: timerToUpdateProgram *deleted*
+8: timerToInvalidateFailedLookupResolutions *new*
+10: timerToUpdateProgram *new*
 
-Before running Timeout callback:: count: 1
-6: timerToUpdateProgram
+Before running Timeout callback:: count: 2
+8: timerToInvalidateFailedLookupResolutions
+10: timerToUpdateProgram
 
 Host is moving to new time
 After running Timeout callback:: count: 0
@@ -395,39 +325,89 @@ Synchronizing program
 CreatingProgramWith::
   roots: ["/home/src/project/witha/a.ts","/home/src/project/withb/b.ts"]
   options: {"noEmit":true,"traceResolution":true,"watch":true,"extendedDiagnostics":true,"explainFiles":true,"configFilePath":"/home/src/project/tsconfig.json"}
-Module 'mymoduleutils' was resolved as ambient module declared in '/home/src/project/witha/node_modules/mymodule/index.d.ts' since this file was not modified.
-[96mwitha/a.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
-
-[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
-[7m [0m [91m                    ~~~~~~~~~~[0m
-
-  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
-    [7m5[0m     export function promisify(): void;
-    [7m [0m [96m                    ~~~~~~~~~[0m
-    'promisify' is declared here.
-
-[96mwithb/b.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
-
-[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
-[7m [0m [91m                    ~~~~~~~~~~[0m
-
-  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
-    [7m5[0m     export function promisify(): void;
-    [7m [0m [96m                    ~~~~~~~~~[0m
-    'promisify' is declared here.
-
+FileWatcher:: Close:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+Reusing resolution of module 'mymodule' from '/home/src/project/witha/a.ts' of old program, it was successfully resolved to '/home/src/project/witha/node_modules/mymodule/index.d.ts'.
+======== Resolving module 'mymoduleutils' from '/home/src/project/witha/a.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/witha/node_modules/mymoduleutils.ts' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.tsx' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.d.ts' does not exist.
+Directory '/home/src/project/witha/node_modules/@types' does not exist, skipping all lookups in it.
+Directory '/home/src/project/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+File '/home/src/project/witha/node_modules/mymoduleutils.js' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.jsx' does not exist.
+Directory '/home/src/project/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+======== Module name 'mymoduleutils' was not resolved. ========
+======== Resolving module 'mymoduleutils' from '/home/src/project/withb/b.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/withb/node_modules/mymoduleutils/package.json' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils.tsx' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils.d.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils/index.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils/index.tsx' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils/index.d.ts' exists - use it as a name resolution result.
+Resolving real path for '/home/src/project/withb/node_modules/mymoduleutils/index.d.ts', result '/home/src/project/withb/node_modules/mymoduleutils/index.d.ts'.
+======== Module name 'mymoduleutils' was successfully resolved to '/home/src/project/withb/node_modules/mymoduleutils/index.d.ts'. ========
+FileWatcher:: Added:: WatchInfo: /home/src/project/withb/node_modules/mymoduleutils/index.d.ts 250 undefined Source file
 ../../../a/lib/lib.d.ts
   Default library for target 'es5'
 witha/node_modules/mymodule/index.d.ts
   Imported via 'mymodule' from file 'witha/a.ts'
 witha/a.ts
   Matched by include pattern '**/*.ts' in 'tsconfig.json'
+withb/node_modules/mymoduleutils/index.d.ts
+  Imported via 'mymoduleutils' from file 'withb/b.ts'
 withb/b.ts
   Matched by include pattern '**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
 
 
+
+PolledWatches::
+/home/src/project/node_modules:
+  {"pollingInterval":500}
+/home/src/project/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.d.ts:
+  {}
+/home/src/project/tsconfig.json:
+  {}
+/home/src/project/witha/a.ts:
+  {}
+/home/src/project/witha/node_modules/mymodule/index.d.ts:
+  {}
+/home/src/project/withb/b.ts:
+  {}
+/home/src/project/withb/node_modules/mymoduleutils/index.d.ts: *new*
+  {}
+
+FsWatches *deleted*::
+/home/src/project/withb/node_modules/mymodule/index.d.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/project:
+  {}
+/home/src/project/witha:
+  {}
+/home/src/project/withb:
+  {}
 
 
 Program root files: [
@@ -442,17 +422,26 @@ Program options: {
   "explainFiles": true,
   "configFilePath": "/home/src/project/tsconfig.json"
 }
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /home/src/project/witha/node_modules/mymodule/index.d.ts
 /home/src/project/witha/a.ts
+/home/src/project/withb/node_modules/mymoduleutils/index.d.ts
 /home/src/project/withb/b.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/node_modules/mymoduleutils/index.d.ts
 /home/src/project/withb/b.ts
 
 Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/project/witha/node_modules/mymodule/index.d.ts (used version)
+/home/src/project/witha/a.ts (computed .d.ts)
+/home/src/project/withb/node_modules/mymoduleutils/index.d.ts (used version)
 /home/src/project/withb/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/moduleResolution/ambient-module-names-are-resolved-correctly.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/ambient-module-names-are-resolved-correctly.js
@@ -1,0 +1,458 @@
+currentDirectory:: /home/src/project useCaseSensitiveFileNames: false
+Input::
+//// [/home/src/project/tsconfig.json]
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "traceResolution": true
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}
+
+//// [/home/src/project/witha/node_modules/mymodule/index.d.ts]
+declare module 'mymodule' {
+    export function readFile(): void;
+}
+declare module 'mymoduleutils' {
+    export function promisify(): void;
+}
+
+
+//// [/home/src/project/witha/a.ts]
+import { readFile } from 'mymodule';
+import { promisify, promisify2 } from 'mymoduleutils';
+readFile();
+promisify();
+promisify2();
+
+
+//// [/home/src/project/withb/node_modules/mymodule/index.d.ts]
+declare module 'mymodule' {
+    export function readFile(): void;
+}
+declare module 'mymoduleutils' {
+    export function promisify2(): void;
+}
+
+
+//// [/home/src/project/withb/b.ts]
+import { readFile } from 'mymodule';
+import { promisify, promisify2 } from 'mymoduleutils';
+readFile();
+promisify();
+promisify2();
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+/a/lib/tsc.js -w --extendedDiagnostics --explainFiles
+Output::
+[[90mHH:MM:SS AM[0m] Starting compilation in watch mode...
+
+Current directory: /home/src/project CaseSensitiveFileNames: false
+FileWatcher:: Added:: WatchInfo: /home/src/project/tsconfig.json 2000 undefined Config file
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/home/src/project/witha/a.ts","/home/src/project/withb/b.ts"]
+  options: {"noEmit":true,"traceResolution":true,"watch":true,"extendedDiagnostics":true,"explainFiles":true,"configFilePath":"/home/src/project/tsconfig.json"}
+FileWatcher:: Added:: WatchInfo: /home/src/project/witha/a.ts 250 undefined Source file
+======== Resolving module 'mymodule' from '/home/src/project/witha/a.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymodule' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/witha/node_modules/mymodule/package.json' does not exist.
+File '/home/src/project/witha/node_modules/mymodule.ts' does not exist.
+File '/home/src/project/witha/node_modules/mymodule.tsx' does not exist.
+File '/home/src/project/witha/node_modules/mymodule.d.ts' does not exist.
+File '/home/src/project/witha/node_modules/mymodule/index.ts' does not exist.
+File '/home/src/project/witha/node_modules/mymodule/index.tsx' does not exist.
+File '/home/src/project/witha/node_modules/mymodule/index.d.ts' exists - use it as a name resolution result.
+Resolving real path for '/home/src/project/witha/node_modules/mymodule/index.d.ts', result '/home/src/project/witha/node_modules/mymodule/index.d.ts'.
+======== Module name 'mymodule' was successfully resolved to '/home/src/project/witha/node_modules/mymodule/index.d.ts'. ========
+======== Resolving module 'mymoduleutils' from '/home/src/project/witha/a.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/witha/node_modules/mymoduleutils.ts' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.tsx' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.d.ts' does not exist.
+Directory '/home/src/project/witha/node_modules/@types' does not exist, skipping all lookups in it.
+Directory '/home/src/project/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+File '/home/src/project/witha/node_modules/mymoduleutils.js' does not exist.
+File '/home/src/project/witha/node_modules/mymoduleutils.jsx' does not exist.
+Directory '/home/src/project/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Directory '/node_modules' does not exist, skipping all lookups in it.
+======== Module name 'mymoduleutils' was not resolved. ========
+FileWatcher:: Added:: WatchInfo: /home/src/project/witha/node_modules/mymodule/index.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
+======== Resolving module 'mymodule' from '/home/src/project/withb/b.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymodule' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/withb/node_modules/mymodule/package.json' does not exist.
+File '/home/src/project/withb/node_modules/mymodule.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymodule.tsx' does not exist.
+File '/home/src/project/withb/node_modules/mymodule.d.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymodule/index.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymodule/index.tsx' does not exist.
+File '/home/src/project/withb/node_modules/mymodule/index.d.ts' exists - use it as a name resolution result.
+Resolving real path for '/home/src/project/withb/node_modules/mymodule/index.d.ts', result '/home/src/project/withb/node_modules/mymodule/index.d.ts'.
+======== Module name 'mymodule' was successfully resolved to '/home/src/project/withb/node_modules/mymodule/index.d.ts'. ========
+======== Resolving module 'mymoduleutils' from '/home/src/project/withb/b.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module 'mymoduleutils' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+File '/home/src/project/withb/node_modules/mymoduleutils.ts' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils.tsx' does not exist.
+File '/home/src/project/withb/node_modules/mymoduleutils.d.ts' does not exist.
+Directory '/home/src/project/withb/node_modules/@types' does not exist, skipping all lookups in it.
+Resolution for module 'mymoduleutils' was found in cache from location '/home/src/project'.
+======== Module name 'mymoduleutils' was not resolved. ========
+FileWatcher:: Added:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
+DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules/@types 1 undefined Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project/node_modules/@types 1 undefined Type roots
+../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+witha/node_modules/mymodule/index.d.ts
+  Imported via 'mymodule' from file 'witha/a.ts'
+witha/a.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+withb/node_modules/mymodule/index.d.ts
+  Imported via 'mymodule' from file 'withb/b.ts'
+withb/b.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+[[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
+
+DirectoryWatcher:: Added:: WatchInfo: /home/src/project 1 undefined Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/project 1 undefined Wild card directory
+
+
+
+PolledWatches::
+/home/src/project/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.d.ts: *new*
+  {}
+/home/src/project/tsconfig.json: *new*
+  {}
+/home/src/project/witha/a.ts: *new*
+  {}
+/home/src/project/witha/node_modules/mymodule/index.d.ts: *new*
+  {}
+/home/src/project/withb/b.ts: *new*
+  {}
+/home/src/project/withb/node_modules/mymodule/index.d.ts: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/project: *new*
+  {}
+
+Program root files: [
+  "/home/src/project/witha/a.ts",
+  "/home/src/project/withb/b.ts"
+]
+Program options: {
+  "noEmit": true,
+  "traceResolution": true,
+  "watch": true,
+  "extendedDiagnostics": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/project/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/node_modules/mymodule/index.d.ts
+/home/src/project/withb/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/node_modules/mymodule/index.d.ts
+/home/src/project/withb/b.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/project/witha/node_modules/mymodule/index.d.ts (used version)
+/home/src/project/witha/a.ts (used version)
+/home/src/project/withb/node_modules/mymodule/index.d.ts (used version)
+/home/src/project/withb/b.ts (used version)
+
+exitCode:: ExitStatus.undefined
+
+Change:: remove a file that will remove module augmentation
+
+Input::
+//// [/home/src/project/withb/b.ts]
+
+import { promisify, promisify2 } from 'mymoduleutils';
+readFile();
+promisify();
+promisify2();
+
+
+//// [/home/src/project/withb/node_modules/mymodule/index.d.ts] deleted
+
+Output::
+FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
+FileWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts 2:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts 2:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymodule/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
+
+
+Timeout callback:: count: 1
+3: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+3: timerToUpdateProgram
+
+Host is moving to new time
+After running Timeout callback:: count: 0
+Output::
+Reloading new file names and options
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/project/witha/a.ts","/home/src/project/withb/b.ts"]
+  options: {"noEmit":true,"traceResolution":true,"watch":true,"extendedDiagnostics":true,"explainFiles":true,"configFilePath":"/home/src/project/tsconfig.json"}
+FileWatcher:: Close:: WatchInfo: /home/src/project/withb/node_modules/mymodule/index.d.ts 250 undefined Source file
+Reusing resolution of module 'mymodule' from '/home/src/project/witha/a.ts' of old program, it was successfully resolved to '/home/src/project/witha/node_modules/mymodule/index.d.ts'.
+Reusing resolution of module 'mymoduleutils' from '/home/src/project/witha/a.ts' of old program, it was not resolved.
+Reusing resolution of module 'mymoduleutils' from '/home/src/project/withb/b.ts' of old program, it was not resolved.
+[96mwitha/a.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
+
+[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
+    [7m5[0m     export function promisify(): void;
+    [7m [0m [96m                    ~~~~~~~~~[0m
+    'promisify' is declared here.
+
+[96mwithb/b.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
+
+[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
+    [7m5[0m     export function promisify(): void;
+    [7m [0m [96m                    ~~~~~~~~~[0m
+    'promisify' is declared here.
+
+[96mwithb/b.ts[0m:[93m3[0m:[93m1[0m - [91merror[0m[90m TS2304: [0mCannot find name 'readFile'.
+
+[7m3[0m readFile();
+[7m [0m [91m~~~~~~~~[0m
+
+../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+witha/node_modules/mymodule/index.d.ts
+  Imported via 'mymodule' from file 'witha/a.ts'
+witha/a.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+withb/b.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+
+
+
+
+PolledWatches::
+/home/src/project/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.d.ts:
+  {}
+/home/src/project/tsconfig.json:
+  {}
+/home/src/project/witha/a.ts:
+  {}
+/home/src/project/witha/node_modules/mymodule/index.d.ts:
+  {}
+/home/src/project/withb/b.ts:
+  {}
+
+FsWatches *deleted*::
+/home/src/project/withb/node_modules/mymodule/index.d.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/project:
+  {}
+
+
+Program root files: [
+  "/home/src/project/witha/a.ts",
+  "/home/src/project/withb/b.ts"
+]
+Program options: {
+  "noEmit": true,
+  "traceResolution": true,
+  "watch": true,
+  "extendedDiagnostics": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/project/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/b.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/project/witha/node_modules/mymodule/index.d.ts (used version)
+/home/src/project/witha/a.ts (computed .d.ts)
+/home/src/project/withb/b.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined
+
+Change:: write a file that will add augmentation
+
+Input::
+//// [/home/src/project/withb/b.ts]
+
+import { promisify, promisify2 } from 'mymoduleutils';
+
+promisify();
+promisify2();
+
+
+//// [/home/src/project/withb/node_modules/mymoduleutils/index.d.ts]
+declare module 'mymoduleutils' {
+    export function promisify2(): void;
+}
+
+
+
+Output::
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils :: WatchInfo: /home/src/project 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/project/withb/node_modules/mymoduleutils/index.d.ts :: WatchInfo: /home/src/project 1 undefined Wild card directory
+FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /home/src/project/withb/b.ts 1:: WatchInfo: /home/src/project/withb/b.ts 250 undefined Source file
+
+
+Timeout callback:: count: 1
+6: timerToUpdateProgram *new*
+
+Before running Timeout callback:: count: 1
+6: timerToUpdateProgram
+
+Host is moving to new time
+After running Timeout callback:: count: 0
+Output::
+Reloading new file names and options
+Synchronizing program
+[[90mHH:MM:SS AM[0m] File change detected. Starting incremental compilation...
+
+CreatingProgramWith::
+  roots: ["/home/src/project/witha/a.ts","/home/src/project/withb/b.ts"]
+  options: {"noEmit":true,"traceResolution":true,"watch":true,"extendedDiagnostics":true,"explainFiles":true,"configFilePath":"/home/src/project/tsconfig.json"}
+Module 'mymoduleutils' was resolved as ambient module declared in '/home/src/project/witha/node_modules/mymodule/index.d.ts' since this file was not modified.
+[96mwitha/a.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
+
+[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
+    [7m5[0m     export function promisify(): void;
+    [7m [0m [96m                    ~~~~~~~~~[0m
+    'promisify' is declared here.
+
+[96mwithb/b.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2724: [0m'"mymoduleutils"' has no exported member named 'promisify2'. Did you mean 'promisify'?
+
+[7m2[0m import { promisify, promisify2 } from 'mymoduleutils';
+[7m [0m [91m                    ~~~~~~~~~~[0m
+
+  [96mwitha/node_modules/mymodule/index.d.ts[0m:[93m5[0m:[93m21[0m
+    [7m5[0m     export function promisify(): void;
+    [7m [0m [96m                    ~~~~~~~~~[0m
+    'promisify' is declared here.
+
+../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+witha/node_modules/mymodule/index.d.ts
+  Imported via 'mymodule' from file 'witha/a.ts'
+witha/a.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+withb/b.ts
+  Matched by include pattern '**/*.ts' in 'tsconfig.json'
+[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+
+
+
+
+
+Program root files: [
+  "/home/src/project/witha/a.ts",
+  "/home/src/project/withb/b.ts"
+]
+Program options: {
+  "noEmit": true,
+  "traceResolution": true,
+  "watch": true,
+  "extendedDiagnostics": true,
+  "explainFiles": true,
+  "configFilePath": "/home/src/project/tsconfig.json"
+}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/home/src/project/witha/node_modules/mymodule/index.d.ts
+/home/src/project/witha/a.ts
+/home/src/project/withb/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/home/src/project/withb/b.ts
+
+Shape signatures in builder refreshed for::
+/home/src/project/withb/b.ts (computed .d.ts)
+
+exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -143,11 +143,9 @@ Output::
 //// [/users/username/projects/project/foo.js] file written with same contents
 
 PolledWatches::
-/users/username/projects/node_modules/@types:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
 /users/username/projects/node_modules:
+  {"pollingInterval":500}
+/users/username/projects/node_modules/@types:
   {"pollingInterval":500}
 
 FsWatches::
@@ -161,11 +159,9 @@ FsWatches::
   {}
 
 FsWatchesRecursive::
-/users/username/projects/project/node_modules/@types:
-  {}
-
-FsWatchesRecursive *deleted*::
 /users/username/projects/project/node_modules:
+  {}
+/users/username/projects/project/node_modules/@types:
   {}
 
 Timeout callback:: count: 0

--- a/tests/baselines/reference/tsserver/completions/works-when-files-are-included-from-two-different-drives-of-windows.js
+++ b/tests/baselines/reference/tsserver/completions/works-when-files-are-included-from-two-different-drives-of-windows.js
@@ -142,9 +142,9 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: e:/myproject/node
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: e:/myproject/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/typescript/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/typescript/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/typescript/node_modules/@types/react/package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location affecting resolution
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: e:/myproject/node_modules/react-router-dom/package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location affecting resolution
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/typescript/node_modules/@types/react-router-dom/package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/typescript/node_modules/@types/react/package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location affecting resolution
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: e:/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: e:/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: e:/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots

--- a/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
+++ b/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
@@ -77,6 +77,8 @@ Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /us
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/src 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/src 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots

--- a/tests/baselines/reference/tsserver/resolutionCache/when-resolution-fails.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/when-resolution-fails.js
@@ -289,3 +289,21 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /user/username/projects/myproject/src/tsconfig.json
+
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src/somefolder 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Scheduled: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src/somefolder 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/src/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Project: /user/username/projects/myproject/src/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/src/somefolder/module1.js
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/src/tsconfig.json WatchType: Wild card directory
+Before running Timeout callback:: count: 1
+1: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+//// [/user/username/projects/myproject/src/somefolder/module1.js]
+export const x = 10;
+
+
+Timeout callback:: count: 1
+1: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation *new*
+
+Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+After running Timeout callback:: count: 0

--- a/tests/baselines/reference/tsserver/resolutionCache/when-resolves-to-ambient-module.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/when-resolves-to-ambient-module.js
@@ -120,6 +120,12 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/typings 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/typings 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/typings 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/typings 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/src/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
@@ -252,6 +258,12 @@ PolledWatches::
 FsWatches::
 /a/lib/lib.d.ts: *new*
   {}
+/user/username/projects: *new*
+  {}
+/user/username/projects/myproject: *new*
+  {}
+/user/username/projects/myproject/src: *new*
+  {}
 /user/username/projects/myproject/src/somefolder/module1.ts: *new*
   {}
 /user/username/projects/myproject/src/tsconfig.json: *new*
@@ -295,3 +307,21 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /user/username/projects/myproject/src/tsconfig.json
+
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src/somefolder 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Scheduled: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src/somefolder 1 undefined Project: /user/username/projects/myproject/src/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/src/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Project: /user/username/projects/myproject/src/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/src/somefolder/module1.js
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/somefolder/module1.js :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/src/tsconfig.json WatchType: Wild card directory
+Before running Timeout callback:: count: 1
+1: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+//// [/user/username/projects/myproject/src/somefolder/module1.js]
+export const x = 10;
+
+
+Timeout callback:: count: 1
+1: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation *new*
+
+Info seq  [hh:mm:ss:mss] Running: /user/username/projects/myproject/src/tsconfig.jsonFailedLookupInvalidation
+After running Timeout callback:: count: 0


### PR DESCRIPTION
When trying to reuse resolutions for a program, we were trying to decide we can just not resolve a module name if it is same name as one of the unmodified source files. 
But that is not correct heuristics as shown in the test added. If we resolve the resolution and we find it and that file augments the ambient module or some other ambient module, we wont do that when using program incrementally (so tsc -watch or tsserver scenarios). Removed that heuristic as the only reliable and same between first time program creation and program with partial structure reuse can tell that certainly. (The added test case shows that incremental program structure does not match the initial program - fails our incremental verifier) 
Found while working on #55968