### PR TITLE
Unpin Node 22 now that 22.5.1 is out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - windows-latest
           - macos-14
         node-version:
-          - '22.4.x'
+          - '22'
           - '20'
           - '18'
           - '16'


### PR DESCRIPTION
22.5.1 fixes the regression from 22.5.0.