### PR TITLE
Fixed a crash when transforming modules with top-level labels

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -993,7 +993,7 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
         return factory.updateLabeledStatement(
             node,
             node.label,
-            Debug.checkDefined(visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock)),
+            visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock) ?? factory.createExpressionStatement(factory.createIdentifier("")),
         );
     }
 

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1419,7 +1419,7 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
         return factory.updateLabeledStatement(
             node,
             node.label,
-            Debug.checkDefined(visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock)),
+            visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock) ?? factory.createExpressionStatement(factory.createIdentifier("")),
         );
     }
 

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).errors.txt
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).errors.txt
@@ -1,0 +1,18 @@
+labeledStatementExportDeclarationNoCrash1.ts(3,14): error TS1155: 'const' declarations must be initialized.
+labeledStatementExportDeclarationNoCrash1.ts(5,1): error TS1184: Modifiers cannot appear here.
+labeledStatementExportDeclarationNoCrash1.ts(5,14): error TS1155: 'const' declarations must be initialized.
+
+
+==== labeledStatementExportDeclarationNoCrash1.ts (3 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59372
+    
+    export const box: string
+                 ~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    subTitle:
+    export const title: string
+    ~~~~~~
+!!! error TS1184: Modifiers cannot appear here.
+                 ~~~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).js
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+//// [labeledStatementExportDeclarationNoCrash1.ts]
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+subTitle:
+export const title: string
+
+
+//// [labeledStatementExportDeclarationNoCrash1.js]
+"use strict";
+// https://github.com/microsoft/TypeScript/issues/59372
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.box = void 0;
+subTitle: ;

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).symbols
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : Symbol(box, Decl(labeledStatementExportDeclarationNoCrash1.ts, 2, 12))
+
+subTitle:
+export const title: string
+>title : Symbol(title, Decl(labeledStatementExportDeclarationNoCrash1.ts, 4, 12))
+

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).types
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=commonjs).types
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : string
+>    : ^^^^^^
+
+subTitle:
+>subTitle : any
+>         : ^^^
+
+export const title: string
+>title : string
+>      : ^^^^^^
+

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).errors.txt
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).errors.txt
@@ -1,0 +1,18 @@
+labeledStatementExportDeclarationNoCrash1.ts(3,14): error TS1155: 'const' declarations must be initialized.
+labeledStatementExportDeclarationNoCrash1.ts(5,1): error TS1184: Modifiers cannot appear here.
+labeledStatementExportDeclarationNoCrash1.ts(5,14): error TS1155: 'const' declarations must be initialized.
+
+
+==== labeledStatementExportDeclarationNoCrash1.ts (3 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59372
+    
+    export const box: string
+                 ~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    subTitle:
+    export const title: string
+    ~~~~~~
+!!! error TS1184: Modifiers cannot appear here.
+                 ~~~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).js
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+//// [labeledStatementExportDeclarationNoCrash1.ts]
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+subTitle:
+export const title: string
+
+
+//// [labeledStatementExportDeclarationNoCrash1.js]
+// https://github.com/microsoft/TypeScript/issues/59372
+export var box;
+subTitle: export var title;

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).symbols
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : Symbol(box, Decl(labeledStatementExportDeclarationNoCrash1.ts, 2, 12))
+
+subTitle:
+export const title: string
+>title : Symbol(title, Decl(labeledStatementExportDeclarationNoCrash1.ts, 4, 12))
+

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).types
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=esnext).types
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : string
+>    : ^^^^^^
+
+subTitle:
+>subTitle : any
+>         : ^^^
+
+export const title: string
+>title : string
+>      : ^^^^^^
+

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).errors.txt
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).errors.txt
@@ -1,0 +1,18 @@
+labeledStatementExportDeclarationNoCrash1.ts(3,14): error TS1155: 'const' declarations must be initialized.
+labeledStatementExportDeclarationNoCrash1.ts(5,1): error TS1184: Modifiers cannot appear here.
+labeledStatementExportDeclarationNoCrash1.ts(5,14): error TS1155: 'const' declarations must be initialized.
+
+
+==== labeledStatementExportDeclarationNoCrash1.ts (3 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59372
+    
+    export const box: string
+                 ~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    subTitle:
+    export const title: string
+    ~~~~~~
+!!! error TS1184: Modifiers cannot appear here.
+                 ~~~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).js
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).js
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+//// [labeledStatementExportDeclarationNoCrash1.ts]
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+subTitle:
+export const title: string
+
+
+//// [labeledStatementExportDeclarationNoCrash1.js]
+// https://github.com/microsoft/TypeScript/issues/59372
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var box, title;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            subTitle: ;
+        }
+    };
+});

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).symbols
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : Symbol(box, Decl(labeledStatementExportDeclarationNoCrash1.ts, 2, 12))
+
+subTitle:
+export const title: string
+>title : Symbol(title, Decl(labeledStatementExportDeclarationNoCrash1.ts, 4, 12))
+

--- a/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).types
+++ b/tests/baselines/reference/labeledStatementExportDeclarationNoCrash1(module=system).types
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts] ////
+
+=== labeledStatementExportDeclarationNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+>box : string
+>    : ^^^^^^
+
+subTitle:
+>subTitle : any
+>         : ^^^
+
+export const title: string
+>title : string
+>      : ^^^^^^
+

--- a/tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts
+++ b/tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts
@@ -1,0 +1,8 @@
+// @strict: true
+// @module: esnext, commonjs, system
+
+// https://github.com/microsoft/TypeScript/issues/59372
+
+export const box: string
+subTitle:
+export const title: string


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59372