### PR TITLE
Add v8-json to coverage output for use with monocart VS Code extension

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,5 +1,5 @@
 {
-    "reporter": ["lcovonly", "cobertura", "v8", "codecov"],
+    "reporter": ["lcovonly", "cobertura", "v8", "v8-json", "codecov"],
     "src": "src",
     "include": ["src/**", "built/local/**"],
     "exclude": ["**/node_modules/**"],


### PR DESCRIPTION
Emitting this info lets us use the monocart VS Code extension, which looks very similar to the HTML report but right in the editor:

![image](https://github.com/user-attachments/assets/9cec74b9-d7e4-4fc9-97c3-f6deaad4a10d)

And yes, it does work in the checker.

![image](https://github.com/user-attachments/assets/59450edd-10cd-4543-8e48-afc4eb51a55a)

I don't measure much difference in the actual coverage tool runtime itself to add this report.