### PR TITLE
Don't crash when observing invalid `export`s in any kind of container

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -69,7 +69,6 @@ import {
     modifierToFlag,
     ModuleBlock,
     Node,
-    ObjectLiteralExpression,
     ObjectTypeDeclaration,
     Program,
     ReturnStatement,
@@ -294,7 +293,7 @@ export namespace DocumentHighlights {
 
     function getNodesToSearchForModifier(declaration: Node, modifierFlag: ModifierFlags): readonly Node[] | undefined {
         // Types of node whose children might have modifiers.
-        const container = declaration.parent as ModuleBlock | SourceFile | Block | CaseClause | DefaultClause | ConstructorDeclaration | MethodDeclaration | FunctionDeclaration | ObjectTypeDeclaration | ObjectLiteralExpression;
+        const container = declaration.parent as ModuleBlock | SourceFile | Block | CaseClause | DefaultClause | ConstructorDeclaration | MethodDeclaration | FunctionDeclaration | ObjectTypeDeclaration;
         switch (container.kind) {
             case SyntaxKind.ModuleBlock:
             case SyntaxKind.SourceFile:
@@ -332,11 +331,8 @@ export namespace DocumentHighlights {
                 return nodes;
 
             // Syntactically invalid positions that the parser might produce anyway
-            case SyntaxKind.ObjectLiteralExpression:
-                return undefined;
-
             default:
-                Debug.assertNever(container, "Invalid container kind.");
+                return undefined;
         }
     }
 

--- a/tests/baselines/reference/exportInLabeledStatement.baseline.jsonc
+++ b/tests/baselines/reference/exportInLabeledStatement.baseline.jsonc
@@ -1,0 +1,7 @@
+// === documentHighlights ===
+// filesToSearch:
+//   /tests/cases/fourslash/a.ts
+
+// === /tests/cases/fourslash/a.ts ===
+// subTitle:
+// /*HIGHLIGHTS*/export const title: string

--- a/tests/cases/fourslash/exportInLabeledStatement.ts
+++ b/tests/cases/fourslash/exportInLabeledStatement.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+//// subTitle:
+//// [|export|] const title: string
+
+verify.baselineDocumentHighlights(test.ranges()[0], { filesToSearch: [test.ranges()[0].fileName] });
+


### PR DESCRIPTION
This fixes an extra crash that I observed when working on https://github.com/microsoft/TypeScript/pull/59374