### PR TITLE
Bring back exported defaultInitCompilerOptions

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -259,6 +259,8 @@ export const libs = libEntries.map(entry => entry[0]);
 export const libMap = new Map(libEntries);
 
 // Watch related options
+
+// Do not delete this without updating the website's tsconfig generation.
 /** @internal */
 export const optionsForWatch: CommandLineOption[] = [
     {
@@ -1619,6 +1621,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     },
 ];
 
+// Do not delete this without updating the website's tsconfig generation.
 /** @internal */
 export const optionDeclarations: CommandLineOption[] = [
     ...commonOptionsWithBuild,
@@ -1702,6 +1705,7 @@ export const buildOpts: CommandLineOption[] = [
     ...optionsForBuild,
 ];
 
+// Do not delete this without updating the website's tsconfig generation.
 /** @internal */
 export const typeAcquisitionDeclarations: CommandLineOption[] = [
     {
@@ -1764,7 +1768,9 @@ const compilerOptionsAlternateMode: AlternateModeDiagnostics = {
     getOptionsNameMap: getBuildOptionsNameMap,
 };
 
-const defaultInitCompilerOptions: CompilerOptions = {
+// Do not delete this without updating the website's tsconfig generation.
+/** @internal @knipignore */
+export const defaultInitCompilerOptions: CompilerOptions = {
     module: ModuleKind.CommonJS,
     target: ScriptTarget.ES2016,
     strict: true,


### PR DESCRIPTION
This was removed in #56817, but is unfortunately used by the website to generate docs: https://github.com/microsoft/TypeScript-Website/blob/251ab25b100a845dfb09c7b739b05d97761f272b/packages/tsconfig-reference/scripts/tsconfigRules.ts#L6-L10

Added a note to the other three too.

We should probably reconsider these.