### PR TITLE
Fixed crash in `classFields` transform related to broken bodyless constructors

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -2420,7 +2420,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 ),
                 multiLine,
             ),
-            /*location*/ constructor?.body
+            /*location*/ constructor?.body,
         );
     }
 

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -2416,11 +2416,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
             factory.createBlock(
                 setTextRange(
                     factory.createNodeArray(statements),
-                    /*location*/ constructor ? constructor.body!.statements : node.members,
+                    /*location*/ constructor?.body ? constructor.body.statements : node.members,
                 ),
                 multiLine,
             ),
-            /*location*/ constructor ? constructor.body : undefined,
+            /*location*/ constructor?.body
         );
     }
 

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -2416,7 +2416,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
             factory.createBlock(
                 setTextRange(
                     factory.createNodeArray(statements),
-                    /*location*/ constructor?.body ? constructor.body.statements : node.members,
+                    /*location*/ constructor?.body?.statements ?? node.members,
                 ),
                 multiLine,
             ),

--- a/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.errors.txt
+++ b/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.errors.txt
@@ -1,0 +1,14 @@
+classFieldsBrokenConstructorEmitNoCrash1.ts(3,3): error TS2390: Constructor implementation is missing.
+classFieldsBrokenConstructorEmitNoCrash1.ts(4,1): error TS1005: '(' expected.
+
+
+==== classFieldsBrokenConstructorEmitNoCrash1.ts (2 errors) ====
+    class Test {
+      prop = 42;
+      constructor
+      ~~~~~~~~~~~
+!!! error TS2390: Constructor implementation is missing.
+    }
+    ~
+!!! error TS1005: '(' expected.
+    

--- a/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.js
+++ b/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts] ////
+
+//// [classFieldsBrokenConstructorEmitNoCrash1.ts]
+class Test {
+  prop = 42;
+  constructor
+}
+
+
+//// [classFieldsBrokenConstructorEmitNoCrash1.js]
+"use strict";
+class Test {
+    constructor() {
+        this.prop = 42;
+    }
+}

--- a/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.symbols
+++ b/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts] ////
+
+=== classFieldsBrokenConstructorEmitNoCrash1.ts ===
+class Test {
+>Test : Symbol(Test, Decl(classFieldsBrokenConstructorEmitNoCrash1.ts, 0, 0))
+
+  prop = 42;
+>prop : Symbol(Test.prop, Decl(classFieldsBrokenConstructorEmitNoCrash1.ts, 0, 12))
+
+  constructor
+}
+

--- a/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.types
+++ b/tests/baselines/reference/classFieldsBrokenConstructorEmitNoCrash1.types
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts] ////
+
+=== classFieldsBrokenConstructorEmitNoCrash1.ts ===
+class Test {
+>Test : Test
+>     : ^^^^
+
+  prop = 42;
+>prop : number
+>     : ^^^^^^
+>42 : 42
+>   : ^^
+
+  constructor
+}
+

--- a/tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts
+++ b/tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts
@@ -1,4 +1,5 @@
 // @strict: true
+// @useDefineForClassFields: false
 // @target: es2021
 
 class Test {

--- a/tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts
+++ b/tests/cases/compiler/classFieldsBrokenConstructorEmitNoCrash1.ts
@@ -1,0 +1,7 @@
+// @strict: true
+// @target: es2021
+
+class Test {
+  prop = 42;
+  constructor
+}


### PR DESCRIPTION
It's just a crash that I noticed in a console when typing out the code