### PR TITLE
Removed usage of keyof any in favor of PropertyKey

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1585,7 +1585,7 @@ type Pick<T, K extends keyof T> = {
 /**
  * Construct a type with a set of properties K of type T
  */
-type Record<K extends keyof any, T> = {
+type Record<K extends PropertyKey, T> = {
     [P in K]: T;
 };
 
@@ -1602,7 +1602,7 @@ type Extract<T, U> = T extends U ? T : never;
 /**
  * Construct a type with the properties of T except for those in type K.
  */
-type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type Omit<T, K extends PropertyKey> = Pick<T, Exclude<keyof T, K>>;
 
 /**
  * Exclude null and undefined from T


### PR DESCRIPTION
## Motivation:
- Despite `keyof any` and `PropertyKey` being equivalent types I believe that `PropertyKey` is easier to understand.
- Mostly beginners to TypeScript will use "Go to Definition" on `Record` and `Omit` so these changes are going to be useful. 
