### PR TITLE
Don't include "this is a crash" as a version in the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,6 @@ body:
 
         Please keep and fill in the line that best applies.
       value: |
-        - This is a crash
         - This changed between versions ______ and _______
         - This changed in commit or PR _______
         - This is the behavior in every version I tried, and I reviewed the FAQ for entries about _________


### PR DESCRIPTION
It seems to me that if there's a crash, we still want to know what versions have the crash, if it's new, if it's old, etc.