### PR TITLE
Add `autoImportSpecifierExcludeRegexes` preference

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -130,7 +130,26 @@ import {
 
 const stringToRegex = memoizeOne((pattern: string) => {
     try {
-        return new RegExp(pattern);
+        let slash = pattern.indexOf("/");
+        if (slash !== 0) {
+            // No leading slash, treat as a pattern
+            return new RegExp(pattern);
+        }
+        const lastSlash = pattern.lastIndexOf("/");
+        if (slash === lastSlash) {
+            // Only one slash, treat as a pattern
+            return new RegExp(pattern);
+        }
+        while ((slash = pattern.indexOf("/", slash + 1)) !== lastSlash) {
+            if (pattern[slash - 1] !== "\\") {
+                // Unescaped middle slash, treat as a pattern
+                return new RegExp(pattern);
+            }
+        }
+        // Only case-insensitive and unicode flags make sense
+        const flags = pattern.substring(lastSlash + 1).replace(/[^iu]/g, "");
+        pattern = pattern.substring(1, lastSlash);
+        return new RegExp(pattern, flags);
     }
     catch {
         return undefined;

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -132,7 +132,9 @@ const stringToRegex = memoizeOne((pattern: string) => {
     try {
         return new RegExp(pattern);
     }
-    catch {}
+    catch {
+        return undefined;
+    }
 });
 
 // Used by importFixes, getEditsForFileRename, and declaration emit to synthesize import module specifiers.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -10251,6 +10251,7 @@ export interface UserPreferences {
     readonly interactiveInlayHints?: boolean;
     readonly allowRenameOfImportPath?: boolean;
     readonly autoImportFileExcludePatterns?: string[];
+    readonly autoImportSpecifierExcludeRegexes?: string[];
     readonly preferTypeOnlyAutoImports?: boolean;
     /**
      * Indicates whether imports should be organized in a case-insensitive manner.

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -84,7 +84,6 @@ import {
     getEffectiveBaseTypeNode,
     getEffectiveModifierFlags,
     getEffectiveTypeAnnotationNode,
-    getEmitModuleResolutionKind,
     getEmitScriptTarget,
     getEscapedTextOfIdentifierOrLiteral,
     getEscapedTextOfJsxAttributeName,
@@ -106,6 +105,7 @@ import {
     getPropertyNameForPropertyNameNode,
     getQuotePreference,
     getReplacementSpanForContextToken,
+    getResolvePackageJsonExports,
     getRootDeclaration,
     getSourceFileOfModule,
     getSwitchedType,
@@ -301,7 +301,6 @@ import {
     ModuleDeclaration,
     moduleExportNameTextEscaped,
     ModuleReference,
-    moduleResolutionSupportsPackageJsonExportsAndImports,
     NamedImportBindings,
     newCaseClauseTracker,
     Node,
@@ -629,12 +628,16 @@ function resolvingModuleSpecifiers<TReturn>(
     cb: (context: ModuleSpecifierResolutionContext) => TReturn,
 ): TReturn {
     const start = timestamp();
-    // Under `--moduleResolution nodenext`, we have to resolve module specifiers up front, because
+    // Under `--moduleResolution nodenext` or `bundler`, we have to resolve module specifiers up front, because
     // package.json exports can mean we *can't* resolve a module specifier (that doesn't include a
     // relative path into node_modules), and we want to filter those completions out entirely.
     // Import statement completions always need specifier resolution because the module specifier is
     // part of their `insertText`, not the `codeActions` creating edits away from the cursor.
-    const needsFullResolution = isForImportStatementCompletion || moduleResolutionSupportsPackageJsonExportsAndImports(getEmitModuleResolutionKind(program.getCompilerOptions()));
+    // Finally, `autoImportSpecifierExcludeRegexes` necessitates eagerly resolving module specifiers
+    // because completion items are being explcitly filtered out by module specifier.
+    const needsFullResolution = isForImportStatementCompletion
+        || getResolvePackageJsonExports(program.getCompilerOptions())
+        || preferences.autoImportSpecifierExcludeRegexes?.length;
     let skippedAny = false;
     let ambientCount = 0;
     let resolvedCount = 0;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -8240,6 +8240,7 @@ declare namespace ts {
         readonly interactiveInlayHints?: boolean;
         readonly allowRenameOfImportPath?: boolean;
         readonly autoImportFileExcludePatterns?: string[];
+        readonly autoImportSpecifierExcludeRegexes?: string[];
         readonly preferTypeOnlyAutoImports?: boolean;
         /**
          * Indicates whether imports should be organized in a case-insensitive manner.

--- a/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
+++ b/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
@@ -19,3 +19,34 @@ verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRe
 verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["^ambient/"] });
 verify.importFixModuleSpecifiers("", ["ambient/utils"], { autoImportSpecifierExcludeRegexes: ["ambient$"] });
 verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"], { autoImportSpecifierExcludeRegexes: ["oops("] });
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "x",
+    source: "ambient",
+    sourceDisplay: "ambient",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "x",
+    source: "ambient/utils",
+    sourceDisplay: "ambient/utils",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true
+  }
+});
+
+verify.completions({
+    marker: "",
+    excludes: ["ambient/utils"],
+    preferences: {
+      includeCompletionsForModuleExports: true,
+      allowIncompleteCompletions: true,
+      autoImportSpecifierExcludeRegexes: ["utils"]
+    },
+})

--- a/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
+++ b/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+
+// @Filename: /node_modules/lib/index.d.ts
+//// declare module "ambient" {
+////     export const x: number;
+//// }
+//// declare module "ambient/utils" {
+////    export const x: number;
+//// }
+
+// @Filename: /index.ts
+//// x/**/
+
+verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"]);
+verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["utils"] });
+verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["/.*?$"]});
+verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["^ambient/"] });
+verify.importFixModuleSpecifiers("", ["ambient/utils"], { autoImportSpecifierExcludeRegexes: ["ambient$"] });
+verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"], { autoImportSpecifierExcludeRegexes: ["oops("] });

--- a/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
+++ b/tests/cases/fourslash/autoImportSpecifierExcludeRegexes1.ts
@@ -15,7 +15,16 @@
 
 verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"]);
 verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["utils"] });
+// case sensitive, no match
+verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"], { autoImportSpecifierExcludeRegexes: ["/UTILS/"] });
+// case insensitive flag given
+verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["/UTILS/i"] });
+// invalid due to unescaped slash, treated as pattern
+verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"], { autoImportSpecifierExcludeRegexes: ["/ambient/utils/"] });
+verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["/ambient\\/utils/"] });
+// no trailing slash, treated as pattern, slash doesn't need to be escaped
 verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["/.*?$"]});
+// no leading slash, treated as pattern, slash doesn't need to be escaped
 verify.importFixModuleSpecifiers("", ["ambient"], { autoImportSpecifierExcludeRegexes: ["^ambient/"] });
 verify.importFixModuleSpecifiers("", ["ambient/utils"], { autoImportSpecifierExcludeRegexes: ["ambient$"] });
 verify.importFixModuleSpecifiers("", ["ambient", "ambient/utils"], { autoImportSpecifierExcludeRegexes: ["oops("] });

--- a/tests/cases/fourslash/autoImportSpecifierExcludeRegexes2.ts
+++ b/tests/cases/fourslash/autoImportSpecifierExcludeRegexes2.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "preserve",
+////         "paths": {
+////             "@app/*": ["./src/*"]
+////         }
+////     }
+//// }
+
+// @Filename: /src/utils.ts
+//// export function add(a: number, b: number) {}
+
+// @Filename: /src/index.ts
+//// add/**/
+
+verify.importFixModuleSpecifiers("", ["./utils"]);
+verify.importFixModuleSpecifiers("", ["@app/utils"], { autoImportSpecifierExcludeRegexes: ["^\\./"] });
+
+verify.importFixModuleSpecifiers("", ["@app/utils"], { importModuleSpecifierPreference: "non-relative" });
+verify.importFixModuleSpecifiers("", ["./utils"], { importModuleSpecifierPreference: "non-relative", autoImportSpecifierExcludeRegexes: ["^@app/"] });
+
+verify.importFixModuleSpecifiers("", [], { autoImportSpecifierExcludeRegexes: ["utils"] });

--- a/tests/cases/fourslash/autoImportSpecifierExcludeRegexes3.ts
+++ b/tests/cases/fourslash/autoImportSpecifierExcludeRegexes3.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+
+// @Filename: /node_modules/pkg/package.json
+//// {
+////     "name": "pkg",
+////     "version": "1.0.0",
+////     "exports": {
+////         ".": "./index.js",
+////         "./utils": "./utils.js"
+////     }
+//// }
+
+// @Filename: /node_modules/pkg/utils.d.ts
+//// export function add(a: number, b: number) {}
+
+// @Filename: /node_modules/pkg/index.d.ts
+//// export * from "./utils";
+
+// @Filename: /src/index.ts
+//// add/**/
+
+verify.importFixModuleSpecifiers("", ["pkg", "pkg/utils"]);
+verify.importFixModuleSpecifiers("", ["pkg/utils"], { autoImportSpecifierExcludeRegexes: ["^pkg$"] });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -686,6 +686,7 @@ declare namespace FourSlashInterface {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly allowRenameOfImportPath?: boolean;
         readonly autoImportFileExcludePatterns?: readonly string[];
+        readonly autoImportSpecifierExcludeRegexes?: readonly string[];
         readonly preferTypeOnlyAutoImports?: boolean;
         readonly organizeImportsIgnoreCase?: "auto" | boolean;
         readonly organizeImportsCollation?: "unicode" | "ordinal";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Closes #55092 

This has the limitation that it doesn't compose very intelligently with the `importModuleSpecifierEnding` preference&mdash;you can set that to `"js"` and then write a regex that excludes `\.js$` and the result will be that you get no (relative) auto imports at all. But I think I'd like to try this and get feedback.