### PR TITLE
Defer checking of class static blocks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -41494,7 +41494,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
 
-    function checkClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration) {
+    function checkClassStaticBlockDeclarationDeferred(node: ClassStaticBlockDeclaration) {
         checkGrammarModifiers(node);
 
         forEachChild(node, checkSourceElement);
@@ -47937,7 +47937,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.MethodSignature:
                 return checkMethodDeclaration(node as MethodDeclaration | MethodSignature);
             case SyntaxKind.ClassStaticBlockDeclaration:
-                return checkClassStaticBlockDeclaration(node as ClassStaticBlockDeclaration);
+                return checkNodeDeferred(node);
             case SyntaxKind.Constructor:
                 return checkConstructorDeclaration(node as ConstructorDeclaration);
             case SyntaxKind.GetAccessor:
@@ -48247,6 +48247,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.MethodSignature:
                 checkFunctionExpressionOrObjectLiteralMethodDeferred(node as FunctionExpression);
+                break;
+            case SyntaxKind.ClassStaticBlockDeclaration:
+                checkClassStaticBlockDeclarationDeferred(node as ClassStaticBlockDeclaration);
                 break;
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:

--- a/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.errors.txt
+++ b/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.errors.txt
@@ -1,0 +1,41 @@
+classStaticBlockDoNotSpoilVariance1.ts(7,35): error TS2344: Type 'A<T>' does not satisfy the constraint 'A<number>'.
+  Type 'T' is not assignable to type 'number'.
+classStaticBlockDoNotSpoilVariance1.ts(20,36): error TS2344: Type 'A2<T>' does not satisfy the constraint 'A2<number>'.
+  Type 'T' is not assignable to type 'number'.
+
+
+==== classStaticBlockDoNotSpoilVariance1.ts (2 errors) ====
+    class A<T = number> {
+      static {
+        type _<T extends A = A> = T;
+      }
+    
+      value!: T;
+      child!: InstanceType<typeof A.B<A<T>>>;
+                                      ~~~~
+!!! error TS2344: Type 'A<T>' does not satisfy the constraint 'A<number>'.
+!!! error TS2344:   Type 'T' is not assignable to type 'number'.
+!!! related TS2208 classStaticBlockDoNotSpoilVariance1.ts:1:9: This type parameter might need an `extends number` constraint.
+    
+      static B = class B<T extends A = A> {
+        parent!: T;
+      };
+    }
+    
+    const A2 = class A2<T = number> {
+      static {
+        type _<T extends A2 = A2> = T;
+      }
+    
+      value!: T;
+      child!: InstanceType<typeof A2.B<A2<T>>>;
+                                       ~~~~~
+!!! error TS2344: Type 'A2<T>' does not satisfy the constraint 'A2<number>'.
+!!! error TS2344:   Type 'T' is not assignable to type 'number'.
+!!! related TS2208 classStaticBlockDoNotSpoilVariance1.ts:14:21: This type parameter might need an `extends number` constraint.
+    
+      static B = class B<T extends A2 = A2> {
+        parent!: T;
+      };
+    };
+    

--- a/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.symbols
+++ b/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.symbols
@@ -1,0 +1,84 @@
+//// [tests/cases/conformance/classes/classStaticBlock/classStaticBlockDoNotSpoilVariance1.ts] ////
+
+=== classStaticBlockDoNotSpoilVariance1.ts ===
+class A<T = number> {
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 8))
+
+  static {
+    type _<T extends A = A> = T;
+>_ : Symbol(_, Decl(classStaticBlockDoNotSpoilVariance1.ts, 1, 10))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 2, 11))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 2, 11))
+  }
+
+  value!: T;
+>value : Symbol(A.value, Decl(classStaticBlockDoNotSpoilVariance1.ts, 3, 3))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 8))
+
+  child!: InstanceType<typeof A.B<A<T>>>;
+>child : Symbol(A.child, Decl(classStaticBlockDoNotSpoilVariance1.ts, 5, 12))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>A.B : Symbol(A.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 6, 41))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>B : Symbol(A.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 6, 41))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 8))
+
+  static B = class B<T extends A = A> {
+>B : Symbol(A.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 6, 41))
+>B : Symbol(B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 8, 12))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 8, 21))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+>A : Symbol(A, Decl(classStaticBlockDoNotSpoilVariance1.ts, 0, 0))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classStaticBlockDoNotSpoilVariance1.ts, 8, 39))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 8, 21))
+
+  };
+}
+
+const A2 = class A2<T = number> {
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 5))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 20))
+
+  static {
+    type _<T extends A2 = A2> = T;
+>_ : Symbol(_, Decl(classStaticBlockDoNotSpoilVariance1.ts, 14, 10))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 15, 11))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 15, 11))
+  }
+
+  value!: T;
+>value : Symbol(A2.value, Decl(classStaticBlockDoNotSpoilVariance1.ts, 16, 3))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 20))
+
+  child!: InstanceType<typeof A2.B<A2<T>>>;
+>child : Symbol(A2.child, Decl(classStaticBlockDoNotSpoilVariance1.ts, 18, 12))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>A2.B : Symbol(A2.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 19, 43))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>B : Symbol(A2.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 19, 43))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 20))
+
+  static B = class B<T extends A2 = A2> {
+>B : Symbol(A2.B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 19, 43))
+>B : Symbol(B, Decl(classStaticBlockDoNotSpoilVariance1.ts, 21, 12))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 21, 21))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+>A2 : Symbol(A2, Decl(classStaticBlockDoNotSpoilVariance1.ts, 13, 10))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classStaticBlockDoNotSpoilVariance1.ts, 21, 41))
+>T : Symbol(T, Decl(classStaticBlockDoNotSpoilVariance1.ts, 21, 21))
+
+  };
+};
+

--- a/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.types
+++ b/tests/baselines/reference/classStaticBlockDoNotSpoilVariance1.types
@@ -1,0 +1,85 @@
+//// [tests/cases/conformance/classes/classStaticBlock/classStaticBlockDoNotSpoilVariance1.ts] ////
+
+=== classStaticBlockDoNotSpoilVariance1.ts ===
+class A<T = number> {
+>A : A<T>
+>  : ^^^^
+
+  static {
+    type _<T extends A = A> = T;
+>_ : T
+>  : ^
+  }
+
+  value!: T;
+>value : T
+>      : ^
+
+  child!: InstanceType<typeof A.B<A<T>>>;
+>child : B<A<T>>
+>      : ^^^^^^^
+>A.B : typeof B
+>    : ^^^^^^^^
+>A : typeof A
+>  : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T extends A = A> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T extends A = A> {    parent!: T;  } : typeof B
+>                                             : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+}
+
+const A2 = class A2<T = number> {
+>A2 : typeof A2
+>   : ^^^^^^^^^
+>class A2<T = number> {  static {    type _<T extends A2 = A2> = T;  }  value!: T;  child!: InstanceType<typeof A2.B<A2<T>>>;  static B = class B<T extends A2 = A2> {    parent!: T;  };} : typeof A2
+>                                                                                                                                                                                          : ^^^^^^^^^
+>A2 : typeof A2
+>   : ^^^^^^^^^
+
+  static {
+    type _<T extends A2 = A2> = T;
+>_ : T
+>  : ^
+  }
+
+  value!: T;
+>value : T
+>      : ^
+
+  child!: InstanceType<typeof A2.B<A2<T>>>;
+>child : B<A2<T>>
+>      : ^^^^^^^^
+>A2.B : typeof B
+>     : ^^^^^^^^
+>A2 : typeof A2
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T extends A2 = A2> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T extends A2 = A2> {    parent!: T;  } : typeof B
+>                                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+

--- a/tests/cases/conformance/classes/classStaticBlock/classStaticBlockDoNotSpoilVariance1.ts
+++ b/tests/cases/conformance/classes/classStaticBlock/classStaticBlockDoNotSpoilVariance1.ts
@@ -1,0 +1,29 @@
+// @strict: true
+// @target: esnext
+// @noEmit: true
+
+class A<T = number> {
+  static {
+    type _<T extends A = A> = T;
+  }
+
+  value!: T;
+  child!: InstanceType<typeof A.B<A<T>>>;
+
+  static B = class B<T extends A = A> {
+    parent!: T;
+  };
+}
+
+const A2 = class A2<T = number> {
+  static {
+    type _<T extends A2 = A2> = T;
+  }
+
+  value!: T;
+  child!: InstanceType<typeof A2.B<A2<T>>>;
+
+  static B = class B<T extends A2 = A2> {
+    parent!: T;
+  };
+};

--- a/tests/cases/fourslash/quickInfoAvoidsClassVarianceCircularity1.ts
+++ b/tests/cases/fourslash/quickInfoAvoidsClassVarianceCircularity1.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @strict: true
+
+//// class A<T extends number = number> {
+////   value!: T;
+////   child!: InstanceType<typeof A.B<A<T>>>;
+////
+////   static B = class B<T extends A> {
+////     parent!: T;
+////   };
+//// }
+////
+//// var a = new A();
+////
+//// a.child.parent.value/**/;
+
+verify.quickInfoAt("", "(property) A<number>.value: number");
+verify.getSemanticDiagnostics([]);


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/52892

This only helps with a specific situation when a type alias defined in a class static block triggered the first variance check in those circular situations. Then all properties referencing `A` again were reentering `getVariancesWorker` and thus it was assumed that they were OK. My comment at the bottom of this post explains more about this kind of situation: https://github.com/microsoft/TypeScript/issues/59606#issue-2461841606

In other words, this only mitigates the problem in this specific situation but it's still possible to run into problems in similar circular situations. 