### PR TITLE
Skip markLinkedReferences import elision walk entirely in some common cases

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -49579,11 +49579,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function checkSingleIdentifier(node: Node) {
             const nodeLinks = getNodeLinks(node);
-            nodeLinks.calculatedFlags |= NodeCheckFlags.ConstructorReference | NodeCheckFlags.CapturedBlockScopedBinding | NodeCheckFlags.BlockScopedBindingInLoop;
-            if (isIdentifier(node) && isExpressionNodeOrShorthandPropertyAssignmentName(node) && !(isPropertyAccessExpression(node.parent) && node.parent.name === node)) {
-                const s = getResolvedSymbol(node);
-                if (s && s !== unknownSymbol) {
-                    checkIdentifierCalculateNodeCheckFlags(node, s);
+            nodeLinks.calculatedFlags |= NodeCheckFlags.ConstructorReference;
+            if (isIdentifier(node)) {
+                nodeLinks.calculatedFlags |= NodeCheckFlags.BlockScopedBindingInLoop | NodeCheckFlags.CapturedBlockScopedBinding; // Can't set on all arbitrary nodes (these nodes have this flag set by `checkSingleBlockScopeBinding` only)
+                if (isExpressionNodeOrShorthandPropertyAssignmentName(node) && !(isPropertyAccessExpression(node.parent) && node.parent.name === node)) {
+                    const s = getResolvedSymbol(node);
+                    if (s && s !== unknownSymbol) {
+                        checkIdentifierCalculateNodeCheckFlags(node, s);
+                    }
                 }
             }
         }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -961,8 +961,7 @@ export function emitFiles(
     }
 
     function markLinkedReferences(file: SourceFile) {
-        if (ts.isSourceFileJS(file)) return; // JS files don't use reference calculations as theyd on't do import ellision, no need to calculate it
-        if (!length(file.imports)) return; // Nothing to possible elide, no need to bother calculating references
+        if (ts.isSourceFileJS(file)) return; // JS files don't use reference calculations as they don't do import ellision, no need to calculate it
         ts.forEachChildRecursively(file, n => {
             if (isImportEqualsDeclaration(n) && !(ts.getSyntacticModifierFlags(n) & ts.ModifierFlags.Export)) return "skip"; // These are deferred and marked in a chain when referenced
             if (ts.isImportDeclaration(n)) return "skip"; // likewise, these are ultimately what get marked by calls on other nodes - we want to skip them

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -961,6 +961,8 @@ export function emitFiles(
     }
 
     function markLinkedReferences(file: SourceFile) {
+        if (ts.isSourceFileJS(file)) return; // JS files don't use reference calculations as theyd on't do import ellision, no need to calculate it
+        if (!length(file.imports)) return; // Nothing to possible elide, no need to bother calculating references
         ts.forEachChildRecursively(file, n => {
             if (isImportEqualsDeclaration(n) && !(ts.getSyntacticModifierFlags(n) & ts.ModifierFlags.Export)) return "skip"; // These are deferred and marked in a chain when referenced
             if (ts.isImportDeclaration(n)) return "skip"; // likewise, these are ultimately what get marked by calls on other nodes - we want to skip them


### PR DESCRIPTION
This should just improve performance of js->js emit with `noCheck` on.