### PR TITLE
Fix: tsc -w is losing working directory in macOS Terminal

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1604,7 +1604,11 @@ export let sys: System = (() => {
             setTimeout,
             clearTimeout,
             clearScreen: () => {
-                process.stdout.write("\x1Bc");
+                process.stdout.write(
+                    platform === "win32"
+                        ? "\u001B[2J\u001B[0f"
+                        : "\u001B[2J\u001B[3J\u001B[H",
+                );
             },
             setBlocking: () => {
                 const handle = (process.stdout as any)?._handle as { setBlocking?: (value: boolean) => void; };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57894.

See [this comment](https://github.com/microsoft/TypeScript/issues/57894#issuecomment-2227449140) for the detailed explanation of the fix.

The escape sequences are taken from [Jest](https://github.com/jestjs/jest/blob/cce44d767e5e1d5c62eaaf5f93fb73748c25266b/packages/jest-util/src/specialChars.ts#L18-L20) that doesn't have the same issue.
