### PR TITLE
Disallow number type from being assignable to enums with known literal members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21536,10 +21536,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (s & TypeFlags.Object && t & TypeFlags.NonPrimitive && !(relation === strictSubtypeRelation && isEmptyAnonymousObjectType(source) && !(getObjectFlags(source) & ObjectFlags.FreshLiteral))) return true;
         if (relation === assignableRelation || relation === comparableRelation) {
             if (s & TypeFlags.Any) return true;
-            // Type number is assignable to any computed numeric enum type or any numeric enum literal type, and
+            // Type number is assignable to any computed numeric enum type, and
             // a numeric literal type is assignable any computed numeric enum type or any numeric enum literal type
-            // with a matching value. These rules exist such that enums can be used for bit-flag purposes.
-            if (s & TypeFlags.Number && (t & TypeFlags.Enum || t & TypeFlags.NumberLiteral && t & TypeFlags.EnumLiteral)) return true;
+            // with a matching value.
+            if (s & TypeFlags.Number && t & TypeFlags.Enum) return true;
             if (
                 s & TypeFlags.NumberLiteral && !(s & TypeFlags.EnumLiteral) && (t & TypeFlags.Enum ||
                     t & TypeFlags.NumberLiteral && t & TypeFlags.EnumLiteral &&

--- a/tests/baselines/reference/compoundAdditionAssignmentLHSCanBeAssigned.errors.txt
+++ b/tests/baselines/reference/compoundAdditionAssignmentLHSCanBeAssigned.errors.txt
@@ -1,10 +1,12 @@
 compoundAdditionAssignmentLHSCanBeAssigned.ts(32,1): error TS2365: Operator '+=' cannot be applied to types 'number' and 'null'.
 compoundAdditionAssignmentLHSCanBeAssigned.ts(33,1): error TS2365: Operator '+=' cannot be applied to types 'number' and 'undefined'.
+compoundAdditionAssignmentLHSCanBeAssigned.ts(37,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundAdditionAssignmentLHSCanBeAssigned.ts(38,1): error TS2322: Type 'number' is not assignable to type 'E'.
 compoundAdditionAssignmentLHSCanBeAssigned.ts(39,1): error TS2365: Operator '+=' cannot be applied to types 'E' and 'null'.
 compoundAdditionAssignmentLHSCanBeAssigned.ts(40,1): error TS2365: Operator '+=' cannot be applied to types 'E' and 'undefined'.
 
 
-==== compoundAdditionAssignmentLHSCanBeAssigned.ts (4 errors) ====
+==== compoundAdditionAssignmentLHSCanBeAssigned.ts (6 errors) ====
     enum E { a, b }
     
     var a: any;
@@ -46,7 +48,11 @@ compoundAdditionAssignmentLHSCanBeAssigned.ts(40,1): error TS2365: Operator '+='
     var x4: E;
     x4 += a;
     x4 += 0;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x4 += E.a;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x4 += null;
     ~~~~~~~~~~
 !!! error TS2365: Operator '+=' cannot be applied to types 'E' and 'null'.

--- a/tests/baselines/reference/compoundArithmeticAssignmentLHSCanBeAssigned.errors.txt
+++ b/tests/baselines/reference/compoundArithmeticAssignmentLHSCanBeAssigned.errors.txt
@@ -2,11 +2,16 @@ compoundArithmeticAssignmentLHSCanBeAssigned.ts(11,7): error TS18050: The value 
 compoundArithmeticAssignmentLHSCanBeAssigned.ts(12,7): error TS18050: The value 'undefined' cannot be used here.
 compoundArithmeticAssignmentLHSCanBeAssigned.ts(18,7): error TS18050: The value 'null' cannot be used here.
 compoundArithmeticAssignmentLHSCanBeAssigned.ts(19,7): error TS18050: The value 'undefined' cannot be used here.
+compoundArithmeticAssignmentLHSCanBeAssigned.ts(22,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundArithmeticAssignmentLHSCanBeAssigned.ts(23,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundArithmeticAssignmentLHSCanBeAssigned.ts(24,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundArithmeticAssignmentLHSCanBeAssigned.ts(25,1): error TS2322: Type 'number' is not assignable to type 'E'.
 compoundArithmeticAssignmentLHSCanBeAssigned.ts(25,7): error TS18050: The value 'null' cannot be used here.
+compoundArithmeticAssignmentLHSCanBeAssigned.ts(26,1): error TS2322: Type 'number' is not assignable to type 'E'.
 compoundArithmeticAssignmentLHSCanBeAssigned.ts(26,7): error TS18050: The value 'undefined' cannot be used here.
 
 
-==== compoundArithmeticAssignmentLHSCanBeAssigned.ts (6 errors) ====
+==== compoundArithmeticAssignmentLHSCanBeAssigned.ts (11 errors) ====
     enum E { a, b, c }
     
     var a: any;
@@ -37,11 +42,21 @@ compoundArithmeticAssignmentLHSCanBeAssigned.ts(26,7): error TS18050: The value 
     
     var x3: E;
     x3 *= a;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 *= b;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 *= c;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 *= null;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
           ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     x3 *= undefined;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
           ~~~~~~~~~
 !!! error TS18050: The value 'undefined' cannot be used here.

--- a/tests/baselines/reference/compoundExponentiationAssignmentLHSCanBeAssigned1.errors.txt
+++ b/tests/baselines/reference/compoundExponentiationAssignmentLHSCanBeAssigned1.errors.txt
@@ -2,11 +2,16 @@ compoundExponentiationAssignmentLHSCanBeAssigned1.ts(11,8): error TS18050: The v
 compoundExponentiationAssignmentLHSCanBeAssigned1.ts(12,8): error TS18050: The value 'undefined' cannot be used here.
 compoundExponentiationAssignmentLHSCanBeAssigned1.ts(18,8): error TS18050: The value 'null' cannot be used here.
 compoundExponentiationAssignmentLHSCanBeAssigned1.ts(19,8): error TS18050: The value 'undefined' cannot be used here.
+compoundExponentiationAssignmentLHSCanBeAssigned1.ts(22,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundExponentiationAssignmentLHSCanBeAssigned1.ts(23,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundExponentiationAssignmentLHSCanBeAssigned1.ts(24,1): error TS2322: Type 'number' is not assignable to type 'E'.
+compoundExponentiationAssignmentLHSCanBeAssigned1.ts(25,1): error TS2322: Type 'number' is not assignable to type 'E'.
 compoundExponentiationAssignmentLHSCanBeAssigned1.ts(25,8): error TS18050: The value 'null' cannot be used here.
+compoundExponentiationAssignmentLHSCanBeAssigned1.ts(26,1): error TS2322: Type 'number' is not assignable to type 'E'.
 compoundExponentiationAssignmentLHSCanBeAssigned1.ts(26,8): error TS18050: The value 'undefined' cannot be used here.
 
 
-==== compoundExponentiationAssignmentLHSCanBeAssigned1.ts (6 errors) ====
+==== compoundExponentiationAssignmentLHSCanBeAssigned1.ts (11 errors) ====
     enum E { a, b, c }
     
     var a: any;
@@ -37,11 +42,21 @@ compoundExponentiationAssignmentLHSCanBeAssigned1.ts(26,8): error TS18050: The v
     
     var x3: E;
     x3 **= a;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 **= b;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 **= c;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     x3 **= null;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
            ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     x3 **= undefined;
+    ~~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
            ~~~~~~~~~
 !!! error TS18050: The value 'undefined' cannot be used here.

--- a/tests/baselines/reference/enumAssignmentCompat5.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat5.errors.txt
@@ -1,9 +1,13 @@
+enumAssignmentCompat5.ts(10,5): error TS2322: Type 'number' is not assignable to type 'E'.
 enumAssignmentCompat5.ts(12,1): error TS2322: Type '4' is not assignable to type 'E'.
 enumAssignmentCompat5.ts(14,1): error TS2322: Type '2' is not assignable to type 'E.A'.
+enumAssignmentCompat5.ts(15,1): error TS2322: Type 'number' is not assignable to type 'E.A'.
+enumAssignmentCompat5.ts(17,5): error TS2322: Type 'number' is not assignable to type 'Computed'.
+enumAssignmentCompat5.ts(18,1): error TS2322: Type 'number' is not assignable to type 'Computed'.
 enumAssignmentCompat5.ts(20,5): error TS2322: Type '1' is not assignable to type 'Computed.A'.
 
 
-==== enumAssignmentCompat5.ts (3 errors) ====
+==== enumAssignmentCompat5.ts (7 errors) ====
     enum E {
         A, B, C
     }
@@ -13,24 +17,29 @@ enumAssignmentCompat5.ts(20,5): error TS2322: Type '1' is not assignable to type
         C = 1 << 3,
     }
     let n: number;
-    let e: E = n; // ok because it's too inconvenient otherwise
+    let e: E = n; // error
+        ~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     e = 0; // ok, in range
-    e = 4; // ok, out of range, but allowed computed enums don't have all members
+    e = 4; // error, out of range, allowed computed enums don't have all members
     ~
 !!! error TS2322: Type '4' is not assignable to type 'E'.
     let a: E.A = 0; // ok, A === 0
     a = 2; // error, 2 !== 0
     ~
 !!! error TS2322: Type '2' is not assignable to type 'E.A'.
-    a = n; // ok
+    a = n; // error
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'E.A'.
     
-    let c: Computed = n; // ok
-    c = n; // ok
-    c = 4; // ok
+    let c: Computed = n; // error
+        ~
+!!! error TS2322: Type 'number' is not assignable to type 'Computed'.
+    c = n; // error
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'Computed'.
+    c = 4; // error
     let ca: Computed.A = 1; // error, Computed.A isn't a literal type because Computed has no enum literals
         ~~
 !!! error TS2322: Type '1' is not assignable to type 'Computed.A'.
-    
-    
-    
     

--- a/tests/baselines/reference/enumAssignmentCompat5.js
+++ b/tests/baselines/reference/enumAssignmentCompat5.js
@@ -10,20 +10,17 @@ enum Computed {
     C = 1 << 3,
 }
 let n: number;
-let e: E = n; // ok because it's too inconvenient otherwise
+let e: E = n; // error
 e = 0; // ok, in range
-e = 4; // ok, out of range, but allowed computed enums don't have all members
+e = 4; // error, out of range, allowed computed enums don't have all members
 let a: E.A = 0; // ok, A === 0
 a = 2; // error, 2 !== 0
-a = n; // ok
+a = n; // error
 
-let c: Computed = n; // ok
-c = n; // ok
-c = 4; // ok
+let c: Computed = n; // error
+c = n; // error
+c = 4; // error
 let ca: Computed.A = 1; // error, Computed.A isn't a literal type because Computed has no enum literals
-
-
-
 
 
 //// [enumAssignmentCompat5.js]
@@ -40,13 +37,13 @@ var Computed;
     Computed[Computed["C"] = 8] = "C";
 })(Computed || (Computed = {}));
 var n;
-var e = n; // ok because it's too inconvenient otherwise
+var e = n; // error
 e = 0; // ok, in range
-e = 4; // ok, out of range, but allowed computed enums don't have all members
+e = 4; // error, out of range, allowed computed enums don't have all members
 var a = 0; // ok, A === 0
 a = 2; // error, 2 !== 0
-a = n; // ok
-var c = n; // ok
-c = n; // ok
-c = 4; // ok
+a = n; // error
+var c = n; // error
+c = n; // error
+c = 4; // error
 var ca = 1; // error, Computed.A isn't a literal type because Computed has no enum literals

--- a/tests/baselines/reference/enumAssignmentCompat5.symbols
+++ b/tests/baselines/reference/enumAssignmentCompat5.symbols
@@ -24,7 +24,7 @@ enum Computed {
 let n: number;
 >n : Symbol(n, Decl(enumAssignmentCompat5.ts, 8, 3))
 
-let e: E = n; // ok because it's too inconvenient otherwise
+let e: E = n; // error
 >e : Symbol(e, Decl(enumAssignmentCompat5.ts, 9, 3))
 >E : Symbol(E, Decl(enumAssignmentCompat5.ts, 0, 0))
 >n : Symbol(n, Decl(enumAssignmentCompat5.ts, 8, 3))
@@ -32,7 +32,7 @@ let e: E = n; // ok because it's too inconvenient otherwise
 e = 0; // ok, in range
 >e : Symbol(e, Decl(enumAssignmentCompat5.ts, 9, 3))
 
-e = 4; // ok, out of range, but allowed computed enums don't have all members
+e = 4; // error, out of range, allowed computed enums don't have all members
 >e : Symbol(e, Decl(enumAssignmentCompat5.ts, 9, 3))
 
 let a: E.A = 0; // ok, A === 0
@@ -43,27 +43,24 @@ let a: E.A = 0; // ok, A === 0
 a = 2; // error, 2 !== 0
 >a : Symbol(a, Decl(enumAssignmentCompat5.ts, 12, 3))
 
-a = n; // ok
+a = n; // error
 >a : Symbol(a, Decl(enumAssignmentCompat5.ts, 12, 3))
 >n : Symbol(n, Decl(enumAssignmentCompat5.ts, 8, 3))
 
-let c: Computed = n; // ok
+let c: Computed = n; // error
 >c : Symbol(c, Decl(enumAssignmentCompat5.ts, 16, 3))
 >Computed : Symbol(Computed, Decl(enumAssignmentCompat5.ts, 2, 1))
 >n : Symbol(n, Decl(enumAssignmentCompat5.ts, 8, 3))
 
-c = n; // ok
+c = n; // error
 >c : Symbol(c, Decl(enumAssignmentCompat5.ts, 16, 3))
 >n : Symbol(n, Decl(enumAssignmentCompat5.ts, 8, 3))
 
-c = 4; // ok
+c = 4; // error
 >c : Symbol(c, Decl(enumAssignmentCompat5.ts, 16, 3))
 
 let ca: Computed.A = 1; // error, Computed.A isn't a literal type because Computed has no enum literals
 >ca : Symbol(ca, Decl(enumAssignmentCompat5.ts, 19, 3))
 >Computed : Symbol(Computed, Decl(enumAssignmentCompat5.ts, 2, 1))
 >A : Symbol(Computed.A, Decl(enumAssignmentCompat5.ts, 3, 15))
-
-
-
 

--- a/tests/baselines/reference/enumAssignmentCompat5.types
+++ b/tests/baselines/reference/enumAssignmentCompat5.types
@@ -51,7 +51,7 @@ let n: number;
 >n : number
 >  : ^^^^^^
 
-let e: E = n; // ok because it's too inconvenient otherwise
+let e: E = n; // error
 >e : E
 >  : ^
 >n : number
@@ -65,7 +65,7 @@ e = 0; // ok, in range
 >0 : 0
 >  : ^
 
-e = 4; // ok, out of range, but allowed computed enums don't have all members
+e = 4; // error, out of range, allowed computed enums don't have all members
 >e = 4 : 4
 >      : ^
 >e : E
@@ -89,7 +89,7 @@ a = 2; // error, 2 !== 0
 >2 : 2
 >  : ^
 
-a = n; // ok
+a = n; // error
 >a = n : number
 >      : ^^^^^^
 >a : E.A
@@ -97,13 +97,13 @@ a = n; // ok
 >n : number
 >  : ^^^^^^
 
-let c: Computed = n; // ok
+let c: Computed = n; // error
 >c : Computed
 >  : ^^^^^^^^
 >n : number
 >  : ^^^^^^
 
-c = n; // ok
+c = n; // error
 >c = n : number
 >      : ^^^^^^
 >c : Computed
@@ -111,7 +111,7 @@ c = n; // ok
 >n : number
 >  : ^^^^^^
 
-c = 4; // ok
+c = 4; // error
 >c = 4 : 4
 >      : ^
 >c : Computed
@@ -126,7 +126,4 @@ let ca: Computed.A = 1; // error, Computed.A isn't a literal type because Comput
 >         : ^^^
 >1 : 1
 >  : ^
-
-
-
 

--- a/tests/baselines/reference/exportAssignmentTopLevelEnumdule.errors.txt
+++ b/tests/baselines/reference/exportAssignmentTopLevelEnumdule.errors.txt
@@ -1,0 +1,21 @@
+foo_1.ts(4,2): error TS2322: Type 'number' is not assignable to type 'foo'.
+
+
+==== foo_1.ts (1 errors) ====
+    import foo = require("./foo_0");
+    var color: foo;
+    if(color === foo.green){
+    	color = foo.answer;
+    	~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'foo'.
+    }
+    
+==== foo_0.ts (0 errors) ====
+    enum foo {
+    	red, green, blue
+    }
+    module foo {
+    	export var answer = 42;
+    }
+    export = foo;
+    

--- a/tests/baselines/reference/numberAssignableToEnum.errors.txt
+++ b/tests/baselines/reference/numberAssignableToEnum.errors.txt
@@ -1,0 +1,11 @@
+numberAssignableToEnum.ts(4,1): error TS2322: Type 'number' is not assignable to type 'E'.
+
+
+==== numberAssignableToEnum.ts (1 errors) ====
+    enum E { A }
+    var n: number;
+    var e: E;
+    e = n;
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
+    n = e;

--- a/tests/baselines/reference/numberAssignableToEnum2.symbols
+++ b/tests/baselines/reference/numberAssignableToEnum2.symbols
@@ -1,0 +1,47 @@
+//// [tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum2.ts] ////
+
+=== numberAssignableToEnum2.ts ===
+declare module mAmbient {
+>mAmbient : Symbol(mAmbient, Decl(numberAssignableToEnum2.ts, 0, 0))
+
+    enum e {
+>e : Symbol(e, Decl(numberAssignableToEnum2.ts, 0, 25))
+
+        x,
+>x : Symbol(e.x, Decl(numberAssignableToEnum2.ts, 1, 12))
+
+        y,
+>y : Symbol(e.y, Decl(numberAssignableToEnum2.ts, 2, 10))
+
+        z
+>z : Symbol(e.z, Decl(numberAssignableToEnum2.ts, 3, 10))
+    }
+}
+
+declare const num: number
+>num : Symbol(num, Decl(numberAssignableToEnum2.ts, 8, 13))
+
+const test1: mAmbient.e = num
+>test1 : Symbol(test1, Decl(numberAssignableToEnum2.ts, 10, 5))
+>mAmbient : Symbol(mAmbient, Decl(numberAssignableToEnum2.ts, 0, 0))
+>e : Symbol(mAmbient.e, Decl(numberAssignableToEnum2.ts, 0, 25))
+>num : Symbol(num, Decl(numberAssignableToEnum2.ts, 8, 13))
+
+const test2: mAmbient.e.x = num
+>test2 : Symbol(test2, Decl(numberAssignableToEnum2.ts, 11, 5))
+>mAmbient : Symbol(mAmbient, Decl(numberAssignableToEnum2.ts, 0, 0))
+>e : Symbol(mAmbient.e, Decl(numberAssignableToEnum2.ts, 0, 25))
+>x : Symbol(mAmbient.e.x, Decl(numberAssignableToEnum2.ts, 1, 12))
+>num : Symbol(num, Decl(numberAssignableToEnum2.ts, 8, 13))
+
+const test3: mAmbient.e = 42
+>test3 : Symbol(test3, Decl(numberAssignableToEnum2.ts, 12, 5))
+>mAmbient : Symbol(mAmbient, Decl(numberAssignableToEnum2.ts, 0, 0))
+>e : Symbol(mAmbient.e, Decl(numberAssignableToEnum2.ts, 0, 25))
+
+const test4: mAmbient.e.x = 42
+>test4 : Symbol(test4, Decl(numberAssignableToEnum2.ts, 13, 5))
+>mAmbient : Symbol(mAmbient, Decl(numberAssignableToEnum2.ts, 0, 0))
+>e : Symbol(mAmbient.e, Decl(numberAssignableToEnum2.ts, 0, 25))
+>x : Symbol(mAmbient.e.x, Decl(numberAssignableToEnum2.ts, 1, 12))
+

--- a/tests/baselines/reference/numberAssignableToEnum2.types
+++ b/tests/baselines/reference/numberAssignableToEnum2.types
@@ -1,0 +1,65 @@
+//// [tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum2.ts] ////
+
+=== numberAssignableToEnum2.ts ===
+declare module mAmbient {
+>mAmbient : typeof mAmbient
+>         : ^^^^^^^^^^^^^^^
+
+    enum e {
+>e : e
+>  : ^
+
+        x,
+>x : e.x
+>  : ^^^
+
+        y,
+>y : e.y
+>  : ^^^
+
+        z
+>z : e.z
+>  : ^^^
+    }
+}
+
+declare const num: number
+>num : number
+>    : ^^^^^^
+
+const test1: mAmbient.e = num
+>test1 : mAmbient.e
+>      : ^^^^^^^^^^
+>mAmbient : any
+>         : ^^^
+>num : number
+>    : ^^^^^^
+
+const test2: mAmbient.e.x = num
+>test2 : mAmbient.e.x
+>      : ^^^^^^^^^^^^
+>mAmbient : any
+>         : ^^^
+>e : any
+>  : ^^^
+>num : number
+>    : ^^^^^^
+
+const test3: mAmbient.e = 42
+>test3 : mAmbient.e
+>      : ^^^^^^^^^^
+>mAmbient : any
+>         : ^^^
+>42 : 42
+>   : ^^
+
+const test4: mAmbient.e.x = 42
+>test4 : mAmbient.e.x
+>      : ^^^^^^^^^^^^
+>mAmbient : any
+>         : ^^^
+>e : any
+>  : ^^^
+>42 : 42
+>   : ^^
+

--- a/tests/baselines/reference/numberAssignableToEnumInsideUnion.errors.txt
+++ b/tests/baselines/reference/numberAssignableToEnumInsideUnion.errors.txt
@@ -1,0 +1,10 @@
+numberAssignableToEnumInsideUnion.ts(3,5): error TS2322: Type 'number' is not assignable to type 'boolean | E'.
+
+
+==== numberAssignableToEnumInsideUnion.ts (1 errors) ====
+    enum E { A, B }
+    let n: number;
+    let z: E | boolean = n;
+        ~
+!!! error TS2322: Type 'number' is not assignable to type 'boolean | E'.
+    

--- a/tests/baselines/reference/numberComparableToEnum.symbols
+++ b/tests/baselines/reference/numberComparableToEnum.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberComparableToEnum.ts] ////
+
+=== numberComparableToEnum.ts ===
+enum E { A }
+>E : Symbol(E, Decl(numberComparableToEnum.ts, 0, 0))
+>A : Symbol(E.A, Decl(numberComparableToEnum.ts, 0, 8))
+
+declare let n: number;
+>n : Symbol(n, Decl(numberComparableToEnum.ts, 2, 11))
+
+declare let e: E;
+>e : Symbol(e, Decl(numberComparableToEnum.ts, 3, 11))
+>E : Symbol(E, Decl(numberComparableToEnum.ts, 0, 0))
+
+e = n as E;
+>e : Symbol(e, Decl(numberComparableToEnum.ts, 3, 11))
+>n : Symbol(n, Decl(numberComparableToEnum.ts, 2, 11))
+>E : Symbol(E, Decl(numberComparableToEnum.ts, 0, 0))
+
+export {}
+

--- a/tests/baselines/reference/numberComparableToEnum.types
+++ b/tests/baselines/reference/numberComparableToEnum.types
@@ -1,0 +1,29 @@
+//// [tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberComparableToEnum.ts] ////
+
+=== numberComparableToEnum.ts ===
+enum E { A }
+>E : E
+>  : ^
+>A : E.A
+>  : ^^^
+
+declare let n: number;
+>n : number
+>  : ^^^^^^
+
+declare let e: E;
+>e : E
+>  : ^
+
+e = n as E;
+>e = n as E : E
+>           : ^
+>e : E
+>  : ^
+>n as E : E
+>       : ^
+>n : number
+>  : ^^^^^^
+
+export {}
+

--- a/tests/baselines/reference/parserRealSource10.errors.txt
+++ b/tests/baselines/reference/parserRealSource10.errors.txt
@@ -9,6 +9,7 @@ parserRealSource10.ts(130,35): error TS2693: 'boolean' only refers to a type, bu
 parserRealSource10.ts(130,43): error TS1011: An element access expression should take an argument.
 parserRealSource10.ts(179,54): error TS2304: Cannot find name 'ErrorRecoverySet'.
 parserRealSource10.ts(184,28): error TS2304: Cannot find name 'ErrorRecoverySet'.
+parserRealSource10.ts(186,58): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Reservation'.
 parserRealSource10.ts(188,34): error TS2304: Cannot find name 'NodeType'.
 parserRealSource10.ts(192,33): error TS2304: Cannot find name 'NodeType'.
 parserRealSource10.ts(198,80): error TS2304: Cannot find name 'NodeType'.
@@ -341,9 +342,10 @@ parserRealSource10.ts(312,149): error TS2304: Cannot find name 'ErrorRecoverySet
 parserRealSource10.ts(355,52): error TS2304: Cannot find name 'NodeType'.
 parserRealSource10.ts(356,53): error TS2304: Cannot find name 'NodeType'.
 parserRealSource10.ts(449,41): error TS1011: An element access expression should take an argument.
+parserRealSource10.ts(452,41): error TS2345: Argument of type 'number' is not assignable to parameter of type 'TokenID'.
 
 
-==== parserRealSource10.ts (343 errors) ====
+==== parserRealSource10.ts (345 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -553,6 +555,8 @@ parserRealSource10.ts(449,41): error TS1011: An element access expression should
 !!! error TS2304: Cannot find name 'ErrorRecoverySet'.
             if (tokenId !== undefined) {
                 tokenTable[tokenId] = new TokenInfo(tokenId, reservation, binopPrecedence,
+                                                             ~~~~~~~~~~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Reservation'.
                                                   binopNodeType, unopPrecedence, unopNodeType, text, ers);
                 if (binopNodeType != NodeType.None) {
                                      ~~~~~~~~
@@ -1483,6 +1487,8 @@ parserRealSource10.ts(449,41): error TS1011: An element access expression should
         export function initializeStaticTokens() {
             for (var i = 0; i <= TokenID.LimFixed; i++) {
                 staticTokens[i] = new Token(i);
+                                            ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'TokenID'.
             }
         }
     }

--- a/tests/baselines/reference/unionSubtypeIfEveryConstituentTypeIsSubtype.errors.txt
+++ b/tests/baselines/reference/unionSubtypeIfEveryConstituentTypeIsSubtype.errors.txt
@@ -22,6 +22,7 @@ unionSubtypeIfEveryConstituentTypeIsSubtype.ts(85,5): error TS2411: Property 'fo
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(91,5): error TS2411: Property 'foo' of type 'string | number' is not assignable to 'string' index type '<T>(x: T) => T'.
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(92,5): error TS2411: Property 'foo2' of type 'number' is not assignable to 'string' index type '<T>(x: T) => T'.
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(99,5): error TS2411: Property 'foo' of type 'string | number' is not assignable to 'string' index type 'E2'.
+unionSubtypeIfEveryConstituentTypeIsSubtype.ts(100,5): error TS2411: Property 'foo2' of type 'number' is not assignable to 'string' index type 'E2'.
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(110,5): error TS2411: Property 'foo' of type 'string | number' is not assignable to 'string' index type 'typeof f'.
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(111,5): error TS2411: Property 'foo2' of type 'number' is not assignable to 'string' index type 'typeof f'.
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(121,5): error TS2411: Property 'foo' of type 'string | number' is not assignable to 'string' index type 'typeof c'.
@@ -30,7 +31,7 @@ unionSubtypeIfEveryConstituentTypeIsSubtype.ts(128,5): error TS2411: Property 'f
 unionSubtypeIfEveryConstituentTypeIsSubtype.ts(129,5): error TS2411: Property 'foo2' of type 'number' is not assignable to 'string' index type 'T'.
 
 
-==== unionSubtypeIfEveryConstituentTypeIsSubtype.ts (30 errors) ====
+==== unionSubtypeIfEveryConstituentTypeIsSubtype.ts (31 errors) ====
     enum e {
         e1,
         e2
@@ -179,6 +180,8 @@ unionSubtypeIfEveryConstituentTypeIsSubtype.ts(129,5): error TS2411: Property 'f
         ~~~
 !!! error TS2411: Property 'foo' of type 'string | number' is not assignable to 'string' index type 'E2'.
         foo2: e | number;
+        ~~~~
+!!! error TS2411: Property 'foo2' of type 'number' is not assignable to 'string' index type 'E2'.
     }
     
     

--- a/tests/baselines/reference/validEnumAssignments.errors.txt
+++ b/tests/baselines/reference/validEnumAssignments.errors.txt
@@ -1,7 +1,8 @@
+validEnumAssignments.ts(20,1): error TS2322: Type 'number' is not assignable to type 'E'.
 validEnumAssignments.ts(26,1): error TS2322: Type '-1' is not assignable to type 'E'.
 
 
-==== validEnumAssignments.ts (1 errors) ====
+==== validEnumAssignments.ts (2 errors) ====
     enum E {
         A,
         B
@@ -22,6 +23,8 @@ validEnumAssignments.ts(26,1): error TS2322: Type '-1' is not assignable to type
     e = E.A;
     e = E.B;
     e = n;
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
     e = null;
     e = undefined;
     e = 1;

--- a/tests/baselines/reference/validNumberAssignments.errors.txt
+++ b/tests/baselines/reference/validNumberAssignments.errors.txt
@@ -1,0 +1,18 @@
+validNumberAssignments.ts(7,5): error TS2322: Type 'number' is not assignable to type 'E'.
+validNumberAssignments.ts(9,1): error TS2322: Type 'number' is not assignable to type 'E'.
+
+
+==== validNumberAssignments.ts (2 errors) ====
+    var x = 1;
+    
+    var a: any = x;
+    var b: Object = x;
+    var c: number = x;
+    enum E { A };
+    var d: E = x;
+        ~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.
+    var e = E.A;
+    e = x;
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'E'.

--- a/tests/baselines/reference/validNumberAssignments.types
+++ b/tests/baselines/reference/validNumberAssignments.types
@@ -9,6 +9,7 @@ var x = 1;
 
 var a: any = x;
 >a : any
+>  : ^^^
 >x : number
 >  : ^^^^^^
 

--- a/tests/cases/compiler/enumAssignmentCompat5.ts
+++ b/tests/cases/compiler/enumAssignmentCompat5.ts
@@ -7,17 +7,14 @@ enum Computed {
     C = 1 << 3,
 }
 let n: number;
-let e: E = n; // ok because it's too inconvenient otherwise
+let e: E = n; // error
 e = 0; // ok, in range
-e = 4; // ok, out of range, but allowed computed enums don't have all members
+e = 4; // error, out of range, allowed computed enums don't have all members
 let a: E.A = 0; // ok, A === 0
 a = 2; // error, 2 !== 0
-a = n; // ok
+a = n; // error
 
-let c: Computed = n; // ok
-c = n; // ok
-c = 4; // ok
+let c: Computed = n; // error
+c = n; // error
+c = 4; // error
 let ca: Computed.A = 1; // error, Computed.A isn't a literal type because Computed has no enum literals
-
-
-

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum2.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum2.ts
@@ -1,0 +1,17 @@
+// @strict: true
+// @noEmit: true
+
+declare module mAmbient {
+    enum e {
+        x,
+        y,
+        z
+    }
+}
+
+declare const num: number
+
+const test1: mAmbient.e = num
+const test2: mAmbient.e.x = num
+const test3: mAmbient.e = 42
+const test4: mAmbient.e.x = 42

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberComparableToEnum.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberComparableToEnum.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+
+enum E { A }
+
+declare let n: number;
+declare let e: E;
+
+e = n as E;
+
+export {}


### PR DESCRIPTION
@jakebailey mentioned this type hole to me and this is an experiment to make assignability rules stricter here. I didn't find a compelling reason in the existing test suite that this rule is particularly important today and I'd be interested in learning what user tests think about that ;p