### PR TITLE
update generated diagnostic messages for isolated declarations

### DIFF
--- a/scripts/processDiagnosticMessages.mjs
+++ b/scripts/processDiagnosticMessages.mjs
@@ -93,20 +93,23 @@ function buildInfoFileOutput(messageTable, inputFilePathRel) {
         "}",
         "",
         "/** @internal */",
-        "export const Diagnostics = {",
+        "export const Diagnostics: Diagnostics = {",
     ];
+    const interfaceResult = ["\r\ninterface Diagnostics {"];
     messageTable.forEach(({ code, category, reportsUnnecessary, elidedInCompatabilityPyramid, reportsDeprecated }, name) => {
         const propName = convertPropertyName(name);
         const argReportsUnnecessary = reportsUnnecessary ? `, /*reportsUnnecessary*/ ${reportsUnnecessary}` : "";
         const argElidedInCompatabilityPyramid = elidedInCompatabilityPyramid ? `${!reportsUnnecessary ? ", /*reportsUnnecessary*/ undefined" : ""}, /*elidedInCompatabilityPyramid*/ ${elidedInCompatabilityPyramid}` : "";
         const argReportsDeprecated = reportsDeprecated ? `${!argElidedInCompatabilityPyramid ? ", /*reportsUnnecessary*/ undefined, /*elidedInCompatabilityPyramid*/ undefined" : ""}, /*reportsDeprecated*/ ${reportsDeprecated}` : "";
 
+        interfaceResult.push(`    ${propName}: DiagnosticMessage;`);
         result.push(`    ${propName}: diag(${code}, DiagnosticCategory.${category}, "${createKey(propName, code)}", ${JSON.stringify(name)}${argReportsUnnecessary}${argElidedInCompatabilityPyramid}${argReportsDeprecated}),`);
     });
 
+    interfaceResult.push("}");
     result.push("};");
 
-    return result.join("\r\n");
+    return result.join("\r\n") + interfaceResult.join("\r\n");
 }
 
 /**


### PR DESCRIPTION
In investigating adopting isolated declarations (#59097), I found that the generated `Diagnostics` needs a type annotation. This updates the script so we're able to provide a type annotation for it. 

(this PR does not turn on the flag but once I make the PR that turns on the flag, I'll link it here: ____)