### PR TITLE
fix(59484): Constructor overload still present in emitted JS

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1985,10 +1985,15 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.parameters = createNodeArray(parameters);
         node.body = body;
 
-        node.transformFlags = propagateChildrenFlags(node.modifiers) |
-            propagateChildrenFlags(node.parameters) |
-            (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-            TransformFlags.ContainsES2015;
+        if (!node.body) {
+            node.transformFlags = TransformFlags.ContainsTypeScript;
+        }
+        else {
+            node.transformFlags = propagateChildrenFlags(node.modifiers) |
+                propagateChildrenFlags(node.parameters) |
+                (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
+                TransformFlags.ContainsES2015;
+        }
 
         node.typeParameters = undefined; // initialized by parser for grammar errors
         node.type = undefined; // initialized by parser for grammar errors

--- a/tests/baselines/reference/constructorOverloads9.js
+++ b/tests/baselines/reference/constructorOverloads9.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/constructorOverloads9.ts] ////
+
+//// [constructorOverloads9.ts]
+export class C {
+    a;
+    constructor();
+    constructor(x = '') {
+        this.a = x;
+    }
+}
+
+
+//// [constructorOverloads9.js]
+export class C {
+    a;
+    constructor(x = '') {
+        this.a = x;
+    }
+}

--- a/tests/baselines/reference/constructorOverloads9.symbols
+++ b/tests/baselines/reference/constructorOverloads9.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/constructorOverloads9.ts] ////
+
+=== constructorOverloads9.ts ===
+export class C {
+>C : Symbol(C, Decl(constructorOverloads9.ts, 0, 0))
+
+    a;
+>a : Symbol(C.a, Decl(constructorOverloads9.ts, 0, 16))
+
+    constructor();
+    constructor(x = '') {
+>x : Symbol(x, Decl(constructorOverloads9.ts, 3, 16))
+
+        this.a = x;
+>this.a : Symbol(C.a, Decl(constructorOverloads9.ts, 0, 16))
+>this : Symbol(C, Decl(constructorOverloads9.ts, 0, 0))
+>a : Symbol(C.a, Decl(constructorOverloads9.ts, 0, 16))
+>x : Symbol(x, Decl(constructorOverloads9.ts, 3, 16))
+    }
+}
+

--- a/tests/baselines/reference/constructorOverloads9.types
+++ b/tests/baselines/reference/constructorOverloads9.types
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/constructorOverloads9.ts] ////
+
+=== constructorOverloads9.ts ===
+export class C {
+>C : C
+>  : ^
+
+    a;
+>a : any
+
+    constructor();
+    constructor(x = '') {
+>x : string
+>  : ^^^^^^
+>'' : ""
+>   : ^^
+
+        this.a = x;
+>this.a = x : string
+>           : ^^^^^^
+>this.a : any
+>this : this
+>     : ^^^^
+>a : any
+>  : ^^^
+>x : string
+>  : ^^^^^^
+    }
+}
+

--- a/tests/cases/compiler/constructorOverloads9.ts
+++ b/tests/cases/compiler/constructorOverloads9.ts
@@ -1,0 +1,8 @@
+// @target: esnext
+export class C {
+    a;
+    constructor();
+    constructor(x = '') {
+        this.a = x;
+    }
+}


### PR DESCRIPTION
Fixes #59484