### PR TITLE
Fixed lack of errors on missing `JSX.Element`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33462,10 +33462,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             error(errorNode, Diagnostics.Cannot_use_JSX_unless_the_jsx_flag_is_provided);
         }
 
-        if (getJsxElementTypeAt(errorNode) === undefined) {
-            if (noImplicitAny) {
-                error(errorNode, Diagnostics.JSX_element_implicitly_has_type_any_because_the_global_type_JSX_Element_does_not_exist);
-            }
+        if (noImplicitAny && isErrorType(getJsxElementTypeAt(errorNode))) {
+            error(errorNode, Diagnostics.JSX_element_implicitly_has_type_any_because_the_global_type_JSX_Element_does_not_exist);
         }
     }
 

--- a/src/testRunner/unittests/tsc/incremental.ts
+++ b/src/testRunner/unittests/tsc/incremental.ts
@@ -287,6 +287,7 @@ declare global {
                     declare namespace JSX {
                         interface ElementChildrenAttribute { children: {}; }
                         interface IntrinsicElements { div: {} }
+                        interface Element<P, T> { props: P; type: T; }
                     }
 
                     declare var React: any;

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.js
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.js
@@ -3,6 +3,7 @@
 //// [checkJsxIntersectionElementPropsType.tsx]
 declare namespace JSX {
     interface ElementAttributesProperty { props: {}; }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 declare class Component<P> {

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.symbols
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.symbols
@@ -7,37 +7,46 @@ declare namespace JSX {
     interface ElementAttributesProperty { props: {}; }
 >ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(checkJsxIntersectionElementPropsType.tsx, 0, 23))
 >props : Symbol(ElementAttributesProperty.props, Decl(checkJsxIntersectionElementPropsType.tsx, 1, 41))
+
+    interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(checkJsxIntersectionElementPropsType.tsx, 1, 54))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 22))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 24))
+>props : Symbol(Element.props, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 29))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 22))
+>type : Symbol(Element.type, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 39))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 24))
 }
 
 declare class Component<P> {
->Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 1))
->P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+>Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 3, 1))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 24))
 
   constructor(props: Readonly<P>);
->props : Symbol(props, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 14))
+>props : Symbol(props, Decl(checkJsxIntersectionElementPropsType.tsx, 6, 14))
 >Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
->P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 24))
 
   readonly props: Readonly<P>;
->props : Symbol(Component.props, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 34))
+>props : Symbol(Component.props, Decl(checkJsxIntersectionElementPropsType.tsx, 6, 34))
 >Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
->P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 24))
 }
 
 class C<T> extends Component<{ x?: boolean; } & T> {}
->C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
->T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 8))
->Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 1))
->x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 30))
->T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 8))
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 8, 1))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 8))
+>Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 3, 1))
+>x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 30))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 8))
 
 const y = new C({foobar: "example"});
->y : Symbol(y, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 5))
->C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
->foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 17))
+>y : Symbol(y, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 5))
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 8, 1))
+>foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 17))
 
 const x = <C foobar="example" />
->x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 5))
->C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
->foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 12))
+>x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 12, 5))
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 8, 1))
+>foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 12, 12))
 

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
@@ -5,6 +5,12 @@ declare namespace JSX {
     interface ElementAttributesProperty { props: {}; }
 >props : {}
 >      : ^^
+
+    interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 declare class Component<P> {
@@ -43,8 +49,10 @@ const y = new C({foobar: "example"});
 >          : ^^^^^^^^^
 
 const x = <C foobar="example" />
->x : error
-><C foobar="example" /> : error
+>x : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+><C foobar="example" /> : JSX.Element<P, T>
+>                       : ^^^^^^^^^^^^^^^^^
 >C : typeof C
 >  : ^^^^^^^^
 >foobar : string

--- a/tests/baselines/reference/contextuallyTypedJsxAttribute.js
+++ b/tests/baselines/reference/contextuallyTypedJsxAttribute.js
@@ -1,6 +1,10 @@
 //// [tests/cases/compiler/contextuallyTypedJsxAttribute.ts] ////
 
 //// [index.tsx]
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+}
+
 interface Elements {
   foo: { callback?: (value: number) => void };
   bar: { callback?: (value: string) => void };

--- a/tests/baselines/reference/contextuallyTypedJsxAttribute.symbols
+++ b/tests/baselines/reference/contextuallyTypedJsxAttribute.symbols
@@ -1,70 +1,83 @@
 //// [tests/cases/compiler/contextuallyTypedJsxAttribute.ts] ////
 
 === index.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(index.tsx, 0, 0))
+
+  interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(index.tsx, 0, 23))
+>P : Symbol(P, Decl(index.tsx, 1, 20))
+>T : Symbol(T, Decl(index.tsx, 1, 22))
+>props : Symbol(Element.props, Decl(index.tsx, 1, 27))
+>P : Symbol(P, Decl(index.tsx, 1, 20))
+>type : Symbol(Element.type, Decl(index.tsx, 1, 37))
+>T : Symbol(T, Decl(index.tsx, 1, 22))
+}
+
 interface Elements {
->Elements : Symbol(Elements, Decl(index.tsx, 0, 0))
+>Elements : Symbol(Elements, Decl(index.tsx, 2, 1))
 
   foo: { callback?: (value: number) => void };
->foo : Symbol(Elements.foo, Decl(index.tsx, 0, 20))
->callback : Symbol(callback, Decl(index.tsx, 1, 8))
->value : Symbol(value, Decl(index.tsx, 1, 21))
+>foo : Symbol(Elements.foo, Decl(index.tsx, 4, 20))
+>callback : Symbol(callback, Decl(index.tsx, 5, 8))
+>value : Symbol(value, Decl(index.tsx, 5, 21))
 
   bar: { callback?: (value: string) => void };
->bar : Symbol(Elements.bar, Decl(index.tsx, 1, 46))
->callback : Symbol(callback, Decl(index.tsx, 2, 8))
->value : Symbol(value, Decl(index.tsx, 2, 21))
+>bar : Symbol(Elements.bar, Decl(index.tsx, 5, 46))
+>callback : Symbol(callback, Decl(index.tsx, 6, 8))
+>value : Symbol(value, Decl(index.tsx, 6, 21))
 }
 
 type Props<C extends keyof Elements> = { as?: C } & Elements[C];
->Props : Symbol(Props, Decl(index.tsx, 3, 1))
->C : Symbol(C, Decl(index.tsx, 5, 11))
->Elements : Symbol(Elements, Decl(index.tsx, 0, 0))
->as : Symbol(as, Decl(index.tsx, 5, 40))
->C : Symbol(C, Decl(index.tsx, 5, 11))
->Elements : Symbol(Elements, Decl(index.tsx, 0, 0))
->C : Symbol(C, Decl(index.tsx, 5, 11))
+>Props : Symbol(Props, Decl(index.tsx, 7, 1))
+>C : Symbol(C, Decl(index.tsx, 9, 11))
+>Elements : Symbol(Elements, Decl(index.tsx, 2, 1))
+>as : Symbol(as, Decl(index.tsx, 9, 40))
+>C : Symbol(C, Decl(index.tsx, 9, 11))
+>Elements : Symbol(Elements, Decl(index.tsx, 2, 1))
+>C : Symbol(C, Decl(index.tsx, 9, 11))
 
 declare function Test<C extends keyof Elements>(props: Props<C>): null;
->Test : Symbol(Test, Decl(index.tsx, 5, 64))
->C : Symbol(C, Decl(index.tsx, 6, 22))
->Elements : Symbol(Elements, Decl(index.tsx, 0, 0))
->props : Symbol(props, Decl(index.tsx, 6, 48))
->Props : Symbol(Props, Decl(index.tsx, 3, 1))
->C : Symbol(C, Decl(index.tsx, 6, 22))
+>Test : Symbol(Test, Decl(index.tsx, 9, 64))
+>C : Symbol(C, Decl(index.tsx, 10, 22))
+>Elements : Symbol(Elements, Decl(index.tsx, 2, 1))
+>props : Symbol(props, Decl(index.tsx, 10, 48))
+>Props : Symbol(Props, Decl(index.tsx, 7, 1))
+>C : Symbol(C, Decl(index.tsx, 10, 22))
 
 <Test
->Test : Symbol(Test, Decl(index.tsx, 5, 64))
+>Test : Symbol(Test, Decl(index.tsx, 9, 64))
 
   as="bar"
->as : Symbol(as, Decl(index.tsx, 8, 5))
+>as : Symbol(as, Decl(index.tsx, 12, 5))
 
   callback={(value) => {}}
->callback : Symbol(callback, Decl(index.tsx, 9, 10))
->value : Symbol(value, Decl(index.tsx, 10, 13))
+>callback : Symbol(callback, Decl(index.tsx, 13, 10))
+>value : Symbol(value, Decl(index.tsx, 14, 13))
 
 />;
 
 Test({
->Test : Symbol(Test, Decl(index.tsx, 5, 64))
+>Test : Symbol(Test, Decl(index.tsx, 9, 64))
 
   as: "bar",
->as : Symbol(as, Decl(index.tsx, 13, 6))
+>as : Symbol(as, Decl(index.tsx, 17, 6))
 
   callback: (value) => {},
->callback : Symbol(callback, Decl(index.tsx, 14, 12))
->value : Symbol(value, Decl(index.tsx, 15, 13))
+>callback : Symbol(callback, Decl(index.tsx, 18, 12))
+>value : Symbol(value, Decl(index.tsx, 19, 13))
 
 });
 
 <Test<'bar'>
->Test : Symbol(Test, Decl(index.tsx, 5, 64))
+>Test : Symbol(Test, Decl(index.tsx, 9, 64))
 
   as="bar"
->as : Symbol(as, Decl(index.tsx, 18, 12))
+>as : Symbol(as, Decl(index.tsx, 22, 12))
 
   callback={(value) => {}}
->callback : Symbol(callback, Decl(index.tsx, 19, 10))
->value : Symbol(value, Decl(index.tsx, 20, 13))
+>callback : Symbol(callback, Decl(index.tsx, 23, 10))
+>value : Symbol(value, Decl(index.tsx, 24, 13))
 
 />;
 

--- a/tests/baselines/reference/contextuallyTypedJsxAttribute.types
+++ b/tests/baselines/reference/contextuallyTypedJsxAttribute.types
@@ -1,6 +1,14 @@
 //// [tests/cases/compiler/contextuallyTypedJsxAttribute.ts] ////
 
 === index.tsx ===
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
+}
+
 interface Elements {
   foo: { callback?: (value: number) => void };
 >foo : { callback?: (value: number) => void; }
@@ -32,7 +40,8 @@ declare function Test<C extends keyof Elements>(props: Props<C>): null;
 >      : ^^^^^^^^
 
 <Test
-><Test  as="bar"  callback={(value) => {}}/> : error
+><Test  as="bar"  callback={(value) => {}}/> : JSX.Element<P, T>
+>                                            : ^^^^^^^^^^^^^^^^^
 >Test : <C extends keyof Elements>(props: Props<C>) => null
 >     : ^ ^^^^^^^^^              ^^     ^^        ^^^^^    
 
@@ -75,7 +84,8 @@ Test({
 });
 
 <Test<'bar'>
-><Test<'bar'>  as="bar"  callback={(value) => {}}/> : error
+><Test<'bar'>  as="bar"  callback={(value) => {}}/> : JSX.Element<P, T>
+>                                                   : ^^^^^^^^^^^^^^^^^
 >Test : <C extends keyof Elements>(props: Props<C>) => null
 >     : ^ ^^^^^^^^^              ^^     ^^        ^^^^^    
 

--- a/tests/baselines/reference/discriminatedUnionJsxElement.js
+++ b/tests/baselines/reference/discriminatedUnionJsxElement.js
@@ -3,6 +3,10 @@
 //// [discriminatedUnionJsxElement.tsx]
 // Repro from #46021
 
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+}
+
 interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
     menuItemsVariant?: MenuItemVariant;
 }
@@ -43,10 +47,16 @@ function ListItem(_data) {
 
 
 //// [discriminatedUnionJsxElement.d.ts]
+declare namespace JSX {
+    interface Element<P, T> {
+        props: P;
+        type: T;
+    }
+}
 interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
     menuItemsVariant?: MenuItemVariant;
 }
-declare function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>): any;
+declare function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>): JSX.Element<P, T>;
 type IListItemData = {
     variant: ListItemVariant.Avatar;
 } | {
@@ -57,3 +67,38 @@ declare enum ListItemVariant {
     Avatar = 1
 }
 declare function ListItem(_data: IListItemData): null;
+
+
+//// [DtsFileErrors]
+
+
+discriminatedUnionJsxElement.d.ts(10,133): error TS2304: Cannot find name 'P'.
+discriminatedUnionJsxElement.d.ts(10,136): error TS2304: Cannot find name 'T'.
+
+
+==== discriminatedUnionJsxElement.d.ts (2 errors) ====
+    declare namespace JSX {
+        interface Element<P, T> {
+            props: P;
+            type: T;
+        }
+    }
+    interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
+        menuItemsVariant?: MenuItemVariant;
+    }
+    declare function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>): JSX.Element<P, T>;
+                                                                                                                                        ~
+!!! error TS2304: Cannot find name 'P'.
+                                                                                                                                           ~
+!!! error TS2304: Cannot find name 'T'.
+    type IListItemData = {
+        variant: ListItemVariant.Avatar;
+    } | {
+        variant: ListItemVariant.OneLine;
+    };
+    declare enum ListItemVariant {
+        OneLine = 0,
+        Avatar = 1
+    }
+    declare function ListItem(_data: IListItemData): null;
+    

--- a/tests/baselines/reference/discriminatedUnionJsxElement.symbols
+++ b/tests/baselines/reference/discriminatedUnionJsxElement.symbols
@@ -3,66 +3,79 @@
 === discriminatedUnionJsxElement.tsx ===
 // Repro from #46021
 
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(discriminatedUnionJsxElement.tsx, 0, 0))
+
+  interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(discriminatedUnionJsxElement.tsx, 2, 23))
+>P : Symbol(P, Decl(discriminatedUnionJsxElement.tsx, 3, 20))
+>T : Symbol(T, Decl(discriminatedUnionJsxElement.tsx, 3, 22))
+>props : Symbol(Element.props, Decl(discriminatedUnionJsxElement.tsx, 3, 27))
+>P : Symbol(P, Decl(discriminatedUnionJsxElement.tsx, 3, 20))
+>type : Symbol(Element.type, Decl(discriminatedUnionJsxElement.tsx, 3, 37))
+>T : Symbol(T, Decl(discriminatedUnionJsxElement.tsx, 3, 22))
+}
+
 interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
->IData : Symbol(IData, Decl(discriminatedUnionJsxElement.tsx, 0, 0))
->MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 2, 16))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
+>IData : Symbol(IData, Decl(discriminatedUnionJsxElement.tsx, 4, 1))
+>MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 16))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
 
     menuItemsVariant?: MenuItemVariant;
->menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 2, 84))
->MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 2, 16))
+>menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 84))
+>MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 16))
 }
 
 function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>) {
->Menu : Symbol(Menu, Decl(discriminatedUnionJsxElement.tsx, 4, 1))
->MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 14))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
->data : Symbol(data, Decl(discriminatedUnionJsxElement.tsx, 6, 81))
->IData : Symbol(IData, Decl(discriminatedUnionJsxElement.tsx, 0, 0))
->MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 14))
+>Menu : Symbol(Menu, Decl(discriminatedUnionJsxElement.tsx, 8, 1))
+>MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 10, 14))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
+>data : Symbol(data, Decl(discriminatedUnionJsxElement.tsx, 10, 81))
+>IData : Symbol(IData, Decl(discriminatedUnionJsxElement.tsx, 4, 1))
+>MenuItemVariant : Symbol(MenuItemVariant, Decl(discriminatedUnionJsxElement.tsx, 10, 14))
 
     const listItemVariant = data.menuItemsVariant ?? ListItemVariant.OneLine;
->listItemVariant : Symbol(listItemVariant, Decl(discriminatedUnionJsxElement.tsx, 7, 9))
->data.menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 2, 84))
->data : Symbol(data, Decl(discriminatedUnionJsxElement.tsx, 6, 81))
->menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 2, 84))
->ListItemVariant.OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
+>listItemVariant : Symbol(listItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 9))
+>data.menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 84))
+>data : Symbol(data, Decl(discriminatedUnionJsxElement.tsx, 10, 81))
+>menuItemsVariant : Symbol(IData.menuItemsVariant, Decl(discriminatedUnionJsxElement.tsx, 6, 84))
+>ListItemVariant.OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
 
     return <ListItem variant={listItemVariant} />;
->ListItem : Symbol(ListItem, Decl(discriminatedUnionJsxElement.tsx, 16, 1))
->variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 8, 20))
->listItemVariant : Symbol(listItemVariant, Decl(discriminatedUnionJsxElement.tsx, 7, 9))
+>ListItem : Symbol(ListItem, Decl(discriminatedUnionJsxElement.tsx, 20, 1))
+>variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 12, 20))
+>listItemVariant : Symbol(listItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 9))
 }
 
 type IListItemData = { variant: ListItemVariant.Avatar; } | { variant: ListItemVariant.OneLine; };
->IListItemData : Symbol(IListItemData, Decl(discriminatedUnionJsxElement.tsx, 9, 1))
->variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 11, 22))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->Avatar : Symbol(ListItemVariant.Avatar, Decl(discriminatedUnionJsxElement.tsx, 14, 12))
->variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 11, 61))
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
->OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
+>IListItemData : Symbol(IListItemData, Decl(discriminatedUnionJsxElement.tsx, 13, 1))
+>variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 15, 22))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>Avatar : Symbol(ListItemVariant.Avatar, Decl(discriminatedUnionJsxElement.tsx, 18, 12))
+>variant : Symbol(variant, Decl(discriminatedUnionJsxElement.tsx, 15, 61))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
+>OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
 
 enum ListItemVariant {
->ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 11, 98))
+>ListItemVariant : Symbol(ListItemVariant, Decl(discriminatedUnionJsxElement.tsx, 15, 98))
 
     OneLine,
->OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 13, 22))
+>OneLine : Symbol(ListItemVariant.OneLine, Decl(discriminatedUnionJsxElement.tsx, 17, 22))
 
     Avatar,
->Avatar : Symbol(ListItemVariant.Avatar, Decl(discriminatedUnionJsxElement.tsx, 14, 12))
+>Avatar : Symbol(ListItemVariant.Avatar, Decl(discriminatedUnionJsxElement.tsx, 18, 12))
 }
 
 function ListItem(_data: IListItemData) {
->ListItem : Symbol(ListItem, Decl(discriminatedUnionJsxElement.tsx, 16, 1))
->_data : Symbol(_data, Decl(discriminatedUnionJsxElement.tsx, 18, 18))
->IListItemData : Symbol(IListItemData, Decl(discriminatedUnionJsxElement.tsx, 9, 1))
+>ListItem : Symbol(ListItem, Decl(discriminatedUnionJsxElement.tsx, 20, 1))
+>_data : Symbol(_data, Decl(discriminatedUnionJsxElement.tsx, 22, 18))
+>IListItemData : Symbol(IListItemData, Decl(discriminatedUnionJsxElement.tsx, 13, 1))
 
     return null; 
 }

--- a/tests/baselines/reference/discriminatedUnionJsxElement.types
+++ b/tests/baselines/reference/discriminatedUnionJsxElement.types
@@ -3,6 +3,14 @@
 === discriminatedUnionJsxElement.tsx ===
 // Repro from #46021
 
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
+}
+
 interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
 >ListItemVariant : any
 >                : ^^^
@@ -13,8 +21,8 @@ interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLin
 }
 
 function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>) {
->Menu : <MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>) => any
->     : ^               ^^^^^^^^^               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^                      ^^^^^^^^
+>Menu : <MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>(data: IData<MenuItemVariant>) => JSX.Element<P, T>
+>     : ^               ^^^^^^^^^               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^                      ^^^^^^^^^^^^^^^^^^^^^^
 >ListItemVariant : any
 >                : ^^^
 >data : IData<MenuItemVariant>
@@ -39,7 +47,8 @@ function Menu<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine>
 >        : ^^^^^^^^^^^^^^^^^^^^^^^
 
     return <ListItem variant={listItemVariant} />;
-><ListItem variant={listItemVariant} /> : error
+><ListItem variant={listItemVariant} /> : JSX.Element<P, T>
+>                                       : ^^^^^^^^^^^^^^^^^
 >ListItem : (_data: IListItemData) => null
 >         : ^     ^^             ^^^^^^^^^
 >variant : ListItemVariant

--- a/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.js
+++ b/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.js
@@ -5,6 +5,7 @@ namespace JSX {
   export interface ElementChildrenAttribute {
     children: {};
   }
+  export interface Element<P, T> { props: P; type: T; }
 }
 
 interface Props {

--- a/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.symbols
+++ b/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.symbols
@@ -10,34 +10,42 @@ namespace JSX {
     children: {};
 >children : Symbol(ElementChildrenAttribute.children, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 1, 45))
   }
+  export interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 3, 3))
+>P : Symbol(P, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 27))
+>T : Symbol(T, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 29))
+>props : Symbol(Element.props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 34))
+>P : Symbol(P, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 27))
+>type : Symbol(Element.type, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 44))
+>T : Symbol(T, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 29))
 }
 
 interface Props {
->Props : Symbol(Props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 1))
+>Props : Symbol(Props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 5, 1))
 
   className?: string | undefined;
->className : Symbol(Props.className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 6, 17))
+>className : Symbol(Props.className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 7, 17))
 }
 
 function NoticeList(props: Props) {
->NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 8, 1))
->props : Symbol(props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 10, 20))
->Props : Symbol(Props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 4, 1))
+>NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 9, 1))
+>props : Symbol(props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 11, 20))
+>Props : Symbol(Props, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 5, 1))
 
   return null;
 }
 
 <NoticeList className="my-notice-list">
->NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 8, 1))
->className : Symbol(className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 14, 11))
+>NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 9, 1))
+>className : Symbol(className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 15, 11))
 
 </NoticeList>;
->NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 8, 1))
+>NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 9, 1))
 
 <NoticeList className="my-notice-list">
->NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 8, 1))
->className : Symbol(className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 17, 11))
+>NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 9, 1))
+>className : Symbol(className, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 18, 11))
 
 </NoticeList>;
->NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 8, 1))
+>NoticeList : Symbol(NoticeList, Decl(jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx, 9, 1))
 

--- a/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.types
+++ b/tests/baselines/reference/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.types
@@ -7,6 +7,11 @@ namespace JSX {
 >children : {}
 >         : ^^
   }
+  export interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 interface Props {
@@ -25,7 +30,8 @@ function NoticeList(props: Props) {
 }
 
 <NoticeList className="my-notice-list">
-><NoticeList className="my-notice-list"></NoticeList> : error
+><NoticeList className="my-notice-list"></NoticeList> : JSX.Element<P, T>
+>                                                     : ^^^^^^^^^^^^^^^^^
 >NoticeList : (props: Props) => null
 >           : ^     ^^     ^^^^^^^^^
 >className : string
@@ -36,7 +42,8 @@ function NoticeList(props: Props) {
 >           : ^     ^^     ^^^^^^^^^
 
 <NoticeList className="my-notice-list">
-><NoticeList className="my-notice-list"></NoticeList> : error
+><NoticeList className="my-notice-list"></NoticeList> : JSX.Element<P, T>
+>                                                     : ^^^^^^^^^^^^^^^^^
 >NoticeList : (props: Props) => null
 >           : ^     ^^     ^^^^^^^^^
 >className : string

--- a/tests/baselines/reference/jsxElementsAsIdentifierNames.js
+++ b/tests/baselines/reference/jsxElementsAsIdentifierNames.js
@@ -6,6 +6,7 @@ declare module JSX {
     interface IntrinsicElements {
         ["package"]: any;
     }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 function A() {

--- a/tests/baselines/reference/jsxElementsAsIdentifierNames.symbols
+++ b/tests/baselines/reference/jsxElementsAsIdentifierNames.symbols
@@ -14,17 +14,25 @@ declare module JSX {
 >["package"] : Symbol(IntrinsicElements["package"], Decl(a.tsx, 2, 33))
 >"package" : Symbol(IntrinsicElements["package"], Decl(a.tsx, 2, 33))
     }
+    interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(a.tsx, 4, 5))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
+>props : Symbol(Element.props, Decl(a.tsx, 5, 29))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>type : Symbol(Element.type, Decl(a.tsx, 5, 39))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
 }
 
 function A() {
->A : Symbol(A, Decl(a.tsx, 5, 1))
+>A : Symbol(A, Decl(a.tsx, 6, 1))
 
     return <package />
 >package : Symbol(JSX.IntrinsicElements["package"], Decl(a.tsx, 2, 33))
 }
 
 function B() {
->B : Symbol(B, Decl(a.tsx, 9, 1))
+>B : Symbol(B, Decl(a.tsx, 10, 1))
 
     return <package></package>
 >package : Symbol(JSX.IntrinsicElements["package"], Decl(a.tsx, 2, 33))

--- a/tests/baselines/reference/jsxElementsAsIdentifierNames.types
+++ b/tests/baselines/reference/jsxElementsAsIdentifierNames.types
@@ -11,24 +11,31 @@ declare module JSX {
 >"package" : "package"
 >          : ^^^^^^^^^
     }
+    interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 function A() {
->A : () => any
->  : ^^^^^^^^^
+>A : () => JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^
 
     return <package />
-><package /> : error
+><package /> : JSX.Element<P, T>
+>            : ^^^^^^^^^^^^^^^^^
 >package : any
 >        : ^^^
 }
 
 function B() {
->B : () => any
->  : ^^^^^^^^^
+>B : () => JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^
 
     return <package></package>
-><package></package> : error
+><package></package> : JSX.Element<P, T>
+>                    : ^^^^^^^^^^^^^^^^^
 >package : any
 >        : ^^^
 >package : any

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.errors.txt
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.errors.txt
@@ -1,3 +1,4 @@
+/index.tsx(1,27): error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
 /index.tsx(1,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
 /index.tsx(1,32): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
 
@@ -100,8 +101,10 @@
         // @ts-ignore
         export import JSX = NotFound;
     }
-==== /index.tsx (2 errors) ====
+==== /index.tsx (3 errors) ====
     export const Comp = () => <div></div>;
+                              ~~~~~
+!!! error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
                               ~~~~~
 !!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
                                    ~~~~~~

--- a/tests/baselines/reference/jsxNamespacePrefixIntrinsics.errors.txt
+++ b/tests/baselines/reference/jsxNamespacePrefixIntrinsics.errors.txt
@@ -1,7 +1,7 @@
-jsxNamespacePrefixIntrinsics.tsx(15,18): error TS2339: Property 'element' does not exist on type 'JSX.IntrinsicElements'.
-jsxNamespacePrefixIntrinsics.tsx(16,30): error TS2322: Type '{ attribute: string; }' is not assignable to type '{ "ns:attribute": string; }'.
+jsxNamespacePrefixIntrinsics.tsx(16,18): error TS2339: Property 'element' does not exist on type 'JSX.IntrinsicElements'.
+jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2322: Type '{ attribute: string; }' is not assignable to type '{ "ns:attribute": string; }'.
   Property 'attribute' does not exist on type '{ "ns:attribute": string; }'. Did you mean '"ns:attribute"'?
-jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2322: Type '{ "ns:invalid": string; }' is not assignable to type '{ "ns:attribute": string; }'.
+jsxNamespacePrefixIntrinsics.tsx(18,30): error TS2322: Type '{ "ns:invalid": string; }' is not assignable to type '{ "ns:attribute": string; }'.
   Property 'ns:invalid' does not exist on type '{ "ns:attribute": string; }'.
 
 
@@ -14,6 +14,7 @@ jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2322: Type '{ "ns:invalid": str
         "ns:NamespacedUpcaseAlsoIntrinsic": any,
         "NS:NamespacedUpcaseAlsoIntrinsic": any
       }
+      interface Element<P, T> { props: P; type: T; }
     }
     
     const valid = <ns:element ns:attribute="yep" />;

--- a/tests/baselines/reference/jsxNamespacePrefixIntrinsics.js
+++ b/tests/baselines/reference/jsxNamespacePrefixIntrinsics.js
@@ -9,6 +9,7 @@ declare namespace JSX {
     "ns:NamespacedUpcaseAlsoIntrinsic": any,
     "NS:NamespacedUpcaseAlsoIntrinsic": any
   }
+  interface Element<P, T> { props: P; type: T; }
 }
 
 const valid = <ns:element ns:attribute="yep" />;

--- a/tests/baselines/reference/jsxNamespacePrefixIntrinsics.symbols
+++ b/tests/baselines/reference/jsxNamespacePrefixIntrinsics.symbols
@@ -20,26 +20,34 @@ declare namespace JSX {
     "NS:NamespacedUpcaseAlsoIntrinsic": any
 >"NS:NamespacedUpcaseAlsoIntrinsic" : Symbol(IntrinsicElements["NS:NamespacedUpcaseAlsoIntrinsic"], Decl(jsxNamespacePrefixIntrinsics.tsx, 5, 44))
   }
+  interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(jsxNamespacePrefixIntrinsics.tsx, 7, 3))
+>P : Symbol(P, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 20))
+>T : Symbol(T, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 22))
+>props : Symbol(Element.props, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 27))
+>P : Symbol(P, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 20))
+>type : Symbol(Element.type, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 37))
+>T : Symbol(T, Decl(jsxNamespacePrefixIntrinsics.tsx, 8, 22))
 }
 
 const valid = <ns:element ns:attribute="yep" />;
->valid : Symbol(valid, Decl(jsxNamespacePrefixIntrinsics.tsx, 10, 5))
->ns:attribute : Symbol(ns:attribute, Decl(jsxNamespacePrefixIntrinsics.tsx, 10, 25))
+>valid : Symbol(valid, Decl(jsxNamespacePrefixIntrinsics.tsx, 11, 5))
+>ns:attribute : Symbol(ns:attribute, Decl(jsxNamespacePrefixIntrinsics.tsx, 11, 25))
 
 const validUpcase1 = <ns:NamespacedUpcaseAlsoIntrinsic />;
->validUpcase1 : Symbol(validUpcase1, Decl(jsxNamespacePrefixIntrinsics.tsx, 11, 5))
+>validUpcase1 : Symbol(validUpcase1, Decl(jsxNamespacePrefixIntrinsics.tsx, 12, 5))
 
 const validUpcase2 = <NS:NamespacedUpcaseAlsoIntrinsic />;
->validUpcase2 : Symbol(validUpcase2, Decl(jsxNamespacePrefixIntrinsics.tsx, 12, 5))
+>validUpcase2 : Symbol(validUpcase2, Decl(jsxNamespacePrefixIntrinsics.tsx, 13, 5))
 
 const invalid1 = <element />;
->invalid1 : Symbol(invalid1, Decl(jsxNamespacePrefixIntrinsics.tsx, 14, 5))
+>invalid1 : Symbol(invalid1, Decl(jsxNamespacePrefixIntrinsics.tsx, 15, 5))
 
 const invalid2 = <ns:element attribute="nope" />;
->invalid2 : Symbol(invalid2, Decl(jsxNamespacePrefixIntrinsics.tsx, 15, 5))
->attribute : Symbol(attribute, Decl(jsxNamespacePrefixIntrinsics.tsx, 15, 28))
+>invalid2 : Symbol(invalid2, Decl(jsxNamespacePrefixIntrinsics.tsx, 16, 5))
+>attribute : Symbol(attribute, Decl(jsxNamespacePrefixIntrinsics.tsx, 16, 28))
 
 const invalid3 = <ns:element ns:invalid="nope" />;
->invalid3 : Symbol(invalid3, Decl(jsxNamespacePrefixIntrinsics.tsx, 16, 5))
->ns:invalid : Symbol(ns:invalid, Decl(jsxNamespacePrefixIntrinsics.tsx, 16, 28))
+>invalid3 : Symbol(invalid3, Decl(jsxNamespacePrefixIntrinsics.tsx, 17, 5))
+>ns:invalid : Symbol(ns:invalid, Decl(jsxNamespacePrefixIntrinsics.tsx, 17, 28))
 

--- a/tests/baselines/reference/jsxNamespacePrefixIntrinsics.types
+++ b/tests/baselines/reference/jsxNamespacePrefixIntrinsics.types
@@ -20,13 +20,18 @@ declare namespace JSX {
 >"NS:NamespacedUpcaseAlsoIntrinsic" : any
 >                                   : ^^^
   }
+  interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 const valid = <ns:element ns:attribute="yep" />;
->valid : any
->      : ^^^
-><ns:element ns:attribute="yep" /> : any
->                                  : ^^^
+>valid : JSX.Element<P, T>
+>      : ^^^^^^^^^^^^^^^^^
+><ns:element ns:attribute="yep" /> : JSX.Element<P, T>
+>                                  : ^^^^^^^^^^^^^^^^^
 >ns : any
 >   : ^^^
 >element : any
@@ -39,38 +44,38 @@ const valid = <ns:element ns:attribute="yep" />;
 >          : ^^^
 
 const validUpcase1 = <ns:NamespacedUpcaseAlsoIntrinsic />;
->validUpcase1 : any
->             : ^^^
-><ns:NamespacedUpcaseAlsoIntrinsic /> : any
->                                     : ^^^
+>validUpcase1 : JSX.Element<P, T>
+>             : ^^^^^^^^^^^^^^^^^
+><ns:NamespacedUpcaseAlsoIntrinsic /> : JSX.Element<P, T>
+>                                     : ^^^^^^^^^^^^^^^^^
 >ns : any
 >   : ^^^
 >NamespacedUpcaseAlsoIntrinsic : any
 >                              : ^^^
 
 const validUpcase2 = <NS:NamespacedUpcaseAlsoIntrinsic />;
->validUpcase2 : any
->             : ^^^
-><NS:NamespacedUpcaseAlsoIntrinsic /> : any
->                                     : ^^^
+>validUpcase2 : JSX.Element<P, T>
+>             : ^^^^^^^^^^^^^^^^^
+><NS:NamespacedUpcaseAlsoIntrinsic /> : JSX.Element<P, T>
+>                                     : ^^^^^^^^^^^^^^^^^
 >NS : any
 >   : ^^^
 >NamespacedUpcaseAlsoIntrinsic : any
 >                              : ^^^
 
 const invalid1 = <element />;
->invalid1 : any
->         : ^^^
-><element /> : any
->            : ^^^
+>invalid1 : JSX.Element<P, T>
+>         : ^^^^^^^^^^^^^^^^^
+><element /> : JSX.Element<P, T>
+>            : ^^^^^^^^^^^^^^^^^
 >element : any
 >        : ^^^
 
 const invalid2 = <ns:element attribute="nope" />;
->invalid2 : any
->         : ^^^
-><ns:element attribute="nope" /> : any
->                                : ^^^
+>invalid2 : JSX.Element<P, T>
+>         : ^^^^^^^^^^^^^^^^^
+><ns:element attribute="nope" /> : JSX.Element<P, T>
+>                                : ^^^^^^^^^^^^^^^^^
 >ns : any
 >   : ^^^
 >element : any
@@ -79,10 +84,10 @@ const invalid2 = <ns:element attribute="nope" />;
 >          : ^^^^^^
 
 const invalid3 = <ns:element ns:invalid="nope" />;
->invalid3 : any
->         : ^^^
-><ns:element ns:invalid="nope" /> : any
->                                 : ^^^
+>invalid3 : JSX.Element<P, T>
+>         : ^^^^^^^^^^^^^^^^^
+><ns:element ns:invalid="nope" /> : JSX.Element<P, T>
+>                                 : ^^^^^^^^^^^^^^^^^
 >ns : any
 >   : ^^^
 >element : any

--- a/tests/baselines/reference/jsxNamespaceReexports.js
+++ b/tests/baselines/reference/jsxNamespaceReexports.js
@@ -7,6 +7,7 @@ namespace JSX {
   export interface IntrinsicElements {
     [key: string]: Record<string, any>;
   }
+  export interface Element<P, T> { props: P; type: T; }
 }
 
 export { createElement, JSX };

--- a/tests/baselines/reference/jsxNamespaceReexports.symbols
+++ b/tests/baselines/reference/jsxNamespaceReexports.symbols
@@ -17,11 +17,19 @@ namespace JSX {
 >key : Symbol(key, Decl(library.ts, 4, 5))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
   }
+  export interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(library.ts, 5, 3))
+>P : Symbol(P, Decl(library.ts, 6, 27))
+>T : Symbol(T, Decl(library.ts, 6, 29))
+>props : Symbol(Element.props, Decl(library.ts, 6, 34))
+>P : Symbol(P, Decl(library.ts, 6, 27))
+>type : Symbol(Element.type, Decl(library.ts, 6, 44))
+>T : Symbol(T, Decl(library.ts, 6, 29))
 }
 
 export { createElement, JSX };
->createElement : Symbol(createElement, Decl(library.ts, 8, 8))
->JSX : Symbol(JSX, Decl(library.ts, 8, 23))
+>createElement : Symbol(createElement, Decl(library.ts, 9, 8))
+>JSX : Symbol(JSX, Decl(library.ts, 9, 23))
 
 === index.tsx ===
 import * as MyLib from "./library";

--- a/tests/baselines/reference/jsxNamespaceReexports.types
+++ b/tests/baselines/reference/jsxNamespaceReexports.types
@@ -16,6 +16,11 @@ namespace JSX {
 >key : string
 >    : ^^^^^^
   }
+  export interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 export { createElement, JSX };
@@ -30,8 +35,10 @@ import * as MyLib from "./library";
 >      : ^^^^^^^^^^^^
 
 const content = <my-element/>;
->content : error
-><my-element/> : error
+>content : MyLib.JSX.Element<P, T>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^
+><my-element/> : MyLib.JSX.Element<P, T>
+>              : ^^^^^^^^^^^^^^^^^^^^^^^
 >my-element : any
 >           : ^^^
 

--- a/tests/baselines/reference/jsxParsingError4(strict=false).js
+++ b/tests/baselines/reference/jsxParsingError4(strict=false).js
@@ -6,6 +6,7 @@ declare namespace JSX {
     interface IntrinsicElements {
         [k: string]: any
     }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 const a = (

--- a/tests/baselines/reference/jsxParsingError4(strict=false).symbols
+++ b/tests/baselines/reference/jsxParsingError4(strict=false).symbols
@@ -13,10 +13,18 @@ declare namespace JSX {
         [k: string]: any
 >k : Symbol(k, Decl(a.tsx, 3, 9))
     }
+    interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(a.tsx, 4, 5))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
+>props : Symbol(Element.props, Decl(a.tsx, 5, 29))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>type : Symbol(Element.type, Decl(a.tsx, 5, 39))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
 }
 
 const a = (
->a : Symbol(a, Decl(a.tsx, 7, 5))
+>a : Symbol(a, Decl(a.tsx, 8, 5))
 
   <public-foo></public-foo>
 >public-foo : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 2, 33))
@@ -25,7 +33,7 @@ const a = (
 );
 
 const b = (
->b : Symbol(b, Decl(a.tsx, 11, 5))
+>b : Symbol(b, Decl(a.tsx, 12, 5))
 
   <public></public>
 >public : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 2, 33))

--- a/tests/baselines/reference/jsxParsingError4(strict=false).types
+++ b/tests/baselines/reference/jsxParsingError4(strict=false).types
@@ -10,14 +10,22 @@ declare namespace JSX {
 >k : string
 >  : ^^^^^^
     }
+    interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 const a = (
->a : error
->(  <public-foo></public-foo>) : error
+>a : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+>(  <public-foo></public-foo>) : JSX.Element<P, T>
+>                              : ^^^^^^^^^^^^^^^^^
 
   <public-foo></public-foo>
-><public-foo></public-foo> : error
+><public-foo></public-foo> : JSX.Element<P, T>
+>                          : ^^^^^^^^^^^^^^^^^
 >public-foo : any
 >           : ^^^
 >public-foo : any
@@ -26,11 +34,14 @@ const a = (
 );
 
 const b = (
->b : error
->(  <public></public>) : error
+>b : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+>(  <public></public>) : JSX.Element<P, T>
+>                      : ^^^^^^^^^^^^^^^^^
 
   <public></public>
-><public></public> : error
+><public></public> : JSX.Element<P, T>
+>                  : ^^^^^^^^^^^^^^^^^
 >public : any
 >       : ^^^
 >public : any

--- a/tests/baselines/reference/jsxParsingError4(strict=true).js
+++ b/tests/baselines/reference/jsxParsingError4(strict=true).js
@@ -6,6 +6,7 @@ declare namespace JSX {
     interface IntrinsicElements {
         [k: string]: any
     }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 const a = (

--- a/tests/baselines/reference/jsxParsingError4(strict=true).symbols
+++ b/tests/baselines/reference/jsxParsingError4(strict=true).symbols
@@ -13,10 +13,18 @@ declare namespace JSX {
         [k: string]: any
 >k : Symbol(k, Decl(a.tsx, 3, 9))
     }
+    interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(a.tsx, 4, 5))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
+>props : Symbol(Element.props, Decl(a.tsx, 5, 29))
+>P : Symbol(P, Decl(a.tsx, 5, 22))
+>type : Symbol(Element.type, Decl(a.tsx, 5, 39))
+>T : Symbol(T, Decl(a.tsx, 5, 24))
 }
 
 const a = (
->a : Symbol(a, Decl(a.tsx, 7, 5))
+>a : Symbol(a, Decl(a.tsx, 8, 5))
 
   <public-foo></public-foo>
 >public-foo : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 2, 33))
@@ -25,7 +33,7 @@ const a = (
 );
 
 const b = (
->b : Symbol(b, Decl(a.tsx, 11, 5))
+>b : Symbol(b, Decl(a.tsx, 12, 5))
 
   <public></public>
 >public : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 2, 33))

--- a/tests/baselines/reference/jsxParsingError4(strict=true).types
+++ b/tests/baselines/reference/jsxParsingError4(strict=true).types
@@ -10,14 +10,22 @@ declare namespace JSX {
 >k : string
 >  : ^^^^^^
     }
+    interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 const a = (
->a : error
->(  <public-foo></public-foo>) : error
+>a : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+>(  <public-foo></public-foo>) : JSX.Element<P, T>
+>                              : ^^^^^^^^^^^^^^^^^
 
   <public-foo></public-foo>
-><public-foo></public-foo> : error
+><public-foo></public-foo> : JSX.Element<P, T>
+>                          : ^^^^^^^^^^^^^^^^^
 >public-foo : any
 >           : ^^^
 >public-foo : any
@@ -26,11 +34,14 @@ const a = (
 );
 
 const b = (
->b : error
->(  <public></public>) : error
+>b : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+>(  <public></public>) : JSX.Element<P, T>
+>                      : ^^^^^^^^^^^^^^^^^
 
   <public></public>
-><public></public> : error
+><public></public> : JSX.Element<P, T>
+>                  : ^^^^^^^^^^^^^^^^^
 >public : any
 >       : ^^^
 >public : any

--- a/tests/baselines/reference/tsc/incremental/serializing-error-chains.js
+++ b/tests/baselines/reference/tsc/incremental/serializing-error-chains.js
@@ -20,6 +20,7 @@ interface ReadonlyArray<T> { readonly length: number }
 declare namespace JSX {
     interface ElementChildrenAttribute { children: {}; }
     interface IntrinsicElements { div: {} }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 declare var React: any;
@@ -45,26 +46,26 @@ declare function Component(props: { children?: number }): any;
 
 Output::
 /lib/tsc -p src/project
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2769: [0mNo overload matches this call.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2769: [0mNo overload matches this call.
   This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
   This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
 
 
-Found 3 errors in the same file, starting at: src/project/index.tsx[90m:10[0m
+Found 3 errors in the same file, starting at: src/project/index.tsx[90m:11[0m
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
@@ -77,7 +78,7 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
 //// [/src/project/tsconfig.tsbuildinfo]
-{"fileNames":["../../lib/lib.d.ts","./index.tsx"],"fileInfos":[{"version":"7198220534-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };\ninterface ReadonlyArray<T> { readonly length: number }","affectsGlobalScope":true},{"version":"42569361247-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)","affectsGlobalScope":true}],"root":[2],"options":{"jsx":2,"module":99,"strict":true},"semanticDiagnosticsPerFile":[[2,[{"start":265,"length":9,"messageText":"This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.","category":1,"code":2746},{"start":265,"length":9,"messageText":"This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.","category":1,"code":2746},{"start":265,"length":9,"code":2769,"category":1,"messageText":{"messageText":"No overload matches this call.","category":1,"code":2769,"next":[{"code":2746,"category":1,"messageText":"This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided."},{"code":2746,"category":1,"messageText":"This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided."}]},"relatedInformation":[]}]]],"version":"FakeTSVersion"}
+{"fileNames":["../../lib/lib.d.ts","./index.tsx"],"fileInfos":[{"version":"7198220534-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };\ninterface ReadonlyArray<T> { readonly length: number }","affectsGlobalScope":true},{"version":"20284851082-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n    interface Element<P, T> { props: P; type: T; }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)","affectsGlobalScope":true}],"root":[2],"options":{"jsx":2,"module":99,"strict":true},"semanticDiagnosticsPerFile":[[2,[{"start":316,"length":9,"messageText":"This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.","category":1,"code":2746},{"start":316,"length":9,"messageText":"This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.","category":1,"code":2746},{"start":316,"length":9,"code":2769,"category":1,"messageText":{"messageText":"No overload matches this call.","category":1,"code":2769,"next":[{"code":2746,"category":1,"messageText":"This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided."},{"code":2746,"category":1,"messageText":"This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided."}]},"relatedInformation":[]}]]],"version":"FakeTSVersion"}
 
 //// [/src/project/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -97,11 +98,11 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
     },
     "./index.tsx": {
       "original": {
-        "version": "42569361247-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
+        "version": "20284851082-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n    interface Element<P, T> { props: P; type: T; }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
         "affectsGlobalScope": true
       },
-      "version": "42569361247-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
-      "signature": "42569361247-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
+      "version": "20284851082-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n    interface Element<P, T> { props: P; type: T; }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
+      "signature": "20284851082-declare namespace JSX {\n    interface ElementChildrenAttribute { children: {}; }\n    interface IntrinsicElements { div: {} }\n    interface Element<P, T> { props: P; type: T; }\n}\n\ndeclare var React: any;\n\ndeclare function Component(props: never): any;\ndeclare function Component(props: { children?: number }): any;\n(<Component>\n    <div />\n    <div />\n</Component>)",
       "affectsGlobalScope": true
     }
   },
@@ -121,21 +122,21 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "./index.tsx",
       [
         {
-          "start": 265,
+          "start": 316,
           "length": 9,
           "messageText": "This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.",
           "category": 1,
           "code": 2746
         },
         {
-          "start": 265,
+          "start": 316,
           "length": 9,
           "messageText": "This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.",
           "category": 1,
           "code": 2746
         },
         {
-          "start": 265,
+          "start": 316,
           "length": 9,
           "code": 2769,
           "category": 1,
@@ -162,7 +163,7 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
     ]
   ],
   "version": "FakeTSVersion",
-  "size": 1944
+  "size": 1996
 }
 
 
@@ -173,26 +174,26 @@ Input::
 
 Output::
 /lib/tsc -p src/project
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2746: [0mThis JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
-[96msrc/project/index.tsx[0m:[93m10[0m:[93m3[0m - [91merror[0m[90m TS2769: [0mNo overload matches this call.
+[96msrc/project/index.tsx[0m:[93m11[0m:[93m3[0m - [91merror[0m[90m TS2769: [0mNo overload matches this call.
   This JSX tag's 'children' prop expects a single child of type 'never', but multiple children were provided.
   This JSX tag's 'children' prop expects a single child of type 'number | undefined', but multiple children were provided.
 
-[7m10[0m (<Component>
+[7m11[0m (<Component>
 [7m  [0m [91m  ~~~~~~~~~[0m
 
 
 
-Found 3 errors in the same file, starting at: src/project/index.tsx[90m:10[0m
+Found 3 errors in the same file, starting at: src/project/index.tsx[90m:11[0m
 
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 

--- a/tests/baselines/reference/tsxAttributesHasInferrableIndex.js
+++ b/tests/baselines/reference/tsxAttributesHasInferrableIndex.js
@@ -8,14 +8,17 @@ interface Attributes {
 function createElement(name: string, attributes: Attributes | undefined, ...contents: string[]) {
     return name;
 }
-namespace createElement.JSX {
-    type Element = string;
+namespace createElement {
+    export namespace JSX {
+        export type Element = string;
+    }
 }
 
 function Button(attributes: Attributes | undefined, contents: string[]) {
     return '';
 }
 const b = <Button></Button>
+const b2 = <Button someProp=""></Button>
 
 
 //// [tsxAttributesHasInferrableIndex.js]
@@ -31,3 +34,4 @@ function Button(attributes, contents) {
     return '';
 }
 var b = createElement(Button, null);
+var b2 = createElement(Button, { someProp: "" });

--- a/tests/baselines/reference/tsxAttributesHasInferrableIndex.symbols
+++ b/tests/baselines/reference/tsxAttributesHasInferrableIndex.symbols
@@ -22,24 +22,33 @@ function createElement(name: string, attributes: Attributes | undefined, ...cont
     return name;
 >name : Symbol(name, Decl(tsxAttributesHasInferrableIndex.tsx, 4, 23))
 }
-namespace createElement.JSX {
+namespace createElement {
 >createElement : Symbol(createElement, Decl(tsxAttributesHasInferrableIndex.tsx, 3, 1), Decl(tsxAttributesHasInferrableIndex.tsx, 6, 1))
->JSX : Symbol(JSX, Decl(tsxAttributesHasInferrableIndex.tsx, 7, 24))
 
-    type Element = string;
->Element : Symbol(Element, Decl(tsxAttributesHasInferrableIndex.tsx, 7, 29))
+    export namespace JSX {
+>JSX : Symbol(JSX, Decl(tsxAttributesHasInferrableIndex.tsx, 7, 25))
+
+        export type Element = string;
+>Element : Symbol(Element, Decl(tsxAttributesHasInferrableIndex.tsx, 8, 26))
+    }
 }
 
 function Button(attributes: Attributes | undefined, contents: string[]) {
->Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 9, 1))
->attributes : Symbol(attributes, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 16))
+>Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 1))
+>attributes : Symbol(attributes, Decl(tsxAttributesHasInferrableIndex.tsx, 13, 16))
 >Attributes : Symbol(Attributes, Decl(tsxAttributesHasInferrableIndex.tsx, 0, 55))
->contents : Symbol(contents, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 51))
+>contents : Symbol(contents, Decl(tsxAttributesHasInferrableIndex.tsx, 13, 51))
 
     return '';
 }
 const b = <Button></Button>
->b : Symbol(b, Decl(tsxAttributesHasInferrableIndex.tsx, 14, 5))
->Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 9, 1))
->Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 9, 1))
+>b : Symbol(b, Decl(tsxAttributesHasInferrableIndex.tsx, 16, 5))
+>Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 1))
+>Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 1))
+
+const b2 = <Button someProp=""></Button>
+>b2 : Symbol(b2, Decl(tsxAttributesHasInferrableIndex.tsx, 17, 5))
+>Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 1))
+>someProp : Symbol(someProp, Decl(tsxAttributesHasInferrableIndex.tsx, 17, 18))
+>Button : Symbol(Button, Decl(tsxAttributesHasInferrableIndex.tsx, 11, 1))
 

--- a/tests/baselines/reference/tsxAttributesHasInferrableIndex.types
+++ b/tests/baselines/reference/tsxAttributesHasInferrableIndex.types
@@ -24,10 +24,12 @@ function createElement(name: string, attributes: Attributes | undefined, ...cont
 >name : string
 >     : ^^^^^^
 }
-namespace createElement.JSX {
-    type Element = string;
+namespace createElement {
+    export namespace JSX {
+        export type Element = string;
 >Element : string
 >        : ^^^^^^
+    }
 }
 
 function Button(attributes: Attributes | undefined, contents: string[]) {
@@ -43,10 +45,24 @@ function Button(attributes: Attributes | undefined, contents: string[]) {
 >   : ^^
 }
 const b = <Button></Button>
->b : error
-><Button></Button> : error
+>b : string
+>  : ^^^^^^
+><Button></Button> : string
+>                  : ^^^^^^
 >Button : (attributes: Attributes | undefined, contents: string[]) => string
 >       : ^          ^^                      ^^        ^^        ^^^^^^^^^^^
+>Button : (attributes: Attributes | undefined, contents: string[]) => string
+>       : ^          ^^                      ^^        ^^        ^^^^^^^^^^^
+
+const b2 = <Button someProp=""></Button>
+>b2 : string
+>   : ^^^^^^
+><Button someProp=""></Button> : string
+>                              : ^^^^^^
+>Button : (attributes: Attributes | undefined, contents: string[]) => string
+>       : ^          ^^                      ^^        ^^        ^^^^^^^^^^^
+>someProp : string
+>         : ^^^^^^
 >Button : (attributes: Attributes | undefined, contents: string[]) => string
 >       : ^          ^^                      ^^        ^^        ^^^^^^^^^^^
 

--- a/tests/baselines/reference/tsxElementResolution16.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution16.errors.txt
@@ -1,7 +1,8 @@
+file.tsx(8,1): error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
 file.tsx(8,1): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
 
 
-==== file.tsx (1 errors) ====
+==== file.tsx (2 errors) ====
     declare module JSX {
     }
     
@@ -10,6 +11,8 @@ file.tsx(8,1): error TS7026: JSX element implicitly has type 'any' because no in
     }
     var obj1: Obj1;
     <obj1 x={10} />; // Error (JSX.Element is implicit any)
+    ~~~~~~~~~~~~~~~
+!!! error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
     ~~~~~~~~~~~~~~~
 !!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
     

--- a/tests/baselines/reference/tsxElementResolution20.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution20.errors.txt
@@ -1,0 +1,16 @@
+file.tsx(9,1): error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+
+
+==== file.tsx (1 errors) ====
+    declare namespace JSX {
+        interface IntrinsicElements { obj1: { x: number }; }
+    }
+    
+    interface Obj1 {
+    	new(n: string): {};
+    }
+    var obj1: Obj1;
+    <obj1 x={10} />; // Error (JSX.Element is implicit any)
+    ~~~~~~~~~~~~~~~
+!!! error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+    

--- a/tests/baselines/reference/tsxElementResolution20.js
+++ b/tests/baselines/reference/tsxElementResolution20.js
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution20.tsx] ////
+
+//// [file.tsx]
+declare namespace JSX {
+    interface IntrinsicElements { obj1: { x: number }; }
+}
+
+interface Obj1 {
+	new(n: string): {};
+}
+var obj1: Obj1;
+<obj1 x={10} />; // Error (JSX.Element is implicit any)
+
+
+//// [file.jsx]
+var obj1;
+<obj1 x={10}/>; // Error (JSX.Element is implicit any)

--- a/tests/baselines/reference/tsxElementResolution20.symbols
+++ b/tests/baselines/reference/tsxElementResolution20.symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution20.tsx] ////
+
+=== file.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(file.tsx, 0, 0))
+
+    interface IntrinsicElements { obj1: { x: number }; }
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(file.tsx, 0, 23))
+>obj1 : Symbol(IntrinsicElements.obj1, Decl(file.tsx, 1, 33))
+>x : Symbol(x, Decl(file.tsx, 1, 41))
+}
+
+interface Obj1 {
+>Obj1 : Symbol(Obj1, Decl(file.tsx, 2, 1))
+
+	new(n: string): {};
+>n : Symbol(n, Decl(file.tsx, 5, 5))
+}
+var obj1: Obj1;
+>obj1 : Symbol(obj1, Decl(file.tsx, 7, 3))
+>Obj1 : Symbol(Obj1, Decl(file.tsx, 2, 1))
+
+<obj1 x={10} />; // Error (JSX.Element is implicit any)
+>obj1 : Symbol(JSX.IntrinsicElements.obj1, Decl(file.tsx, 1, 33))
+>x : Symbol(x, Decl(file.tsx, 8, 5))
+

--- a/tests/baselines/reference/tsxElementResolution20.types
+++ b/tests/baselines/reference/tsxElementResolution20.types
@@ -1,0 +1,30 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution20.tsx] ////
+
+=== file.tsx ===
+declare namespace JSX {
+    interface IntrinsicElements { obj1: { x: number }; }
+>obj1 : { x: number; }
+>     : ^^^^^      ^^^
+>x : number
+>  : ^^^^^^
+}
+
+interface Obj1 {
+	new(n: string): {};
+>n : string
+>  : ^^^^^^
+}
+var obj1: Obj1;
+>obj1 : Obj1
+>     : ^^^^
+
+<obj1 x={10} />; // Error (JSX.Element is implicit any)
+><obj1 x={10} /> : any
+>                : ^^^
+>obj1 : Obj1
+>     : ^^^^
+>x : number
+>  : ^^^^^^
+>10 : 10
+>   : ^^
+

--- a/tests/baselines/reference/tsxElementResolution21.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution21.errors.txt
@@ -1,0 +1,20 @@
+tsxElementResolution21.tsx(10,11): error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+tsxElementResolution21.tsx(10,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+
+
+==== tsxElementResolution21.tsx (2 errors) ====
+    function createElement(name: string) {
+        return name;
+    }
+    namespace createElement.JSX {
+        export type Element = string;
+        export type ElementType = string;
+        export type IntrinsicElements = { div: {} };
+    }
+    
+    const d = <div/> // JSX namespace is not correctly defined here
+              ~~~~~~
+!!! error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+              ~~~~~~
+!!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+    

--- a/tests/baselines/reference/tsxElementResolution21.symbols
+++ b/tests/baselines/reference/tsxElementResolution21.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution21.tsx] ////
+
+=== tsxElementResolution21.tsx ===
+function createElement(name: string) {
+>createElement : Symbol(createElement, Decl(tsxElementResolution21.tsx, 0, 0), Decl(tsxElementResolution21.tsx, 2, 1))
+>name : Symbol(name, Decl(tsxElementResolution21.tsx, 0, 23))
+
+    return name;
+>name : Symbol(name, Decl(tsxElementResolution21.tsx, 0, 23))
+}
+namespace createElement.JSX {
+>createElement : Symbol(createElement, Decl(tsxElementResolution21.tsx, 0, 0), Decl(tsxElementResolution21.tsx, 2, 1))
+>JSX : Symbol(JSX, Decl(tsxElementResolution21.tsx, 3, 24))
+
+    export type Element = string;
+>Element : Symbol(Element, Decl(tsxElementResolution21.tsx, 3, 29))
+
+    export type ElementType = string;
+>ElementType : Symbol(ElementType, Decl(tsxElementResolution21.tsx, 4, 33))
+
+    export type IntrinsicElements = { div: {} };
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(tsxElementResolution21.tsx, 5, 37))
+>div : Symbol(div, Decl(tsxElementResolution21.tsx, 6, 37))
+}
+
+const d = <div/> // JSX namespace is not correctly defined here
+>d : Symbol(d, Decl(tsxElementResolution21.tsx, 9, 5))
+

--- a/tests/baselines/reference/tsxElementResolution21.types
+++ b/tests/baselines/reference/tsxElementResolution21.types
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution21.tsx] ////
+
+=== tsxElementResolution21.tsx ===
+function createElement(name: string) {
+>createElement : (name: string) => string
+>              : ^    ^^      ^^^^^^^^^^^
+>name : string
+>     : ^^^^^^
+
+    return name;
+>name : string
+>     : ^^^^^^
+}
+namespace createElement.JSX {
+    export type Element = string;
+>Element : string
+>        : ^^^^^^
+
+    export type ElementType = string;
+>ElementType : string
+>            : ^^^^^^
+
+    export type IntrinsicElements = { div: {} };
+>IntrinsicElements : IntrinsicElements
+>                  : ^^^^^^^^^^^^^^^^^
+>div : {}
+>    : ^^
+}
+
+const d = <div/> // JSX namespace is not correctly defined here
+>d : any
+>  : ^^^
+><div/> : any
+>       : ^^^
+>div : any
+>    : ^^^
+

--- a/tests/baselines/reference/tsxElementResolution22.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution22.errors.txt
@@ -1,0 +1,20 @@
+tsxElementResolution22.tsx(10,11): error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+tsxElementResolution22.tsx(10,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+
+
+==== tsxElementResolution22.tsx (2 errors) ====
+    function createElement(name: string) {
+        return name;
+    }
+    namespace createElement.JSX {
+        type Element = string;
+        type ElementType = string;
+        type IntrinsicElements = { div: {} };
+    }
+    
+    const d = <div/> // JSX namespace is not correctly defined here
+              ~~~~~~
+!!! error TS2602: JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.
+              ~~~~~~
+!!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+    

--- a/tests/baselines/reference/tsxElementResolution22.symbols
+++ b/tests/baselines/reference/tsxElementResolution22.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution22.tsx] ////
+
+=== tsxElementResolution22.tsx ===
+function createElement(name: string) {
+>createElement : Symbol(createElement, Decl(tsxElementResolution22.tsx, 0, 0), Decl(tsxElementResolution22.tsx, 2, 1))
+>name : Symbol(name, Decl(tsxElementResolution22.tsx, 0, 23))
+
+    return name;
+>name : Symbol(name, Decl(tsxElementResolution22.tsx, 0, 23))
+}
+namespace createElement.JSX {
+>createElement : Symbol(createElement, Decl(tsxElementResolution22.tsx, 0, 0), Decl(tsxElementResolution22.tsx, 2, 1))
+>JSX : Symbol(JSX, Decl(tsxElementResolution22.tsx, 3, 24))
+
+    type Element = string;
+>Element : Symbol(Element, Decl(tsxElementResolution22.tsx, 3, 29))
+
+    type ElementType = string;
+>ElementType : Symbol(ElementType, Decl(tsxElementResolution22.tsx, 4, 26))
+
+    type IntrinsicElements = { div: {} };
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(tsxElementResolution22.tsx, 5, 30))
+>div : Symbol(div, Decl(tsxElementResolution22.tsx, 6, 30))
+}
+
+const d = <div/> // JSX namespace is not correctly defined here
+>d : Symbol(d, Decl(tsxElementResolution22.tsx, 9, 5))
+

--- a/tests/baselines/reference/tsxElementResolution22.types
+++ b/tests/baselines/reference/tsxElementResolution22.types
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/jsx/tsxElementResolution22.tsx] ////
+
+=== tsxElementResolution22.tsx ===
+function createElement(name: string) {
+>createElement : (name: string) => string
+>              : ^    ^^      ^^^^^^^^^^^
+>name : string
+>     : ^^^^^^
+
+    return name;
+>name : string
+>     : ^^^^^^
+}
+namespace createElement.JSX {
+    type Element = string;
+>Element : string
+>        : ^^^^^^
+
+    type ElementType = string;
+>ElementType : string
+>            : ^^^^^^
+
+    type IntrinsicElements = { div: {} };
+>IntrinsicElements : IntrinsicElements
+>                  : ^^^^^^^^^^^^^^^^^
+>div : {}
+>    : ^^
+}
+
+const d = <div/> // JSX namespace is not correctly defined here
+>d : any
+>  : ^^^
+><div/> : any
+>       : ^^^
+>div : any
+>    : ^^^
+

--- a/tests/baselines/reference/tsxSpreadInvalidType.errors.txt
+++ b/tests/baselines/reference/tsxSpreadInvalidType.errors.txt
@@ -1,11 +1,12 @@
-a.tsx(9,21): error TS2698: Spread types may only be created from object types.
 a.tsx(10,21): error TS2698: Spread types may only be created from object types.
 a.tsx(11,21): error TS2698: Spread types may only be created from object types.
+a.tsx(12,21): error TS2698: Spread types may only be created from object types.
 
 
 ==== a.tsx (3 errors) ====
     namespace JSX {
         export interface IntrinsicElements { [key: string]: any }
+        export interface Element<P, T> { props: P; type: T; }
     }
     
     const a = {} as never;

--- a/tests/baselines/reference/tsxSpreadInvalidType.js
+++ b/tests/baselines/reference/tsxSpreadInvalidType.js
@@ -3,6 +3,7 @@
 //// [a.tsx]
 namespace JSX {
     export interface IntrinsicElements { [key: string]: any }
+    export interface Element<P, T> { props: P; type: T; }
 }
 
 const a = {} as never;

--- a/tests/baselines/reference/tsxSpreadInvalidType.symbols
+++ b/tests/baselines/reference/tsxSpreadInvalidType.symbols
@@ -7,30 +7,39 @@ namespace JSX {
     export interface IntrinsicElements { [key: string]: any }
 >IntrinsicElements : Symbol(IntrinsicElements, Decl(a.tsx, 0, 15))
 >key : Symbol(key, Decl(a.tsx, 1, 42))
+
+    export interface Element<P, T> { props: P; type: T; }
+>Element : Symbol(Element, Decl(a.tsx, 1, 61))
+>P : Symbol(P, Decl(a.tsx, 2, 29))
+>T : Symbol(T, Decl(a.tsx, 2, 31))
+>props : Symbol(Element.props, Decl(a.tsx, 2, 36))
+>P : Symbol(P, Decl(a.tsx, 2, 29))
+>type : Symbol(Element.type, Decl(a.tsx, 2, 46))
+>T : Symbol(T, Decl(a.tsx, 2, 31))
 }
 
 const a = {} as never;
->a : Symbol(a, Decl(a.tsx, 4, 5))
+>a : Symbol(a, Decl(a.tsx, 5, 5))
 
 const b = null;
->b : Symbol(b, Decl(a.tsx, 5, 5))
+>b : Symbol(b, Decl(a.tsx, 6, 5))
 
 const c = undefined;
->c : Symbol(c, Decl(a.tsx, 6, 5))
+>c : Symbol(c, Decl(a.tsx, 7, 5))
 >undefined : Symbol(undefined)
 
 const d = <div { ...a } />
->d : Symbol(d, Decl(a.tsx, 8, 5))
+>d : Symbol(d, Decl(a.tsx, 9, 5))
 >div : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 1, 40))
->a : Symbol(a, Decl(a.tsx, 4, 5))
+>a : Symbol(a, Decl(a.tsx, 5, 5))
 
 const e = <div { ...b } />
->e : Symbol(e, Decl(a.tsx, 9, 5))
+>e : Symbol(e, Decl(a.tsx, 10, 5))
 >div : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 1, 40))
->b : Symbol(b, Decl(a.tsx, 5, 5))
+>b : Symbol(b, Decl(a.tsx, 6, 5))
 
 const f = <div { ...c } />
->f : Symbol(f, Decl(a.tsx, 10, 5))
+>f : Symbol(f, Decl(a.tsx, 11, 5))
 >div : Symbol(JSX.IntrinsicElements.__index, Decl(a.tsx, 1, 40))
->c : Symbol(c, Decl(a.tsx, 6, 5))
+>c : Symbol(c, Decl(a.tsx, 7, 5))
 

--- a/tests/baselines/reference/tsxSpreadInvalidType.types
+++ b/tests/baselines/reference/tsxSpreadInvalidType.types
@@ -5,6 +5,12 @@ namespace JSX {
     export interface IntrinsicElements { [key: string]: any }
 >key : string
 >    : ^^^^^^
+
+    export interface Element<P, T> { props: P; type: T; }
+>props : P
+>      : ^
+>type : T
+>     : ^
 }
 
 const a = {} as never;
@@ -26,30 +32,30 @@ const c = undefined;
 >          : ^^^^^^^^^
 
 const d = <div { ...a } />
->d : any
->  : ^^^
-><div { ...a } /> : any
->                 : ^^^
+>d : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+><div { ...a } /> : JSX.Element<P, T>
+>                 : ^^^^^^^^^^^^^^^^^
 >div : any
 >    : ^^^
 >a : never
 >  : ^^^^^
 
 const e = <div { ...b } />
->e : any
->  : ^^^
-><div { ...b } /> : any
->                 : ^^^
+>e : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+><div { ...b } /> : JSX.Element<P, T>
+>                 : ^^^^^^^^^^^^^^^^^
 >div : any
 >    : ^^^
 >b : null
 >  : ^^^^
 
 const f = <div { ...c } />
->f : any
->  : ^^^
-><div { ...c } /> : any
->                 : ^^^
+>f : JSX.Element<P, T>
+>  : ^^^^^^^^^^^^^^^^^
+><div { ...c } /> : JSX.Element<P, T>
+>                 : ^^^^^^^^^^^^^^^^^
 >div : any
 >    : ^^^
 >c : undefined

--- a/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
+++ b/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
@@ -2,6 +2,10 @@
 // @noImplicitAny: true
 
 // @filename: index.tsx
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+}
+
 interface Elements {
   foo: { callback?: (value: number) => void };
   bar: { callback?: (value: string) => void };

--- a/tests/cases/compiler/discriminatedUnionJsxElement.tsx
+++ b/tests/cases/compiler/discriminatedUnionJsxElement.tsx
@@ -4,6 +4,10 @@
 
 // Repro from #46021
 
+declare namespace JSX {
+  interface Element<P, T> { props: P; type: T; }
+}
+
 interface IData<MenuItemVariant extends ListItemVariant = ListItemVariant.OneLine> {
     menuItemsVariant?: MenuItemVariant;
 }

--- a/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
+++ b/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
@@ -5,6 +5,7 @@ namespace JSX {
   export interface ElementChildrenAttribute {
     children: {};
   }
+  export interface Element<P, T> { props: P; type: T; }
 }
 
 interface Props {

--- a/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
+++ b/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
@@ -7,6 +7,7 @@ declare module JSX {
     interface IntrinsicElements {
         ["package"]: any;
     }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 function A() {

--- a/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
+++ b/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
@@ -9,6 +9,7 @@ declare namespace JSX {
     "ns:NamespacedUpcaseAlsoIntrinsic": any,
     "NS:NamespacedUpcaseAlsoIntrinsic": any
   }
+  interface Element<P, T> { props: P; type: T; }
 }
 
 const valid = <ns:element ns:attribute="yep" />;

--- a/tests/cases/compiler/jsxNamespaceReexports.tsx
+++ b/tests/cases/compiler/jsxNamespaceReexports.tsx
@@ -9,6 +9,7 @@ namespace JSX {
   export interface IntrinsicElements {
     [key: string]: Record<string, any>;
   }
+  export interface Element<P, T> { props: P; type: T; }
 }
 
 export { createElement, JSX };

--- a/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
+++ b/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
@@ -8,11 +8,14 @@ interface Attributes {
 function createElement(name: string, attributes: Attributes | undefined, ...contents: string[]) {
     return name;
 }
-namespace createElement.JSX {
-    type Element = string;
+namespace createElement {
+    export namespace JSX {
+        export type Element = string;
+    }
 }
 
 function Button(attributes: Attributes | undefined, contents: string[]) {
     return '';
 }
 const b = <Button></Button>
+const b2 = <Button someProp=""></Button>

--- a/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
+++ b/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
@@ -2,6 +2,7 @@
 // @strict: true
 declare namespace JSX {
     interface ElementAttributesProperty { props: {}; }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 declare class Component<P> {

--- a/tests/cases/conformance/jsx/jsxParsingError4.tsx
+++ b/tests/cases/conformance/jsx/jsxParsingError4.tsx
@@ -7,6 +7,7 @@ declare namespace JSX {
     interface IntrinsicElements {
         [k: string]: any
     }
+    interface Element<P, T> { props: P; type: T; }
 }
 
 const a = (

--- a/tests/cases/conformance/jsx/tsxElementResolution20.tsx
+++ b/tests/cases/conformance/jsx/tsxElementResolution20.tsx
@@ -1,0 +1,12 @@
+//@filename: file.tsx
+//@jsx: preserve
+//@noImplicitAny: true
+declare namespace JSX {
+    interface IntrinsicElements { obj1: { x: number }; }
+}
+
+interface Obj1 {
+	new(n: string): {};
+}
+var obj1: Obj1;
+<obj1 x={10} />; // Error (JSX.Element is implicit any)

--- a/tests/cases/conformance/jsx/tsxElementResolution21.tsx
+++ b/tests/cases/conformance/jsx/tsxElementResolution21.tsx
@@ -1,0 +1,13 @@
+// @strict: true
+// @jsx: preserve
+// @noEmit: true
+function createElement(name: string) {
+    return name;
+}
+namespace createElement.JSX {
+    export type Element = string;
+    export type ElementType = string;
+    export type IntrinsicElements = { div: {} };
+}
+
+const d = <div/> // JSX namespace is not correctly defined here

--- a/tests/cases/conformance/jsx/tsxElementResolution22.tsx
+++ b/tests/cases/conformance/jsx/tsxElementResolution22.tsx
@@ -1,0 +1,13 @@
+// @strict: true
+// @jsx: preserve
+// @noEmit: true
+function createElement(name: string) {
+    return name;
+}
+namespace createElement.JSX {
+    type Element = string;
+    type ElementType = string;
+    type IntrinsicElements = { div: {} };
+}
+
+const d = <div/> // JSX namespace is not correctly defined here

--- a/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
@@ -3,6 +3,7 @@
 // @filename: a.tsx
 namespace JSX {
     export interface IntrinsicElements { [key: string]: any }
+    export interface Element<P, T> { props: P; type: T; }
 }
 
 const a = {} as never;


### PR DESCRIPTION
I found this when fixing `self-check` failure in https://github.com/microsoft/TypeScript/pull/59559