### PR TITLE
consistently check for >, >=, <, <= for unconstrained types with strictNullChecks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27493,6 +27493,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return type === unknownUnionType ? unknownType : type;
     }
 
+    // use to determine if a parameter may be undefined or null (or is unknown/unconstrained)
+    function getUnknownIfMaybeUnknown(type: Type) {
+        return (strictNullChecks && type.flags & TypeFlags.Instantiable) ? getBaseConstraintOfType(type) || unknownType : type;
+    }
+
     function getTypeWithDefault(type: Type, defaultExpression: Expression) {
         return defaultExpression ?
             getUnionType([getNonUndefinedType(type), getTypeOfExpression(defaultExpression)]) :
@@ -39677,8 +39682,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.LessThanEqualsToken:
             case SyntaxKind.GreaterThanEqualsToken:
                 if (checkForDisallowedESSymbolOperand(operator)) {
-                    leftType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(leftType, left));
-                    rightType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(rightType, right));
+
+                    leftType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(getUnknownIfMaybeUnknown(leftType), left));
+                    rightType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(getUnknownIfMaybeUnknown(rightType), right));
                     reportOperatorErrorUnless((left, right) => {
                         if (isTypeAny(left) || isTypeAny(right)) {
                             return true;

--- a/tests/baselines/reference/unconstrainedTypeComparison.errors.txt
+++ b/tests/baselines/reference/unconstrainedTypeComparison.errors.txt
@@ -1,0 +1,109 @@
+unconstrainedTypeComparison.ts(2,12): error TS18046: 'a' is of type 'unknown'.
+unconstrainedTypeComparison.ts(2,16): error TS18046: 'b' is of type 'unknown'.
+unconstrainedTypeComparison.ts(6,12): error TS18049: 'a' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(6,16): error TS18049: 'b' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(10,12): error TS18046: 'a' is of type 'unknown'.
+unconstrainedTypeComparison.ts(10,16): error TS18046: 'b' is of type 'unknown'.
+unconstrainedTypeComparison.ts(14,12): error TS18046: 'a' is of type 'unknown'.
+unconstrainedTypeComparison.ts(14,16): error TS18046: 'b' is of type 'unknown'.
+unconstrainedTypeComparison.ts(18,12): error TS18049: 'a' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(18,16): error TS18049: 'b' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(22,12): error TS18046: 'a' is of type 'unknown'.
+unconstrainedTypeComparison.ts(22,16): error TS18046: 'b' is of type 'unknown'.
+unconstrainedTypeComparison.ts(26,12): error TS18048: 'a' is possibly 'undefined'.
+unconstrainedTypeComparison.ts(26,16): error TS18048: 'b' is possibly 'undefined'.
+unconstrainedTypeComparison.ts(30,12): error TS18047: 'a' is possibly 'null'.
+unconstrainedTypeComparison.ts(30,16): error TS18047: 'b' is possibly 'null'.
+unconstrainedTypeComparison.ts(34,12): error TS18049: 'a' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(34,16): error TS18049: 'b' is possibly 'null' or 'undefined'.
+unconstrainedTypeComparison.ts(45,12): error TS18047: 'a' is possibly 'null'.
+unconstrainedTypeComparison.ts(45,16): error TS18048: 'b' is possibly 'undefined'.
+
+
+==== unconstrainedTypeComparison.ts (20 errors) ====
+    function f1<T>(a: T, b: T): boolean {
+        return a > b;
+               ~
+!!! error TS18046: 'a' is of type 'unknown'.
+                   ~
+!!! error TS18046: 'b' is of type 'unknown'.
+    }
+    
+    function f2<T extends {} | undefined | null>(a: T, b: T): boolean {
+        return a > b;
+               ~
+!!! error TS18049: 'a' is possibly 'null' or 'undefined'.
+                   ~
+!!! error TS18049: 'b' is possibly 'null' or 'undefined'.
+    }
+    
+    function f3<T extends unknown>(a: T, b: T): boolean {
+        return a > b;
+               ~
+!!! error TS18046: 'a' is of type 'unknown'.
+                   ~
+!!! error TS18046: 'b' is of type 'unknown'.
+    }
+    
+    function f4<T, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18046: 'a' is of type 'unknown'.
+                   ~
+!!! error TS18046: 'b' is of type 'unknown'.
+    }
+    
+    function f5<T extends {} | undefined | null, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18049: 'a' is possibly 'null' or 'undefined'.
+                   ~
+!!! error TS18049: 'b' is possibly 'null' or 'undefined'.
+    }
+    
+    function f6<T extends unknown, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18046: 'a' is of type 'unknown'.
+                   ~
+!!! error TS18046: 'b' is of type 'unknown'.
+    }
+    
+    function f7<T extends {} | undefined, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18048: 'a' is possibly 'undefined'.
+                   ~
+!!! error TS18048: 'b' is possibly 'undefined'.
+    }
+    
+    function f8<T extends {} | null, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18047: 'a' is possibly 'null'.
+                   ~
+!!! error TS18047: 'b' is possibly 'null'.
+    }
+    
+    function f9<T extends undefined | null, U extends T>(a: U, b: U): boolean {
+        return a > b;
+               ~
+!!! error TS18049: 'a' is possibly 'null' or 'undefined'.
+                   ~
+!!! error TS18049: 'b' is possibly 'null' or 'undefined'.
+    }
+    
+    
+    function compare<T>(a: T, b: T): boolean {
+        if (a === undefined) {
+            return false;
+        }
+        if (b === null) {
+            return false;
+        }
+        return a > b;
+               ~
+!!! error TS18047: 'a' is possibly 'null'.
+                   ~
+!!! error TS18048: 'b' is possibly 'undefined'.
+    }

--- a/tests/baselines/reference/unconstrainedTypeComparison.symbols
+++ b/tests/baselines/reference/unconstrainedTypeComparison.symbols
@@ -1,0 +1,156 @@
+//// [tests/cases/compiler/unconstrainedTypeComparison.ts] ////
+
+=== unconstrainedTypeComparison.ts ===
+function f1<T>(a: T, b: T): boolean {
+>f1 : Symbol(f1, Decl(unconstrainedTypeComparison.ts, 0, 0))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 0, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 0, 15))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 0, 12))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 0, 20))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 0, 12))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 0, 15))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 0, 20))
+}
+
+function f2<T extends {} | undefined | null>(a: T, b: T): boolean {
+>f2 : Symbol(f2, Decl(unconstrainedTypeComparison.ts, 2, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 4, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 4, 45))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 4, 12))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 4, 50))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 4, 12))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 4, 45))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 4, 50))
+}
+
+function f3<T extends unknown>(a: T, b: T): boolean {
+>f3 : Symbol(f3, Decl(unconstrainedTypeComparison.ts, 6, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 8, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 8, 31))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 8, 12))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 8, 36))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 8, 12))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 8, 31))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 8, 36))
+}
+
+function f4<T, U extends T>(a: U, b: U): boolean {
+>f4 : Symbol(f4, Decl(unconstrainedTypeComparison.ts, 10, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 12, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 12, 14))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 12, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 12, 28))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 12, 14))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 12, 33))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 12, 14))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 12, 28))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 12, 33))
+}
+
+function f5<T extends {} | undefined | null, U extends T>(a: U, b: U): boolean {
+>f5 : Symbol(f5, Decl(unconstrainedTypeComparison.ts, 14, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 16, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 16, 44))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 16, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 16, 58))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 16, 44))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 16, 63))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 16, 44))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 16, 58))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 16, 63))
+}
+
+function f6<T extends unknown, U extends T>(a: U, b: U): boolean {
+>f6 : Symbol(f6, Decl(unconstrainedTypeComparison.ts, 18, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 20, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 20, 30))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 20, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 20, 44))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 20, 30))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 20, 49))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 20, 30))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 20, 44))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 20, 49))
+}
+
+function f7<T extends {} | undefined, U extends T>(a: U, b: U): boolean {
+>f7 : Symbol(f7, Decl(unconstrainedTypeComparison.ts, 22, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 24, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 24, 37))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 24, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 24, 51))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 24, 37))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 24, 56))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 24, 37))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 24, 51))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 24, 56))
+}
+
+function f8<T extends {} | null, U extends T>(a: U, b: U): boolean {
+>f8 : Symbol(f8, Decl(unconstrainedTypeComparison.ts, 26, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 28, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 28, 32))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 28, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 28, 46))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 28, 32))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 28, 51))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 28, 32))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 28, 46))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 28, 51))
+}
+
+function f9<T extends undefined | null, U extends T>(a: U, b: U): boolean {
+>f9 : Symbol(f9, Decl(unconstrainedTypeComparison.ts, 30, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 32, 12))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 32, 39))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 32, 12))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 32, 53))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 32, 39))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 32, 58))
+>U : Symbol(U, Decl(unconstrainedTypeComparison.ts, 32, 39))
+
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 32, 53))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 32, 58))
+}
+
+
+function compare<T>(a: T, b: T): boolean {
+>compare : Symbol(compare, Decl(unconstrainedTypeComparison.ts, 34, 1))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 37, 17))
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 37, 20))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 37, 17))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 37, 25))
+>T : Symbol(T, Decl(unconstrainedTypeComparison.ts, 37, 17))
+
+    if (a === undefined) {
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 37, 20))
+>undefined : Symbol(undefined)
+
+        return false;
+    }
+    if (b === null) {
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 37, 25))
+
+        return false;
+    }
+    return a > b;
+>a : Symbol(a, Decl(unconstrainedTypeComparison.ts, 37, 20))
+>b : Symbol(b, Decl(unconstrainedTypeComparison.ts, 37, 25))
+}

--- a/tests/baselines/reference/unconstrainedTypeComparison.types
+++ b/tests/baselines/reference/unconstrainedTypeComparison.types
@@ -1,0 +1,195 @@
+//// [tests/cases/compiler/unconstrainedTypeComparison.ts] ////
+
+=== unconstrainedTypeComparison.ts ===
+function f1<T>(a: T, b: T): boolean {
+>f1 : <T>(a: T, b: T) => boolean
+>   : ^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+}
+
+function f2<T extends {} | undefined | null>(a: T, b: T): boolean {
+>f2 : <T extends {} | undefined | null>(a: T, b: T) => boolean
+>   : ^ ^^^^^^^^^                     ^^ ^^ ^^ ^^ ^^^^^       
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+}
+
+function f3<T extends unknown>(a: T, b: T): boolean {
+>f3 : <T extends unknown>(a: T, b: T) => boolean
+>   : ^ ^^^^^^^^^       ^^ ^^ ^^ ^^ ^^^^^       
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+}
+
+function f4<T, U extends T>(a: U, b: U): boolean {
+>f4 : <T, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+function f5<T extends {} | undefined | null, U extends T>(a: U, b: U): boolean {
+>f5 : <T extends {} | undefined | null, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^^^^^^^^                     ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+function f6<T extends unknown, U extends T>(a: U, b: U): boolean {
+>f6 : <T extends unknown, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^^^^^^^^       ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+function f7<T extends {} | undefined, U extends T>(a: U, b: U): boolean {
+>f7 : <T extends {} | undefined, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^^^^^^^^              ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+function f8<T extends {} | null, U extends T>(a: U, b: U): boolean {
+>f8 : <T extends {} | null, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^^^^^^^^         ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+function f9<T extends undefined | null, U extends T>(a: U, b: U): boolean {
+>f9 : <T extends undefined | null, U extends T>(a: U, b: U) => boolean
+>   : ^ ^^^^^^^^^                ^^ ^^^^^^^^^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : U
+>  : ^
+>b : U
+>  : ^
+
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : U
+>  : ^
+>b : U
+>  : ^
+}
+
+
+function compare<T>(a: T, b: T): boolean {
+>compare : <T>(a: T, b: T) => boolean
+>        : ^ ^^ ^^ ^^ ^^ ^^^^^       
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+    if (a === undefined) {
+>a === undefined : boolean
+>                : ^^^^^^^
+>a : T
+>  : ^
+>undefined : undefined
+>          : ^^^^^^^^^
+
+        return false;
+>false : false
+>      : ^^^^^
+    }
+    if (b === null) {
+>b === null : boolean
+>           : ^^^^^^^
+>b : T
+>  : ^
+
+        return false;
+>false : false
+>      : ^^^^^
+    }
+    return a > b;
+>a > b : boolean
+>      : ^^^^^^^
+>a : T & ({} | null)
+>  : ^^^^^^^^^^^^^^^
+>b : T & ({} | undefined)
+>  : ^^^^^^^^^^^^^^^^^^^^
+}

--- a/tests/cases/compiler/unconstrainedTypeComparison.ts
+++ b/tests/cases/compiler/unconstrainedTypeComparison.ts
@@ -1,0 +1,50 @@
+
+// @strict: true
+// @noemit: true
+
+function f1<T>(a: T, b: T): boolean {
+    return a > b;
+}
+
+function f2<T extends {} | undefined | null>(a: T, b: T): boolean {
+    return a > b;
+}
+
+function f3<T extends unknown>(a: T, b: T): boolean {
+    return a > b;
+}
+
+function f4<T, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+function f5<T extends {} | undefined | null, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+function f6<T extends unknown, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+function f7<T extends {} | undefined, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+function f8<T extends {} | null, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+function f9<T extends undefined | null, U extends T>(a: U, b: U): boolean {
+    return a > b;
+}
+
+
+function compare<T>(a: T, b: T): boolean {
+    if (a === undefined) {
+        return false;
+    }
+    if (b === null) {
+        return false;
+    }
+    return a > b;
+}


### PR DESCRIPTION
fixes #50603, which bisected to #49119

Previously: unconstrained type parameters were inconsistently checked in comparisons, as shown below (5.5.3 [playground](https://www.typescriptlang.org/play/?ts=5.5.3#code/GYVwdgxgLglg9mABMOcA8AVAfACgIYBciGANIgEZEYCUiA3gFCLOIBOAplCK0nluQG4GAXwZjQkWAmSoATJkTsAHlHZgAJgGdE4ANZg4AdzC5CxMpWK1GLNp269+Q0ePDR4SFHADMC5ao1tOmFEAB9EMBAAGyiwnQ12YBgwdnVTKgsqayYWDi4eRD5BESA)): 
```typescript
function f<T>(a: T, b: T) {
   return a > b; \\ okay
}

function g<T extends {} | undefined | null>(a: T, b: T) {
   return a > b; \\ error!! 
      \\ 'a' is possibly 'null' or 'undefined'.ts(18049)
      \\ 'b' is possibly 'null' or 'undefined'.ts(18049)
}
```
That would allow us to write `f(undefined, undefined)` 

Now:

```typescript
    function f1<T>(a: T, b: T): boolean {
        return a > b;
               ~
!!! error TS18046: 'a' is of type 'unknown'.
                   ~
!!! error TS18046: 'b' is of type 'unknown'.
    }
    
    function f2<T extends {} | undefined | null>(a: T, b: T): boolean {
        return a > b;
               ~
!!! error TS18049: 'a' is possibly 'null' or 'undefined'.
                   ~
!!! error TS18049: 'b' is possibly 'null' or 'undefined'.
    }    
```
This PR does not affect the checking of unconstrained types in other locations.
