### PR TITLE
Avoid circularity when contextual parent type of static property is its class

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31166,7 +31166,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getContextualTypeForStaticPropertyDeclaration(declaration: PropertyDeclaration, contextFlags: ContextFlags | undefined): Type | undefined {
         const parentType = isExpression(declaration.parent) && getContextualType(declaration.parent, contextFlags);
-        if (!parentType) return undefined;
+        if (!parentType || getSymbolOfDeclaration(declaration.parent) === parentType.symbol) return undefined;
         return getTypeOfPropertyOfContextualType(parentType, getSymbolOfDeclaration(declaration).escapedName);
     }
 

--- a/tests/baselines/reference/classStaticPropertyContextuallyTypedByItselfNoError1.symbols
+++ b/tests/baselines/reference/classStaticPropertyContextuallyTypedByItselfNoError1.symbols
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/classStaticPropertyContextuallyTypedByItselfNoError1.ts] ////
+
+=== classStaticPropertyContextuallyTypedByItselfNoError1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59271
+
+declare function returnInput<T>(input: T): T;
+>returnInput : Symbol(returnInput, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 0, 0))
+>T : Symbol(T, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 2, 29))
+>input : Symbol(input, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 2, 32))
+>T : Symbol(T, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 2, 29))
+>T : Symbol(T, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 2, 29))
+
+const a = returnInput(
+>a : Symbol(a, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 4, 5))
+>returnInput : Symbol(returnInput, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 0, 0))
+
+  class A {
+>A : Symbol(A, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 4, 22))
+
+    static foo = {};
+>foo : Symbol(A.foo, Decl(classStaticPropertyContextuallyTypedByItselfNoError1.ts, 5, 11))
+
+  },
+);
+

--- a/tests/baselines/reference/classStaticPropertyContextuallyTypedByItselfNoError1.types
+++ b/tests/baselines/reference/classStaticPropertyContextuallyTypedByItselfNoError1.types
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/classStaticPropertyContextuallyTypedByItselfNoError1.ts] ////
+
+=== classStaticPropertyContextuallyTypedByItselfNoError1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59271
+
+declare function returnInput<T>(input: T): T;
+>returnInput : <T>(input: T) => T
+>            : ^ ^^     ^^ ^^^^^ 
+>input : T
+>      : ^
+
+const a = returnInput(
+>a : typeof A
+>  : ^^^^^^^^
+>returnInput(  class A {    static foo = {};  },) : typeof A
+>                                                 : ^^^^^^^^
+>returnInput : <T>(input: T) => T
+>            : ^ ^^     ^^ ^^^^^ 
+
+  class A {
+>class A {    static foo = {};  } : typeof A
+>                                 : ^^^^^^^^
+>A : typeof A
+>  : ^^^^^^^^
+
+    static foo = {};
+>foo : {}
+>    : ^^
+>{} : {}
+>   : ^^
+
+  },
+);
+

--- a/tests/cases/compiler/classStaticPropertyContextuallyTypedByItselfNoError1.ts
+++ b/tests/cases/compiler/classStaticPropertyContextuallyTypedByItselfNoError1.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59271
+
+declare function returnInput<T>(input: T): T;
+
+const a = returnInput(
+  class A {
+    static foo = {};
+  },
+);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59271