### PR TITLE
Verify that perf_hooks result actually contains the performance object

### DIFF
--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -31,11 +31,14 @@ function tryGetPerformance() {
     if (isNodeLikeSystem()) {
         try {
             // By default, only write native events when generating a cpu profile or using the v8 profiler.
-            const { performance } = require("perf_hooks") as typeof import("perf_hooks");
-            return {
-                shouldWriteNativeEvents: false,
-                performance,
-            };
+            // Some environments may polyfill this module with an empty object; verify the object has the expected shape.
+            const { performance } = require("perf_hooks") as Partial<typeof import("perf_hooks")>;
+            if (performance) {
+                return {
+                    shouldWriteNativeEvents: false,
+                    performance,
+                };
+            }
         }
         catch {
             // ignore errors


### PR DESCRIPTION
I guess some environments polyfill this with `{}` or something. Only use the module if `performance` is there. This broke in #57875.

Fixes #59296