### PR TITLE
Not filtering return type using generic in generic async function

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31300,11 +31300,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const signature = getContextualSignatureForFunctionLikeDeclaration(functionDecl as FunctionExpression);
         if (signature && !isResolvingReturnTypeOfSignature(signature)) {
             const returnType = getReturnTypeOfSignature(signature);
-            
+
             if (returnType.flags & TypeFlags.Never) {
                 return returnType;
             }
-            
+
             const functionFlags = getFunctionFlags(functionDecl);
             if (functionFlags & FunctionFlags.Generator) {
                 return filterType(returnType, t => {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31308,7 +31308,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             if (functionFlags & FunctionFlags.Async) {
                 return filterType(returnType, t => {
-                    return !!(t.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void | TypeFlags.InstantiableNonPrimitive)) || !!getAwaitedTypeOfPromise(t);
+                    return !!(t.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void | TypeFlags.InstantiableNonPrimitive)) || isGenericType(t) || !!getAwaitedTypeOfPromise(t);
                 });
             }
             return returnType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31300,6 +31300,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const signature = getContextualSignatureForFunctionLikeDeclaration(functionDecl as FunctionExpression);
         if (signature && !isResolvingReturnTypeOfSignature(signature)) {
             const returnType = getReturnTypeOfSignature(signature);
+            
+            if (returnType.flags & TypeFlags.Never) {
+                return returnType;
+            }
+            
             const functionFlags = getFunctionFlags(functionDecl);
             if (functionFlags & FunctionFlags.Generator) {
                 return filterType(returnType, t => {
@@ -31307,9 +31312,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 });
             }
             if (functionFlags & FunctionFlags.Async) {
-                return filterType(returnType, t => {
-                    return !!(t.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void | TypeFlags.InstantiableNonPrimitive)) || isGenericType(t) || !!getAwaitedTypeOfPromise(t);
+                const filtered = filterType(returnType, t => {
+                    return !!(t.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void | TypeFlags.InstantiableNonPrimitive)) || !!getAwaitedTypeOfPromise(t);
                 });
+                return filtered.flags & TypeFlags.Never ? returnType : filtered;
             }
             return returnType;
         }

--- a/tests/baselines/reference/returnTypeWithGenericAsyncFunction.js
+++ b/tests/baselines/reference/returnTypeWithGenericAsyncFunction.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/returnTypeWithGenericAsyncFunction.ts] ////
+
+//// [index.ts]
+type MockFactoryWithHelper<M = unknown> = (
+  importOriginal: <T extends M = M>() => Promise<T>
+) => Partial<Record<keyof M, any>>;
+type PromiseMockFactoryWithHelper<M = unknown> = (
+  importOriginal: <T extends M = M>() => Promise<T>
+) => Promise<Partial<Record<keyof M, any>>>;
+
+const util: {
+  mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void;
+  mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void;
+} = {
+  mock: (() => {}) as any,
+};
+
+util.mock(import("pkg"), async (importOriginal) => ({
+  ...(await importOriginal()),
+}));
+
+//// [import.d.ts]
+export interface ImportInterface {}
+//// [require.d.ts]
+export interface RequireInterface {}
+//// [package.json]
+{
+  "name": "pkg",
+  "version": "0.0.1",
+  "exports": {
+      "import": "./import.js",
+      "require": "./require.js"
+  }
+}
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const util = {
+    mock: (() => { }),
+};
+util.mock(import("pkg"), async (importOriginal) => ({
+    ...(await importOriginal()),
+}));

--- a/tests/baselines/reference/returnTypeWithGenericAsyncFunction.symbols
+++ b/tests/baselines/reference/returnTypeWithGenericAsyncFunction.symbols
@@ -1,0 +1,87 @@
+//// [tests/cases/compiler/returnTypeWithGenericAsyncFunction.ts] ////
+
+=== /index.ts ===
+type MockFactoryWithHelper<M = unknown> = (
+>MockFactoryWithHelper : Symbol(MockFactoryWithHelper, Decl(index.ts, 0, 0))
+>M : Symbol(M, Decl(index.ts, 0, 27))
+
+  importOriginal: <T extends M = M>() => Promise<T>
+>importOriginal : Symbol(importOriginal, Decl(index.ts, 0, 43))
+>T : Symbol(T, Decl(index.ts, 1, 19))
+>M : Symbol(M, Decl(index.ts, 0, 27))
+>M : Symbol(M, Decl(index.ts, 0, 27))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(index.ts, 1, 19))
+
+) => Partial<Record<keyof M, any>>;
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>M : Symbol(M, Decl(index.ts, 0, 27))
+
+type PromiseMockFactoryWithHelper<M = unknown> = (
+>PromiseMockFactoryWithHelper : Symbol(PromiseMockFactoryWithHelper, Decl(index.ts, 2, 35))
+>M : Symbol(M, Decl(index.ts, 3, 34))
+
+  importOriginal: <T extends M = M>() => Promise<T>
+>importOriginal : Symbol(importOriginal, Decl(index.ts, 3, 50))
+>T : Symbol(T, Decl(index.ts, 4, 19))
+>M : Symbol(M, Decl(index.ts, 3, 34))
+>M : Symbol(M, Decl(index.ts, 3, 34))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(index.ts, 4, 19))
+
+) => Promise<Partial<Record<keyof M, any>>>;
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>M : Symbol(M, Decl(index.ts, 3, 34))
+
+const util: {
+>util : Symbol(util, Decl(index.ts, 7, 5))
+
+  mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void;
+>mock : Symbol(mock, Decl(index.ts, 7, 13), Decl(index.ts, 8, 72))
+>T : Symbol(T, Decl(index.ts, 8, 7))
+>module : Symbol(module, Decl(index.ts, 8, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(index.ts, 8, 7))
+>factory : Symbol(factory, Decl(index.ts, 8, 29))
+>MockFactoryWithHelper : Symbol(MockFactoryWithHelper, Decl(index.ts, 0, 0))
+>T : Symbol(T, Decl(index.ts, 8, 7))
+
+  mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void;
+>mock : Symbol(mock, Decl(index.ts, 7, 13), Decl(index.ts, 8, 72))
+>T : Symbol(T, Decl(index.ts, 9, 7))
+>module : Symbol(module, Decl(index.ts, 9, 10))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(index.ts, 9, 7))
+>factory : Symbol(factory, Decl(index.ts, 9, 29))
+>PromiseMockFactoryWithHelper : Symbol(PromiseMockFactoryWithHelper, Decl(index.ts, 2, 35))
+>T : Symbol(T, Decl(index.ts, 9, 7))
+
+} = {
+  mock: (() => {}) as any,
+>mock : Symbol(mock, Decl(index.ts, 10, 5))
+
+};
+
+util.mock(import("pkg"), async (importOriginal) => ({
+>util.mock : Symbol(mock, Decl(index.ts, 7, 13), Decl(index.ts, 8, 72))
+>util : Symbol(util, Decl(index.ts, 7, 5))
+>mock : Symbol(mock, Decl(index.ts, 7, 13), Decl(index.ts, 8, 72))
+>"pkg" : Symbol("/node_modules/pkg/import", Decl(import.d.ts, 0, 0))
+>importOriginal : Symbol(importOriginal, Decl(index.ts, 14, 32))
+
+  ...(await importOriginal()),
+>importOriginal : Symbol(importOriginal, Decl(index.ts, 14, 32))
+
+}));
+
+=== /node_modules/pkg/import.d.ts ===
+export interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
+
+=== /node_modules/pkg/require.d.ts ===
+export interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
+

--- a/tests/baselines/reference/returnTypeWithGenericAsyncFunction.types
+++ b/tests/baselines/reference/returnTypeWithGenericAsyncFunction.types
@@ -1,0 +1,96 @@
+//// [tests/cases/compiler/returnTypeWithGenericAsyncFunction.ts] ////
+
+=== /index.ts ===
+type MockFactoryWithHelper<M = unknown> = (
+>MockFactoryWithHelper : MockFactoryWithHelper<M>
+>                      : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  importOriginal: <T extends M = M>() => Promise<T>
+>importOriginal : <T extends M = M>() => Promise<T>
+>               : ^ ^^^^^^^^^ ^^^^^^^^^^^          
+
+) => Partial<Record<keyof M, any>>;
+type PromiseMockFactoryWithHelper<M = unknown> = (
+>PromiseMockFactoryWithHelper : PromiseMockFactoryWithHelper<M>
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  importOriginal: <T extends M = M>() => Promise<T>
+>importOriginal : <T extends M = M>() => Promise<T>
+>               : ^ ^^^^^^^^^ ^^^^^^^^^^^          
+
+) => Promise<Partial<Record<keyof M, any>>>;
+
+const util: {
+>util : { mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void; mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void; }
+>     : ^^^^^^^ ^^      ^^          ^^       ^^^                        ^^^    ^^^^^^^ ^^      ^^          ^^       ^^^                               ^^^    ^^^
+
+  mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void;
+>mock : { <T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void; <T_1>(module: Promise<T_1>, factory?: PromiseMockFactoryWithHelper<T_1>): void; }
+>     : ^^^ ^^      ^^          ^^       ^^^                        ^^^    ^^^^^^^^      ^^            ^^       ^^^                                 ^^^    ^^^
+>module : Promise<T>
+>       : ^^^^^^^^^^
+>factory : MockFactoryWithHelper<T>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void;
+>mock : { <T_1>(module: Promise<T_1>, factory?: MockFactoryWithHelper<T_1>): void; <T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void; }
+>     : ^^^^^^^^      ^^            ^^       ^^^                          ^^^    ^^^ ^^      ^^          ^^       ^^^                               ^^^    ^^^
+>module : Promise<T>
+>       : ^^^^^^^^^^
+>factory : PromiseMockFactoryWithHelper<T>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+} = {
+>{  mock: (() => {}) as any,} : { mock: any; }
+>                             : ^^^^^^^^   ^^^
+
+  mock: (() => {}) as any,
+>mock : any
+>(() => {}) as any : any
+>(() => {}) : () => void
+>           : ^^^^^^^^^^
+>() => {} : () => void
+>         : ^^^^^^^^^^
+
+};
+
+util.mock(import("pkg"), async (importOriginal) => ({
+>util.mock(import("pkg"), async (importOriginal) => ({  ...(await importOriginal()),})) : void
+>                                                                                       : ^^^^
+>util.mock : { <T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void; <T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void; }
+>          : ^^^ ^^      ^^          ^^       ^^^                        ^^^    ^^^ ^^      ^^          ^^       ^^^                               ^^^    ^^^
+>util : { mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void; mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void; }
+>     : ^^^^^^^ ^^      ^^          ^^       ^^^                        ^^^    ^^^^^^^ ^^      ^^          ^^       ^^^                               ^^^    ^^^
+>mock : { <T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void; <T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void; }
+>     : ^^^ ^^      ^^          ^^       ^^^                        ^^^    ^^^ ^^      ^^          ^^       ^^^                               ^^^    ^^^
+>import("pkg") : Promise<{ default: typeof import("/node_modules/pkg/import"); }>
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"pkg" : "pkg"
+>      : ^^^^^
+>async (importOriginal) => ({  ...(await importOriginal()),}) : (importOriginal: <T extends { default: typeof import("/node_modules/pkg/import"); } = { default: typeof import("/node_modules/pkg/import"); }>() => Promise<T>) => Promise<{ default?: any; }>
+>                                                             : ^              ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>importOriginal : <T extends { default: typeof import("/node_modules/pkg/import"); } = { default: typeof import("/node_modules/pkg/import"); }>() => Promise<T>
+>               : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>({  ...(await importOriginal()),}) : { default?: any; }
+>                                   : ^^^^^^^^^^^^^^^^^^
+>{  ...(await importOriginal()),} : { default?: any; }
+>                                 : ^^^^^^^^^^^^^^^^^^
+
+  ...(await importOriginal()),
+>(await importOriginal()) : Partial<Record<"default", any>>
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>await importOriginal() : Partial<Record<"default", any>>
+>                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>importOriginal() : Promise<Partial<Record<"default", any>>>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>importOriginal : <T extends { default: typeof import("/node_modules/pkg/import"); } = { default: typeof import("/node_modules/pkg/import"); }>() => Promise<T>
+>               : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+}));
+
+=== /node_modules/pkg/import.d.ts ===
+
+export interface ImportInterface {}
+=== /node_modules/pkg/require.d.ts ===
+
+export interface RequireInterface {}

--- a/tests/cases/compiler/returnTypeWithGenericAsyncFunction.ts
+++ b/tests/cases/compiler/returnTypeWithGenericAsyncFunction.ts
@@ -1,0 +1,35 @@
+// @module: nodenext
+// @target: esnext
+// @outDir: out
+// @filename: /index.ts
+type MockFactoryWithHelper<M = unknown> = (
+  importOriginal: <T extends M = M>() => Promise<T>
+) => Partial<Record<keyof M, any>>;
+type PromiseMockFactoryWithHelper<M = unknown> = (
+  importOriginal: <T extends M = M>() => Promise<T>
+) => Promise<Partial<Record<keyof M, any>>>;
+
+const util: {
+  mock<T>(module: Promise<T>, factory?: MockFactoryWithHelper<T>): void;
+  mock<T>(module: Promise<T>, factory?: PromiseMockFactoryWithHelper<T>): void;
+} = {
+  mock: (() => {}) as any,
+};
+
+util.mock(import("pkg"), async (importOriginal) => ({
+  ...(await importOriginal()),
+}));
+
+// @filename: /node_modules/pkg/import.d.ts
+export interface ImportInterface {}
+// @filename: /node_modules/pkg/require.d.ts
+export interface RequireInterface {}
+// @filename: /node_modules/pkg/package.json
+{
+  "name": "pkg",
+  "version": "0.0.1",
+  "exports": {
+      "import": "./import.js",
+      "require": "./require.js"
+  }
+}


### PR DESCRIPTION
Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

This issue created by https://github.com/microsoft/TypeScript/pull/51196/files#diff-d9ab6589e714c71e657f601cf30ff51dfc607fc98419bf72e04f6b0fa92cc4b8R29780-R29792

Fixes #59281
