### PR TITLE
Add generics for getElementById etc.?

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -7303,20 +7303,20 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * Returns a reference to the first object with the specified value of the ID attribute.
      * @param elementId String that specifies the ID value.
      */
-    getElementById(elementId: string): HTMLElement | null;
+    getElementById<E extends HTMLElement = HTMLElement>(elementId: string): E | null;
     /**
      * Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/getElementsByClassName)
      */
-    getElementsByClassName(classNames: string): HTMLCollectionOf<Element>;
+    getElementsByClassName<E extends Element = Element>(classNames: string): HTMLCollectionOf<E>;
     /**
      * Gets a collection of objects based on the value of the NAME or ID attribute.
      * @param elementName Gets a collection of objects based on the value of the NAME or ID attribute.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/getElementsByName)
      */
-    getElementsByName(elementName: string): NodeListOf<HTMLElement>;
+    getElementsByName<E extends HTMLElement = HTMLElement>(elementName: string): NodeListOf<E>;
     /**
      * Retrieves a collection of objects based on the specified element name.
      * @param name Specifies the name of an element.


### PR DESCRIPTION
I was coding today and noticed that I could cast querySelector() with generics, like querySelector<HTMLInputElement>('.my-input-class')!.value

This was nicer to do inline compared to (querySelector('.my-input-class') as HTMLInputElement).value

I tried to do the same with getElementById() but noticed that did not work

I am wondering if it is possible to make the getElementById() etc. methods generic like querySelector() so you can use generics inline like getElementById<HTMLInputElement>('someid')!.value instead of (getElementById('someid') as HTMLInputElement).value.

I just like the way it reads better.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
