### PR TITLE
Fixing range for primary edit

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2318,7 +2318,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     runWithTemporaryFileUpdate(rootFile: string, updatedText: string, cb: (updatedProgram: Program, originalProgram: Program | undefined, updatedFile: SourceFile) => void) {
         const originalProgram = this.program;
         const rootSourceFile = Debug.checkDefined(this.program?.getSourceFile(rootFile), "Expected file to be part of program");
-        const originalText = Debug.checkDefined(rootSourceFile.getText());
+        const originalText = Debug.checkDefined(rootSourceFile.getFullText());
 
         this.getScriptInfo(rootFile)?.editContent(0, originalText.length, updatedText);
         this.updateGraph();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2326,7 +2326,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             cb(this.program!, originalProgram, (this.program?.getSourceFile(rootFile))!);
         }
         finally {
-            this.getScriptInfo(rootFile)?.editContent(0, this.program!.getSourceFile(rootFile)!.getText().length, originalText);
+            this.getScriptInfo(rootFile)?.editContent(0, this.program!.getSourceFile(rootFile)!.getFullText().length, originalText);
         }
     }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2326,7 +2326,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             cb(this.program!, originalProgram, (this.program?.getSourceFile(rootFile))!);
         }
         finally {
-            this.getScriptInfo(rootFile)?.editContent(0, this.program!.getSourceFile(rootFile)!.getFullText().length, originalText);
+            this.getScriptInfo(rootFile)?.editContent(0, updatedText.length, originalText);
         }
     }
 

--- a/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_addInNextLine.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/pasteEdits_addInNextLine.js
@@ -1,0 +1,328 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+//// [/a.ts]
+
+
+
+
+
+
+//// [/b.ts]
+export interface Foo { }
+export const a = 1;
+export const t = 1;
+
+export const foo: Foo = { };
+export const k = a+ t;
+
+//// [/lib.d.ts]
+lib.d.ts-Text
+
+//// [/lib.decorators.d.ts]
+lib.decorators.d.ts-Text
+
+//// [/lib.decorators.legacy.d.ts]
+lib.decorators.legacy.d.ts-Text
+
+//// [/tsconfig.json]
+{ "files": ["a.ts", "b.ts"] }
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "arguments": {
+        "file": "/a.ts"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /a.ts ProjectRootPath: undefined:: Result: /tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/tsconfig.json",
+        "reason": "Creating possible configured project for /a.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json : {
+ "rootNames": [
+  "/a.ts",
+  "/b.ts"
+ ],
+ "options": {
+  "configFilePath": "/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /b.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/a.ts SVC-1-0 "\n\n\n\n"
+	/b.ts Text-1 "export interface Foo { }\nexport const a = 1;\nexport const t = 1;\n\nexport const foo: Foo = { };\nexport const k = a+ t;"
+
+
+	lib.d.ts
+	  Default library for target 'es5'
+	lib.decorators.d.ts
+	  Library referenced via 'decorators' from file 'lib.d.ts'
+	lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file 'lib.d.ts'
+	a.ts
+	  Part of 'files' list in tsconfig.json
+	b.ts
+	  Part of 'files' list in tsconfig.json
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/a.ts",
+        "configFile": "/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /a.ts ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "open",
+      "request_seq": 0,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After Request
+watchedFiles::
+/b.ts: *new*
+  {"pollingInterval":500}
+/lib.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts: *new*
+  {"pollingInterval":500}
+/tsconfig.json: *new*
+  {"pollingInterval":2000}
+
+Projects::
+/tsconfig.json (Configured) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+
+ScriptInfos::
+/a.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /tsconfig.json *default*
+/b.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.legacy.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 1,
+      "type": "request",
+      "arguments": {
+        "formatOptions": {
+          "indentSize": 4,
+          "tabSize": 4,
+          "newLineCharacter": "\n",
+          "convertTabsToSpaces": true,
+          "indentStyle": 2,
+          "insertSpaceAfterConstructor": false,
+          "insertSpaceAfterCommaDelimiter": true,
+          "insertSpaceAfterSemicolonInForStatements": true,
+          "insertSpaceBeforeAndAfterBinaryOperators": true,
+          "insertSpaceAfterKeywordsInControlFlowStatements": true,
+          "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+          "insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
+          "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+          "insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
+          "insertSpaceBeforeFunctionParenthesis": false,
+          "placeOpenBraceOnNewLineForFunctions": false,
+          "placeOpenBraceOnNewLineForControlBlocks": false,
+          "semicolons": "ignore",
+          "trimTrailingWhitespace": true,
+          "indentSwitchCase": true
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] Format host information updated
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 1,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 2,
+      "type": "request",
+      "arguments": {
+        "file": "/a.ts",
+        "pastedText": [
+          "export const foo: Foo = {};"
+        ],
+        "pasteLocations": [
+          {
+            "start": {
+              "line": 4,
+              "offset": 1
+            },
+            "end": {
+              "line": 4,
+              "offset": 1
+            }
+          }
+        ],
+        "copiedFrom": {
+          "file": "b.ts",
+          "spans": [
+            {
+              "start": {
+                "line": 5,
+                "offset": 1
+              },
+              "end": {
+                "line": 5,
+                "offset": 29
+              }
+            }
+          ]
+        }
+      },
+      "command": "getPasteEdits"
+    }
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (5)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/a.ts SVC-1-1 "\n\n\nexport const foo: Foo = {};\n"
+	/b.ts Text-1 "export interface Foo { }\nexport const a = 1;\nexport const t = 1;\n\nexport const foo: Foo = { };\nexport const k = a+ t;"
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "getPasteEdits",
+      "request_seq": 2,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      },
+      "body": {
+        "edits": [
+          {
+            "fileName": "/a.ts",
+            "textChanges": [
+              {
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "newText": "import { Foo } from \"./b\";\n"
+              },
+              {
+                "start": {
+                  "line": 4,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 4,
+                  "offset": 1
+                },
+                "newText": "export const foo: Foo = {};"
+              }
+            ]
+          }
+        ],
+        "fixId": "providePostPasteEdits"
+      }
+    }
+After Request
+Projects::
+/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+ScriptInfos::
+/a.ts (Open) *changed*
+    version: SVC-1-2 *changed*
+    containingProjects: 1
+        /tsconfig.json *default*
+/b.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json
+/lib.decorators.legacy.d.ts
+    version: Text-1
+    containingProjects: 1
+        /tsconfig.json

--- a/tests/cases/fourslash/server/pasteEdits_addInNextLine.ts
+++ b/tests/cases/fourslash/server/pasteEdits_addInNextLine.ts
@@ -2,7 +2,6 @@
 
 // @Filename: /a.ts
 ////
-//// [||]
 ////
 ////
 //// [||]
@@ -10,8 +9,11 @@
 
 // @Filename: /b.ts
 //// export interface Foo { }
+//// export const a = 1;
+//// export const t = 1;
 ////
-//// [|export const foo: Foo = {};|]
+//// [|export const foo: Foo = { };|]
+//// [|export const k = a+ t;|]
 
 // @Filename: /tsconfig.json
 ////{ "files": ["a.ts", "b.ts"] }
@@ -20,15 +22,16 @@ const range = test.ranges();
 verify.pasteEdits({
     args: {
         pastedText: [`export const foo: Foo = {};`],
-        pasteLocations: [range[0], range[1]],
-        copiedFrom: { file: "b.ts", range: [range[2]] },
+        pasteLocations: [range[0]],
+        copiedFrom: { file: "b.ts", range: [range[1]] },
     },
     newFileContents: {
         "/a.ts":
 `import { Foo } from "./b";
 
 
+
 export const foo: Foo = {};
-console.log(abc);`
+`
     }
 });

--- a/tests/cases/fourslash/server/pasteEdits_addInNextLine.ts
+++ b/tests/cases/fourslash/server/pasteEdits_addInNextLine.ts
@@ -1,0 +1,34 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /a.ts
+////
+//// [||]
+////
+////
+//// [||]
+//// 
+
+// @Filename: /b.ts
+//// export interface Foo { }
+////
+//// [|export const foo: Foo = {};|]
+
+// @Filename: /tsconfig.json
+////{ "files": ["a.ts", "b.ts"] }
+
+const range = test.ranges();
+verify.pasteEdits({
+    args: {
+        pastedText: [`export const foo: Foo = {};`],
+        pasteLocations: [range[0], range[1]],
+        copiedFrom: { file: "b.ts", range: [range[2]] },
+    },
+    newFileContents: {
+        "/a.ts":
+`import { Foo } from "./b";
+
+
+export const foo: Foo = {};
+console.log(abc);`
+    }
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/58936 
Due to `getText()` and not `getFullText()`, new line characters were getting ignored when trying to perform a temporary file update which later made the paste at the wrong positions.