### PR TITLE
Fixed crash when reusing nodes referring to symbols inaccessible after emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6137,7 +6137,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             host = context.enclosingDeclaration,
             annotationType = getTypeFromTypeNode(context, existing, /*noMappedTypes*/ true),
         ) {
-            if (annotationType && typeNodeIsEquivalentToType(host, type, annotationType) && existingTypeNodeIsNotReferenceOrIsReferenceWithCompatibleTypeArgumentCount(existing, type)) {
+            if (annotationType && !context.notReusableNodes?.has(existing) && typeNodeIsEquivalentToType(host, type, annotationType) && existingTypeNodeIsNotReferenceOrIsReferenceWithCompatibleTypeArgumentCount(existing, type)) {
                 const result = tryReuseExistingTypeNodeHelper(context, existing);
                 if (result) {
                     return result;
@@ -6191,6 +6191,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 typeParameterNamesByText: undefined,
                 typeParameterNamesByTextNextNameCount: undefined,
                 mapper: undefined,
+                notReusableNodes: undefined,
             };
             context.tracker = new SymbolTrackerImpl(context, tracker, moduleResolverHost);
             const resultingNode = cb(context);
@@ -8570,7 +8571,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (cancellationToken && cancellationToken.throwIfCancellationRequested) {
                 cancellationToken.throwIfCancellationRequested();
             }
-            let hadError = false;
+            let erroredNode: Node | undefined;
+            let unreportedErrors: (() => void)[] | undefined;
             const { finalizeBoundary, startRecoveryScope } = createRecoveryBoundary();
             const transformed = visitNode(existing, visitExistingNodeTreeSymbols, isTypeNode);
             if (!finalizeBoundary()) {
@@ -8579,16 +8581,30 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             context.approximateLength += existing.end - existing.pos;
             return transformed;
 
+            function hasError() {
+                return !!erroredNode || !!unreportedErrors;
+            }
+
             function visitExistingNodeTreeSymbols(node: Node): Node | undefined {
                 // If there was an error in a sibling node bail early, the result will be discarded anyway
-                if (hadError) return node;
+                if (hasError()) return node;
                 const recover = startRecoveryScope();
                 const onExitNewScope = isNewScopeNode(node) ? onEnterNewScope(node) : undefined;
                 const result = visitExistingNodeTreeSymbolsWorker(node);
                 onExitNewScope?.();
 
                 // If there was an error, maybe we can recover by serializing the actual type of the node
-                if (hadError) {
+                if (hasError()) {
+                    if (erroredNode) {
+                        context.notReusableNodes ??= new Set();
+                        context.notReusableNodes.add(erroredNode);
+
+                        while (erroredNode.parent && erroredNode.parent !== existing) {
+                            context.notReusableNodes.add(erroredNode);
+                            erroredNode = erroredNode.parent;
+                        }
+                    }
+
                     if (isTypeNode(node) && !isTypePredicateNode(node)) {
                         recover();
                         return serializeExistingTypeNode(context, node);
@@ -8606,7 +8622,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             function createRecoveryBoundary() {
                 let trackedSymbols: TrackedSymbol[];
-                let unreportedErrors: (() => void)[];
+                unreportedErrors = undefined;
                 const oldTracker = context.tracker;
                 const oldTrackedSymbols = context.trackedSymbols;
                 context.trackedSymbols = undefined;
@@ -8641,7 +8657,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 };
 
                 function markError(unreportedError: () => void) {
-                    hadError = true;
                     (unreportedErrors ??= []).push(unreportedError);
                 }
 
@@ -8649,7 +8664,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const trackedSymbolsTop = trackedSymbols?.length ?? 0;
                     const unreportedErrorsTop = unreportedErrors?.length ?? 0;
                     return () => {
-                        hadError = false;
+                        erroredNode = undefined;
                         // Reset the tracked symbols to before the error
                         if (trackedSymbols) {
                             trackedSymbols.length = trackedSymbolsTop;
@@ -8666,7 +8681,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     context.encounteredError = oldEncounteredError;
 
                     unreportedErrors?.forEach(fn => fn());
-                    if (hadError) {
+                    if (hasError()) {
                         return false;
                     }
                     trackedSymbols?.forEach(
@@ -8849,7 +8864,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (canReuseTypeNode(context, node)) {
                         return node;
                     }
-                    hadError = true;
+                    erroredNode = node;
                     return node;
                 }
                 if (isTypeParameterDeclaration(node)) {
@@ -8865,7 +8880,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isIndexedAccessTypeNode(node)) {
                     const result = tryVisitIndexedAccess(node);
                     if (!result) {
-                        hadError = true;
+                        erroredNode = node;
                         return node;
                     }
                     return result;
@@ -8876,7 +8891,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (result) {
                         return result;
                     }
-                    hadError = true;
+                    erroredNode = node;
                     return node;
                 }
                 if (isLiteralImportTypeNode(node)) {
@@ -8929,7 +8944,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isTypeQueryNode(node)) {
                     const result = tryVisitTypeQuery(node);
                     if (!result) {
-                        hadError = true;
+                        erroredNode = node;
                         return node;
                     }
                     return result;
@@ -8972,10 +8987,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     let parameterName;
                     if (isIdentifier(node.parameterName)) {
                         const { node: result, introducesError } = trackExistingEntityName(node.parameterName, context);
-                        // Should not usually happen the only case is when a type predicate comes from a JSDoc type annotation with it's own parameter symbol definition.
-                        // /** @type {(v: unknown) => v is undefined} */
-                        // const isUndef = v => v === undefined;
-                        hadError = hadError || introducesError;
+                        if (introducesError) {
+                            // Should not usually happen the only case when erroredNode might already be set is when a type predicate comes from a JSDoc type annotation with it's own parameter symbol definition.
+                            // /** @type {(v: unknown) => v is undefined} */
+                            // const isUndef = v => v === undefined;
+                            erroredNode ??= node.parameterName;
+                        }
                         parameterName = result;
                     }
                     else {
@@ -9016,14 +9033,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isTypeOperatorNode(node)) {
                     if (node.operator === SyntaxKind.UniqueKeyword && node.type.kind === SyntaxKind.SymbolKeyword) {
                         if (!canReuseTypeNode(context, node)) {
-                            hadError = true;
+                            erroredNode = node;
                             return node;
                         }
                     }
                     else if (node.operator === SyntaxKind.KeyOfKeyword) {
                         const result = tryVisitKeyOf(node);
                         if (!result) {
-                            hadError = true;
+                            erroredNode = node;
                             return node;
                         }
                         return result;
@@ -52603,6 +52620,7 @@ interface NodeBuilderContext {
     reverseMappedStack: ReverseMappedSymbol[] | undefined;
     bundled: boolean;
     mapper: TypeMapper | undefined;
+    notReusableNodes: Set<Node> | undefined;
 }
 
 class SymbolTrackerImpl implements SymbolTracker {

--- a/tests/baselines/reference/classExpressionInClassInstantiationEmit1.js
+++ b/tests/baselines/reference/classExpressionInClassInstantiationEmit1.js
@@ -1,0 +1,252 @@
+//// [tests/cases/compiler/classExpressionInClassInstantiationEmit1.ts] ////
+
+//// [classExpressionInClassInstantiationEmit1.ts]
+class A1<T> {
+  child!: InstanceType<typeof A1.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A2 = class<T> {
+  child!: InstanceType<typeof A2.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A3 = class A3<T> {
+  child!: InstanceType<typeof A3.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A4 = class C<T> {
+  child!: InstanceType<typeof C.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+class A5<T> {
+  child!: typeof A5.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A6 = class<T> {
+  child!: typeof A6.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A7 = class A7<T> {
+  child!: typeof A7.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A8 = class C<T> {
+  child!: typeof C.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+
+//// [classExpressionInClassInstantiationEmit1.js]
+"use strict";
+var __setFunctionName = (this && this.__setFunctionName) || function (f, name, prefix) {
+    if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+    return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var _a, _b, _c, _d, _e, _f;
+var A1 = /** @class */ (function () {
+    function A1() {
+    }
+    A1.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }());
+    return A1;
+}());
+;
+var A2 = (_a = /** @class */ (function () {
+        function class_1() {
+        }
+        return class_1;
+    }()),
+    __setFunctionName(_a, "A2"),
+    _a.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _a);
+var A3 = (_b = /** @class */ (function () {
+        function A3() {
+        }
+        return A3;
+    }()),
+    _b.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _b);
+var A4 = (_c = /** @class */ (function () {
+        function C() {
+        }
+        return C;
+    }()),
+    _c.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _c);
+var A5 = /** @class */ (function () {
+    function A5() {
+    }
+    A5.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }());
+    return A5;
+}());
+;
+var A6 = (_d = /** @class */ (function () {
+        function class_2() {
+        }
+        return class_2;
+    }()),
+    __setFunctionName(_d, "A6"),
+    _d.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _d);
+var A7 = (_e = /** @class */ (function () {
+        function A7() {
+        }
+        return A7;
+    }()),
+    _e.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _e);
+var A8 = (_f = /** @class */ (function () {
+        function C() {
+        }
+        return C;
+    }()),
+    _f.B = /** @class */ (function () {
+        function B() {
+        }
+        return B;
+    }()),
+    _f);
+
+
+//// [classExpressionInClassInstantiationEmit1.d.ts]
+declare class A1<T> {
+    child: InstanceType<typeof A1.B<T>>;
+    static B: {
+        new <T_1>(): {
+            parent: T_1;
+        };
+    };
+}
+declare const A2: {
+    new <T>(): {
+        child: InstanceType<typeof A2.B<T>>;
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};
+declare const A3: {
+    new <T>(): {
+        child: InstanceType<{
+            new (): {
+                parent: T;
+            };
+        }>;
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};
+declare const A4: {
+    new <T>(): {
+        child: InstanceType<{
+            new (): {
+                parent: T;
+            };
+        }>;
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};
+declare class A5<T> {
+    child: typeof A5.B<T>;
+    static B: {
+        new <T_1>(): {
+            parent: T_1;
+        };
+    };
+}
+declare const A6: {
+    new <T>(): {
+        child: typeof A6.B<T>;
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};
+declare const A7: {
+    new <T>(): {
+        child: {
+            new (): {
+                parent: T;
+            };
+        };
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};
+declare const A8: {
+    new <T>(): {
+        child: {
+            new (): {
+                parent: T;
+            };
+        };
+    };
+    B: {
+        new <T>(): {
+            parent: T;
+        };
+    };
+};

--- a/tests/baselines/reference/classExpressionInClassInstantiationEmit1.symbols
+++ b/tests/baselines/reference/classExpressionInClassInstantiationEmit1.symbols
@@ -1,0 +1,195 @@
+//// [tests/cases/compiler/classExpressionInClassInstantiationEmit1.ts] ////
+
+=== classExpressionInClassInstantiationEmit1.ts ===
+class A1<T> {
+>A1 : Symbol(A1, Decl(classExpressionInClassInstantiationEmit1.ts, 0, 0))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 0, 9))
+
+  child!: InstanceType<typeof A1.B<T>>;
+>child : Symbol(A1.child, Decl(classExpressionInClassInstantiationEmit1.ts, 0, 13))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>A1.B : Symbol(A1.B, Decl(classExpressionInClassInstantiationEmit1.ts, 1, 39))
+>A1 : Symbol(A1, Decl(classExpressionInClassInstantiationEmit1.ts, 0, 0))
+>B : Symbol(A1.B, Decl(classExpressionInClassInstantiationEmit1.ts, 1, 39))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 0, 9))
+
+  static B = class B<T> {
+>B : Symbol(A1.B, Decl(classExpressionInClassInstantiationEmit1.ts, 1, 39))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 2, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 2, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 2, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 2, 21))
+
+  };
+};
+
+const A2 = class<T> {
+>A2 : Symbol(A2, Decl(classExpressionInClassInstantiationEmit1.ts, 7, 5))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 7, 17))
+
+  child!: InstanceType<typeof A2.B<T>>;
+>child : Symbol(A2.child, Decl(classExpressionInClassInstantiationEmit1.ts, 7, 21))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>A2.B : Symbol(A2.B, Decl(classExpressionInClassInstantiationEmit1.ts, 8, 39))
+>A2 : Symbol(A2, Decl(classExpressionInClassInstantiationEmit1.ts, 7, 5))
+>B : Symbol(A2.B, Decl(classExpressionInClassInstantiationEmit1.ts, 8, 39))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 7, 17))
+
+  static B = class B<T> {
+>B : Symbol(A2.B, Decl(classExpressionInClassInstantiationEmit1.ts, 8, 39))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 9, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 9, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 9, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 9, 21))
+
+  };
+};
+
+const A3 = class A3<T> {
+>A3 : Symbol(A3, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 5))
+>A3 : Symbol(A3, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 10))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 20))
+
+  child!: InstanceType<typeof A3.B<T>>;
+>child : Symbol(A3.child, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 24))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>A3.B : Symbol(A3.B, Decl(classExpressionInClassInstantiationEmit1.ts, 15, 39))
+>A3 : Symbol(A3, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 10))
+>B : Symbol(A3.B, Decl(classExpressionInClassInstantiationEmit1.ts, 15, 39))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 14, 20))
+
+  static B = class B<T> {
+>B : Symbol(A3.B, Decl(classExpressionInClassInstantiationEmit1.ts, 15, 39))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 16, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 16, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 16, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 16, 21))
+
+  };
+};
+
+const A4 = class C<T> {
+>A4 : Symbol(A4, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 5))
+>C : Symbol(C, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 10))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 19))
+
+  child!: InstanceType<typeof C.B<T>>;
+>child : Symbol(C.child, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 23))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>C.B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 22, 38))
+>C : Symbol(C, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 10))
+>B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 22, 38))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 21, 19))
+
+  static B = class B<T> {
+>B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 22, 38))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 23, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 23, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 23, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 23, 21))
+
+  };
+};
+
+class A5<T> {
+>A5 : Symbol(A5, Decl(classExpressionInClassInstantiationEmit1.ts, 26, 2))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 28, 9))
+
+  child!: typeof A5.B<T>;
+>child : Symbol(A5.child, Decl(classExpressionInClassInstantiationEmit1.ts, 28, 13))
+>A5.B : Symbol(A5.B, Decl(classExpressionInClassInstantiationEmit1.ts, 29, 25))
+>A5 : Symbol(A5, Decl(classExpressionInClassInstantiationEmit1.ts, 26, 2))
+>B : Symbol(A5.B, Decl(classExpressionInClassInstantiationEmit1.ts, 29, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 28, 9))
+
+  static B = class B<T> {
+>B : Symbol(A5.B, Decl(classExpressionInClassInstantiationEmit1.ts, 29, 25))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 30, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 30, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 30, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 30, 21))
+
+  };
+};
+
+const A6 = class<T> {
+>A6 : Symbol(A6, Decl(classExpressionInClassInstantiationEmit1.ts, 35, 5))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 35, 17))
+
+  child!: typeof A6.B<T>;
+>child : Symbol(A6.child, Decl(classExpressionInClassInstantiationEmit1.ts, 35, 21))
+>A6.B : Symbol(A6.B, Decl(classExpressionInClassInstantiationEmit1.ts, 36, 25))
+>A6 : Symbol(A6, Decl(classExpressionInClassInstantiationEmit1.ts, 35, 5))
+>B : Symbol(A6.B, Decl(classExpressionInClassInstantiationEmit1.ts, 36, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 35, 17))
+
+  static B = class B<T> {
+>B : Symbol(A6.B, Decl(classExpressionInClassInstantiationEmit1.ts, 36, 25))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 37, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 37, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 37, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 37, 21))
+
+  };
+};
+
+const A7 = class A7<T> {
+>A7 : Symbol(A7, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 5))
+>A7 : Symbol(A7, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 10))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 20))
+
+  child!: typeof A7.B<T>;
+>child : Symbol(A7.child, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 24))
+>A7.B : Symbol(A7.B, Decl(classExpressionInClassInstantiationEmit1.ts, 43, 25))
+>A7 : Symbol(A7, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 10))
+>B : Symbol(A7.B, Decl(classExpressionInClassInstantiationEmit1.ts, 43, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 42, 20))
+
+  static B = class B<T> {
+>B : Symbol(A7.B, Decl(classExpressionInClassInstantiationEmit1.ts, 43, 25))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 44, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 44, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 44, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 44, 21))
+
+  };
+};
+
+const A8 = class C<T> {
+>A8 : Symbol(A8, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 5))
+>C : Symbol(C, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 10))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 19))
+
+  child!: typeof C.B<T>;
+>child : Symbol(C.child, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 23))
+>C.B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 50, 24))
+>C : Symbol(C, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 10))
+>B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 50, 24))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 49, 19))
+
+  static B = class B<T> {
+>B : Symbol(C.B, Decl(classExpressionInClassInstantiationEmit1.ts, 50, 24))
+>B : Symbol(B, Decl(classExpressionInClassInstantiationEmit1.ts, 51, 12))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 51, 21))
+
+    parent!: T;
+>parent : Symbol(B.parent, Decl(classExpressionInClassInstantiationEmit1.ts, 51, 25))
+>T : Symbol(T, Decl(classExpressionInClassInstantiationEmit1.ts, 51, 21))
+
+  };
+};
+

--- a/tests/baselines/reference/classExpressionInClassInstantiationEmit1.types
+++ b/tests/baselines/reference/classExpressionInClassInstantiationEmit1.types
@@ -1,0 +1,255 @@
+//// [tests/cases/compiler/classExpressionInClassInstantiationEmit1.ts] ////
+
+=== classExpressionInClassInstantiationEmit1.ts ===
+class A1<T> {
+>A1 : A1<T>
+>   : ^^^^^
+
+  child!: InstanceType<typeof A1.B<T>>;
+>child : B<T>
+>      : ^^^^
+>A1.B : typeof B
+>     : ^^^^^^^^
+>A1 : typeof A1
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A2 = class<T> {
+>A2 : typeof A2
+>   : ^^^^^^^^^
+>class<T> {  child!: InstanceType<typeof A2.B<T>>;  static B = class B<T> {    parent!: T;  };} : typeof A2
+>                                                                                               : ^^^^^^^^^
+
+  child!: InstanceType<typeof A2.B<T>>;
+>child : B<T>
+>      : ^^^^
+>A2.B : typeof B
+>     : ^^^^^^^^
+>A2 : typeof A2
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A3 = class A3<T> {
+>A3 : typeof A3
+>   : ^^^^^^^^^
+>class A3<T> {  child!: InstanceType<typeof A3.B<T>>;  static B = class B<T> {    parent!: T;  };} : typeof A3
+>                                                                                                  : ^^^^^^^^^
+>A3 : typeof A3
+>   : ^^^^^^^^^
+
+  child!: InstanceType<typeof A3.B<T>>;
+>child : B<T>
+>      : ^^^^
+>A3.B : typeof B
+>     : ^^^^^^^^
+>A3 : typeof A3
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A4 = class C<T> {
+>A4 : typeof C
+>   : ^^^^^^^^
+>class C<T> {  child!: InstanceType<typeof C.B<T>>;  static B = class B<T> {    parent!: T;  };} : typeof C
+>                                                                                                : ^^^^^^^^
+>C : typeof C
+>  : ^^^^^^^^
+
+  child!: InstanceType<typeof C.B<T>>;
+>child : B<T>
+>      : ^^^^
+>C.B : typeof B
+>    : ^^^^^^^^
+>C : typeof C
+>  : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+class A5<T> {
+>A5 : A5<T>
+>   : ^^^^^
+
+  child!: typeof A5.B<T>;
+>child : typeof A5.B<T>
+>      :               
+>A5.B : typeof B
+>     : ^^^^^^^^
+>A5 : typeof A5
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A6 = class<T> {
+>A6 : typeof A6
+>   : ^^^^^^^^^
+>class<T> {  child!: typeof A6.B<T>;  static B = class B<T> {    parent!: T;  };} : typeof A6
+>                                                                                 : ^^^^^^^^^
+
+  child!: typeof A6.B<T>;
+>child : typeof A6.B<T>
+>      :               
+>A6.B : typeof B
+>     : ^^^^^^^^
+>A6 : typeof A6
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A7 = class A7<T> {
+>A7 : typeof A7
+>   : ^^^^^^^^^
+>class A7<T> {  child!: typeof A7.B<T>;  static B = class B<T> {    parent!: T;  };} : typeof A7
+>                                                                                    : ^^^^^^^^^
+>A7 : typeof A7
+>   : ^^^^^^^^^
+
+  child!: typeof A7.B<T>;
+>child : { new (): B<T>; prototype: A7<any>.B<any>; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>A7.B : typeof B
+>     : ^^^^^^^^
+>A7 : typeof A7
+>   : ^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+
+const A8 = class C<T> {
+>A8 : typeof C
+>   : ^^^^^^^^
+>class C<T> {  child!: typeof C.B<T>;  static B = class B<T> {    parent!: T;  };} : typeof C
+>                                                                                  : ^^^^^^^^
+>C : typeof C
+>  : ^^^^^^^^
+
+  child!: typeof C.B<T>;
+>child : { new (): B<T>; prototype: C<any>.B<any>; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>C.B : typeof B
+>    : ^^^^^^^^
+>C : typeof C
+>  : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+  static B = class B<T> {
+>B : typeof B
+>  : ^^^^^^^^
+>class B<T> {    parent!: T;  } : typeof B
+>                               : ^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+
+    parent!: T;
+>parent : T
+>       : ^
+
+  };
+};
+

--- a/tests/cases/compiler/classExpressionInClassInstantiationEmit1.ts
+++ b/tests/cases/compiler/classExpressionInClassInstantiationEmit1.ts
@@ -1,0 +1,58 @@
+// @strict: true
+// @declaration: true
+
+class A1<T> {
+  child!: InstanceType<typeof A1.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A2 = class<T> {
+  child!: InstanceType<typeof A2.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A3 = class A3<T> {
+  child!: InstanceType<typeof A3.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A4 = class C<T> {
+  child!: InstanceType<typeof C.B<T>>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+class A5<T> {
+  child!: typeof A5.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A6 = class<T> {
+  child!: typeof A6.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A7 = class A7<T> {
+  child!: typeof A7.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};
+
+const A8 = class C<T> {
+  child!: typeof C.B<T>;
+  static B = class B<T> {
+    parent!: T;
+  };
+};

--- a/tests/cases/fourslash/quickInfoClassExpressionInClassInstantiation1.ts
+++ b/tests/cases/fourslash/quickInfoClassExpressionInClassInstantiation1.ts
@@ -1,0 +1,74 @@
+/// <reference path="fourslash.ts"/>
+
+//// class A1<T> {
+////   /*1*/child!: InstanceType<typeof A1.B<T>>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A2 = class<T> {
+////   /*2*/child!: InstanceType<typeof A2.B<T>>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A3 = class A3<T> {
+////   /*3*/child!: InstanceType<typeof A3.B<T>>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A4 = class C<T> {
+////   /*4*/child!: InstanceType<typeof C.B<T>>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// class A5<T> {
+////   /*5*/child!: typeof A5.B<T>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A6 = class<T> {
+////   /*6*/child!: typeof A6.B<T>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A7 = class A7<T> {
+////   /*7*/child!: typeof A7.B<T>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+////
+//// const A8 = class C<T> {
+////   /*8*/child!: typeof C.B<T>;
+////   static B = class B<T> {
+////     parent!: T;
+////   };
+//// };
+
+verify.quickInfos({
+    1: "(property) A1<T>.child: B<T>",
+    2: "(property) A2<T>.child: B<T>",
+    3: "(property) A3<T>.child: B<T>",
+    4: "(property) C<T>.child: B<T>",
+    5: "(property) A5<T>.child: typeof A5.B<T>",
+    6: "(property) A6<T>.child: typeof A6.B<T>",
+    7: `(property) A7<T>.child: {
+    new (): B<T>;
+    prototype: A7<any>.B<any>;
+}`,
+    8: `(property) C<T>.child: {
+    new (): B<T>;
+    prototype: C<any>.B<any>;
+}`
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59600
I bisected the regression to https://github.com/microsoft/TypeScript/pull/58066 , cc @weswigham 