### PR TITLE
Ignore `any` in contextual intersection types

### DIFF
--- a/tests/baselines/reference/contextualIntersectionTypes.symbols
+++ b/tests/baselines/reference/contextualIntersectionTypes.symbols
@@ -1,0 +1,129 @@
+//// [tests/cases/compiler/contextualIntersectionTypes.ts] ////
+
+=== contextualIntersectionTypes.ts ===
+// https://github.com/microsoft/TypeScript/issues/59473
+
+const a: [any] & [1] = [1];
+>a : Symbol(a, Decl(contextualIntersectionTypes.ts, 2, 5))
+
+const b: { ml: any } & { ml: 'edge' } = { ml: 'edge' };
+>b : Symbol(b, Decl(contextualIntersectionTypes.ts, 3, 5))
+>ml : Symbol(ml, Decl(contextualIntersectionTypes.ts, 3, 10))
+>ml : Symbol(ml, Decl(contextualIntersectionTypes.ts, 3, 24))
+>ml : Symbol(ml, Decl(contextualIntersectionTypes.ts, 3, 41))
+
+// https://github.com/microsoft/TypeScript/issues/48812
+
+type Action<TEvent extends { type: string }> = (ev: TEvent) => void;
+>Action : Symbol(Action, Decl(contextualIntersectionTypes.ts, 3, 55))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 7, 12))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 7, 28))
+>ev : Symbol(ev, Decl(contextualIntersectionTypes.ts, 7, 48))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 7, 12))
+
+interface MachineConfig<TEvent extends { type: string }> {
+>MachineConfig : Symbol(MachineConfig, Decl(contextualIntersectionTypes.ts, 7, 68))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 9, 40))
+
+  schema: {
+>schema : Symbol(MachineConfig.schema, Decl(contextualIntersectionTypes.ts, 9, 58))
+
+    events: TEvent;
+>events : Symbol(events, Decl(contextualIntersectionTypes.ts, 10, 11))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+
+  };
+  on?: {
+>on : Symbol(MachineConfig.on, Decl(contextualIntersectionTypes.ts, 12, 4))
+
+    [K in TEvent["type"]]?: Action<TEvent extends { type: K } ? TEvent : never>;
+>K : Symbol(K, Decl(contextualIntersectionTypes.ts, 14, 5))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+>Action : Symbol(Action, Decl(contextualIntersectionTypes.ts, 3, 55))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 14, 51))
+>K : Symbol(K, Decl(contextualIntersectionTypes.ts, 14, 5))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+
+  } & {
+    "*"?: Action<TEvent>;
+>"*" : Symbol("*", Decl(contextualIntersectionTypes.ts, 15, 7))
+>Action : Symbol(Action, Decl(contextualIntersectionTypes.ts, 3, 55))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 9, 24))
+
+  };
+}
+
+declare function createMachine<TEvent extends { type: string }>(
+>createMachine : Symbol(createMachine, Decl(contextualIntersectionTypes.ts, 18, 1))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 20, 31))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 20, 47))
+
+  config: MachineConfig<TEvent>
+>config : Symbol(config, Decl(contextualIntersectionTypes.ts, 20, 64))
+>MachineConfig : Symbol(MachineConfig, Decl(contextualIntersectionTypes.ts, 7, 68))
+>TEvent : Symbol(TEvent, Decl(contextualIntersectionTypes.ts, 20, 31))
+
+): void;
+
+createMachine({
+>createMachine : Symbol(createMachine, Decl(contextualIntersectionTypes.ts, 18, 1))
+
+  schema: {
+>schema : Symbol(schema, Decl(contextualIntersectionTypes.ts, 24, 15))
+
+    events: {} as { type: "FOO" } | { type: "BAR" },
+>events : Symbol(events, Decl(contextualIntersectionTypes.ts, 25, 11))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 26, 19))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 26, 37))
+
+  },
+  on: {
+>on : Symbol(on, Decl(contextualIntersectionTypes.ts, 27, 4))
+
+    FOO: (ev) => {
+>FOO : Symbol(FOO, Decl(contextualIntersectionTypes.ts, 28, 7))
+>ev : Symbol(ev, Decl(contextualIntersectionTypes.ts, 29, 10))
+
+      ev.type;
+>ev.type : Symbol(type, Decl(contextualIntersectionTypes.ts, 26, 19))
+>ev : Symbol(ev, Decl(contextualIntersectionTypes.ts, 29, 10))
+>type : Symbol(type, Decl(contextualIntersectionTypes.ts, 26, 19))
+
+    },
+  },
+});
+
+// https://github.com/microsoft/TypeScript/issues/49307#issuecomment-1196014488
+
+type Validate<T> = T & { [K in keyof T]: object }
+>Validate : Symbol(Validate, Decl(contextualIntersectionTypes.ts, 33, 3))
+>T : Symbol(T, Decl(contextualIntersectionTypes.ts, 37, 14))
+>T : Symbol(T, Decl(contextualIntersectionTypes.ts, 37, 14))
+>K : Symbol(K, Decl(contextualIntersectionTypes.ts, 37, 26))
+>T : Symbol(T, Decl(contextualIntersectionTypes.ts, 37, 14))
+
+declare function f<S, T extends Record<string, (state: S) => any>>(s: S, x: Validate<T>): void;
+>f : Symbol(f, Decl(contextualIntersectionTypes.ts, 37, 49))
+>S : Symbol(S, Decl(contextualIntersectionTypes.ts, 38, 19))
+>T : Symbol(T, Decl(contextualIntersectionTypes.ts, 38, 21))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>state : Symbol(state, Decl(contextualIntersectionTypes.ts, 38, 48))
+>S : Symbol(S, Decl(contextualIntersectionTypes.ts, 38, 19))
+>s : Symbol(s, Decl(contextualIntersectionTypes.ts, 38, 67))
+>S : Symbol(S, Decl(contextualIntersectionTypes.ts, 38, 19))
+>x : Symbol(x, Decl(contextualIntersectionTypes.ts, 38, 72))
+>Validate : Symbol(Validate, Decl(contextualIntersectionTypes.ts, 33, 3))
+>T : Symbol(T, Decl(contextualIntersectionTypes.ts, 38, 21))
+
+f(0, {
+>f : Symbol(f, Decl(contextualIntersectionTypes.ts, 37, 49))
+
+  foo: s => s + 1,
+>foo : Symbol(foo, Decl(contextualIntersectionTypes.ts, 40, 6))
+>s : Symbol(s, Decl(contextualIntersectionTypes.ts, 41, 6))
+>s : Symbol(s, Decl(contextualIntersectionTypes.ts, 41, 6))
+
+})
+

--- a/tests/baselines/reference/contextualIntersectionTypes.types
+++ b/tests/baselines/reference/contextualIntersectionTypes.types
@@ -1,0 +1,172 @@
+//// [tests/cases/compiler/contextualIntersectionTypes.ts] ////
+
+=== contextualIntersectionTypes.ts ===
+// https://github.com/microsoft/TypeScript/issues/59473
+
+const a: [any] & [1] = [1];
+>a : [any] & [1]
+>  : ^^^^^^^^^^^
+>[1] : [1]
+>    : ^^^
+>1 : 1
+>  : ^
+
+const b: { ml: any } & { ml: 'edge' } = { ml: 'edge' };
+>b : { ml: any; } & { ml: "edge"; }
+>  : ^^^^^^   ^^^^^^^^^^^^      ^^^
+>ml : any
+>ml : "edge"
+>   : ^^^^^^
+>{ ml: 'edge' } : { ml: "edge"; }
+>               : ^^^^^^^^^^^^^^^
+>ml : "edge"
+>   : ^^^^^^
+>'edge' : "edge"
+>       : ^^^^^^
+
+// https://github.com/microsoft/TypeScript/issues/48812
+
+type Action<TEvent extends { type: string }> = (ev: TEvent) => void;
+>Action : Action<TEvent>
+>       : ^^^^^^^^^^^^^^
+>type : string
+>     : ^^^^^^
+>ev : TEvent
+>   : ^^^^^^
+
+interface MachineConfig<TEvent extends { type: string }> {
+>type : string
+>     : ^^^^^^
+
+  schema: {
+>schema : { events: TEvent; }
+>       : ^^^^^^^^^^      ^^^
+
+    events: TEvent;
+>events : TEvent
+>       : ^^^^^^
+
+  };
+  on?: {
+>on : ({ [K in TEvent["type"]]?: Action<TEvent extends { type: K; } ? TEvent : never> | undefined; } & { "*"?: Action<TEvent>; }) | undefined
+>   : ^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^^^^^^^^^^^^^^^^
+
+    [K in TEvent["type"]]?: Action<TEvent extends { type: K } ? TEvent : never>;
+>type : K
+>     : ^
+
+  } & {
+    "*"?: Action<TEvent>;
+>"*" : Action<TEvent> | undefined
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  };
+}
+
+declare function createMachine<TEvent extends { type: string }>(
+>createMachine : <TEvent extends { type: string; }>(config: MachineConfig<TEvent>) => void
+>              : ^      ^^^^^^^^^                 ^^      ^^                     ^^^^^    
+>type : string
+>     : ^^^^^^
+
+  config: MachineConfig<TEvent>
+>config : MachineConfig<TEvent>
+>       : ^^^^^^^^^^^^^^^^^^^^^
+
+): void;
+
+createMachine({
+>createMachine({  schema: {    events: {} as { type: "FOO" } | { type: "BAR" },  },  on: {    FOO: (ev) => {      ev.type;    },  },}) : void
+>                                                                                                                                      : ^^^^
+>createMachine : <TEvent extends { type: string; }>(config: MachineConfig<TEvent>) => void
+>              : ^      ^^^^^^^^^                 ^^      ^^                     ^^^^^    
+>{  schema: {    events: {} as { type: "FOO" } | { type: "BAR" },  },  on: {    FOO: (ev) => {      ev.type;    },  },} : { schema: { events: { type: "FOO"; } | { type: "BAR"; }; }; on: { FOO: (ev: { type: "FOO"; }) => void; }; }
+>                                                                                                                       : ^^^^^^^^^^^^^^^^^^^^                                   ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^
+
+  schema: {
+>schema : { events: { type: "FOO"; } | { type: "BAR"; }; }
+>       : ^^^^^^^^^^                                   ^^^
+>{    events: {} as { type: "FOO" } | { type: "BAR" },  } : { events: { type: "FOO"; } | { type: "BAR"; }; }
+>                                                         : ^^^^^^^^^^                                   ^^^
+
+    events: {} as { type: "FOO" } | { type: "BAR" },
+>events : { type: "FOO"; } | { type: "BAR"; }
+>       : ^^^^^^^^     ^^^^^^^^^^^^^^     ^^^
+>{} as { type: "FOO" } | { type: "BAR" } : { type: "FOO"; } | { type: "BAR"; }
+>                                        : ^^^^^^^^     ^^^^^^^^^^^^^^     ^^^
+>{} : {}
+>   : ^^
+>type : "FOO"
+>     : ^^^^^
+>type : "BAR"
+>     : ^^^^^
+
+  },
+  on: {
+>on : { FOO: (ev: { type: "FOO"; }) => void; }
+>   : ^^^^^^^^  ^^^^^^^^^^     ^^^^^^^^^^^^^^^
+>{    FOO: (ev) => {      ev.type;    },  } : { FOO: (ev: { type: "FOO"; }) => void; }
+>                                           : ^^^^^^^^  ^^^^^^^^^^     ^^^^^^^^^^^^^^^
+
+    FOO: (ev) => {
+>FOO : (ev: { type: "FOO"; }) => void
+>    : ^  ^^^^^^^^^^     ^^^^^^^^^^^^
+>(ev) => {      ev.type;    } : (ev: { type: "FOO"; }) => void
+>                             : ^  ^^^^^^^^^^     ^^^^^^^^^^^^
+>ev : { type: "FOO"; }
+>   : ^^^^^^^^     ^^^
+
+      ev.type;
+>ev.type : "FOO"
+>        : ^^^^^
+>ev : { type: "FOO"; }
+>   : ^^^^^^^^     ^^^
+>type : "FOO"
+>     : ^^^^^
+
+    },
+  },
+});
+
+// https://github.com/microsoft/TypeScript/issues/49307#issuecomment-1196014488
+
+type Validate<T> = T & { [K in keyof T]: object }
+>Validate : Validate<T>
+>         : ^^^^^^^^^^^
+
+declare function f<S, T extends Record<string, (state: S) => any>>(s: S, x: Validate<T>): void;
+>f : <S, T extends Record<string, (state: S) => any>>(s: S, x: Validate<T>) => void
+>  : ^ ^^ ^^^^^^^^^                                 ^^ ^^ ^^ ^^           ^^^^^    
+>state : S
+>      : ^
+>s : S
+>  : ^
+>x : Validate<T>
+>  : ^^^^^^^^^^^
+
+f(0, {
+>f(0, {  foo: s => s + 1,}) : void
+>                           : ^^^^
+>f : <S, T extends Record<string, (state: S) => any>>(s: S, x: Validate<T>) => void
+>  : ^ ^^ ^^^^^^^^^                                 ^^ ^^ ^^ ^^           ^^^^^    
+>0 : 0
+>  : ^
+>{  foo: s => s + 1,} : { foo: (s: number) => number; }
+>                     : ^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+
+  foo: s => s + 1,
+>foo : (s: number) => number
+>    : ^ ^^^^^^^^^^^^^^^^^^^
+>s => s + 1 : (s: number) => number
+>           : ^ ^^^^^^^^^^^^^^^^^^^
+>s : number
+>  : ^^^^^^
+>s + 1 : number
+>      : ^^^^^^
+>s : number
+>  : ^^^^^^
+>1 : 1
+>  : ^
+
+})
+

--- a/tests/cases/compiler/contextualIntersectionTypes.ts
+++ b/tests/cases/compiler/contextualIntersectionTypes.ts
@@ -1,0 +1,46 @@
+// @strict: true
+// @noemit: true
+
+// https://github.com/microsoft/TypeScript/issues/59473
+
+const a: [any] & [1] = [1];
+const b: { ml: any } & { ml: 'edge' } = { ml: 'edge' };
+
+// https://github.com/microsoft/TypeScript/issues/48812
+
+type Action<TEvent extends { type: string }> = (ev: TEvent) => void;
+
+interface MachineConfig<TEvent extends { type: string }> {
+  schema: {
+    events: TEvent;
+  };
+  on?: {
+    [K in TEvent["type"]]?: Action<TEvent extends { type: K } ? TEvent : never>;
+  } & {
+    "*"?: Action<TEvent>;
+  };
+}
+
+declare function createMachine<TEvent extends { type: string }>(
+  config: MachineConfig<TEvent>
+): void;
+
+createMachine({
+  schema: {
+    events: {} as { type: "FOO" } | { type: "BAR" },
+  },
+  on: {
+    FOO: (ev) => {
+      ev.type;
+    },
+  },
+});
+
+// https://github.com/microsoft/TypeScript/issues/49307#issuecomment-1196014488
+
+type Validate<T> = T & { [K in keyof T]: object }
+declare function f<S, T extends Record<string, (state: S) => any>>(s: S, x: Validate<T>): void;
+
+f(0, {
+  foo: s => s + 1,
+})


### PR DESCRIPTION
Implements what I describe [here](https://github.com/microsoft/TypeScript/issues/59473#issuecomment-2267080315).

Fixes #48812.
Fixes #55150.
Fixes #59473.
