### PR TITLE
Avoid checking class expressions more than once

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -45953,9 +45953,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkClassExpression(node: ClassExpression): Type {
-        checkClassLikeDeclaration(node);
-        checkNodeDeferred(node);
-        checkClassExpressionExternalHelpers(node);
+        const nodeLinks = getNodeLinks(node);
+        if (!(nodeLinks.flags & NodeCheckFlags.TypeChecked)) {
+            nodeLinks.flags |= NodeCheckFlags.TypeChecked;
+            checkClassLikeDeclaration(node);
+            checkNodeDeferred(node);
+            checkClassExpressionExternalHelpers(node);
+        }
         return getTypeOfSymbol(getSymbolOfDeclaration(node));
     }
 


### PR DESCRIPTION
When investigating https://github.com/microsoft/TypeScript/issues/52892 I noticed that a class expression in the circular situation could be checked more than once. 

I couldn't recognize any issue being *fixed* by this. I manually confirmed that various diagnostics could be created by this wrapped code more than once... but `DiagnosticCollection['add']` uses a deduplication mechanism so this can't be observed. 