### PR TITLE
fix(59587): permit trailing commas in type parameter printing

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -10013,7 +10013,7 @@ export const enum ListFormat {
     SourceFileStatements = MultiLine | NoTrailingNewLine,
     Decorators = MultiLine | Optional | SpaceAfterList,
     TypeArguments = CommaDelimited | SpaceBetweenSiblings | SingleLine | AngleBrackets | Optional,
-    TypeParameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | AngleBrackets | Optional,
+    TypeParameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | AngleBrackets | Optional | AllowTrailingComma,
     Parameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | Parenthesis,
     IndexSignatureParameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | Indented | SquareBrackets,
     JSDocComment = MultiLine | AsteriskDelimited,

--- a/src/testRunner/unittests/printer.ts
+++ b/src/testRunner/unittests/printer.ts
@@ -100,6 +100,16 @@ describe("unittests:: PrinterAPI", () => {
                 ts.ScriptKind.TSX,
             ));
         });
+
+        printsCorrectly("typeParameters", {}, printer => {
+            return printer.printFile(ts.createSourceFile(
+                "source.tsx",
+                String.raw`export const id = <T,>(id: T): T => id;`,
+                ts.ScriptTarget.Latest,
+                /*setParentNodes*/ undefined,
+                ts.ScriptKind.TSX,
+            ));
+        });
     });
 
     describe("No duplicate ref directives when emiting .d.ts->.d.ts", () => {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -8142,7 +8142,7 @@ declare namespace ts {
         SourceFileStatements = 131073,
         Decorators = 2146305,
         TypeArguments = 53776,
-        TypeParameters = 53776,
+        TypeParameters = 53840,
         Parameters = 2576,
         IndexSignatureParameters = 8848,
         JSDocComment = 33,

--- a/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.js
+++ b/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.js
@@ -24,4 +24,4 @@ function CustomSelect2(x) { }
 //// [index.d.ts]
 import { Props } from "react-select";
 export declare const CustomSelect1: <Option>(x: Props<Option> & {}) => void;
-export declare function CustomSelect2<Option>(x: Props<Option> & {}): void;
+export declare function CustomSelect2<Option,>(x: Props<Option> & {}): void;

--- a/tests/baselines/reference/declarationEmitTypeParameterNameInOuterScope.js
+++ b/tests/baselines/reference/declarationEmitTypeParameterNameInOuterScope.js
@@ -34,10 +34,10 @@ function b2(x) { return x; }
 declare class A {
 }
 declare var a: <A>(x: A) => A;
-declare function a2<A>(x: A): A;
+declare function a2<A,>(x: A): A;
 declare var a3: <A>(x: A) => globalThis.A;
-declare function a4<A>(x: A): globalThis.A;
+declare function a4<A,>(x: A): globalThis.A;
 interface B {
 }
 declare var b: <B>(x: B) => B;
-declare function b2<B>(x: B): B;
+declare function b2<B,>(x: B): B;

--- a/tests/baselines/reference/inferenceExactOptionalProperties2.types
+++ b/tests/baselines/reference/inferenceExactOptionalProperties2.types
@@ -89,8 +89,8 @@ type ToProvidedActor<TActors extends Record<string, UnknownActorLogic>> =
   }>;
 
 declare function setup<
->setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
->      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                            
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>,>(config: TConfig) => void; }
+>      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                             
 
   TActors extends Record<string, UnknownActorLogic> = {},
 >(implementations?: {
@@ -129,8 +129,8 @@ setup({
 >                                                            : ^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^      ^^^^^^^^^^^^^^    
 >setup({  actors: { counter: counterLogic },}) : { createMachine: <const TConfig extends MachineConfig<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>>(config: TConfig) => void; }
 >                                              : ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^      ^^^^^^^^^^^^^^    ^^^
->setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
->      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                            
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>,>(config: TConfig) => void; }
+>      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                             
 >{  actors: { counter: counterLogic },} : { actors: { counter: ActorLogic<{ type: "INCREMENT"; }>; }; }
 >                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^
 
@@ -193,8 +193,8 @@ setup().createMachine({
 >                      : ^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^    
 >setup() : { createMachine: <const TConfig extends MachineConfig<never>>(config: TConfig) => void; }
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^    ^^^
->setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
->      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                            
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; }) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>,>(config: TConfig) => void; }
+>      : ^       ^^^^^^^^^                                 ^^^^^^^               ^^^                                                   ^^^^^                                                                                                             
 >createMachine : <const TConfig extends MachineConfig<never>>(config: TConfig) => void
 >              : ^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^    
 >{  entry: assign(() => ({})),} : { entry: AssignAction<never>; }

--- a/tests/baselines/reference/printerApi/printsFileCorrectly.typeParameters.js
+++ b/tests/baselines/reference/printerApi/printsFileCorrectly.typeParameters.js
@@ -1,0 +1,1 @@
+export const id = <T,>(id: T): T => id;


### PR DESCRIPTION
Fixes #59587