### PR TITLE
Refactor codepaths relying on uncomparable `=== undefined`

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -529,9 +529,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     var thisParentContainer: IsContainer | EntityNameExpression; // Container one level up
     var blockScopeContainer: IsBlockScopedContainer;
     var lastContainer: HasLocals;
-    var delayedTypeAliases: (JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag)[];
+    var delayedTypeAliases: (JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag)[] | undefined;
     var seenThisKeyword: boolean;
-    var jsDocImports: JSDocImportTag[];
+    var jsDocImports: JSDocImportTag[] | undefined;
 
     // state used by control flow analysis
     var currentFlow: FlowNode;
@@ -611,8 +611,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         thisParentContainer = undefined!;
         blockScopeContainer = undefined!;
         lastContainer = undefined!;
-        delayedTypeAliases = undefined!;
-        jsDocImports = undefined!;
+        delayedTypeAliases = undefined;
+        jsDocImports = undefined;
         seenThisKeyword = false;
         currentFlow = undefined!;
         currentBreakTarget = undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12509,7 +12509,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isReferenceToSomeType(type: Type, targets: readonly Type[]) {
-        if (type === undefined || (getObjectFlags(type) & ObjectFlags.Reference) === 0) {
+        if ((getObjectFlags(type) & ObjectFlags.Reference) === 0) {
             return false;
         }
         for (const target of targets) {
@@ -12521,9 +12521,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isReferenceToType(type: Type, target: Type) {
-        return type !== undefined
-            && target !== undefined
-            && (getObjectFlags(type) & ObjectFlags.Reference) !== 0
+        return (getObjectFlags(type) & ObjectFlags.Reference) !== 0
             && (type as TypeReference).target === target;
     }
 
@@ -18797,9 +18795,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     else {
                         let suggestion: string | undefined;
                         if (propName !== undefined && (suggestion = getSuggestionForNonexistentProperty(propName as string, objectType))) {
-                            if (suggestion !== undefined) {
-                                error(accessExpression.argumentExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName as string, typeToString(objectType), suggestion);
-                            }
+                            error(accessExpression.argumentExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName as string, typeToString(objectType), suggestion);
                         }
                         else {
                             const suggestion = getSuggestionForNonexistentIndexSignature(objectType, accessExpression, indexType);
@@ -29794,7 +29790,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isExportOrExportExpression(location: Node) {
         return !!findAncestor(location, n => {
-            const parent = n.parent;
+            const parent = n.parent as Node | undefined;
             if (parent === undefined) {
                 return "quit";
             }
@@ -35130,7 +35126,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const typeArgumentTypes = fillMissingTypeArguments(map(typeArgumentNodes, getTypeFromTypeNode), typeParameters, getMinTypeArgumentCount(typeParameters), isJavascript);
         let mapper: TypeMapper | undefined;
         for (let i = 0; i < typeArgumentNodes.length; i++) {
-            Debug.assert(typeParameters[i] !== undefined, "Should not call checkTypeArguments with too many type arguments");
+            Debug.assertIsDefined(typeParameters[i], "Should not call checkTypeArguments with too many type arguments");
             const constraint = getConstraintOfTypeParameter(typeParameters[i]);
             if (constraint) {
                 const errorInfo = reportErrors && headMessage ? (() => chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Type_0_does_not_satisfy_the_constraint_1)) : undefined;
@@ -45510,7 +45506,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Grammar checking
         checkGrammarStatementInAmbientContext(node);
 
-        let firstDefaultClause: CaseOrDefaultClause;
+        let firstDefaultClause: CaseOrDefaultClause | undefined;
         let hasDuplicateDefaultClause = false;
 
         const expressionType = checkExpression(node.expression);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2266,7 +2266,7 @@ const typeAcquisitionDeclaration: TsConfigOnlyOption = {
     elementOptions: getCommandLineTypeAcquisitionMap(),
     extraKeyDiagnostics: typeAcquisitionDidYouMeanDiagnostics,
 };
-let _tsconfigRootOptions: TsConfigOnlyOption;
+let _tsconfigRootOptions: TsConfigOnlyOption | undefined;
 function getTsconfigRootOptionsMap() {
     if (_tsconfigRootOptions === undefined) {
         _tsconfigRootOptions = {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -457,20 +457,18 @@ export function sameFlatMap<T>(array: readonly T[], mapfn: (x: T, i: number) => 
 /** @internal */
 export function sameFlatMap<T>(array: readonly T[], mapfn: (x: T, i: number) => T | readonly T[]): readonly T[] {
     let result: T[] | undefined;
-    if (array !== undefined) {
-        for (let i = 0; i < array.length; i++) {
-            const item = array[i];
-            const mapped = mapfn(item, i);
-            if (result || item !== mapped || isArray(mapped)) {
-                if (!result) {
-                    result = array.slice(0, i);
-                }
-                if (isArray(mapped)) {
-                    addRange(result, mapped);
-                }
-                else {
-                    result.push(mapped);
-                }
+    for (let i = 0; i < array.length; i++) {
+        const item = array[i];
+        const mapped = mapfn(item, i);
+        if (result || item !== mapped || isArray(mapped)) {
+            if (!result) {
+                result = array.slice(0, i);
+            }
+            if (isArray(mapped)) {
+                addRange(result, mapped);
+            }
+            else {
+                result.push(mapped);
             }
         }
     }
@@ -842,22 +840,20 @@ export function compact<T>(array: T[]): T[]; // eslint-disable-line @typescript-
 /** @internal */
 export function compact<T>(array: readonly T[]): readonly T[]; // eslint-disable-line @typescript-eslint/unified-signatures
 /** @internal */
-export function compact<T>(array: readonly T[]): readonly T[] {
+export function compact<T>(array: readonly (T | undefined | null | false | 0 | "")[]): readonly T[] { // eslint-disable-line no-restricted-syntax
     let result: T[] | undefined;
-    if (array !== undefined) {
-        for (let i = 0; i < array.length; i++) {
-            const v = array[i];
-            // Either the result has been initialized (and is looking to collect truthy values separately),
-            // or we've hit our first falsy value and need to copy over the current stretch of truthy values.
-            if (result ?? !v) {
-                result ??= array.slice(0, i);
-                if (v) {
-                    result.push(v);
-                }
+    for (let i = 0; i < array.length; i++) {
+        const v = array[i];
+        // Either the result has been initialized (and is looking to collect truthy values separately),
+        // or we've hit our first falsy value and need to copy over the current stretch of truthy values.
+        if (result ?? !v) {
+            result ??= array.slice(0, i) as T[];
+            if (v) {
+                result.push(v);
             }
         }
     }
-    return result ?? array;
+    return result ?? (array as T[]);
 }
 
 /**
@@ -1948,10 +1944,7 @@ export function equateValues<T>(a: T, b: T) {
  * @internal
  */
 export function equateStringsCaseInsensitive(a: string, b: string) {
-    return a === b
-        || a !== undefined
-            && b !== undefined
-            && a.toUpperCase() === b.toUpperCase();
+    return a === b || a.toUpperCase() === b.toUpperCase();
 }
 
 /**
@@ -2028,8 +2021,6 @@ export function min<T>(items: readonly T[], compare: Comparer<T>): T | undefined
  */
 export function compareStringsCaseInsensitive(a: string, b: string) {
     if (a === b) return Comparison.EqualTo;
-    if (a === undefined) return Comparison.LessThan;
-    if (b === undefined) return Comparison.GreaterThan;
     a = a.toUpperCase();
     b = b.toUpperCase();
     return a < b ? Comparison.LessThan : a > b ? Comparison.GreaterThan : Comparison.EqualTo;
@@ -2049,8 +2040,6 @@ export function compareStringsCaseInsensitive(a: string, b: string) {
  */
 export function compareStringsCaseInsensitiveEslintCompatible(a: string, b: string) {
     if (a === b) return Comparison.EqualTo;
-    if (a === undefined) return Comparison.LessThan;
-    if (b === undefined) return Comparison.GreaterThan;
     a = a.toLowerCase();
     b = b.toLowerCase();
     return a < b ? Comparison.LessThan : a > b ? Comparison.GreaterThan : Comparison.EqualTo;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4973,7 +4973,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
     function getSeparatingLineTerminatorCount(previousNode: Node | undefined, nextNode: Node, format: ListFormat): number {
         if (format & ListFormat.PreserveLines || preserveSourceNewlines) {
-            if (previousNode === undefined || nextNode === undefined) {
+            if (previousNode === undefined) {
                 return 0;
             }
             if (nextNode.kind === SyntaxKind.JsxText) {

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1170,7 +1170,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         else if (isNodeArray(elements)) {
             if (hasTrailingComma === undefined || elements.hasTrailingComma === hasTrailingComma) {
                 // Ensure the transform flags have been aggregated for this NodeArray
-                if (elements.transformFlags === undefined) {
+                if ((elements.transformFlags as TransformFlags | undefined) === undefined) {
                     aggregateChildrenFlags(elements as MutableNodeArray<T>);
                 }
                 Debug.attachNodeArrayDebugInfo(elements);
@@ -6351,7 +6351,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
 
     // @api
     function cloneNode<T extends Node | undefined>(node: T): T;
-    function cloneNode<T extends Node>(node: T) {
+    function cloneNode<T extends Node>(node: T | undefined) {
         // We don't use "clone" from core.ts here, as we need to preserve the prototype chain of
         // the original node. We also need to exclude specific properties and only include own-
         // properties (to skip members already defined on the shared prototype).

--- a/src/compiler/factory/parenthesizerRules.ts
+++ b/src/compiler/factory/parenthesizerRules.ts
@@ -53,7 +53,7 @@ import {
 /** @internal */
 export function createParenthesizerRules(factory: NodeFactory): ParenthesizerRules {
     interface BinaryPlusExpression extends BinaryExpression {
-        cachedLiteralKind: SyntaxKind;
+        cachedLiteralKind: SyntaxKind | undefined;
     }
 
     let binaryLeftOperandParenthesizerCache: Map<BinaryOperator, (node: Expression) => Expression> | undefined;
@@ -257,8 +257,9 @@ export function createParenthesizerRules(factory: NodeFactory): ParenthesizerRul
         }
 
         if (node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken) {
-            if ((node as BinaryPlusExpression).cachedLiteralKind !== undefined) {
-                return (node as BinaryPlusExpression).cachedLiteralKind;
+            const n = node as BinaryPlusExpression;
+            if (n.cachedLiteralKind !== undefined) {
+                return n.cachedLiteralKind;
             }
 
             const leftKind = getLiteralKindOfBinaryPlusOperand((node as BinaryExpression).left);

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -332,14 +332,14 @@ export interface ModuleResolutionState {
  * @internal
  */
 export interface PackageJsonPathFields {
-    typings?: string;
+    typings?: string | null; // eslint-disable-line no-restricted-syntax
     types?: string;
     typesVersions?: MapLike<MapLike<string[]>>;
     main?: string;
     tsconfig?: string;
     type?: string;
-    imports?: object;
-    exports?: object;
+    imports?: object | null; // eslint-disable-line no-restricted-syntax
+    exports?: object | null; // eslint-disable-line no-restricted-syntax
     name?: string;
     dependencies?: MapLike<string>;
     peerDependencies?: MapLike<string>;
@@ -351,8 +351,8 @@ interface PackageJson extends PackageJsonPathFields {
     version?: string;
 }
 
-function readPackageJsonField<K extends MatchingKeys<PackageJson, string | undefined>>(jsonContent: PackageJson, fieldName: K, typeOfTag: "string", state: ModuleResolutionState): PackageJson[K] | undefined;
-function readPackageJsonField<K extends MatchingKeys<PackageJson, object | undefined>>(jsonContent: PackageJson, fieldName: K, typeOfTag: "object", state: ModuleResolutionState): PackageJson[K] | undefined; // eslint-disable-line @typescript-eslint/unified-signatures
+function readPackageJsonField<K extends MatchingKeys<PackageJson, string | undefined | null>>(jsonContent: PackageJson, fieldName: K, typeOfTag: "string", state: ModuleResolutionState): PackageJson[K] | undefined; // eslint-disable-line no-restricted-syntax
+function readPackageJsonField<K extends MatchingKeys<PackageJson, object | undefined | null>>(jsonContent: PackageJson, fieldName: K, typeOfTag: "object", state: ModuleResolutionState): PackageJson[K] | undefined; // eslint-disable-line @typescript-eslint/unified-signatures, no-restricted-syntax
 function readPackageJsonField<K extends keyof PackageJson>(jsonContent: PackageJson, fieldName: K, typeOfTag: "string" | "object", state: ModuleResolutionState): PackageJson[K] | undefined {
     if (!hasProperty(jsonContent, fieldName)) {
         if (state.traceEnabled) {
@@ -2265,7 +2265,7 @@ export function getEntrypointsFromPackageJsonInfo(
 
 function loadEntrypointsFromExportMap(
     scope: PackageJsonInfo,
-    exports: object,
+    exports: object | null, // eslint-disable-line no-restricted-syntax
     state: ModuleResolutionState & { host: GetPackageJsonEntrypointsHost; },
     extensions: Extensions,
 ): PathAndExtension[] | undefined {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1246,10 +1246,10 @@ function forEachChildInPartiallyEmittedExpression<T>(node: PartiallyEmittedExpre
  * that they appear in the source code. The language service depends on this property to locate nodes by position.
  */
 export function forEachChild<T>(node: Node, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    if (node === undefined || node.kind <= SyntaxKind.LastToken) {
+    if (node.kind <= SyntaxKind.LastToken) {
         return;
     }
-    const fn = (forEachChildTable as Record<SyntaxKind, ForEachChildFunction<any>>)[node.kind];
+    const fn = (forEachChildTable as Partial<Record<SyntaxKind, ForEachChildFunction<any>>>)[node.kind];
     return fn === undefined ? undefined : fn(node, cbNode, cbNodes);
 }
 
@@ -9490,7 +9490,7 @@ namespace Parser {
 
             function parseSatisfiesTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocSatisfiesTag {
                 const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ false);
-                const comments = margin !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), margin, indentText) : undefined;
+                const comments = parseTrailingTagComments(start, getNodePos(), margin, indentText);
                 return finishNode(factory.createJSDocSatisfiesTag(tagName, typeExpression, comments), start);
             }
 
@@ -9506,7 +9506,7 @@ namespace Parser {
                 const moduleSpecifier = parseModuleSpecifier();
                 const attributes = tryParseImportAttributes();
 
-                const comments = margin !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), margin, indentText) : undefined;
+                const comments = parseTrailingTagComments(start, getNodePos(), margin, indentText);
                 return finishNode(factory.createJSDocImportTag(tagName, importClause, moduleSpecifier, attributes, comments), start);
             }
 

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -783,8 +783,6 @@ const relativePathSegmentRegExp = /(?:\/\/)|(?:^|\/)\.\.?(?:$|\/)/;
 
 function comparePathsWorker(a: string, b: string, componentComparer: (a: string, b: string) => Comparison) {
     if (a === b) return Comparison.EqualTo;
-    if (a === undefined) return Comparison.LessThan;
-    if (b === undefined) return Comparison.GreaterThan;
 
     // NOTE: Performance optimization - shortcut if the root segments differ as there would be no
     //       need to perform path reduction.
@@ -872,7 +870,6 @@ export function containsPath(parent: string, child: string, currentDirectory?: s
     else if (typeof currentDirectory === "boolean") {
         ignoreCase = currentDirectory;
     }
-    if (parent === undefined || child === undefined) return false;
     if (parent === child) return true;
     const parentComponents = reducePathComponents(getPathComponents(parent));
     const childComponents = reducePathComponents(getPathComponents(child));

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1239,7 +1239,7 @@ export interface SyntheticReferenceFileLocation {
 
 /** @internal */
 export function isReferenceFileLocation(location: ReferenceFileLocation | SyntheticReferenceFileLocation): location is ReferenceFileLocation {
-    return (location as ReferenceFileLocation).pos !== undefined;
+    return typeof (location as ReferenceFileLocation).pos === "number";
 }
 
 /** @internal */
@@ -1584,7 +1584,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     let processingOtherFiles: SourceFile[] | undefined;
     let files: SourceFile[];
     let symlinks: SymlinkCache | undefined;
-    let commonSourceDirectory: string;
+    let commonSourceDirectory: string | undefined;
     let typeChecker: TypeChecker;
     let classifiableNames: Set<__String>;
     let fileReasons = createMultiMap<Path, FileIncludeReason>();
@@ -1675,7 +1675,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 containingSourceFile,
             ).map(resolved =>
                 resolved ?
-                    ((resolved as ResolvedModuleFull).extension !== undefined) ?
+                    (typeof (resolved as ResolvedModuleFull).extension === "string") ?
                         { resolvedModule: resolved as ResolvedModuleFull } :
                         // An older host may have omitted extension, in which case we should infer it from the file extension of resolvedFileName.
                         { resolvedModule: { ...resolved, extension: extensionFromPath(resolved.resolvedFileName) } } :

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1510,8 +1510,6 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
             pos++;
         }
 
-        Debug.assert(resultingToken !== undefined);
-
         tokenValue = contents;
         return resultingToken;
     }

--- a/src/compiler/semver.ts
+++ b/src/compiler/semver.ts
@@ -331,7 +331,7 @@ function parseHyphen(left: string, right: string, comparators: Comparator[]) {
     return true;
 }
 
-function parseComparator(operator: string, text: string, comparators: Comparator[]) {
+function parseComparator(operator: string | undefined, text: string, comparators: Comparator[]) {
     const result = parsePartial(text);
     if (!result) return false;
 

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -206,7 +206,7 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
             let newNameIndex: number | undefined;
             if (raw.sourceIndex !== undefined) {
                 newSourceIndex = sourceIndexToNewSourceIndexMap[raw.sourceIndex];
-                if (newSourceIndex === undefined) {
+                if (typeof newSourceIndex === "undefined") {
                     // Apply offsets to each position and fixup source entries
                     const rawPath = map.sources[raw.sourceIndex];
                     const relativePath = map.sourceRoot ? combinePaths(map.sourceRoot, rawPath) : rawPath;
@@ -222,7 +222,7 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
                 if (map.names && raw.nameIndex !== undefined) {
                     if (!nameIndexToNewNameIndexMap) nameIndexToNewNameIndexMap = [];
                     newNameIndex = nameIndexToNewNameIndexMap[raw.nameIndex];
-                    if (newNameIndex === undefined) {
+                    if (typeof newNameIndex === "undefined") {
                         nameIndexToNewNameIndexMap[raw.nameIndex] = newNameIndex = addName(map.names[raw.nameIndex]);
                     }
                 }
@@ -753,7 +753,7 @@ export function createDocumentPositionMapper(host: DocumentPositionMapperHost, m
 
     function getSourceMappings(sourceIndex: number) {
         if (sourceMappings === undefined) {
-            const lists: SourceMappedPosition[][] = [];
+            const lists: (SourceMappedPosition)[][] = [];
             for (const mapping of getDecodedMappings()) {
                 if (!isSourceMappedPosition(mapping)) continue;
                 let list = lists[mapping.sourceIndex];
@@ -788,9 +788,11 @@ export function createDocumentPositionMapper(host: DocumentPositionMapperHost, m
             // if no exact match, closest is 2's complement of result
             targetIndex = ~targetIndex;
         }
-
+        if (targetIndex > sourceMappings.length - 1) {
+            return loc;
+        }
         const mapping = sourceMappings[targetIndex];
-        if (mapping === undefined || mapping.sourceIndex !== sourceIndex) {
+        if (mapping.sourceIndex !== sourceIndex) {
             return loc;
         }
 
@@ -806,9 +808,11 @@ export function createDocumentPositionMapper(host: DocumentPositionMapperHost, m
             // if no exact match, closest is 2's complement of result
             targetIndex = ~targetIndex;
         }
-
+        if (targetIndex > generatedMappings.length - 1) {
+            return loc;
+        }
         const mapping = generatedMappings[targetIndex];
-        if (mapping === undefined || !isSourceMappedPosition(mapping)) {
+        if (!isSourceMappedPosition(mapping)) {
             return loc;
         }
 

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -58,7 +58,7 @@ export namespace tracingEnabled {
     export function startTracing(tracingMode: Mode, traceDir: string, configFilePath?: string) {
         Debug.assert(!tracing, "Tracing already started");
 
-        if (fs === undefined) {
+        if (typeof fs === "undefined") {
             try {
                 fs = require("fs");
             }

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -295,7 +295,7 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
         },
         set onSubstituteNode(value) {
             Debug.assert(state < TransformationState.Initialized, "Cannot modify transformation hooks after initialization has completed.");
-            Debug.assert(value !== undefined, "Value must not be 'undefined'");
+            Debug.assertIsDefined(value, "Value must not be 'undefined'");
             onSubstituteNode = value;
         },
         get onEmitNode() {
@@ -303,7 +303,7 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
         },
         set onEmitNode(value) {
             Debug.assert(state < TransformationState.Initialized, "Cannot modify transformation hooks after initialization has completed.");
-            Debug.assert(value !== undefined, "Value must not be 'undefined'");
+            Debug.assertIsDefined(value, "Value must not be 'undefined'");
             onEmitNode = value;
         },
         addDiagnostic(diag) {

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -173,11 +173,11 @@ export function createGetSymbolAccessibilityDiagnosticForNodeName(node: Declarat
     }
     function getAccessorNameVisibilityError(symbolAccessibilityResult: SymbolAccessibilityResult) {
         const diagnosticMessage = getAccessorNameVisibilityDiagnosticMessage(symbolAccessibilityResult);
-        return diagnosticMessage !== undefined ? {
+        return {
             diagnosticMessage,
             errorNode: node,
             typeName: (node as NamedDeclaration).name,
-        } : undefined;
+        };
     }
 
     function getAccessorNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
@@ -202,13 +202,13 @@ export function createGetSymbolAccessibilityDiagnosticForNodeName(node: Declarat
         }
     }
 
-    function getMethodNameVisibilityError(symbolAccessibilityResult: SymbolAccessibilityResult): SymbolAccessibilityDiagnostic | undefined {
+    function getMethodNameVisibilityError(symbolAccessibilityResult: SymbolAccessibilityResult): SymbolAccessibilityDiagnostic {
         const diagnosticMessage = getMethodNameVisibilityDiagnosticMessage(symbolAccessibilityResult);
-        return diagnosticMessage !== undefined ? {
+        return {
             diagnosticMessage,
             errorNode: node,
             typeName: (node as NamedDeclaration).name,
-        } : undefined;
+        };
     }
 
     function getMethodNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
@@ -421,11 +421,11 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
 
     function getParameterDeclarationTypeVisibilityError(symbolAccessibilityResult: SymbolAccessibilityResult): SymbolAccessibilityDiagnostic | undefined {
         const diagnosticMessage: DiagnosticMessage = getParameterDeclarationTypeVisibilityDiagnosticMessage(symbolAccessibilityResult);
-        return diagnosticMessage !== undefined ? {
+        return {
             diagnosticMessage,
             errorNode: node,
             typeName: (node as NamedDeclaration).name,
-        } : undefined;
+        };
     }
 
     function getParameterDeclarationTypeVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult): DiagnosticMessage {

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -370,7 +370,7 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     // allocating objects to store the same information to avoid GC overhead.
     //
     let labelOffsets: number[] | undefined; // The operation offset at which the label is defined.
-    let labelExpressions: Mutable<LiteralExpression>[][] | undefined; // The NumericLiteral nodes bound to each label.
+    let labelExpressions: (Mutable<LiteralExpression>[] | undefined)[] | undefined; // The NumericLiteral nodes bound to each label.
     let nextLabelId = 1; // The next label id to use.
 
     // Operations store information about generated code for the function body. This
@@ -2525,12 +2525,8 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
             }
 
             const expression = factory.createNumericLiteral(Number.MAX_SAFE_INTEGER);
-            if (labelExpressions[label] === undefined) {
-                labelExpressions[label] = [expression];
-            }
-            else {
-                labelExpressions[label].push(expression);
-            }
+            labelExpressions[label] ??= [];
+            labelExpressions[label].push(expression);
 
             return expression;
         }
@@ -2944,12 +2940,8 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
                 if (labelNumbers === undefined) {
                     labelNumbers = [];
                 }
-                if (labelNumbers[labelNumber] === undefined) {
-                    labelNumbers[labelNumber] = [label];
-                }
-                else {
-                    labelNumbers[labelNumber].push(label);
-                }
+                labelNumbers[labelNumber] ??= [];
+                labelNumbers[labelNumber].push(label);
             }
         }
     }
@@ -2961,7 +2953,7 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
         if (labelExpressions !== undefined && labelNumbers !== undefined) {
             for (let labelNumber = 0; labelNumber < labelNumbers.length; labelNumber++) {
                 const labels = labelNumbers[labelNumber];
-                if (labels !== undefined) {
+                if (labels) {
                     for (const label of labels) {
                         const expressions = labelExpressions[label];
                         if (expressions !== undefined) {

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -597,7 +597,7 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
             const parameterName = localName ? factory.getGeneratedNameForNode(localName) : factory.createUniqueName("");
             const statements: Statement[] = [];
             for (const entry of group.externalImports) {
-                const importVariableName = getLocalNameForExternalImport(factory, entry, currentSourceFile)!; // TODO: GH#18217
+                const importVariableName = getLocalNameForExternalImport(factory, entry, currentSourceFile);
                 switch (entry.kind) {
                     case SyntaxKind.ImportDeclaration:
                         if (!entry.importClause) {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -261,7 +261,7 @@ export function transformTypeScript(context: TransformationContext) {
 
     // These variables contain state that changes as we descend into the tree.
     let currentSourceFile: SourceFile;
-    let currentNamespace: ModuleDeclaration;
+    let currentNamespace: ModuleDeclaration | undefined;
     let currentNamespaceContainerName: Identifier;
     let currentLexicalScope: SourceFile | Block | ModuleBlock | CaseBlock;
     let currentScopeFirstDeclarationsOfName: Map<__String, Node> | undefined;

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -1704,7 +1704,7 @@ function getUpToDateStatusWorker<T extends BuilderProgram>(state: SolutionBuilde
             }
 
             // We have an output older than an upstream output - we are out of date
-            Debug.assert(oldestOutputFileName !== undefined, "Should have an oldest output filename here");
+            Debug.assertIsDefined(oldestOutputFileName, "Should have an oldest output filename here");
             return {
                 type: UpToDateStatusType.OutOfDateWithUpstream,
                 outOfDateOutputFileName: oldestOutputFileName,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6151,7 +6151,7 @@ export function createTextWriter(newLine: string): EmitTextWriter {
     }
 
     function writeText(s: string) {
-        if (s && s.length) {
+        if (s.length) {
             if (lineStart) {
                 s = getIndentString(indent) + s;
                 lineStart = false;
@@ -6181,15 +6181,13 @@ export function createTextWriter(newLine: string): EmitTextWriter {
     }
 
     function rawWrite(s: string) {
-        if (s !== undefined) {
-            output += s;
-            updateLineCountAndPosFor(s);
-            hasTrailingComment = false;
-        }
+        output += s;
+        updateLineCountAndPosFor(s);
+        hasTrailingComment = false;
     }
 
     function writeLiteral(s: string) {
-        if (s && s.length) {
+        if (s.length) {
             write(s);
         }
     }

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -2401,7 +2401,7 @@ export function isStatement(node: Node): node is Statement {
 
 function isBlockStatement(node: Node): node is Block {
     if (node.kind !== SyntaxKind.Block) return false;
-    if (node.parent !== undefined) {
+    if (node.parent) {
         if (node.parent.kind === SyntaxKind.TryStatement || node.parent.kind === SyntaxKind.CatchClause) {
             return false;
         }

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -146,7 +146,7 @@ export function visitNode<TIn extends Node | undefined, TVisited extends Node | 
     lift?: (node: readonly Node[]) => Node,
 ): Node | (TIn & undefined) | (TVisited & undefined);
 export function visitNode(
-    node: Node,
+    node: Node | undefined,
     visitor: Visitor,
     test?: (node: Node) => boolean,
     lift?: (node: readonly Node[]) => Node,
@@ -343,7 +343,7 @@ function visitArrayWorker(
     // Visit each original node.
     for (let i = 0; i < count; i++) {
         const node = nodes[i + start];
-        const visited = node !== undefined ? (visitor ? visitor(node) : node) : undefined;
+        const visited = visitor ? visitor(node) : node;
         if (updated !== undefined || visited === undefined || visited !== node) {
             if (updated === undefined) {
                 // Ensure we have a copy of `nodes`, up to the current index.

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -56,7 +56,7 @@ export class System implements ts.System {
     public readFile(path: string) {
         try {
             const content = this.vfs.readFileSync(path, "utf8");
-            return content === undefined ? undefined : Utils.removeByteOrderMark(content);
+            return Utils.removeByteOrderMark(content);
         }
         catch {
             return undefined;

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1885,7 +1885,7 @@ export interface VerifyDocumentHighlightsOptions {
     filesToSearch: readonly string[];
 }
 
-export type NewFileContent = string | { readonly [filename: string]: string; };
+export type NewFileContent = string | { readonly [filename: string]: string | undefined; };
 
 export interface NewContentOptions {
     // Exactly one of these should be defined.

--- a/src/harness/tsserverLogger.ts
+++ b/src/harness/tsserverLogger.ts
@@ -4,7 +4,7 @@ import { Compiler } from "./harnessIO.js";
 export const HarnessLSCouldNotResolveModule = "HarnessLanguageService:: Could not resolve module";
 
 export function replaceAll(source: string, searchValue: string, replaceValue: string): string {
-    let result: string | undefined = (source as string & { replaceAll: typeof source.replace; }).replaceAll?.(searchValue, replaceValue);
+    let result: string | undefined = (source as (string & { replaceAll?: typeof source.replace; })).replaceAll?.(searchValue, replaceValue);
 
     if (result !== undefined) {
         return result;

--- a/src/harness/util.ts
+++ b/src/harness/util.ts
@@ -6,7 +6,7 @@ import * as ts from "./_namespaces/ts.js";
 
 const testPathPrefixRegExp = /(?:(file:\/{3})|\/)\.(ts|lib|src)\//g;
 export function removeTestPathPrefixes(text: string, retainTrailingDirectorySeparator?: boolean): string {
-    return text !== undefined ? text.replace(testPathPrefixRegExp, (_, scheme) => scheme || (retainTrailingDirectorySeparator ? "/" : "")) : undefined!; // TODO: GH#18217
+    return text.replace(testPathPrefixRegExp, (_, scheme) => scheme || (retainTrailingDirectorySeparator ? "/" : ""));
 }
 
 function createDiagnosticMessageReplacer<R extends (messageArgs: string[], ...args: string[]) => string[]>(diagnosticMessage: ts.DiagnosticMessage, replacer: R) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1678,7 +1678,7 @@ export class ProjectService {
     }
 
     findProject(projectName: string): Project | undefined {
-        if (projectName === undefined) {
+        if (typeof projectName === "undefined") {
             return undefined;
         }
         if (isInferredProjectName(projectName)) {
@@ -3702,7 +3702,7 @@ export class ProjectService {
 
     /** @internal */
     getSourceFileLike(fileName: string, projectNameOrProject: string | Project, declarationInfo?: ScriptInfo): SourceFileLike | undefined {
-        const project = (projectNameOrProject as Project).projectName ? projectNameOrProject as Project : this.findProject(projectNameOrProject as string);
+        const project = typeof projectNameOrProject === "string" ? this.findProject(projectNameOrProject) : projectNameOrProject;
         if (project) {
             const path = project.toPath(fileName);
             const sourceFile = project.getSourceFile(path);
@@ -5231,7 +5231,7 @@ export class ProjectService {
     }
 
     private watchPackageJsonFile(file: string, path: Path, project: Project | WildcardWatcher) {
-        Debug.assert(project !== undefined);
+        Debug.assertIsDefined(project);
         let result = (this.packageJsonFilesMap ??= new Map()).get(path);
         if (!result) {
             // this.invalidateProjectPackageJson(path);
@@ -5312,7 +5312,7 @@ function createIncompleteCompletionsCache(): IncompleteCompletionsCache {
 export type ScriptInfoOrConfig = ScriptInfo | TsConfigSourceFile;
 /** @internal */
 export function isConfigFile(config: ScriptInfoOrConfig): config is TsConfigSourceFile {
-    return (config as TsConfigSourceFile).kind !== undefined;
+    return !!(config as TsConfigSourceFile).kind;
 }
 
 function printProjectWithoutFileNames(project: Project) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -291,7 +291,7 @@ interface GeneratedFileWatcher {
 }
 type GeneratedFileWatcherMap = GeneratedFileWatcher | Map<Path, GeneratedFileWatcher>;
 function isGeneratedFileWatcher(watch: GeneratedFileWatcherMap): watch is GeneratedFileWatcher {
-    return (watch as GeneratedFileWatcher).generatedFilePath !== undefined;
+    return !!(watch as GeneratedFileWatcher).generatedFilePath;
 }
 
 /** @internal */
@@ -1177,7 +1177,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     }
 
     isClosed() {
-        return this.rootFilesMap === undefined;
+        return !this.rootFilesMap;
     }
 
     hasRoots() {

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -145,8 +145,6 @@ export class TextStorage {
      * returns true if text changed
      */
     public reload(newText: string): boolean {
-        Debug.assert(newText !== undefined);
-
         // Reload always has fresh content
         this.pendingReloadFromDisk = false;
 
@@ -273,9 +271,9 @@ export class TextStorage {
     }
 
     private getFileTextAndSize(tempFileName?: string): { text: string; fileSize?: number; } {
-        let text: string;
+        let text: string | undefined;
         const fileName = tempFileName || this.info.fileName;
-        const getText = () => text === undefined ? (text = this.host.readFile(fileName) || "") : text;
+        const getText = () => (text ??= this.host.readFile(fileName) ?? "");
         // Only non typescript files have size limitation
         if (!hasTSFileExtension(this.info.fileName)) {
             const fileSize = this.host.getFileSize ? this.host.getFileSize(fileName) : getText().length;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -987,7 +987,7 @@ export class Session<TMessage = string> implements EventSender {
 
     private performanceData: PerformanceData | undefined;
 
-    private currentRequestId!: number;
+    private currentRequestId: number | undefined;
     private errorCheck: MultistepOperation;
 
     protected host: ServerHost;
@@ -1024,7 +1024,7 @@ export class Session<TMessage = string> implements EventSender {
             : undefined;
         const multistepOperationHost: MultistepOperationHost = {
             executeWithRequestId: (requestId, action, performanceData) => this.executeWithRequestId(requestId, action, performanceData),
-            getCurrentRequestId: () => this.currentRequestId,
+            getCurrentRequestId: () => this.currentRequestId!, // TODO: GH#18217
             getPerformanceData: () => this.performanceData,
             getServerHost: () => this.host,
             logError: (err, cmd) => this.logError(err, cmd),
@@ -2614,7 +2614,7 @@ export class Session<TMessage = string> implements EventSender {
 
     private reload(args: protocol.ReloadRequestArgs) {
         const file = toNormalizedPath(args.file);
-        const tempFileName = args.tmpfile === undefined ? undefined : toNormalizedPath(args.tmpfile);
+        const tempFileName = typeof args.tmpfile === "undefined" ? undefined : toNormalizedPath(args.tmpfile);
         const info = this.projectService.getScriptInfoForNormalizedPath(file);
         if (info) {
             this.changeSeq++;
@@ -2820,7 +2820,7 @@ export class Session<TMessage = string> implements EventSender {
     }
 
     private isLocation(locationOrSpan: protocol.FileLocationOrRangeRequestArgs): locationOrSpan is protocol.FileLocationRequestArgs {
-        return (locationOrSpan as protocol.FileLocationRequestArgs).line !== undefined;
+        return typeof (locationOrSpan as protocol.FileLocationRequestArgs).line === "number";
     }
 
     private extractPositionOrRange(args: protocol.FileLocationOrRangeRequestArgs, scriptInfo: ScriptInfo): number | TextRange {
@@ -3725,7 +3725,7 @@ export class Session<TMessage = string> implements EventSender {
 
     private resetCurrentRequest(requestId: number): void {
         Debug.assert(this.currentRequestId === requestId);
-        this.currentRequestId = undefined!; // TODO: GH#18217
+        this.currentRequestId = undefined;
         this.cancellationToken.resetRequest(requestId);
     }
 

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -718,8 +718,6 @@ function tryGetValueFromType(context: CodeFixContextBase, checker: TypeChecker, 
         if (decl === undefined) return createUndefined();
 
         const signature = checker.getSignaturesOfType(type, SignatureKind.Call);
-        if (signature === undefined) return createUndefined();
-
         const func = createSignatureDeclarationFromSignature(SyntaxKind.FunctionExpression, context, quotePreference, signature[0], createStubbedBody(Diagnostics.Function_not_implemented.message, quotePreference), /*name*/ undefined, /*modifiers*/ undefined, /*optional*/ undefined, /*enclosingDeclaration*/ enclosingDeclaration, importAdder) as FunctionExpression | undefined;
         return func ?? createUndefined();
     }

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -140,7 +140,6 @@ function getInfo(sourceFile: SourceFile, pos: number, context: CodeFixContextBas
     else {
         const meaning = getMeaningFromLocation(node);
         const name = getTextOfNode(node);
-        Debug.assert(name !== undefined, "name should be defined");
         suggestedSymbol = checker.getSuggestedSymbolForNonexistentSymbol(node, name, convertSemanticMeaningToSymbolFlags(meaning));
     }
 

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -948,7 +948,7 @@ export function importSymbols(importAdder: ImportAdder, symbols: readonly Symbol
 }
 
 /** @internal */
-export function findAncestorMatchingSpan(sourceFile: SourceFile, span: TextSpan): Node {
+export function findAncestorMatchingSpan(sourceFile: SourceFile, span: TextSpan): Node | undefined {
     const end = textSpanEnd(span);
     let token = getTokenAtPosition(sourceFile, span.start);
     while (token.end < end) {

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -1224,7 +1224,7 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
         for (let i = 0; i < length; i++) {
             const symbol = checker.createSymbol(SymbolFlags.FunctionScopedVariable, escapeLeadingUnderscores(`arg${i}`));
             symbol.links.type = combineTypes(calls.map(call => call.argumentTypes[i] || checker.getUndefinedType()));
-            if (calls.some(call => call.argumentTypes[i] === undefined)) {
+            if (calls.some(call => call.argumentTypes.length <= i)) {
                 symbol.flags |= SymbolFlags.Optional;
             }
             parameters.push(symbol);

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -332,7 +332,7 @@ function nodeEntry(node: Node, kind: NodeEntryKind = EntryKind.Node): NodeEntry 
 
 /** @internal */
 export function isContextWithStartAndEndNode(node: ContextNode): node is ContextWithStartAndEndNode {
-    return node && (node as Node).kind === undefined;
+    return node && (node as { kind?: SyntaxKind; }).kind === undefined;
 }
 
 function getContextNodeForNodeEntry(node: Node): ContextNode | undefined {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -1480,8 +1480,8 @@ function getCloseTokenForOpenToken(kind: SyntaxKind) {
 }
 
 let internedSizes: { tabSize: number; indentSize: number; };
-let internedTabsIndentation: string[] | undefined;
-let internedSpacesIndentation: string[] | undefined;
+let internedTabsIndentation: (string | undefined)[] | undefined;
+let internedSpacesIndentation: (string | undefined)[] | undefined;
 
 /** @internal */
 export function getIndentationString(indentation: number, options: EditorSettings): string {
@@ -1498,9 +1498,7 @@ export function getIndentationString(indentation: number, options: EditorSetting
         const spaces = indentation - tabs * options.tabSize!;
 
         let tabString: string;
-        if (!internedTabsIndentation) {
-            internedTabsIndentation = [];
-        }
+        internedTabsIndentation ??= [];
 
         if (internedTabsIndentation[tabs] === undefined) {
             internedTabsIndentation[tabs] = tabString = repeatString("\t", tabs);
@@ -1515,9 +1513,7 @@ export function getIndentationString(indentation: number, options: EditorSetting
         let spacesString: string;
         const quotient = Math.floor(indentation / options.indentSize!);
         const remainder = indentation % options.indentSize!;
-        if (!internedSpacesIndentation) {
-            internedSpacesIndentation = [];
-        }
+        internedSpacesIndentation ??= [];
 
         if (internedSpacesIndentation[quotient] === undefined) {
             spacesString = repeatString(" ", options.indentSize! * quotient);

--- a/src/services/formatting/rulesMap.ts
+++ b/src/services/formatting/rulesMap.ts
@@ -85,7 +85,7 @@ function buildMap(rules: readonly RuleSpec[]): readonly (readonly Rule[])[] {
             for (const right of rule.rightTokenRange.tokens) {
                 const index = getRuleBucketIndex(left, right);
                 let rulesBucket = map[index];
-                if (rulesBucket === undefined) {
+                if (!Array.isArray(rulesBucket)) {
                     rulesBucket = map[index] = [];
                 }
                 addRule(rulesBucket, rule.rule, specificRule, rulesBucketConstructionStateList, index);

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -405,8 +405,8 @@ export namespace SmartIndenter {
 
     export function childStartsOnTheSameLineWithElseInIfStatement(parent: Node, child: TextRangeWithKind, childStartLine: number, sourceFile: SourceFileLike): boolean {
         if (parent.kind === SyntaxKind.IfStatement && (parent as IfStatement).elseStatement === child) {
-            const elseKeyword = findChildOfKind(parent, SyntaxKind.ElseKeyword, sourceFile)!;
-            Debug.assert(elseKeyword !== undefined);
+            const elseKeyword = findChildOfKind(parent, SyntaxKind.ElseKeyword, sourceFile);
+            Debug.assertIsDefined(elseKeyword);
 
             const elseKeywordStartLine = getStartLineAndCharacterForNode(elseKeyword, sourceFile).line;
             return elseKeywordStartLine === childStartLine;

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -530,7 +530,7 @@ function forEachPossibleImportOrExportStatement<T>(sourceFileLike: SourceFileLik
 
 /** Calls `action` for each import, re-export, or require() in a file. */
 function forEachImport(sourceFile: SourceFile, action: (importStatement: ImporterOrCallExpression, imported: StringLiteralLike) => void): void {
-    if (sourceFile.externalModuleIndicator || sourceFile.imports !== undefined) {
+    if (sourceFile.externalModuleIndicator || sourceFile.imports) {
         for (const i of sourceFile.imports) {
             action(importFromModuleSpecifier(i), i);
         }

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -426,7 +426,7 @@ export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): Comple
         const name = param.name.text;
         if (
             jsdoc.tags!.some(t => t !== tag && isJSDocParameterTag(t) && isIdentifier(t.name) && t.name.escapedText === name) // TODO: GH#18217
-            || nameThusFar !== undefined && !startsWith(name, nameThusFar)
+            || !startsWith(name, nameThusFar)
         ) {
             return undefined;
         }

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -272,9 +272,7 @@ function getTopLevelExportGroups(sourceFile: SourceFile) {
     let groupIndex = 0;
     while (i < len) {
         if (isExportDeclaration(statements[i])) {
-            if (topLevelExportGroups[groupIndex] === undefined) {
-                topLevelExportGroups[groupIndex] = [];
-            }
+            topLevelExportGroups[groupIndex] ??= [];
             const exportDecl = statements[i] as ExportDeclaration;
             if (exportDecl.moduleSpecifier) {
                 topLevelExportGroups[groupIndex].push(exportDecl);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -16,6 +16,7 @@ import {
     compareProperties,
     compareStringsCaseSensitive,
     compareValues,
+    concatenate,
     contains,
     ContinueStatement,
     createDiagnosticForNode,
@@ -1552,7 +1553,7 @@ function extractConstantInScope(
     }
 }
 
-function getContainingVariableDeclarationIfInList(node: Node, scope: Scope) {
+function getContainingVariableDeclarationIfInList(node: Node | undefined, scope: Scope) {
     let prevNode;
     while (node !== undefined && node !== scope) {
         if (
@@ -1769,12 +1770,7 @@ function getPropertyAssignmentsForWritesAndVariableDeclarations(
     const variableAssignments = map(exposedVariableDeclarations, v => factory.createShorthandPropertyAssignment(v.symbol.name));
     const writeAssignments = map(writes, w => factory.createShorthandPropertyAssignment(w.symbol.name));
 
-    // TODO: GH#18217 `variableAssignments` not possibly undefined!
-    return variableAssignments === undefined
-        ? writeAssignments!
-        : writeAssignments === undefined
-        ? variableAssignments
-        : variableAssignments.concat(writeAssignments);
+    return concatenate(variableAssignments, writeAssignments);
 }
 
 function isReadonlyArray(v: any): v is readonly any[] {
@@ -1898,7 +1894,7 @@ function collectReadsAndWrites(
         const seenTypeParameterUsages = new Map<string, TypeParameter>(); // Key is type ID
 
         let i = 0;
-        for (let curr: Node = unmodifiedNode; curr !== undefined && i < scopes.length; curr = curr.parent) {
+        for (let curr: Node | undefined = unmodifiedNode; curr !== undefined && i < scopes.length; curr = curr.parent as Node | undefined) {
             if (curr === scopes[i]) {
                 // Copy current contents of seenTypeParameterUsages into scope.
                 seenTypeParameterUsages.forEach((typeParameter, id) => {

--- a/src/services/refactors/helpers.ts
+++ b/src/services/refactors/helpers.ts
@@ -35,7 +35,7 @@ export interface RefactorErrorInfo {
  * @internal
  */
 export function isRefactorErrorInfo(info: unknown): info is RefactorErrorInfo {
-    return (info as RefactorErrorInfo).error !== undefined;
+    return !!(info as RefactorErrorInfo).error;
 }
 
 /**

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1952,7 +1952,7 @@ export function createLanguageService(
     // TODO: GH#18217 frequently asserted as defined
     function getProgram(): Program | undefined {
         if (languageServiceMode === LanguageServiceMode.Syntactic) {
-            Debug.assert(program === undefined);
+            Debug.assert(!program);
             return undefined;
         }
 

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -420,7 +420,7 @@ function tryGetParameterInfo(startingToken: Node, position: number, sourceFile: 
     const nonNullableContextualType = contextualType.getNonNullableType();
 
     const symbol = nonNullableContextualType.symbol;
-    if (symbol === undefined) return undefined;
+    if (!symbol) return undefined;
 
     const signature = lastOrUndefined(nonNullableContextualType.getCallSignatures());
     if (signature === undefined) return undefined;

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -118,7 +118,6 @@ export function getSourceMapper(host: SourceMapperHost): SourceMapper {
         const declarationPath = outPath ?
             removeFileExtension(outPath) + Extension.Dts :
             getDeclarationEmitOutputFilePathWorker(info.fileName, program.getCompilerOptions(), program);
-        if (declarationPath === undefined) return undefined;
 
         const newLoc = getDocumentPositionMapper(declarationPath, info.fileName).getGeneratedPosition(info);
         return newLoc === info ? undefined : newLoc;

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -736,10 +736,6 @@ function getCompletionEntriesForDirectoryFragment(
     exclude?: string,
     result = createNameAndKindSet(),
 ): NameAndKindSet {
-    if (fragment === undefined) {
-        fragment = "";
-    }
-
     fragment = normalizeSlashes(fragment);
 
     /**

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2012,7 +2012,7 @@ function removeOptionality(type: Type, isOptionalExpression: boolean, isOptional
 }
 
 /** @internal */
-export function isPossiblyTypeArgumentPosition(token: Node, sourceFile: SourceFile, checker: TypeChecker): boolean {
+export function isPossiblyTypeArgumentPosition(token: Node | undefined, sourceFile: SourceFile, checker: TypeChecker): boolean {
     const info = getPossibleTypeArgumentsInfo(token, sourceFile);
     return info !== undefined && (isPartOfTypeNode(info.called) ||
         getPossibleGenericSignatures(info.called, info.nTypeArguments, checker).length !== 0 ||

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -166,7 +166,7 @@ class CompilerTest {
     // equivalent to other files on the file system not directly passed to the compiler (ie things that are referenced by other files)
     private otherFiles: Compiler.TestFile[];
 
-    constructor(fileName: string, testCaseContent?: TestCaseParser.TestCaseContent, configurationOverrides?: TestCaseParser.CompilerSettings) {
+    constructor(fileName: string, testCaseContent?: TestCaseParser.TestCaseContent, configurationOverrides?: Required<TestCaseParser.CompilerSettings>) {
         const absoluteRootDir = vfs.srcFolder;
         this.fileName = fileName;
         this.justName = vpath.basename(fileName);
@@ -180,7 +180,7 @@ class CompilerTest {
                 if (configuredName) {
                     configuredName += ",";
                 }
-                configuredName += `${key.toLowerCase()}=${configurationOverrides[key].toLowerCase()}`;
+                configuredName += `${key.toLowerCase()}=${configurationOverrides[key]!.toLowerCase()}`;
             }
             if (configuredName) {
                 const extname = vpath.extname(this.justName);
@@ -284,11 +284,11 @@ class CompilerTest {
 
     public verifySourceMapRecord() {
         if (this.options.sourceMap || this.options.inlineSourceMap || this.options.declarationMap) {
-            const record = Utils.removeTestPathPrefixes(this.result.getSourceMapRecord()!);
+            const record = this.result.getSourceMapRecord();
             const baseline = (this.options.noEmitOnError && this.result.diagnostics.length !== 0) || record === undefined
                 // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
                 ? null // eslint-disable-line no-restricted-syntax
-                : record;
+                : Utils.removeTestPathPrefixes(record);
             Baseline.runBaseline(this.configuredName.replace(/\.tsx?$/, ".sourcemap.txt"), baseline);
         }
     }

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -200,7 +200,7 @@ export function start(importTests: () => Promise<unknown>) {
         return `${perfdataFileNameFragment}${target ? `.${target}` : ""}.json`;
     }
 
-    function readSavedPerfData(target?: string): { [testHash: string]: number; } | undefined {
+    function readSavedPerfData(target?: string): { [testHash: string]: number | undefined; } | undefined {
         const perfDataContents = IO.readFile(perfdataFileName(target));
         if (perfDataContents) {
             return JSON.parse(perfDataContents);
@@ -212,7 +212,7 @@ export function start(importTests: () => Promise<unknown>) {
         return `tsrunner-${runner}://${test}`;
     }
 
-    function startDelayed(perfData: { [testHash: string]: number; } | undefined, totalCost: number) {
+    function startDelayed(perfData: { [testHash: string]: number | undefined; } | undefined, totalCost: number) {
         console.log(`Discovered ${tasks.length} unittest suites` + (newTasks.length ? ` and ${newTasks.length} new suites.` : "."));
         console.log("Discovering runner-based tests...");
         const discoverStart = +(new Date());
@@ -236,13 +236,13 @@ export function start(importTests: () => Promise<unknown>) {
                 }
                 else {
                     const hashedName = hashName(runner.kind(), file);
-                    size = perfData[hashedName];
-                    if (size === undefined) {
+                    if (perfData[hashedName] === undefined) {
                         size = 0;
                         unknownValue = hashedName;
                         newTasks.push({ runner: runner.kind(), file, size });
                         continue;
                     }
+                    size = perfData[hashedName];
                 }
                 tasks.push({ runner: runner.kind(), file, size });
                 totalCost += size;
@@ -637,12 +637,13 @@ export function start(importTests: () => Promise<unknown>) {
             // Note, sub-suites are not indexed (we assume such granularity is not required)
             let size = 0;
             if (perfData) {
-                size = perfData[hashName("unittest", title)];
-                if (size === undefined) {
+                const savedData = perfData[hashName("unittest", title)];
+                if (savedData === undefined) {
                     newTasks.push({ runner: "unittest", file: title, size: 0 });
                     unknownValue = title;
                     return;
                 }
+                size = savedData;
             }
             tasks.push({ runner: "unittest", file: title, size });
             totalCost += size;

--- a/src/testRunner/unittests/helpers.ts
+++ b/src/testRunner/unittests/helpers.ts
@@ -36,9 +36,6 @@ export class SourceText implements ts.IScriptSnapshot {
     }
 
     static New(references: string, importsAndExports: string, program: string): SourceText {
-        ts.Debug.assert(references !== undefined);
-        ts.Debug.assert(importsAndExports !== undefined);
-        ts.Debug.assert(program !== undefined);
         return new SourceText(references + newLine, importsAndExports + newLine, program || "");
     }
 
@@ -47,15 +44,12 @@ export class SourceText implements ts.IScriptSnapshot {
     }
 
     public updateReferences(newReferences: string): SourceText {
-        ts.Debug.assert(newReferences !== undefined);
         return new SourceText(newReferences + newLine, this.importsAndExports, this.program, this.changedPart | ChangedPart.references, this.version + 1);
     }
     public updateImportsAndExports(newImportsAndExports: string): SourceText {
-        ts.Debug.assert(newImportsAndExports !== undefined);
         return new SourceText(this.references, newImportsAndExports + newLine, this.program, this.changedPart | ChangedPart.importsAndExports, this.version + 1);
     }
     public updateProgram(newProgram: string): SourceText {
-        ts.Debug.assert(newProgram !== undefined);
         return new SourceText(this.references, this.importsAndExports, newProgram, this.changedPart | ChangedPart.program, this.version + 1);
     }
 

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -11,7 +11,7 @@ function verifyMissingFilePaths(missing: ReturnType<ts.Program["getMissingFilePa
     const map = new Set(expected);
     for (const missing of missingPaths) {
         const value = map.has(missing);
-        assert.isTrue(value, `${missing} to be ${value === undefined ? "not present" : "present only once"}, in actual: ${missingPaths} expected: ${expected}`);
+        assert.isTrue(value, `${missing} to be ${!value ? "not present" : "present only once"}, in actual: ${missingPaths} expected: ${expected}`);
         map.delete(missing);
     }
     const notFound = ts.arrayFrom(ts.mapDefinedIterator(map.keys(), k => map.has(k) ? k : undefined));

--- a/src/testRunner/unittests/services/colorization.ts
+++ b/src/testRunner/unittests/services/colorization.ts
@@ -6,7 +6,7 @@ import * as ts from "../../_namespaces/ts.js";
 
 interface ClassificationEntry {
     value: any;
-    classification: ts.TokenClass;
+    classification: ts.TokenClass | undefined;
     position?: number;
 }
 
@@ -50,8 +50,7 @@ describe("unittests:: services:: Colorization", () => {
         return createClassification(text, ts.TokenClass.StringLiteral, position);
     }
     function finalEndOfLineState(value: number): ClassificationEntry {
-        // TODO: GH#18217
-        return { value, classification: undefined!, position: 0 };
+        return { value, classification: undefined, position: 0 };
     }
     function createClassification(value: string, classification: ts.TokenClass, position?: number): ClassificationEntry {
         return { value, classification, position };

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -1218,12 +1218,6 @@ export * from "lib";
     }
 
     function assertListEqual(list1: readonly ts.Node[], list2: readonly ts.Node[]) {
-        if (list1 === undefined || list2 === undefined) {
-            assert.isUndefined(list1);
-            assert.isUndefined(list2);
-            return;
-        }
-
         assert.equal(list1.length, list2.length);
         for (let i = 0; i < list1.length; i++) {
             assertEqual(list1[i], list2[i]);

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -457,7 +457,7 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
                 if (match) {
                     // if port is specified - use port + 1
                     // otherwise pick a default port depending on if 'debug' or 'inspect' and use its value + 1
-                    const currentPort = match[2] !== undefined
+                    const currentPort = typeof match[2] === "string"
                         ? +match[2]
                         : match[1].charAt(0) === "d" ? 5858 : 9229;
                     execArgv.push(`--${match[1]}=${currentPort + 1}`);


### PR DESCRIPTION
This could be pushed as part of https://github.com/microsoft/TypeScript/pull/59559 and it would fix the `self-check` there (when combined with https://github.com/microsoft/TypeScript/pull/59584 ). I think there it might be easier to review this in isolation though and that changes here (at least most of them) are good regardless of what will happen to https://github.com/microsoft/TypeScript/pull/59559 

I suspect many of those checks are artifacts of the fact that the codebase is old and originally it was written without `strictNullChecks`. Some of the changes are more risky than others as there could be some incorrect `!` passed to those call sites. I have inspected all of the paths I've touched to derisk this but I'm just a human 😉 The good thing is that the existing tests pass :) 
