### PR TITLE
Allow trailing commas on lambda type parameter lists

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4508,7 +4508,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (isFunctionLike(parentNode) && parentNode.typeArguments) { // Quick info uses type arguments in place of type parameters on instantiated signatures
             return emitTypeArguments(parentNode, parentNode.typeArguments);
         }
-        emitList(parentNode, typeParameters, ListFormat.TypeParameters);
+        emitList(parentNode, typeParameters, ListFormat.TypeParameters | (isArrowFunction(parentNode) ? ListFormat.AllowTrailingComma : ListFormat.None));
     }
 
     function emitParameters(parentNode: Node, parameters: NodeArray<ParameterDeclaration>) {

--- a/src/testRunner/unittests/printer.ts
+++ b/src/testRunner/unittests/printer.ts
@@ -100,6 +100,17 @@ describe("unittests:: PrinterAPI", () => {
                 ts.ScriptKind.TSX,
             ));
         });
+
+        // https://github.com/microsoft/TypeScript/issues/59587
+        printsCorrectly("lambda type parameter lists in tsx", {}, printer => {
+            return printer.printFile(ts.createSourceFile(
+                "source.tsx",
+                String.raw`export const id = <T,>(id: T): T => id`,
+                ts.ScriptTarget.ESNext,
+                /*setParentNodes*/ undefined,
+                ts.ScriptKind.TSX,
+            ));
+        });
     });
 
     describe("No duplicate ref directives when emiting .d.ts->.d.ts", () => {

--- a/tests/baselines/reference/printerApi/printsFileCorrectly.lambda type parameter lists in tsx.js
+++ b/tests/baselines/reference/printerApi/printsFileCorrectly.lambda type parameter lists in tsx.js
@@ -1,0 +1,1 @@
+export const id = <T,>(id: T): T => id;


### PR DESCRIPTION
Fixes #59587

We don't want trailing commas on most type parameter lists, since they're not required, but in lambdas they may be needed for syntactic disambiguation in `.tsx`, so we should preserve them on them.