### PR TITLE
Use set instead of array for late visible statements

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5787,7 +5787,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function hasVisibleDeclarations(symbol: Symbol, shouldComputeAliasToMakeVisible: boolean): SymbolVisibilityResult | undefined {
-        let aliasesToMakeVisible: LateVisibilityPaintedStatement[] | undefined;
+        let aliasesToMakeVisible: Set<LateVisibilityPaintedStatement> | undefined;
         if (!every(filter(symbol.declarations, d => d.kind !== SyntaxKind.Identifier), getIsDeclarationVisible)) {
             return undefined;
         }
@@ -5856,7 +5856,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // since we will do the emitting later in trackSymbol.
             if (shouldComputeAliasToMakeVisible) {
                 getNodeLinks(declaration).isVisible = true;
-                aliasesToMakeVisible = appendIfUnique(aliasesToMakeVisible, aliasingStatement);
+                (aliasesToMakeVisible ??= new Set()).add(aliasingStatement);
             }
             return true;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5616,7 +5616,7 @@ export type LateVisibilityPaintedStatement =
 /** @internal */
 export interface SymbolVisibilityResult {
     accessibility: SymbolAccessibility;
-    aliasesToMakeVisible?: LateVisibilityPaintedStatement[]; // aliases that need to have this symbol visible
+    aliasesToMakeVisible?: Set<LateVisibilityPaintedStatement>; // aliases that need to have this symbol visible
     errorSymbolName?: string; // Optional symbol name that results in error
     errorNode?: Node; // optional node that results in error
 }


### PR DESCRIPTION
Probably not going to be perf critical but I'm looking at places we use arrays and then scan over them repeatedly.