### PR TITLE
Add environment variable to disable recursive watchDirectory tests

### DIFF
--- a/src/testRunner/unittests/sys/symlinkWatching.ts
+++ b/src/testRunner/unittests/sys/symlinkWatching.ts
@@ -713,7 +713,7 @@ describe("unittests:: sys:: symlinkWatching::", () => {
         });
 
         if (osFlavor !== TestServerHostOsFlavor.Linux) {
-            describe("recursive watchDirectory using fsEvents", () => {
+            (process?.env.NO_RECURSIVE_WATCHDIRECTORY_TESTS ? describe.skip : describe)("recursive watchDirectory using fsEvents", () => {
                 before(() => {
                     setupRecursiveFsEvents("recursivefsevents");
                     setupRecursiveFsEvents("recursivefseventssub");


### PR DESCRIPTION
One of the `symlinkWatching` tests does not appear to be reliable on Windows 11. This changes the tests to be run conditionally based on the presence or absence of a `NO_RECURSIVE_WATCHDIRECTORY_TESTS` environment variable until such time as we can determine the cause.

When `NO_RECURSIVE_WATCHDIRECTORY_TESTS` is set, it marks the test suite as "skipped" so that the related tests are reported as "pending" in the results.