### PR TITLE
When resolving from @types resolve node instead of core node modules

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5237,6 +5237,10 @@
         "category": "Message",
         "code": 6184
     },
+    "Found core node module '{0}', looking in 'node'": {
+        "category": "Message",
+        "code": 6185
+    },
     "Enable strict checking of function types.": {
         "category": "Message",
         "code": 6186

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -525,6 +525,69 @@ function getCandidateFromTypeRoot(typeRoot: string, typeReferenceDirectiveName: 
     return combinePaths(typeRoot, nameForLookup);
 }
 
+const unprefixedNodeCoreModuleList = [
+    "assert",
+    "assert/strict",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "dns/promises",
+    "domain",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "https",
+    "http2",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "stream/promises",
+    "string_decoder",
+    "timers",
+    "timers/promises",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "util/types",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+];
+
+const prefixedNodeCoreModuleList = unprefixedNodeCoreModuleList.map(name => `node:${name}`);
+
+/** @internal */
+export const nodeCoreModuleList: readonly string[] = [...unprefixedNodeCoreModuleList, ...prefixedNodeCoreModuleList];
+
+/** @internal */
+export const nodeCoreModules = new Set(nodeCoreModuleList);
+
+/** @internal */
+export function nonRelativeModuleNameForTypingCache(moduleName: string) {
+    return nodeCoreModules.has(moduleName) ? "node" : moduleName;
+}
+
 /**
  * @param {string | undefined} containingFile - file that contains type reference directive, can be undefined if containing file is unknown.
  * This is possible in case if resolution is performed for directives specified via 'types' parameter. In this case initial path for secondary lookups

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -49,6 +49,7 @@ import {
     ModuleResolutionCache,
     moduleResolutionNameAndModeGetter,
     mutateMap,
+    nonRelativeModuleNameForTypingCache,
     noopFileWatcher,
     normalizePath,
     packageIdToString,
@@ -195,7 +196,6 @@ export interface ResolutionCacheHost extends MinimalResolutionCacheHost {
     getCachedDirectoryStructureHost(): CachedDirectoryStructureHost | undefined;
     projectName?: string;
     getGlobalCache?(): string | undefined;
-    globalCacheResolutionModuleName?(externalModuleName: string): string;
     writeLog(s: string): void;
     getCurrentProgram(): Program | undefined;
     fileIsOpen(filePath: Path): boolean;
@@ -542,7 +542,7 @@ function resolveModuleNameUsingGlobalCache(
         // create different collection of failed lookup locations for second pass
         // if it will fail and we've already found something during the first pass - we don't want to pollute its results
         const { resolvedModule, failedLookupLocations, affectingLocations, resolutionDiagnostics } = loadModuleFromGlobalCache(
-            Debug.checkDefined(resolutionHost.globalCacheResolutionModuleName)(moduleName),
+            nonRelativeModuleNameForTypingCache(moduleName),
             resolutionHost.projectName,
             compilerOptions,
             host,

--- a/src/harness/incrementalUtils.ts
+++ b/src/harness/incrementalUtils.ts
@@ -507,7 +507,6 @@ function verifyProgram(service: ts.server.ProjectService, project: ts.server.Pro
         getCompilationSettings: project.getCompilationSettings.bind(project),
         projectName: project.projectName,
         getGlobalCache: project.getGlobalCache.bind(project),
-        globalCacheResolutionModuleName: project.globalCacheResolutionModuleName.bind(project),
         fileIsOpen: project.fileIsOpen.bind(project),
         getCurrentProgram: () => project.getCurrentProgram(),
 

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -19,6 +19,7 @@ import {
     hasJSFileExtension,
     mapDefined,
     MapLike,
+    nonRelativeModuleNameForTypingCache,
     normalizePath,
     Path,
     readConfigFile,
@@ -59,69 +60,6 @@ export interface CachedTyping {
 export function isTypingUpToDate(cachedTyping: CachedTyping, availableTypingVersions: MapLike<string>) {
     const availableVersion = new Version(getProperty(availableTypingVersions, `ts${versionMajorMinor}`) || getProperty(availableTypingVersions, "latest")!);
     return availableVersion.compareTo(cachedTyping.version) <= 0;
-}
-
-const unprefixedNodeCoreModuleList = [
-    "assert",
-    "assert/strict",
-    "async_hooks",
-    "buffer",
-    "child_process",
-    "cluster",
-    "console",
-    "constants",
-    "crypto",
-    "dgram",
-    "diagnostics_channel",
-    "dns",
-    "dns/promises",
-    "domain",
-    "events",
-    "fs",
-    "fs/promises",
-    "http",
-    "https",
-    "http2",
-    "inspector",
-    "module",
-    "net",
-    "os",
-    "path",
-    "perf_hooks",
-    "process",
-    "punycode",
-    "querystring",
-    "readline",
-    "repl",
-    "stream",
-    "stream/promises",
-    "string_decoder",
-    "timers",
-    "timers/promises",
-    "tls",
-    "trace_events",
-    "tty",
-    "url",
-    "util",
-    "util/types",
-    "v8",
-    "vm",
-    "wasi",
-    "worker_threads",
-    "zlib",
-];
-
-const prefixedNodeCoreModuleList = unprefixedNodeCoreModuleList.map(name => `node:${name}`);
-
-/** @internal */
-export const nodeCoreModuleList: readonly string[] = [...unprefixedNodeCoreModuleList, ...prefixedNodeCoreModuleList];
-
-/** @internal */
-export const nodeCoreModules = new Set(nodeCoreModuleList);
-
-/** @internal */
-export function nonRelativeModuleNameForTypingCache(moduleName: string) {
-    return nodeCoreModules.has(moduleName) ? "node" : moduleName;
 }
 
 /**

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -75,7 +75,6 @@ import {
     isExternalModuleNameRelative,
     isInsideNodeModules,
     JSDocParsingMode,
-    JsTyping,
     LanguageService,
     LanguageServiceHost,
     LanguageServiceMode,
@@ -903,9 +902,6 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     getGlobalCache() {
         return this.getTypeAcquisition().enable ? this.projectService.typingsInstaller.globalTypingsCacheLocation : undefined;
     }
-
-    /** @internal */
-    globalCacheResolutionModuleName = JsTyping.nonRelativeModuleNameForTypingCache;
 
     /** @internal */
     fileIsOpen(filePath: Path) {

--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -11,8 +11,8 @@ import {
     InstallPackageAction,
     isExternalModuleNameRelative,
     isStringLiteral,
-    JsTyping,
     LanguageServiceHost,
+    nodeCoreModules,
     parsePackageName,
     SourceFile,
     tryCast,
@@ -71,6 +71,6 @@ function tryGetImportedPackageName(sourceFile: SourceFile, pos: number): string 
 
 function getTypesPackageNameToInstall(packageName: string, host: LanguageServiceHost, diagCode: number): string | undefined {
     return diagCode === errorCodeCannotFindModule
-        ? (JsTyping.nodeCoreModules.has(packageName) ? "@types/node" : undefined)
+        ? (nodeCoreModules.has(packageName) ? "@types/node" : undefined)
         : (host.isKnownTypesPackageName?.(packageName) ? getTypesPackageName(packageName) : undefined);
 }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -272,7 +272,6 @@ import {
     JSDocTypedefTag,
     JSDocTypeExpression,
     JSDocTypeTag,
-    JsTyping,
     JsxAttribute,
     JsxAttributes,
     JsxClosingElement,
@@ -307,6 +306,7 @@ import {
     Node,
     NodeArray,
     NodeBuilderFlags,
+    nodeCoreModules,
     NodeFlags,
     nodeIsMissing,
     NumericLiteral,
@@ -4149,7 +4149,7 @@ function getCompletionData(
             const moduleFile = tryCast(info.moduleSymbol.valueDeclaration, isSourceFile);
             if (!moduleFile) {
                 const moduleName = stripQuotes(info.moduleSymbol.name);
-                if (JsTyping.nodeCoreModules.has(moduleName) && startsWith(moduleName, "node:") !== shouldUseUriStyleNodeCoreModules(sourceFile, program)) {
+                if (nodeCoreModules.has(moduleName) && startsWith(moduleName, "node:") !== shouldUseUriStyleNodeCoreModules(sourceFile, program)) {
                     return false;
                 }
                 return packageJsonFilter

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -269,7 +269,6 @@ import {
     JSDocLinkDisplayPart,
     JSDocLinkPlain,
     JSDocTypedefTag,
-    JsTyping,
     JsxEmit,
     JsxOpeningLikeElement,
     JsxTagNameExpression,
@@ -295,6 +294,7 @@ import {
     Node,
     NodeArray,
     NodeBuilderFlags,
+    nodeCoreModules,
     NodeFlags,
     nodeIsMissing,
     nodeIsPresent,
@@ -3845,7 +3845,7 @@ export function createPackageJsonImportFilter(fromFile: SourceFile | FutureSourc
         // from Node core modules or not. We can start by seeing if the user is actually using
         // any node core modules, as opposed to simply having @types/node accidentally as a
         // dependency of a dependency.
-        if (isFullSourceFile(fromFile) && isSourceFileJS(fromFile) && JsTyping.nodeCoreModules.has(moduleSpecifier)) {
+        if (isFullSourceFile(fromFile) && isSourceFileJS(fromFile) && nodeCoreModules.has(moduleSpecifier)) {
             if (usesNodeCoreModules === undefined) {
                 usesNodeCoreModules = consumesNodeCoreModules(fromFile);
             }
@@ -3890,7 +3890,7 @@ export function createPackageJsonImportFilter(fromFile: SourceFile | FutureSourc
 
 /** @internal */
 export function consumesNodeCoreModules(sourceFile: SourceFile): boolean {
-    return some(sourceFile.imports, ({ text }) => JsTyping.nodeCoreModules.has(text));
+    return some(sourceFile.imports, ({ text }) => nodeCoreModules.has(text));
 }
 
 /** @internal */
@@ -4128,7 +4128,7 @@ export function isDeprecatedDeclaration(decl: Declaration) {
 /** @internal */
 export function shouldUseUriStyleNodeCoreModules(file: SourceFile | FutureSourceFile, program: Program): boolean {
     const decisionFromFile = firstDefined(file.imports, node => {
-        if (JsTyping.nodeCoreModules.has(node.text)) {
+        if (nodeCoreModules.has(node.text)) {
             return startsWith(node.text, "node:");
         }
     });

--- a/src/testRunner/unittests/helpers.ts
+++ b/src/testRunner/unittests/helpers.ts
@@ -118,23 +118,23 @@ export function createTestCompilerHost(texts: readonly NamedSourceText[], target
     });
     if (useCaseSensitiveFileNames === undefined) useCaseSensitiveFileNames = ts.sys && ts.sys.useCaseSensitiveFileNames;
     const getCanonicalFileName = ts.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const filesByPath = ts.mapEntries(files, (fileName, file) => [ts.toPath(fileName, "", getCanonicalFileName), file]);
+    const filesByPath = ts.mapEntries(files, (fileName, file) => [ts.toPath(fileName, "/", getCanonicalFileName), file]);
     const trace: string[] = [];
     const result: TestCompilerHost = {
         trace: s => trace.push(s),
         getTrace: () => trace,
         clearTrace: () => trace.length = 0,
-        getSourceFile: fileName => filesByPath.get(ts.toPath(fileName, "", getCanonicalFileName)),
+        getSourceFile: fileName => filesByPath.get(ts.toPath(fileName, "/", getCanonicalFileName)),
         getDefaultLibFileName: () => "lib.d.ts",
         writeFile: ts.notImplemented,
-        getCurrentDirectory: () => "",
+        getCurrentDirectory: () => "/",
         getDirectories: () => [],
         getCanonicalFileName,
         useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
         getNewLine: () => ts.sys ? ts.sys.newLine : newLine,
-        fileExists: fileName => filesByPath.has(ts.toPath(fileName, "", getCanonicalFileName)),
+        fileExists: fileName => filesByPath.has(ts.toPath(fileName, "/", getCanonicalFileName)),
         readFile: fileName => {
-            const file = filesByPath.get(ts.toPath(fileName, "", getCanonicalFileName));
+            const file = filesByPath.get(ts.toPath(fileName, "/", getCanonicalFileName));
             return file && file.text;
         },
     };

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -1455,7 +1455,7 @@ describe("unittests:: tsserver:: typingsInstaller:: discover typings", () => {
         const { discoverTypings, baseline } = setup([f]);
         const cache = new Map<string, ts.JsTyping.CachedTyping>();
 
-        for (const name of ts.JsTyping.nodeCoreModuleList) {
+        for (const name of ts.nodeCoreModuleList) {
             discoverTypings(
                 [f.path],
                 ts.getDirectoryPath(f.path as ts.Path),

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
@@ -39,7 +39,7 @@ declare module './b1' { interface B { y: string; } }
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -49,11 +49,11 @@ resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs1/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs1/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs1/package.json"
+    "/node_modules/@types/typerefs1/package.json"
   ]
 }
 
@@ -66,7 +66,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -74,7 +74,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -84,36 +84,36 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving type reference directive 'typerefs1', containing file 'f1.ts', root directory 'node_modules/@types'. ========
-Resolving with primary search path 'node_modules/@types'.
-File 'node_modules/@types/typerefs1/package.json' does not exist.
-File 'node_modules/@types/typerefs1/index.d.ts' exists - use it as a name resolution result.
-======== Type reference directive 'typerefs1' was successfully resolved to 'node_modules/@types/typerefs1/index.d.ts', primary: true. ========
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving type reference directive 'typerefs1', containing file '/f1.ts', root directory '/node_modules/@types'. ========
+Resolving with primary search path '/node_modules/@types'.
+File '/node_modules/@types/typerefs1/package.json' does not exist.
+File '/node_modules/@types/typerefs1/index.d.ts' exists - use it as a name resolution result.
+======== Type reference directive 'typerefs1' was successfully resolved to '/node_modules/@types/typerefs1/index.d.ts', primary: true. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
-======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========
-Resolving with primary search path 'node_modules/@types'.
-File 'node_modules/@types/typerefs2/package.json' does not exist.
-File 'node_modules/@types/typerefs2/index.d.ts' exists - use it as a name resolution result.
-======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========
-======== Resolving module './b2' from 'f2.ts'. ========
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
+======== Resolving type reference directive 'typerefs2', containing file '/f2.ts', root directory '/node_modules/@types'. ========
+Resolving with primary search path '/node_modules/@types'.
+File '/node_modules/@types/typerefs2/package.json' does not exist.
+File '/node_modules/@types/typerefs2/index.d.ts' exists - use it as a name resolution result.
+======== Type reference directive 'typerefs2' was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts', primary: true. ========
+======== Resolving module './b2' from '/f2.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b2.ts' exists - use it as a name resolution result.
-======== Module name './b2' was successfully resolved to 'b2.ts'. ========
-======== Resolving module './f1' from 'f2.ts'. ========
+File '/b2.ts' exists - use it as a name resolution result.
+======== Module name './b2' was successfully resolved to '/b2.ts'. ========
+======== Resolving module './f1' from '/f2.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'f1.ts' exists - use it as a name resolution result.
-======== Module name './f1' was successfully resolved to 'f1.ts'. ========
+File '/f1.ts' exists - use it as a name resolution result.
+======== Module name './f1' was successfully resolved to '/f1.ts'. ========
 
 MissingPaths:: []
 
@@ -164,7 +164,7 @@ declare module './b1' { interface B { y: string; } }
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -174,11 +174,11 @@ resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs1/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs1/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs1/package.json"
+    "/node_modules/@types/typerefs1/package.json"
   ]
 }
 
@@ -191,7 +191,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -199,7 +199,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -209,26 +209,26 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving type reference directive 'typerefs1', containing file 'f1.ts', root directory 'node_modules/@types'. ========
-Resolving with primary search path 'node_modules/@types'.
-File 'node_modules/@types/typerefs1/package.json' does not exist.
-File 'node_modules/@types/typerefs1/index.d.ts' exists - use it as a name resolution result.
-======== Type reference directive 'typerefs1' was successfully resolved to 'node_modules/@types/typerefs1/index.d.ts', primary: true. ========
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving type reference directive 'typerefs1', containing file '/f1.ts', root directory '/node_modules/@types'. ========
+Resolving with primary search path '/node_modules/@types'.
+File '/node_modules/@types/typerefs1/package.json' does not exist.
+File '/node_modules/@types/typerefs1/index.d.ts' exists - use it as a name resolution result.
+======== Type reference directive 'typerefs1' was successfully resolved to '/node_modules/@types/typerefs1/index.d.ts', primary: true. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
-Reusing resolution of type reference directive 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.
-Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.
-Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
+Reusing resolution of type reference directive 'typerefs2' from '/f2.ts' of old program, it was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts'.
+Reusing resolution of module './b2' from '/f2.ts' of old program, it was successfully resolved to '/b2.ts'.
+Reusing resolution of module './f1' from '/f2.ts' of old program, it was successfully resolved to '/f1.ts'.
 
 MissingPaths:: [
   "lib.d.ts"
@@ -280,7 +280,7 @@ declare module './b1' { interface B { y: string; } }
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -296,7 +296,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -304,7 +304,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -314,21 +314,21 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
-Reusing resolution of type reference directive 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.
-Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.
-Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
+Reusing resolution of type reference directive 'typerefs2' from '/f2.ts' of old program, it was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts'.
+Reusing resolution of module './b2' from '/f2.ts' of old program, it was successfully resolved to '/b2.ts'.
+Reusing resolution of module './f1' from '/f2.ts' of old program, it was successfully resolved to '/f1.ts'.
 
 MissingPaths:: [
   "lib.d.ts"
@@ -380,7 +380,7 @@ declare module './b1' { interface B { y: string; } }
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -396,7 +396,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -404,7 +404,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -414,21 +414,21 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
-Reusing resolution of type reference directive 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.
-Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.
-Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
+Reusing resolution of type reference directive 'typerefs2' from '/f2.ts' of old program, it was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts'.
+Reusing resolution of module './b2' from '/f2.ts' of old program, it was successfully resolved to '/b2.ts'.
+Reusing resolution of module './f1' from '/f2.ts' of old program, it was successfully resolved to '/f1.ts'.
 
 MissingPaths:: [
   "lib.d.ts"
@@ -479,7 +479,7 @@ declare module './b1' { interface B { y: string; } }
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -495,7 +495,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -503,7 +503,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -513,18 +513,18 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
 
 MissingPaths:: [
   "lib.d.ts"
@@ -576,7 +576,7 @@ import { B } from './b1';
 resolvedModules:
 ./b1: {
   "resolvedModule": {
-    "resolvedFileName": "b1.ts",
+    "resolvedFileName": "/b1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -592,7 +592,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -600,7 +600,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -610,21 +610,21 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-======== Resolving module './b1' from 'f1.ts'. ========
+======== Resolving module './b1' from '/f1.ts'. ========
 Explicitly specified module resolution kind: 'Classic'.
-File 'b1.ts' exists - use it as a name resolution result.
-======== Module name './b1' was successfully resolved to 'b1.ts'. ========
-Reusing resolution of type reference directive 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.
-Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.
-Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.
+File '/b1.ts' exists - use it as a name resolution result.
+======== Module name './b1' was successfully resolved to '/b1.ts'. ========
+Reusing resolution of type reference directive 'typerefs2' from '/f2.ts' of old program, it was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts'.
+Reusing resolution of module './b2' from '/f2.ts' of old program, it was successfully resolved to '/b2.ts'.
+Reusing resolution of module './f1' from '/f2.ts' of old program, it was successfully resolved to '/f1.ts'.
 
 MissingPaths:: [
   "lib.d.ts"
@@ -683,7 +683,7 @@ import { BB } from './f1';
 resolvedModules:
 ./b2: {
   "resolvedModule": {
-    "resolvedFileName": "b2.ts",
+    "resolvedFileName": "/b2.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -691,7 +691,7 @@ resolvedModules:
 }
 ./f1: {
   "resolvedModule": {
-    "resolvedFileName": "f1.ts",
+    "resolvedFileName": "/f1.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -701,17 +701,17 @@ resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
-    "resolvedFileName": "node_modules/@types/typerefs2/index.d.ts",
-    "isExternalLibraryImport": false
+    "resolvedFileName": "/node_modules/@types/typerefs2/index.d.ts",
+    "isExternalLibraryImport": true
   },
   "failedLookupLocations": [
-    "node_modules/@types/typerefs2/package.json"
+    "/node_modules/@types/typerefs2/package.json"
   ]
 }
 
-Reusing resolution of type reference directive 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.
-Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.
-Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.
+Reusing resolution of type reference directive 'typerefs2' from '/f2.ts' of old program, it was successfully resolved to '/node_modules/@types/typerefs2/index.d.ts'.
+Reusing resolution of module './b2' from '/f2.ts' of old program, it was successfully resolved to '/b2.ts'.
+Reusing resolution of module './f1' from '/f2.ts' of old program, it was successfully resolved to '/f1.ts'.
 
 MissingPaths:: [
   "lib.d.ts"

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -50,7 +50,7 @@ var z = 1;
 resolvedModules:
 b: {
   "resolvedModule": {
-    "resolvedFileName": "b.ts",
+    "resolvedFileName": "/b.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -73,14 +73,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -63,14 +63,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs1/package.json",
-    "node_modules/@types/typerefs1/index.d.ts",
-    "node_modules/typerefs1/package.json",
-    "node_modules/typerefs1.d.ts",
-    "node_modules/typerefs1/index.d.ts",
-    "node_modules/@types/typerefs1/package.json",
-    "node_modules/@types/typerefs1.d.ts",
-    "node_modules/@types/typerefs1/index.d.ts"
+    "/node_modules/@types/typerefs1/package.json",
+    "/node_modules/@types/typerefs1/index.d.ts",
+    "/node_modules/typerefs1/package.json",
+    "/node_modules/typerefs1.d.ts",
+    "/node_modules/typerefs1/index.d.ts",
+    "/node_modules/@types/typerefs1/package.json",
+    "/node_modules/@types/typerefs1.d.ts",
+    "/node_modules/@types/typerefs1/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
@@ -20,28 +20,28 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
 automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a/index.d.ts",
-    "node_modules/a/package.json",
-    "node_modules/a.d.ts",
-    "node_modules/a/index.d.ts",
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a.d.ts",
-    "node_modules/@types/a/index.d.ts"
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a/index.d.ts",
+    "/node_modules/a/package.json",
+    "/node_modules/a.d.ts",
+    "/node_modules/a/index.d.ts",
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a.d.ts",
+    "/node_modules/@types/a/index.d.ts"
   ]
 }
 
@@ -77,28 +77,28 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
 automaticTypeDirectiveResolutions:
 b: {
   "failedLookupLocations": [
-    "node_modules/@types/b/package.json",
-    "node_modules/@types/b/index.d.ts",
-    "node_modules/b/package.json",
-    "node_modules/b.d.ts",
-    "node_modules/b/index.d.ts",
-    "node_modules/@types/b/package.json",
-    "node_modules/@types/b.d.ts",
-    "node_modules/@types/b/index.d.ts"
+    "/node_modules/@types/b/package.json",
+    "/node_modules/@types/b/index.d.ts",
+    "/node_modules/b/package.json",
+    "/node_modules/b.d.ts",
+    "/node_modules/b/index.d.ts",
+    "/node_modules/@types/b/package.json",
+    "/node_modules/@types/b.d.ts",
+    "/node_modules/@types/b/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -64,14 +64,14 @@ var x = 100
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
@@ -20,28 +20,28 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
 automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a/index.d.ts",
-    "node_modules/a/package.json",
-    "node_modules/a.d.ts",
-    "node_modules/a/index.d.ts",
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a.d.ts",
-    "node_modules/@types/a/index.d.ts"
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a/index.d.ts",
+    "/node_modules/a/package.json",
+    "/node_modules/a.d.ts",
+    "/node_modules/a/index.d.ts",
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a.d.ts",
+    "/node_modules/@types/a/index.d.ts"
   ]
 }
 
@@ -77,28 +77,28 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
 automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a/index.d.ts",
-    "node_modules/a/package.json",
-    "node_modules/a.d.ts",
-    "node_modules/a/index.d.ts",
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a.d.ts",
-    "node_modules/@types/a/index.d.ts"
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a/index.d.ts",
+    "/node_modules/a/package.json",
+    "/node_modules/a.d.ts",
+    "/node_modules/a/index.d.ts",
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a.d.ts",
+    "/node_modules/@types/a/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
@@ -26,12 +26,12 @@ typerefs: {
     "/a/node_modules/@types/typerefs/index.d.ts",
     "/node_modules/@types/typerefs/package.json",
     "/node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -74,12 +74,12 @@ typerefs: {
     "/a/node_modules/@types/typerefs/index.d.ts",
     "/node_modules/@types/typerefs/package.json",
     "/node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
+++ b/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
@@ -6,21 +6,21 @@ const myX: number = a.x;
 resolvedModules:
 a: {
   "failedLookupLocations": [
-    "node_modules/a/package.json",
-    "node_modules/a.ts",
-    "node_modules/a.tsx",
-    "node_modules/a.d.ts",
-    "node_modules/a/index.ts",
-    "node_modules/a/index.tsx",
-    "node_modules/a/index.d.ts",
-    "node_modules/@types/a/package.json",
-    "node_modules/@types/a.d.ts",
-    "node_modules/@types/a/index.d.ts",
-    "node_modules/a/package.json",
-    "node_modules/a.js",
-    "node_modules/a.jsx",
-    "node_modules/a/index.js",
-    "node_modules/a/index.jsx"
+    "/node_modules/a/package.json",
+    "/node_modules/a.ts",
+    "/node_modules/a.tsx",
+    "/node_modules/a.d.ts",
+    "/node_modules/a/index.ts",
+    "/node_modules/a/index.tsx",
+    "/node_modules/a/index.d.ts",
+    "/node_modules/@types/a/package.json",
+    "/node_modules/@types/a.d.ts",
+    "/node_modules/@types/a/index.d.ts",
+    "/node_modules/a/package.json",
+    "/node_modules/a.js",
+    "/node_modules/a.jsx",
+    "/node_modules/a/index.js",
+    "/node_modules/a/index.jsx"
   ]
 }
 
@@ -29,27 +29,27 @@ File: file2.ts
 
 
 
-======== Resolving module 'a' from 'file1.ts'. ========
+======== Resolving module 'a' from '/file1.ts'. ========
 Explicitly specified module resolution kind: 'Node10'.
 Loading module 'a' from 'node_modules' folder, target file types: TypeScript, Declaration.
 Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
-File 'node_modules/a/package.json' does not exist.
-File 'node_modules/a.ts' does not exist.
-File 'node_modules/a.tsx' does not exist.
-File 'node_modules/a.d.ts' does not exist.
-File 'node_modules/a/index.ts' does not exist.
-File 'node_modules/a/index.tsx' does not exist.
-File 'node_modules/a/index.d.ts' does not exist.
-File 'node_modules/@types/a/package.json' does not exist.
-File 'node_modules/@types/a.d.ts' does not exist.
-File 'node_modules/@types/a/index.d.ts' does not exist.
+File '/node_modules/a/package.json' does not exist.
+File '/node_modules/a.ts' does not exist.
+File '/node_modules/a.tsx' does not exist.
+File '/node_modules/a.d.ts' does not exist.
+File '/node_modules/a/index.ts' does not exist.
+File '/node_modules/a/index.tsx' does not exist.
+File '/node_modules/a/index.d.ts' does not exist.
+File '/node_modules/@types/a/package.json' does not exist.
+File '/node_modules/@types/a.d.ts' does not exist.
+File '/node_modules/@types/a/index.d.ts' does not exist.
 Loading module 'a' from 'node_modules' folder, target file types: JavaScript.
 Searching all ancestor node_modules directories for fallback extensions: JavaScript.
-File 'node_modules/a/package.json' does not exist according to earlier cached lookups.
-File 'node_modules/a.js' does not exist.
-File 'node_modules/a.jsx' does not exist.
-File 'node_modules/a/index.js' does not exist.
-File 'node_modules/a/index.jsx' does not exist.
+File '/node_modules/a/package.json' does not exist according to earlier cached lookups.
+File '/node_modules/a.js' does not exist.
+File '/node_modules/a.jsx' does not exist.
+File '/node_modules/a/index.js' does not exist.
+File '/node_modules/a/index.jsx' does not exist.
 ======== Module name 'a' was not resolved. ========
 
 MissingPaths:: [
@@ -61,7 +61,7 @@ file1.ts(2,20): error TS2307: Cannot find module 'a' or its corresponding type d
 
 
 Program 2 Reused:: SafeModules
-File: node_modules/a/index.d.ts
+File: /node_modules/a/index.d.ts
 
 export declare let x: number;
 
@@ -73,18 +73,18 @@ const myX: number = a.x;
 resolvedModules:
 a: {
   "resolvedModule": {
-    "resolvedFileName": "node_modules/a/index.d.ts",
+    "resolvedFileName": "/node_modules/a/index.d.ts",
     "extension": ".d.ts",
     "isExternalLibraryImport": true,
     "resolvedUsingTsExtension": false
   },
   "failedLookupLocations": [
-    "node_modules/a/package.json",
-    "node_modules/a.ts",
-    "node_modules/a.tsx",
-    "node_modules/a.d.ts",
-    "node_modules/a/index.ts",
-    "node_modules/a/index.tsx"
+    "/node_modules/a/package.json",
+    "/node_modules/a.ts",
+    "/node_modules/a.tsx",
+    "/node_modules/a.d.ts",
+    "/node_modules/a/index.ts",
+    "/node_modules/a/index.tsx"
   ]
 }
 
@@ -93,18 +93,18 @@ File: file2.ts
 
 
 
-======== Resolving module 'a' from 'file1.ts'. ========
+======== Resolving module 'a' from '/file1.ts'. ========
 Explicitly specified module resolution kind: 'Node10'.
 Loading module 'a' from 'node_modules' folder, target file types: TypeScript, Declaration.
 Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
-File 'node_modules/a/package.json' does not exist.
-File 'node_modules/a.ts' does not exist.
-File 'node_modules/a.tsx' does not exist.
-File 'node_modules/a.d.ts' does not exist.
-File 'node_modules/a/index.ts' does not exist.
-File 'node_modules/a/index.tsx' does not exist.
-File 'node_modules/a/index.d.ts' exists - use it as a name resolution result.
-======== Module name 'a' was successfully resolved to 'node_modules/a/index.d.ts'. ========
+File '/node_modules/a/package.json' does not exist.
+File '/node_modules/a.ts' does not exist.
+File '/node_modules/a.tsx' does not exist.
+File '/node_modules/a.d.ts' does not exist.
+File '/node_modules/a/index.ts' does not exist.
+File '/node_modules/a/index.tsx' does not exist.
+File '/node_modules/a/index.d.ts' exists - use it as a name resolution result.
+======== Module name 'a' was successfully resolved to '/node_modules/a/index.d.ts'. ========
 
 MissingPaths:: []
 

--- a/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics-when-diagnostics-are-not-queried.js
+++ b/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics-when-diagnostics-are-not-queried.js
@@ -546,7 +546,7 @@ Skipped diagnostics
 
 Program 1 Reused:: Not
 Diagnostics:
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -555,7 +555,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -564,7 +564,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -573,7 +573,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -582,7 +582,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -591,7 +591,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -600,7 +600,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -885,7 +885,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -894,7 +894,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -903,7 +903,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -912,7 +912,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -921,7 +921,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(7,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(7,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -930,7 +930,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(8,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(8,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -939,7 +939,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(9,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(9,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -953,7 +953,7 @@ MissingPaths:: [
 
 Program 2 Reused:: Completely
 Diagnostics:
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -962,7 +962,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -971,7 +971,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -980,7 +980,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -989,7 +989,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -998,7 +998,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -1007,7 +1007,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1507,7 +1507,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
@@ -1515,7 +1515,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1523,7 +1523,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
@@ -1531,7 +1531,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1539,7 +1539,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/anotherFile.ts'
@@ -1547,7 +1547,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1560,7 +1560,7 @@ MissingPaths:: [
 
 Program 4 Reused:: SafeModules
 Diagnostics:
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -1569,7 +1569,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1577,7 +1577,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -1586,7 +1586,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -1594,7 +1594,7 @@ Diagnostics:
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -1603,7 +1603,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -1612,7 +1612,7 @@ Diagnostics:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'

--- a/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics.js
+++ b/tests/baselines/reference/reuseProgramStructure/handles-file-preprocessing-dignostics.js
@@ -267,7 +267,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -276,7 +276,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -285,7 +285,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -294,7 +294,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -303,7 +303,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -312,7 +312,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -321,7 +321,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -604,7 +604,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -613,7 +613,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -622,7 +622,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -631,7 +631,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -640,7 +640,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -649,7 +649,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(6,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -658,7 +658,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(7,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -926,7 +926,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -935,7 +935,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/anotherFile.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -943,7 +943,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/oneMore.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -952,7 +952,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/oneMore.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'
@@ -960,7 +960,7 @@ MissingPaths:: [
     Imported via "./struct" from file '/src/project/src/anotherFile.ts'
     Imported via "./Struct" from file '/src/project/src/oneMore.ts'
     Imported via "./struct" from file '/src/project/src/oneMore.ts'
-/src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(3,22): error TS1261: Already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' differs from file name '/src/project/node_modules/fp-ts/lib/struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -969,7 +969,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
+src/project/src/struct.d.ts(4,22): error TS1149: File name '/src/project/node_modules/fp-ts/lib/struct.d.ts' differs from already included file name '/src/project/node_modules/fp-ts/lib/Struct.d.ts' only in casing.
   The file is in the program because:
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/struct.d.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/struct.d.ts'
@@ -978,7 +978,7 @@ MissingPaths:: [
     Imported via "fp-ts/lib/Struct" from file '/src/project/src/oneMore.ts'
     Imported via "fp-ts/lib/struct" from file '/src/project/src/oneMore.ts'
     Root file specified for compilation
-/src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
+src/project/src/struct.d.ts(5,22): error TS1149: File name '/src/project/src/Struct.d.ts' differs from already included file name '/src/project/src/struct.d.ts' only in casing.
   The file is in the program because:
     Root file specified for compilation
     Imported via "./Struct" from file '/src/project/src/struct.d.ts'

--- a/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -68,14 +68,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -63,14 +63,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -64,14 +64,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
@@ -110,8 +110,8 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/node_modules/b/index.d.ts(2,8): error TS1259: Module '"/node_modules/b/node_modules/x/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
-/node_modules/b/node_modules/x/index.d.ts(3,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
+node_modules/b/index.d.ts(2,8): error TS1259: Module '"/node_modules/b/node_modules/x/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+node_modules/b/node_modules/x/index.d.ts(3,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
@@ -220,7 +220,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
+a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
   Property 'y' is missing in type 'import("/node_modules/b/node_modules/x/index").default' but required in type 'import("/node_modules/a/node_modules/x/index").default'.
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
@@ -225,7 +225,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
+a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
   Types have separate declarations of a private property 'x'.
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
@@ -110,8 +110,8 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/node_modules/b/index.d.ts(2,8): error TS1259: Module '"/node_modules/b/node_modules/x/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
-/node_modules/b/node_modules/x/index.d.ts(3,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
+node_modules/b/index.d.ts(2,8): error TS1259: Module '"/node_modules/b/node_modules/x/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+node_modules/b/node_modules/x/index.d.ts(3,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
@@ -220,7 +220,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
+a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
   Property 'y' is missing in type 'import("/node_modules/b/node_modules/x/index").default' but required in type 'import("/node_modules/a/node_modules/x/index").default'.
 
 

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
@@ -225,7 +225,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
+a.ts(3,3): error TS2345: Argument of type 'import("/node_modules/b/node_modules/x/index").default' is not assignable to parameter of type 'import("/node_modules/a/node_modules/x/index").default'.
   Types have separate declarations of a private property 'x'.
 
 

--- a/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
@@ -1,5 +1,5 @@
 Program 1 Reused:: Not
-File: b.ts
+File: /b.ts
 
 
 var y = 2
@@ -11,7 +11,7 @@ var x = 1
 resolvedModules:
 b: {
   "resolvedModule": {
-    "resolvedFileName": "b.ts",
+    "resolvedFileName": "/b.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -23,12 +23,12 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-a.ts(2,17): error TS2306: File 'b.ts' is not a module.
+a.ts(2,17): error TS2306: File '/b.ts' is not a module.
 
 
 
 Program 2 Reused:: Completely
-File: b.ts
+File: /b.ts
 
 
 var y = 2
@@ -40,7 +40,7 @@ var x = 2
 resolvedModules:
 b: {
   "resolvedModule": {
-    "resolvedFileName": "b.ts",
+    "resolvedFileName": "/b.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -52,7 +52,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-a.ts(2,17): error TS2306: File 'b.ts' is not a module.
+a.ts(2,17): error TS2306: File '/b.ts' is not a module.
 
 
 
@@ -71,7 +71,7 @@ MissingPaths:: [
 
 
 Program 4 Reused:: SafeModules
-File: b.ts
+File: /b.ts
 
 
 var y = 2
@@ -85,7 +85,7 @@ var x = 2
 resolvedModules:
 b: {
   "resolvedModule": {
-    "resolvedFileName": "b.ts",
+    "resolvedFileName": "/b.ts",
     "extension": ".ts",
     "isExternalLibraryImport": false,
     "resolvedUsingTsExtension": false
@@ -93,14 +93,14 @@ b: {
 }
 c: {
   "failedLookupLocations": [
-    "c.ts",
-    "c.tsx",
-    "c.d.ts",
-    "node_modules/@types/c/package.json",
-    "node_modules/@types/c.d.ts",
-    "node_modules/@types/c/index.d.ts",
-    "c.js",
-    "c.jsx"
+    "/c.ts",
+    "/c.tsx",
+    "/c.d.ts",
+    "/node_modules/@types/c/package.json",
+    "/node_modules/@types/c.d.ts",
+    "/node_modules/@types/c/index.d.ts",
+    "/c.js",
+    "/c.jsx"
   ]
 }
 
@@ -109,7 +109,7 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-a.ts(2,15): error TS2306: File 'b.ts' is not a module.
+a.ts(2,15): error TS2306: File '/b.ts' is not a module.
 a.ts(3,31): error TS2792: Cannot find module 'c'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
 
 

--- a/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
@@ -117,6 +117,6 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a.ts(2,39): error TS2688: Cannot find type definition file for 'typedefs2'.
+a.ts(2,39): error TS2688: Cannot find type definition file for 'typedefs2'.
 
 

--- a/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
@@ -20,14 +20,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 
@@ -66,14 +66,14 @@ var x = 1
 resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs/index.d.ts",
-    "node_modules/typerefs/package.json",
-    "node_modules/typerefs.d.ts",
-    "node_modules/typerefs/index.d.ts",
-    "node_modules/@types/typerefs/package.json",
-    "node_modules/@types/typerefs.d.ts",
-    "node_modules/@types/typerefs/index.d.ts"
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs/index.d.ts",
+    "/node_modules/typerefs/package.json",
+    "/node_modules/typerefs.d.ts",
+    "/node_modules/typerefs/index.d.ts",
+    "/node_modules/@types/typerefs/package.json",
+    "/node_modules/@types/typerefs.d.ts",
+    "/node_modules/@types/typerefs/index.d.ts"
   ]
 }
 

--- a/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -15,93 +15,16 @@ fs: {
     "/fs.ts",
     "/fs.tsx",
     "/fs.d.ts",
-    "/a/b/node_modules/@types/node/package.json",
-    "/a/b/node_modules/@types/node.d.ts",
-    "/a/b/node_modules/@types/node/index.d.ts",
-    "/a/node_modules/@types/node/package.json",
-    "/a/node_modules/@types/node.d.ts",
-    "/a/node_modules/@types/node/index.d.ts",
+    "/a/b/node_modules/@types/fs/package.json",
+    "/a/b/node_modules/@types/fs.d.ts",
+    "/a/b/node_modules/@types/fs/index.d.ts",
+    "/a/node_modules/@types/fs/package.json",
+    "/a/node_modules/@types/fs.d.ts",
+    "/a/node_modules/@types/fs/index.d.ts",
+    "/node_modules/@types/fs/package.json",
+    "/node_modules/@types/fs.d.ts",
+    "/node_modules/@types/fs/index.d.ts",
     "/node_modules/@types/node/package.json",
-    "/node_modules/@types/node.d.ts",
-    "/node_modules/@types/node/index.d.ts",
-    "/a/b/fs.js",
-    "/a/b/fs.jsx",
-    "/a/fs.js",
-    "/a/fs.jsx",
-    "/fs.js",
-    "/fs.jsx"
-  ]
-}
-
-File: /a/b/node.d.ts
-
-
-declare module 'fs' {}
-
-======== Resolving module 'fs' from '/a/b/app.ts'. ========
-Module resolution kind is not specified, using 'Classic'.
-File '/a/b/fs.ts' does not exist.
-File '/a/b/fs.tsx' does not exist.
-File '/a/b/fs.d.ts' does not exist.
-File '/a/fs.ts' does not exist.
-File '/a/fs.tsx' does not exist.
-File '/a/fs.d.ts' does not exist.
-File '/fs.ts' does not exist.
-File '/fs.tsx' does not exist.
-File '/fs.d.ts' does not exist.
-Searching all ancestor node_modules directories for preferred extensions: Declaration.
-Found core node module 'fs', looking in 'node'
-File '/a/b/node_modules/@types/node/package.json' does not exist.
-File '/a/b/node_modules/@types/node.d.ts' does not exist.
-File '/a/b/node_modules/@types/node/index.d.ts' does not exist.
-Found core node module 'fs', looking in 'node'
-File '/a/node_modules/@types/node/package.json' does not exist.
-File '/a/node_modules/@types/node.d.ts' does not exist.
-File '/a/node_modules/@types/node/index.d.ts' does not exist.
-Found core node module 'fs', looking in 'node'
-File '/node_modules/@types/node/package.json' does not exist.
-File '/node_modules/@types/node.d.ts' does not exist.
-File '/node_modules/@types/node/index.d.ts' does not exist.
-File '/a/b/fs.js' does not exist.
-File '/a/b/fs.jsx' does not exist.
-File '/a/fs.js' does not exist.
-File '/a/fs.jsx' does not exist.
-File '/fs.js' does not exist.
-File '/fs.jsx' does not exist.
-======== Module name 'fs' was not resolved. ========
-
-MissingPaths:: [
-  "lib.d.ts"
-]
-
-
-
-
-Program 2 Reused:: Completely
-File: /a/b/app.ts
-
-import * as fs from 'fs'
-var x = 1;
-resolvedModules:
-fs: {
-  "failedLookupLocations": [
-    "/a/b/fs.ts",
-    "/a/b/fs.tsx",
-    "/a/b/fs.d.ts",
-    "/a/fs.ts",
-    "/a/fs.tsx",
-    "/a/fs.d.ts",
-    "/fs.ts",
-    "/fs.tsx",
-    "/fs.d.ts",
-    "/a/b/node_modules/@types/node/package.json",
-    "/a/b/node_modules/@types/node.d.ts",
-    "/a/b/node_modules/@types/node/index.d.ts",
-    "/a/node_modules/@types/node/package.json",
-    "/a/node_modules/@types/node.d.ts",
-    "/a/node_modules/@types/node/index.d.ts",
-    "/node_modules/@types/node/package.json",
-    "/node_modules/@types/node.d.ts",
     "/node_modules/@types/node/index.d.ts",
     "/a/b/fs.js",
     "/a/b/fs.jsx",
@@ -138,6 +61,90 @@ File '/a/node_modules/@types/fs/index.d.ts' does not exist.
 File '/node_modules/@types/fs/package.json' does not exist.
 File '/node_modules/@types/fs.d.ts' does not exist.
 File '/node_modules/@types/fs/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/node_modules/@types/node/package.json' does not exist.
+File '/node_modules/@types/node/index.d.ts' does not exist.
+File '/a/b/fs.js' does not exist.
+File '/a/b/fs.jsx' does not exist.
+File '/a/fs.js' does not exist.
+File '/a/fs.jsx' does not exist.
+File '/fs.js' does not exist.
+File '/fs.jsx' does not exist.
+======== Module name 'fs' was not resolved. ========
+
+MissingPaths:: [
+  "lib.d.ts"
+]
+
+
+
+
+Program 2 Reused:: Completely
+File: /a/b/app.ts
+
+import * as fs from 'fs'
+var x = 1;
+resolvedModules:
+fs: {
+  "failedLookupLocations": [
+    "/a/b/fs.ts",
+    "/a/b/fs.tsx",
+    "/a/b/fs.d.ts",
+    "/a/fs.ts",
+    "/a/fs.tsx",
+    "/a/fs.d.ts",
+    "/fs.ts",
+    "/fs.tsx",
+    "/fs.d.ts",
+    "/a/b/node_modules/@types/fs/package.json",
+    "/a/b/node_modules/@types/fs.d.ts",
+    "/a/b/node_modules/@types/fs/index.d.ts",
+    "/a/node_modules/@types/fs/package.json",
+    "/a/node_modules/@types/fs.d.ts",
+    "/a/node_modules/@types/fs/index.d.ts",
+    "/node_modules/@types/fs/package.json",
+    "/node_modules/@types/fs.d.ts",
+    "/node_modules/@types/fs/index.d.ts",
+    "/node_modules/@types/node/package.json",
+    "/node_modules/@types/node/index.d.ts",
+    "/a/b/fs.js",
+    "/a/b/fs.jsx",
+    "/a/fs.js",
+    "/a/fs.jsx",
+    "/fs.js",
+    "/fs.jsx"
+  ]
+}
+
+File: /a/b/node.d.ts
+
+
+declare module 'fs' {}
+
+======== Resolving module 'fs' from '/a/b/app.ts'. ========
+Module resolution kind is not specified, using 'Classic'.
+File '/a/b/fs.ts' does not exist.
+File '/a/b/fs.tsx' does not exist.
+File '/a/b/fs.d.ts' does not exist.
+File '/a/fs.ts' does not exist.
+File '/a/fs.tsx' does not exist.
+File '/a/fs.d.ts' does not exist.
+File '/fs.ts' does not exist.
+File '/fs.tsx' does not exist.
+File '/fs.d.ts' does not exist.
+Searching all ancestor node_modules directories for preferred extensions: Declaration.
+File '/a/b/node_modules/@types/fs/package.json' does not exist.
+File '/a/b/node_modules/@types/fs.d.ts' does not exist.
+File '/a/b/node_modules/@types/fs/index.d.ts' does not exist.
+File '/a/node_modules/@types/fs/package.json' does not exist.
+File '/a/node_modules/@types/fs.d.ts' does not exist.
+File '/a/node_modules/@types/fs/index.d.ts' does not exist.
+File '/node_modules/@types/fs/package.json' does not exist.
+File '/node_modules/@types/fs.d.ts' does not exist.
+File '/node_modules/@types/fs/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/node_modules/@types/node/package.json' does not exist.
+File '/node_modules/@types/node/index.d.ts' does not exist.
 File '/a/b/fs.js' does not exist.
 File '/a/b/fs.jsx' does not exist.
 File '/a/fs.js' does not exist.
@@ -170,14 +177,16 @@ fs: {
     "/fs.ts",
     "/fs.tsx",
     "/fs.d.ts",
-    "/a/b/node_modules/@types/node/package.json",
-    "/a/b/node_modules/@types/node.d.ts",
-    "/a/b/node_modules/@types/node/index.d.ts",
-    "/a/node_modules/@types/node/package.json",
-    "/a/node_modules/@types/node.d.ts",
-    "/a/node_modules/@types/node/index.d.ts",
+    "/a/b/node_modules/@types/fs/package.json",
+    "/a/b/node_modules/@types/fs.d.ts",
+    "/a/b/node_modules/@types/fs/index.d.ts",
+    "/a/node_modules/@types/fs/package.json",
+    "/a/node_modules/@types/fs.d.ts",
+    "/a/node_modules/@types/fs/index.d.ts",
+    "/node_modules/@types/fs/package.json",
+    "/node_modules/@types/fs.d.ts",
+    "/node_modules/@types/fs/index.d.ts",
     "/node_modules/@types/node/package.json",
-    "/node_modules/@types/node.d.ts",
     "/node_modules/@types/node/index.d.ts",
     "/a/b/fs.js",
     "/a/b/fs.jsx",
@@ -205,17 +214,17 @@ File '/fs.ts' does not exist.
 File '/fs.tsx' does not exist.
 File '/fs.d.ts' does not exist.
 Searching all ancestor node_modules directories for preferred extensions: Declaration.
-Found core node module 'fs', looking in 'node'
-File '/a/b/node_modules/@types/node/package.json' does not exist.
-File '/a/b/node_modules/@types/node.d.ts' does not exist.
-File '/a/b/node_modules/@types/node/index.d.ts' does not exist.
-Found core node module 'fs', looking in 'node'
-File '/a/node_modules/@types/node/package.json' does not exist.
-File '/a/node_modules/@types/node.d.ts' does not exist.
-File '/a/node_modules/@types/node/index.d.ts' does not exist.
+File '/a/b/node_modules/@types/fs/package.json' does not exist.
+File '/a/b/node_modules/@types/fs.d.ts' does not exist.
+File '/a/b/node_modules/@types/fs/index.d.ts' does not exist.
+File '/a/node_modules/@types/fs/package.json' does not exist.
+File '/a/node_modules/@types/fs.d.ts' does not exist.
+File '/a/node_modules/@types/fs/index.d.ts' does not exist.
+File '/node_modules/@types/fs/package.json' does not exist.
+File '/node_modules/@types/fs.d.ts' does not exist.
+File '/node_modules/@types/fs/index.d.ts' does not exist.
 Found core node module 'fs', looking in 'node'
 File '/node_modules/@types/node/package.json' does not exist.
-File '/node_modules/@types/node.d.ts' does not exist.
 File '/node_modules/@types/node/index.d.ts' does not exist.
 File '/a/b/fs.js' does not exist.
 File '/a/b/fs.jsx' does not exist.
@@ -229,6 +238,6 @@ MissingPaths:: [
   "lib.d.ts"
 ]
 
-/a/b/app.ts(2,21): error TS2792: Cannot find module 'fs'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
+a/b/app.ts(2,21): error TS2792: Cannot find module 'fs'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
 
 

--- a/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/should-not-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -15,15 +15,15 @@ fs: {
     "/fs.ts",
     "/fs.tsx",
     "/fs.d.ts",
-    "/a/b/node_modules/@types/fs/package.json",
-    "/a/b/node_modules/@types/fs.d.ts",
-    "/a/b/node_modules/@types/fs/index.d.ts",
-    "/a/node_modules/@types/fs/package.json",
-    "/a/node_modules/@types/fs.d.ts",
-    "/a/node_modules/@types/fs/index.d.ts",
-    "/node_modules/@types/fs/package.json",
-    "/node_modules/@types/fs.d.ts",
-    "/node_modules/@types/fs/index.d.ts",
+    "/a/b/node_modules/@types/node/package.json",
+    "/a/b/node_modules/@types/node.d.ts",
+    "/a/b/node_modules/@types/node/index.d.ts",
+    "/a/node_modules/@types/node/package.json",
+    "/a/node_modules/@types/node.d.ts",
+    "/a/node_modules/@types/node/index.d.ts",
+    "/node_modules/@types/node/package.json",
+    "/node_modules/@types/node.d.ts",
+    "/node_modules/@types/node/index.d.ts",
     "/a/b/fs.js",
     "/a/b/fs.jsx",
     "/a/fs.js",
@@ -50,15 +50,18 @@ File '/fs.ts' does not exist.
 File '/fs.tsx' does not exist.
 File '/fs.d.ts' does not exist.
 Searching all ancestor node_modules directories for preferred extensions: Declaration.
-File '/a/b/node_modules/@types/fs/package.json' does not exist.
-File '/a/b/node_modules/@types/fs.d.ts' does not exist.
-File '/a/b/node_modules/@types/fs/index.d.ts' does not exist.
-File '/a/node_modules/@types/fs/package.json' does not exist.
-File '/a/node_modules/@types/fs.d.ts' does not exist.
-File '/a/node_modules/@types/fs/index.d.ts' does not exist.
-File '/node_modules/@types/fs/package.json' does not exist.
-File '/node_modules/@types/fs.d.ts' does not exist.
-File '/node_modules/@types/fs/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/a/b/node_modules/@types/node/package.json' does not exist.
+File '/a/b/node_modules/@types/node.d.ts' does not exist.
+File '/a/b/node_modules/@types/node/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/a/node_modules/@types/node/package.json' does not exist.
+File '/a/node_modules/@types/node.d.ts' does not exist.
+File '/a/node_modules/@types/node/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/node_modules/@types/node/package.json' does not exist.
+File '/node_modules/@types/node.d.ts' does not exist.
+File '/node_modules/@types/node/index.d.ts' does not exist.
 File '/a/b/fs.js' does not exist.
 File '/a/b/fs.jsx' does not exist.
 File '/a/fs.js' does not exist.
@@ -91,15 +94,15 @@ fs: {
     "/fs.ts",
     "/fs.tsx",
     "/fs.d.ts",
-    "/a/b/node_modules/@types/fs/package.json",
-    "/a/b/node_modules/@types/fs.d.ts",
-    "/a/b/node_modules/@types/fs/index.d.ts",
-    "/a/node_modules/@types/fs/package.json",
-    "/a/node_modules/@types/fs.d.ts",
-    "/a/node_modules/@types/fs/index.d.ts",
-    "/node_modules/@types/fs/package.json",
-    "/node_modules/@types/fs.d.ts",
-    "/node_modules/@types/fs/index.d.ts",
+    "/a/b/node_modules/@types/node/package.json",
+    "/a/b/node_modules/@types/node.d.ts",
+    "/a/b/node_modules/@types/node/index.d.ts",
+    "/a/node_modules/@types/node/package.json",
+    "/a/node_modules/@types/node.d.ts",
+    "/a/node_modules/@types/node/index.d.ts",
+    "/node_modules/@types/node/package.json",
+    "/node_modules/@types/node.d.ts",
+    "/node_modules/@types/node/index.d.ts",
     "/a/b/fs.js",
     "/a/b/fs.jsx",
     "/a/fs.js",
@@ -167,15 +170,15 @@ fs: {
     "/fs.ts",
     "/fs.tsx",
     "/fs.d.ts",
-    "/a/b/node_modules/@types/fs/package.json",
-    "/a/b/node_modules/@types/fs.d.ts",
-    "/a/b/node_modules/@types/fs/index.d.ts",
-    "/a/node_modules/@types/fs/package.json",
-    "/a/node_modules/@types/fs.d.ts",
-    "/a/node_modules/@types/fs/index.d.ts",
-    "/node_modules/@types/fs/package.json",
-    "/node_modules/@types/fs.d.ts",
-    "/node_modules/@types/fs/index.d.ts",
+    "/a/b/node_modules/@types/node/package.json",
+    "/a/b/node_modules/@types/node.d.ts",
+    "/a/b/node_modules/@types/node/index.d.ts",
+    "/a/node_modules/@types/node/package.json",
+    "/a/node_modules/@types/node.d.ts",
+    "/a/node_modules/@types/node/index.d.ts",
+    "/node_modules/@types/node/package.json",
+    "/node_modules/@types/node.d.ts",
+    "/node_modules/@types/node/index.d.ts",
     "/a/b/fs.js",
     "/a/b/fs.jsx",
     "/a/fs.js",
@@ -202,15 +205,18 @@ File '/fs.ts' does not exist.
 File '/fs.tsx' does not exist.
 File '/fs.d.ts' does not exist.
 Searching all ancestor node_modules directories for preferred extensions: Declaration.
-File '/a/b/node_modules/@types/fs/package.json' does not exist.
-File '/a/b/node_modules/@types/fs.d.ts' does not exist.
-File '/a/b/node_modules/@types/fs/index.d.ts' does not exist.
-File '/a/node_modules/@types/fs/package.json' does not exist.
-File '/a/node_modules/@types/fs.d.ts' does not exist.
-File '/a/node_modules/@types/fs/index.d.ts' does not exist.
-File '/node_modules/@types/fs/package.json' does not exist.
-File '/node_modules/@types/fs.d.ts' does not exist.
-File '/node_modules/@types/fs/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/a/b/node_modules/@types/node/package.json' does not exist.
+File '/a/b/node_modules/@types/node.d.ts' does not exist.
+File '/a/b/node_modules/@types/node/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/a/node_modules/@types/node/package.json' does not exist.
+File '/a/node_modules/@types/node.d.ts' does not exist.
+File '/a/node_modules/@types/node/index.d.ts' does not exist.
+Found core node module 'fs', looking in 'node'
+File '/node_modules/@types/node/package.json' does not exist.
+File '/node_modules/@types/node.d.ts' does not exist.
+File '/node_modules/@types/node/index.d.ts' does not exist.
 File '/a/b/fs.js' does not exist.
 File '/a/b/fs.jsx' does not exist.
 File '/a/fs.js' does not exist.

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -177,15 +177,15 @@ Program options: {
 Program structureReused: SafeModules
 Program files::
 /a/lib/lib.d.ts
-/users/username/projects/project/foo.ts
 /users/username/projects/project/node_modules/@types/node/index.d.ts
+/users/username/projects/project/foo.ts
 
 Semantic diagnostics in builder refreshed for::
-/users/username/projects/project/foo.ts
 /users/username/projects/project/node_modules/@types/node/index.d.ts
+/users/username/projects/project/foo.ts
 
 Shape signatures in builder refreshed for::
-/users/username/projects/project/foo.ts (computed .d.ts)
 /users/username/projects/project/node_modules/@types/node/index.d.ts (used version)
+/users/username/projects/project/foo.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportReExportFromAmbientModule.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportReExportFromAmbientModule.js
@@ -78,8 +78,8 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/index.ts Text-1 "access"
 	/lib.d.ts Text-1 lib.d.ts-Text
-	/node_modules/@types/fs-extra/index.d.ts Text-1 "export * from \"fs\";"
 	/node_modules/@types/node/index.d.ts Text-1 "declare module \"fs\" {\n  export function accessSync(path: string): void;\n}"
+	/node_modules/@types/fs-extra/index.d.ts Text-1 "export * from \"fs\";"
 
 
 	lib.decorators.d.ts
@@ -92,10 +92,11 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Matched by default include pattern '**/*'
 	lib.d.ts
 	  Matched by default include pattern '**/*'
+	node_modules/@types/node/index.d.ts
+	  Imported via "fs" from file 'node_modules/@types/fs-extra/index.d.ts'
+	  Entry point for implicit type library 'node'
 	node_modules/@types/fs-extra/index.d.ts
 	  Entry point for implicit type library 'fs-extra'
-	node_modules/@types/node/index.d.ts
-	  Entry point for implicit type library 'node'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] event:
@@ -127,8 +128,8 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
 	/tsconfig.json SVC-1-0 "{\n  \"compilerOptions\": {\n    \"module\": \"commonjs\"\n  }\n}"
-	/node_modules/@types/fs-extra/index.d.ts Text-1 "export * from \"fs\";"
 	/node_modules/@types/node/index.d.ts Text-1 "declare module \"fs\" {\n  export function accessSync(path: string): void;\n}"
+	/node_modules/@types/fs-extra/index.d.ts Text-1 "export * from \"fs\";"
 
 
 	lib.d.ts
@@ -139,10 +140,11 @@ Info seq  [hh:mm:ss:mss] 	Files (6)
 	  Library referenced via 'decorators.legacy' from file 'lib.d.ts'
 	tsconfig.json
 	  Root file specified for compilation
+	node_modules/@types/node/index.d.ts
+	  Imported via "fs" from file 'node_modules/@types/fs-extra/index.d.ts'
+	  Entry point for implicit type library 'node'
 	node_modules/@types/fs-extra/index.d.ts
 	  Entry point for implicit type library 'fs-extra'
-	node_modules/@types/node/index.d.ts
-	  Entry point for implicit type library 'node'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)

--- a/tests/baselines/reference/tsserver/fourslashServer/importSuggestionsCache_coreNodeModules.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/importSuggestionsCache_coreNodeModules.js
@@ -3512,9 +3512,9 @@ Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (5)
 	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
 	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/node_modules/@types/node/index.d.ts Text-1 "declare module 'fs' {\n  export function readFile(): void;\n}\ndeclare module 'util' {\n  export function promisify(): void;\n}"
 	/a.js SVC-2-34 "import { promisify } from 'util';\nreadF"
 	/lib.d.ts Text-1 lib.d.ts-Text
-	/node_modules/@types/node/index.d.ts Text-1 "declare module 'fs' {\n  export function readFile(): void;\n}\ndeclare module 'util' {\n  export function promisify(): void;\n}"
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] getCompletionData: Get current token: *


### PR DESCRIPTION
On top of #59243 
- Resolves `@types/node` for core node module names if resolution failed. 
- This helps with picking up node without having to put it in types when they are specified. 
- Only single change that seems like desirable