### PR TITLE
Don't treat an instantiation expression as an assertion in skipOuterExpressions

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6553,6 +6553,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
                 return updateSatisfiesExpression(outerExpression, expression, outerExpression.type);
             case SyntaxKind.NonNullExpression:
                 return updateNonNullExpression(outerExpression, expression);
+            case SyntaxKind.ExpressionWithTypeArguments:
+                return updateExpressionWithTypeArguments(outerExpression, expression, outerExpression.typeArguments);
             case SyntaxKind.PartiallyEmittedExpression:
                 return updatePartiallyEmittedExpression(outerExpression, expression);
         }

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -634,7 +634,7 @@ export function isOuterExpression(node: Node, kinds = OuterExpressionKinds.All):
             return (kinds & OuterExpressionKinds.TypeAssertions) !== 0;
         case SyntaxKind.ExpressionWithTypeArguments:
             return (kinds & OuterExpressionKinds.ExpressionsWithTypeArguments) !== 0;
-            case SyntaxKind.NonNullExpression:
+        case SyntaxKind.NonNullExpression:
             return (kinds & OuterExpressionKinds.NonNullAssertions) !== 0;
         case SyntaxKind.PartiallyEmittedExpression:
             return (kinds & OuterExpressionKinds.PartiallyEmittedExpressions) !== 0;

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -630,10 +630,11 @@ export function isOuterExpression(node: Node, kinds = OuterExpressionKinds.All):
             return (kinds & OuterExpressionKinds.Parentheses) !== 0;
         case SyntaxKind.TypeAssertionExpression:
         case SyntaxKind.AsExpression:
-        case SyntaxKind.ExpressionWithTypeArguments:
         case SyntaxKind.SatisfiesExpression:
             return (kinds & OuterExpressionKinds.TypeAssertions) !== 0;
-        case SyntaxKind.NonNullExpression:
+        case SyntaxKind.ExpressionWithTypeArguments:
+            return (kinds & OuterExpressionKinds.ExpressionsWithTypeArguments) !== 0;
+            case SyntaxKind.NonNullExpression:
             return (kinds & OuterExpressionKinds.NonNullAssertions) !== 0;
         case SyntaxKind.PartiallyEmittedExpression:
             return (kinds & OuterExpressionKinds.PartiallyEmittedExpressions) !== 0;

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1689,7 +1689,7 @@ export function transformTypeScript(context: TransformationContext) {
     }
 
     function visitParenthesizedExpression(node: ParenthesizedExpression): Expression {
-        const innerExpression = skipOuterExpressions(node.expression, ~OuterExpressionKinds.Assertions);
+        const innerExpression = skipOuterExpressions(node.expression, ~(OuterExpressionKinds.Assertions | OuterExpressionKinds.ExpressionsWithTypeArguments));
         if (isAssertionExpression(innerExpression) || isSatisfiesExpression(innerExpression)) {
             // Make sure we consider all nested cast expressions, e.g.:
             // (<any><number><any>-A).x;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8481,7 +8481,7 @@ export const enum OuterExpressionKinds {
     Assertions = TypeAssertions | NonNullAssertions,
     All = Parentheses | Assertions | PartiallyEmittedExpressions | ExpressionsWithTypeArguments,
 
-    ExcludeJSDocTypeAssertion = 1 << 5,
+    ExcludeJSDocTypeAssertion = 1 << 31,
 }
 
 /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8476,11 +8476,12 @@ export const enum OuterExpressionKinds {
     TypeAssertions = 1 << 1,
     NonNullAssertions = 1 << 2,
     PartiallyEmittedExpressions = 1 << 3,
+    ExpressionsWithTypeArguments = 1 << 4,
 
     Assertions = TypeAssertions | NonNullAssertions,
-    All = Parentheses | Assertions | PartiallyEmittedExpressions,
+    All = Parentheses | Assertions | PartiallyEmittedExpressions | ExpressionsWithTypeArguments,
 
-    ExcludeJSDocTypeAssertion = 1 << 4,
+    ExcludeJSDocTypeAssertion = 1 << 5,
 }
 
 /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8491,6 +8491,7 @@ export type OuterExpression =
     | SatisfiesExpression
     | AsExpression
     | NonNullExpression
+    | ExpressionWithTypeArguments
     | PartiallyEmittedExpression;
 
 /** @internal */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7349,7 +7349,7 @@ declare namespace ts {
         ExpressionsWithTypeArguments = 16,
         Assertions = 6,
         All = 31,
-        ExcludeJSDocTypeAssertion = 32,
+        ExcludeJSDocTypeAssertion = -2147483648,
     }
     type ImmediatelyInvokedFunctionExpression = CallExpression & {
         readonly expression: FunctionExpression;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7346,9 +7346,10 @@ declare namespace ts {
         TypeAssertions = 2,
         NonNullAssertions = 4,
         PartiallyEmittedExpressions = 8,
+        ExpressionsWithTypeArguments = 16,
         Assertions = 6,
-        All = 15,
-        ExcludeJSDocTypeAssertion = 16,
+        All = 31,
+        ExcludeJSDocTypeAssertion = 32,
     }
     type ImmediatelyInvokedFunctionExpression = CallExpression & {
         readonly expression: FunctionExpression;

--- a/tests/baselines/reference/assignmentToInstantiationExpression.errors.txt
+++ b/tests/baselines/reference/assignmentToInstantiationExpression.errors.txt
@@ -1,17 +1,26 @@
+assignmentToInstantiationExpression.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 assignmentToInstantiationExpression.ts(6,1): error TS2454: Variable 'getValue' is used before being assigned.
+assignmentToInstantiationExpression.ts(6,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+assignmentToInstantiationExpression.ts(10,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 
 
-==== assignmentToInstantiationExpression.ts (1 errors) ====
+==== assignmentToInstantiationExpression.ts (4 errors) ====
     let obj: { fn?: <T>() => T } = {};
     obj.fn<number> = () => 1234;
+    ~~~~~~~~~~~~~~
+!!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
     
     
     let getValue: <T>() => T;
     getValue<number> = () => 1234;
     ~~~~~~~~
 !!! error TS2454: Variable 'getValue' is used before being assigned.
+    ~~~~~~~~~~~~~~~~
+!!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
     
     
     let getValue2!: <T>() => T;
     getValue2<number> = () => 1234;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
     

--- a/tests/baselines/reference/assignmentToInstantiationExpression.errors.txt
+++ b/tests/baselines/reference/assignmentToInstantiationExpression.errors.txt
@@ -1,0 +1,17 @@
+assignmentToInstantiationExpression.ts(6,1): error TS2454: Variable 'getValue' is used before being assigned.
+
+
+==== assignmentToInstantiationExpression.ts (1 errors) ====
+    let obj: { fn?: <T>() => T } = {};
+    obj.fn<number> = () => 1234;
+    
+    
+    let getValue: <T>() => T;
+    getValue<number> = () => 1234;
+    ~~~~~~~~
+!!! error TS2454: Variable 'getValue' is used before being assigned.
+    
+    
+    let getValue2!: <T>() => T;
+    getValue2<number> = () => 1234;
+    

--- a/tests/baselines/reference/assignmentToInstantiationExpression.js
+++ b/tests/baselines/reference/assignmentToInstantiationExpression.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/assignmentToInstantiationExpression.ts] ////
+
+//// [assignmentToInstantiationExpression.ts]
+let obj: { fn?: <T>() => T } = {};
+obj.fn<number> = () => 1234;
+
+
+let getValue: <T>() => T;
+getValue<number> = () => 1234;
+
+
+let getValue2!: <T>() => T;
+getValue2<number> = () => 1234;
+
+
+//// [assignmentToInstantiationExpression.js]
+"use strict";
+var obj = {};
+(obj.fn) = function () { return 1234; };
+var getValue;
+(getValue) = function () { return 1234; };
+var getValue2;
+(getValue2) = function () { return 1234; };

--- a/tests/baselines/reference/assignmentToInstantiationExpression.symbols
+++ b/tests/baselines/reference/assignmentToInstantiationExpression.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/assignmentToInstantiationExpression.ts] ////
+
+=== assignmentToInstantiationExpression.ts ===
+let obj: { fn?: <T>() => T } = {};
+>obj : Symbol(obj, Decl(assignmentToInstantiationExpression.ts, 0, 3))
+>fn : Symbol(fn, Decl(assignmentToInstantiationExpression.ts, 0, 10))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 0, 17))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 0, 17))
+
+obj.fn<number> = () => 1234;
+>obj.fn : Symbol(fn, Decl(assignmentToInstantiationExpression.ts, 0, 10))
+>obj : Symbol(obj, Decl(assignmentToInstantiationExpression.ts, 0, 3))
+>fn : Symbol(fn, Decl(assignmentToInstantiationExpression.ts, 0, 10))
+
+
+let getValue: <T>() => T;
+>getValue : Symbol(getValue, Decl(assignmentToInstantiationExpression.ts, 4, 3))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 4, 15))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 4, 15))
+
+getValue<number> = () => 1234;
+>getValue : Symbol(getValue, Decl(assignmentToInstantiationExpression.ts, 4, 3))
+
+
+let getValue2!: <T>() => T;
+>getValue2 : Symbol(getValue2, Decl(assignmentToInstantiationExpression.ts, 8, 3))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 8, 17))
+>T : Symbol(T, Decl(assignmentToInstantiationExpression.ts, 8, 17))
+
+getValue2<number> = () => 1234;
+>getValue2 : Symbol(getValue2, Decl(assignmentToInstantiationExpression.ts, 8, 3))
+

--- a/tests/baselines/reference/assignmentToInstantiationExpression.types
+++ b/tests/baselines/reference/assignmentToInstantiationExpression.types
@@ -1,0 +1,61 @@
+//// [tests/cases/compiler/assignmentToInstantiationExpression.ts] ////
+
+=== assignmentToInstantiationExpression.ts ===
+let obj: { fn?: <T>() => T } = {};
+>obj : { fn?: <T>() => T; }
+>    : ^^^^^^^          ^^^
+>fn : (<T>() => T) | undefined
+>   : ^^ ^^^^^^^ ^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+obj.fn<number> = () => 1234;
+>obj.fn<number> = () => 1234 : () => number
+>                            : ^^^^^^^^^^^^
+>obj.fn<number> : (() => number) | undefined
+>               : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obj.fn : (<T>() => T) | undefined
+>       : ^^ ^^^^^^^ ^^^^^^^^^^^^^
+>obj : { fn?: <T>() => T; }
+>    : ^^^^^^^          ^^^
+>fn : (<T>() => T) | undefined
+>   : ^^ ^^^^^^^ ^^^^^^^^^^^^^
+>() => 1234 : () => number
+>           : ^^^^^^^^^^^^
+>1234 : 1234
+>     : ^^^^
+
+
+let getValue: <T>() => T;
+>getValue : <T>() => T
+>         : ^ ^^^^^^^ 
+
+getValue<number> = () => 1234;
+>getValue<number> = () => 1234 : () => number
+>                              : ^^^^^^^^^^^^
+>getValue<number> : () => number
+>                 : ^^^^^^^^^^^^
+>getValue : <T>() => T
+>         : ^ ^^^^^^^ 
+>() => 1234 : () => number
+>           : ^^^^^^^^^^^^
+>1234 : 1234
+>     : ^^^^
+
+
+let getValue2!: <T>() => T;
+>getValue2 : <T>() => T
+>          : ^ ^^^^^^^ 
+
+getValue2<number> = () => 1234;
+>getValue2<number> = () => 1234 : () => number
+>                               : ^^^^^^^^^^^^
+>getValue2<number> : () => number
+>                  : ^^^^^^^^^^^^
+>getValue2 : <T>() => T
+>          : ^ ^^^^^^^ 
+>() => 1234 : () => number
+>           : ^^^^^^^^^^^^
+>1234 : 1234
+>     : ^^^^
+

--- a/tests/cases/compiler/assignmentToInstantiationExpression.ts
+++ b/tests/cases/compiler/assignmentToInstantiationExpression.ts
@@ -1,0 +1,12 @@
+// @strict: true
+
+let obj: { fn?: <T>() => T } = {};
+obj.fn<number> = () => 1234;
+
+
+let getValue: <T>() => T;
+getValue<number> = () => 1234;
+
+
+let getValue2!: <T>() => T;
+getValue2<number> = () => 1234;


### PR DESCRIPTION
#50820 added `ExpressionWithTypeArguments` to `isOuterExpression` but treated it as an assertion, which then caused the checker to skip past it in reference checking. Split that out so we can skip past it in transforms like we did previously, which feels better because an instantiation is not really an assertion.

Also, while here, fix the fact that other `OuterExpression` related code was not `ExpressionWithTypeArguments` either.

Fixes #59535