### PR TITLE
Use 'BuiltinAsyncIterator' spelling

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2162,7 +2162,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getGlobalIteratorType: getGlobalAsyncIteratorType,
         getGlobalIterableType: getGlobalAsyncIterableType,
         getGlobalIterableIteratorType: getGlobalAsyncIterableIteratorType,
-        getGlobalBuiltinIteratorType: getGlobalAsyncBuiltinIteratorType,
+        getGlobalBuiltinIteratorType: getGlobalBuiltinAsyncIteratorType,
         getGlobalGeneratorType: getGlobalAsyncGeneratorType,
         resolveIterationType: (type, errorNode) => getAwaitedType(type, errorNode, Diagnostics.Type_of_await_operand_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member),
         mustHaveANextMethodDiagnostic: Diagnostics.An_async_iterator_must_have_a_next_method,
@@ -2246,7 +2246,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var deferredGlobalAsyncIterableType: GenericType | undefined;
     var deferredGlobalAsyncIteratorType: GenericType | undefined;
     var deferredGlobalAsyncIterableIteratorType: GenericType | undefined;
-    var deferredGlobalAsyncBuiltinIteratorType: GenericType | undefined;
+    var deferredGlobalBuiltinAsyncIteratorType: GenericType | undefined;
     var deferredGlobalAsyncGeneratorType: GenericType | undefined;
     var deferredGlobalTemplateStringsArrayType: ObjectType | undefined;
     var deferredGlobalImportMetaType: ObjectType;
@@ -16941,8 +16941,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return (deferredGlobalAsyncIterableIteratorType ||= getGlobalType("AsyncIterableIterator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
     }
 
-    function getGlobalAsyncBuiltinIteratorType(reportErrors: boolean) {
-        return (deferredGlobalAsyncBuiltinIteratorType ||= getGlobalType("AsyncBuiltinIterator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
+    function getGlobalBuiltinAsyncIteratorType(reportErrors: boolean) {
+        return (deferredGlobalBuiltinAsyncIteratorType ||= getGlobalType("BuiltinAsyncIterator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
     }
 
     function getGlobalAsyncGeneratorType(reportErrors: boolean) {
@@ -44797,7 +44797,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // As an optimization, if the type is an instantiation of the following global type, then
         // just grab its related type arguments:
         // - `Iterable<T, TReturn, TNext>` or `AsyncIterable<T, TReturn, TNext>`
-        // - `BuiltinIterator<T, TReturn, TNext>` or `AsyncBuiltinIterator<T, TReturn, TNext>`
+        // - `BuiltinIterator<T, TReturn, TNext>` or `BuiltinAsyncIterator<T, TReturn, TNext>`
         // - `IterableIterator<T, TReturn, TNext>` or `AsyncIterableIterator<T, TReturn, TNext>`
         // - `Generator<T, TReturn, TNext>` or `AsyncGenerator<T, TReturn, TNext>`
         if (
@@ -44925,7 +44925,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // As an optimization, if the type is an instantiation of one of the following global types,
         // then just grab its related type arguments:
         // - `IterableIterator<T, TReturn, TNext>` or `AsyncIterableIterator<T, TReturn, TNext>`
-        // - `BuiltinIterator<T, TReturn, TNext>` or `AsyncBuiltinIterator<T, TReturn, TNext>`
+        // - `BuiltinIterator<T, TReturn, TNext>` or `BuiltinAsyncIterator<T, TReturn, TNext>`
         // - `Iterator<T, TReturn, TNext>` or `AsyncIterator<T, TReturn, TNext>`
         // - `Generator<T, TReturn, TNext>` or `AsyncGenerator<T, TReturn, TNext>`
         if (

--- a/src/lib/dom.asynciterable.generated.d.ts
+++ b/src/lib/dom.asynciterable.generated.d.ts
@@ -3,13 +3,13 @@
 /////////////////////////////
 
 interface FileSystemDirectoryHandle {
-    [Symbol.asyncIterator](): AsyncBuiltinIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
-    entries(): AsyncBuiltinIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
-    keys(): AsyncBuiltinIterator<string, BuiltinIteratorReturn>;
-    values(): AsyncBuiltinIterator<FileSystemHandle, BuiltinIteratorReturn>;
+    [Symbol.asyncIterator](): BuiltinAsyncIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
+    entries(): BuiltinAsyncIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
+    keys(): BuiltinAsyncIterator<string, BuiltinIteratorReturn>;
+    values(): BuiltinAsyncIterator<FileSystemHandle, BuiltinIteratorReturn>;
 }
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncBuiltinIterator<R, BuiltinIteratorReturn>;
-    values(options?: ReadableStreamIteratorOptions): AsyncBuiltinIterator<R, BuiltinIteratorReturn>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): BuiltinAsyncIterator<R, BuiltinIteratorReturn>;
+    values(options?: ReadableStreamIteratorOptions): BuiltinAsyncIterator<R, BuiltinIteratorReturn>;
 }

--- a/src/lib/es2018.asyncgenerator.d.ts
+++ b/src/lib/es2018.asyncgenerator.d.ts
@@ -1,6 +1,6 @@
 /// <reference lib="es2018.asynciterable" />
 
-interface AsyncGenerator<T = unknown, TReturn = any, TNext = any> extends AsyncBuiltinIterator<T, TReturn, TNext> {
+interface AsyncGenerator<T = unknown, TReturn = any, TNext = any> extends BuiltinAsyncIterator<T, TReturn, TNext> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
     next(...[value]: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
     return(value: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;

--- a/src/lib/es2018.asynciterable.d.ts
+++ b/src/lib/es2018.asynciterable.d.ts
@@ -24,6 +24,6 @@ interface AsyncIterableIterator<T, TReturn = any, TNext = any> extends AsyncIter
     [Symbol.asyncIterator](): AsyncIterableIterator<T, TReturn, TNext>;
 }
 
-interface AsyncBuiltinIterator<T, TReturn = any, TNext = any> extends AsyncIterator<T, TReturn, TNext> {
-    [Symbol.asyncIterator](): AsyncBuiltinIterator<T, TReturn, TNext>;
+interface BuiltinAsyncIterator<T, TReturn = any, TNext = any> extends AsyncIterator<T, TReturn, TNext> {
+    [Symbol.asyncIterator](): BuiltinAsyncIterator<T, TReturn, TNext>;
 }

--- a/src/lib/webworker.asynciterable.generated.d.ts
+++ b/src/lib/webworker.asynciterable.generated.d.ts
@@ -3,13 +3,13 @@
 /////////////////////////////
 
 interface FileSystemDirectoryHandle {
-    [Symbol.asyncIterator](): AsyncBuiltinIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
-    entries(): AsyncBuiltinIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
-    keys(): AsyncBuiltinIterator<string, BuiltinIteratorReturn>;
-    values(): AsyncBuiltinIterator<FileSystemHandle, BuiltinIteratorReturn>;
+    [Symbol.asyncIterator](): BuiltinAsyncIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
+    entries(): BuiltinAsyncIterator<[string, FileSystemHandle], BuiltinIteratorReturn>;
+    keys(): BuiltinAsyncIterator<string, BuiltinIteratorReturn>;
+    values(): BuiltinAsyncIterator<FileSystemHandle, BuiltinIteratorReturn>;
 }
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncBuiltinIterator<R, BuiltinIteratorReturn>;
-    values(options?: ReadableStreamIteratorOptions): AsyncBuiltinIterator<R, BuiltinIteratorReturn>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): BuiltinAsyncIterator<R, BuiltinIteratorReturn>;
+    values(options?: ReadableStreamIteratorOptions): BuiltinAsyncIterator<R, BuiltinIteratorReturn>;
 }


### PR DESCRIPTION
This renames `AsyncBuiltinIterator` to `BuiltinAsyncIterator`, which is a more accurate description of the definition.