### PR TITLE
Make sure the script is only attached to project during createProgram execution

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -713,7 +713,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                 // This was missing path earlier but now the file exists. Update the root
                 existingValue.info = scriptInfo;
             }
-            if (!this.languageService.getCurrentProgram()) {
+            if (!this.languageService.getCurrentProgram(false)) {
                 // Make sure the script is only attached to project during createProgram execution
                 scriptInfo.attachToProject(this);
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -713,7 +713,10 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                 // This was missing path earlier but now the file exists. Update the root
                 existingValue.info = scriptInfo;
             }
-            scriptInfo.attachToProject(this);
+            if (!this.languageService.getCurrentProgram()) {
+                // Make sure the script is only attached to project during createProgram execution
+                scriptInfo.attachToProject(this);
+            }
         }
         return scriptInfo;
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -713,7 +713,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                 // This was missing path earlier but now the file exists. Update the root
                 existingValue.info = scriptInfo;
             }
-            if (!this.languageService.getCurrentProgram(false)) {
+            if (!this.languageService.getCurrentProgram(/*acceptOutdatedProgram*/ false)) {
                 // Make sure the script is only attached to project during createProgram execution
                 scriptInfo.attachToProject(this);
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -713,8 +713,9 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                 // This was missing path earlier but now the file exists. Update the root
                 existingValue.info = scriptInfo;
             }
-            if (!this.languageService.getCurrentProgram(/*acceptOutdatedProgram*/ false)) {
-                // Make sure the script is only attached to project during createProgram execution
+            // Make sure the script is only attached to project during createProgram execution
+            const creatingProgram = !this.languageService.getCurrentProgram(/*acceptOutdatedProgram*/ false);
+            if (creatingProgram) {
                 scriptInfo.attachToProject(this);
             }
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1816,6 +1816,7 @@ export function createLanguageService(
             oldProgram: program,
             projectReferences,
         };
+        program = undefined!;
         program = createProgram(options);
 
         // 'getOrCreateSourceFile' depends on caching but should be used past this point.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1633,6 +1633,7 @@ export function createLanguageService(
 
     const syntaxTreeCache: SyntaxTreeCache = new SyntaxTreeCache(host);
     let program: Program;
+    let creatingProgram = false;
     let lastProjectVersion: string;
     let lastTypesRootVersion = 0;
 
@@ -1816,8 +1817,9 @@ export function createLanguageService(
             oldProgram: program,
             projectReferences,
         };
-        program = undefined!;
+        creatingProgram = true;
         program = createProgram(options);
+        creatingProgram = false;
 
         // 'getOrCreateSourceFile' depends on caching but should be used past this point.
         // After this point, the cache needs to be cleared to allow all collected snapshots to be released
@@ -3397,7 +3399,12 @@ export function createLanguageService(
         getEmitOutput,
         getNonBoundSourceFile,
         getProgram,
-        getCurrentProgram: () => program,
+        getCurrentProgram: (acceptOutdatedProgram = true) => {
+            if (!acceptOutdatedProgram && creatingProgram) {
+                return undefined;
+            }
+            return program;
+        },
         getAutoImportProvider,
         updateIsDefinitionOfReferencedSymbols,
         getApplicableRefactors,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -679,7 +679,7 @@ export interface LanguageService {
     getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean, forceDtsEmit?: boolean): EmitOutput;
 
     getProgram(): Program | undefined;
-    /** @internal */ getCurrentProgram(): Program | undefined;
+    /** @internal */ getCurrentProgram(acceptOutdatedProgram?: boolean): Program | undefined;
 
     /** @internal */ getNonBoundSourceFile(fileName: string): SourceFile;
     /** @internal */ getAutoImportProvider(): Program | undefined;


### PR DESCRIPTION
Fixes #59349

Refer to https://github.com/microsoft/TypeScript/issues/59349#issuecomment-2237627259.

> This should not be called anytime except when creating program and attaching files into the program as this one ensures project and LS are in sync with respect to files and scriptinfos in the program.

This PR adds conditions to `attachToProject` to cover this assumption.