### PR TITLE
Always treat `.d.*.ts` files as commonjs-format modules for the purposes of import interop

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1396,8 +1396,8 @@ export function getImpliedNodeFormatForFileWorker(
     const shouldLookupFromPackageJson = ModuleResolutionKind.Node16 <= moduleResolution && moduleResolution <= ModuleResolutionKind.NodeNext
         || pathContainsNodeModules(fileName);
     return fileExtensionIsOneOf(fileName, [Extension.Dmts, Extension.Mts, Extension.Mjs]) ? ModuleKind.ESNext :
-        fileExtensionIsOneOf(fileName, [Extension.Dcts, Extension.Cts, Extension.Cjs]) ? ModuleKind.CommonJS :
-        shouldLookupFromPackageJson && (fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) || isDeclarationFileName(fileName)) ? lookupFromPackageJson() :
+        fileExtensionIsOneOf(fileName, [Extension.Dcts, Extension.Cts, Extension.Cjs]) || (isDeclarationFileName(fileName) && !fileExtensionIs(fileName, Extension.Dts)) ? ModuleKind.CommonJS :
+        shouldLookupFromPackageJson && fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) ? lookupFromPackageJson() :
         undefined; // other extensions, like `json` or `tsbuildinfo`, are set as `undefined` here but they should never be fed through the transformer pipeline
 
     function lookupFromPackageJson(): Partial<CreateSourceFileOptions> {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1397,7 +1397,7 @@ export function getImpliedNodeFormatForFileWorker(
         || pathContainsNodeModules(fileName);
     return fileExtensionIsOneOf(fileName, [Extension.Dmts, Extension.Mts, Extension.Mjs]) ? ModuleKind.ESNext :
         fileExtensionIsOneOf(fileName, [Extension.Dcts, Extension.Cts, Extension.Cjs]) ? ModuleKind.CommonJS :
-        shouldLookupFromPackageJson && fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) ? lookupFromPackageJson() :
+        shouldLookupFromPackageJson && (fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) || isDeclarationFileName(fileName)) ? lookupFromPackageJson() :
         undefined; // other extensions, like `json` or `tsbuildinfo`, are set as `undefined` here but they should never be fed through the transformer pipeline
 
     function lookupFromPackageJson(): Partial<CreateSourceFileOptions> {

--- a/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.errors.txt
+++ b/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.errors.txt
@@ -1,0 +1,66 @@
+cjs/index.mts(2,6): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+cjs/index.mts(4,7): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+cjs/secondary.cts(2,6): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+cjs/secondary.cts(4,7): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+esm/index.mts(2,6): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+esm/index.mts(4,7): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+esm/secondary.cts(2,6): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+esm/secondary.cts(4,7): error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+
+
+==== cjs/package.json (0 errors) ====
+    { "type": "commonjs" }
+==== cjs/foo.json (0 errors) ====
+    ["foo", "bar", "baz"]
+==== cjs/foo.d.json.ts (0 errors) ====
+    declare const data: ["foo", "bar", "baz"];
+    export = data;
+==== cjs/index.mts (2 errors) ====
+    import data from "./foo.json" with { type: "json" };
+    data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+         ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+    import data2 = require("./foo.json");
+    data2.default; // `data2` is the whole json object, no `default`
+          ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+==== cjs/secondary.cts (2 errors) ====
+    import data from "./foo.json";
+    data.default; // error (cjs format `.d.json.ts`, export= object is require result)
+         ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+    import data2 = require("./foo.json");
+    data2.default; // `data2` is the whole json object, no `default`
+          ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+==== esm/package.json (0 errors) ====
+    { "type": "module" }
+==== esm/foo.json (0 errors) ====
+    ["foo", "bar", "baz"]
+==== esm/foo.d.json.ts (0 errors) ====
+    declare const data: ["foo", "bar", "baz"];
+    export = data;
+==== esm/index.mts (2 errors) ====
+    import data from "./foo.json" with { type: "json" };
+    data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+         ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+    import data2 = require("./foo.json");
+    data2.default; // `data2` is the whole json object, no `default`
+          ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+==== esm/secondary.cts (2 errors) ====
+    import data from "./foo.json";
+    data.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+         ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+    import data2 = require("./foo.json");
+    data2.default; // `data2` is the whole json object, no `default`
+          ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type '["foo", "bar", "baz"]'.
+==== root.mts (0 errors) ====
+    import "./cjs/index.mjs";
+    import "./cjs/secondary.mjs";
+    import "./mjs/index.mjs";
+    import "./mjs/secondary.mjs";
+    

--- a/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.js
+++ b/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.js
@@ -1,0 +1,97 @@
+//// [tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts] ////
+
+//// [package.json]
+{ "type": "commonjs" }
+//// [foo.json]
+["foo", "bar", "baz"]
+//// [foo.d.json.ts]
+declare const data: ["foo", "bar", "baz"];
+export = data;
+//// [index.mts]
+import data from "./foo.json" with { type: "json" };
+data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [secondary.cts]
+import data from "./foo.json";
+data.default; // error (cjs format `.d.json.ts`, export= object is require result)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [package.json]
+{ "type": "module" }
+//// [foo.json]
+["foo", "bar", "baz"]
+//// [foo.d.json.ts]
+declare const data: ["foo", "bar", "baz"];
+export = data;
+//// [index.mts]
+import data from "./foo.json" with { type: "json" };
+data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [secondary.cts]
+import data from "./foo.json";
+data.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [root.mts]
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";
+
+
+//// [index.mjs]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+import data from "./foo.json" with { type: "json" };
+data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+const data2 = __require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [secondary.cjs]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const foo_json_1 = __importDefault(require("./foo.json"));
+foo_json_1.default.default; // error (cjs format `.d.json.ts`, export= object is require result)
+const data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [index.mjs]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+import data from "./foo.json" with { type: "json" };
+data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+const data2 = __require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [secondary.cjs]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const foo_json_1 = __importDefault(require("./foo.json"));
+foo_json_1.default.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+const data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
+//// [root.mjs]
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";
+
+
+//// [index.d.mts]
+export {};
+//// [secondary.d.cts]
+export {};
+//// [index.d.mts]
+export {};
+//// [secondary.d.cts]
+export {};
+//// [root.d.mts]
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";

--- a/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.symbols
+++ b/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.symbols
@@ -1,0 +1,75 @@
+//// [tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts] ////
+
+=== cjs/foo.d.json.ts ===
+declare const data: ["foo", "bar", "baz"];
+>data : Symbol(data, Decl(foo.d.json.ts, 0, 13))
+
+export = data;
+>data : Symbol(data, Decl(foo.d.json.ts, 0, 13))
+
+=== cjs/index.mts ===
+import data from "./foo.json" with { type: "json" };
+>data : Symbol(data, Decl(index.mts, 0, 6))
+
+data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+>data : Symbol(data, Decl(index.mts, 0, 6))
+
+import data2 = require("./foo.json");
+>data2 : Symbol(data2, Decl(index.mts, 1, 13))
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2 : Symbol(data2, Decl(index.mts, 1, 13))
+
+=== cjs/secondary.cts ===
+import data from "./foo.json";
+>data : Symbol(data, Decl(secondary.cts, 0, 6))
+
+data.default; // error (cjs format `.d.json.ts`, export= object is require result)
+>data : Symbol(data, Decl(secondary.cts, 0, 6))
+
+import data2 = require("./foo.json");
+>data2 : Symbol(data2, Decl(secondary.cts, 1, 13))
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2 : Symbol(data2, Decl(secondary.cts, 1, 13))
+
+=== esm/foo.d.json.ts ===
+declare const data: ["foo", "bar", "baz"];
+>data : Symbol(data, Decl(foo.d.json.ts, 0, 13))
+
+export = data;
+>data : Symbol(data, Decl(foo.d.json.ts, 0, 13))
+
+=== esm/index.mts ===
+import data from "./foo.json" with { type: "json" };
+>data : Symbol(data, Decl(index.mts, 0, 6))
+
+data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+>data : Symbol(data, Decl(index.mts, 0, 6))
+
+import data2 = require("./foo.json");
+>data2 : Symbol(data2, Decl(index.mts, 1, 13))
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2 : Symbol(data2, Decl(index.mts, 1, 13))
+
+=== esm/secondary.cts ===
+import data from "./foo.json";
+>data : Symbol(data, Decl(secondary.cts, 0, 6))
+
+data.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+>data : Symbol(data, Decl(secondary.cts, 0, 6))
+
+import data2 = require("./foo.json");
+>data2 : Symbol(data2, Decl(secondary.cts, 1, 13))
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2 : Symbol(data2, Decl(secondary.cts, 1, 13))
+
+=== root.mts ===
+
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";
+

--- a/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.types
+++ b/tests/baselines/reference/resolveJsonModuleAllowArbitraryExtensionsNodeNext.types
@@ -1,0 +1,131 @@
+//// [tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts] ////
+
+=== cjs/foo.d.json.ts ===
+declare const data: ["foo", "bar", "baz"];
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+export = data;
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+=== cjs/index.mts ===
+import data from "./foo.json" with { type: "json" };
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>type : any
+>     : ^^^
+
+data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+>data.default : any
+>             : ^^^
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+import data2 = require("./foo.json");
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2.default : any
+>              : ^^^
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+=== cjs/secondary.cts ===
+import data from "./foo.json";
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+data.default; // error (cjs format `.d.json.ts`, export= object is require result)
+>data.default : any
+>             : ^^^
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+import data2 = require("./foo.json");
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2.default : any
+>              : ^^^
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+=== esm/foo.d.json.ts ===
+declare const data: ["foo", "bar", "baz"];
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+export = data;
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+=== esm/index.mts ===
+import data from "./foo.json" with { type: "json" };
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>type : any
+>     : ^^^
+
+data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+>data.default : any
+>             : ^^^
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+import data2 = require("./foo.json");
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2.default : any
+>              : ^^^
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+=== esm/secondary.cts ===
+import data from "./foo.json";
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+data.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+>data.default : any
+>             : ^^^
+>data : ["foo", "bar", "baz"]
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+import data2 = require("./foo.json");
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+
+data2.default; // `data2` is the whole json object, no `default`
+>data2.default : any
+>              : ^^^
+>data2 : ["foo", "bar", "baz"]
+>      : ^^^^^^^^^^^^^^^^^^^^^
+>default : any
+>        : ^^^
+
+=== root.mts ===
+
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";
+

--- a/tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts
+++ b/tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts
@@ -1,0 +1,48 @@
+// @declaration: true
+// @module: nodenext
+// @allowArbitraryExtensions: true
+// @resolveJsonModule: true
+// @listFiles: true
+// @filename: cjs/package.json
+{ "type": "commonjs" }
+// @filename: cjs/foo.json
+["foo", "bar", "baz"]
+// @filename: cjs/foo.d.json.ts
+declare const data: ["foo", "bar", "baz"];
+export default data;
+// @filename: cjs/index.mts
+import data from "./foo.json" with { type: "json" };
+
+data.default; // foo.d.json.ts is cjs format - no error (`default` is whole file, file has `default` member)
+// This means the `.d.json.ts` actually represents a
+// { "default": ["foo", "bar", "baz"] }
+// and _not_ a straight `["foo", "bar", "baz"]`
+// @filename: cjs/secondary.cts
+import data from "./foo.json";
+
+data.default; // no error (cjs format `.d.json.ts`, represents a json object with a `default` member)
+// @filename: esm/package.json
+{ "type": "module" }
+// @filename: esm/foo.json
+["foo", "bar", "baz"]
+// @filename: esm/foo.d.json.ts
+declare const data: ["foo", "bar", "baz"];
+export default data;
+// NOTE: an "esm format" .d.json.ts should never have any exports except
+// `default`, since node doesn't create named exports for `.json` imports
+// That means this file actually represents a
+// `["foo", "bar", "baz"]` json document, but since it's "esm format",
+// will not be importable from a cjs caller.
+// @filename: esm/index.mts
+import data from "./foo.json" with { type: "json" };
+
+data.default; // foo.d.json.ts is esm format - error! (default is the one declared in the file)
+// @filename: esm/secondary.cts
+import data from "./foo.json"; // error (attempt to import esm format file in cjs file via `import`)
+
+data.default;
+// @filename: root.mts
+import "./cjs/index.mjs";
+import "./cjs/secondary.mjs";
+import "./mjs/index.mjs";
+import "./mjs/secondary.mjs";

--- a/tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts
+++ b/tests/cases/compiler/resolveJsonModuleAllowArbitraryExtensionsNodeNext.ts
@@ -9,38 +9,34 @@
 ["foo", "bar", "baz"]
 // @filename: cjs/foo.d.json.ts
 declare const data: ["foo", "bar", "baz"];
-export default data;
+export = data;
 // @filename: cjs/index.mts
 import data from "./foo.json" with { type: "json" };
-
-data.default; // foo.d.json.ts is cjs format - no error (`default` is whole file, file has `default` member)
-// This means the `.d.json.ts` actually represents a
-// { "default": ["foo", "bar", "baz"] }
-// and _not_ a straight `["foo", "bar", "baz"]`
+data.default; // foo.d.json.ts is cjs format - error (`default` is whole file, file has no `default` member)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
 // @filename: cjs/secondary.cts
 import data from "./foo.json";
-
-data.default; // no error (cjs format `.d.json.ts`, represents a json object with a `default` member)
+data.default; // error (cjs format `.d.json.ts`, export= object is require result)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
 // @filename: esm/package.json
 { "type": "module" }
 // @filename: esm/foo.json
 ["foo", "bar", "baz"]
 // @filename: esm/foo.d.json.ts
 declare const data: ["foo", "bar", "baz"];
-export default data;
-// NOTE: an "esm format" .d.json.ts should never have any exports except
-// `default`, since node doesn't create named exports for `.json` imports
-// That means this file actually represents a
-// `["foo", "bar", "baz"]` json document, but since it's "esm format",
-// will not be importable from a cjs caller.
+export = data;
 // @filename: esm/index.mts
 import data from "./foo.json" with { type: "json" };
-
-data.default; // foo.d.json.ts is esm format - error! (default is the one declared in the file)
+data.default; // foo.d.json.ts is cjs format despite package - error! (default import is already the whole json object)
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
 // @filename: esm/secondary.cts
-import data from "./foo.json"; // error (attempt to import esm format file in cjs file via `import`)
-
-data.default;
+import data from "./foo.json";
+data.default; // `export=` object is the whole `require` result, hoisted to `default` by interop helper, no 2nd default
+import data2 = require("./foo.json");
+data2.default; // `data2` is the whole json object, no `default`
 // @filename: root.mts
 import "./cjs/index.mjs";
 import "./cjs/secondary.mjs";


### PR DESCRIPTION
Fixes #57229

The way `allowSyntheticDefaultImports`/`esModuleInterop` and `module: nodenext`'s `"type": "module"` detection interplay in the context of `.d.*.ts` files right now is... confusing. Since they *are* `.ts` files, they do _currently_ get assigned a `package.json`-`type`-dependent module kind, which determines if the module is made available as a `default` or not on an esm import, and if a cjs file can import it _at all_, and furthermore we have heuristics involving the presence of a `default` in the declaration file which can then disable the synthetic `default` creation for interop'd imports (import statements in cjs format files under `module: nodenext`).

This menagerie of behaviors means that to write a declaration file for a json file similar to `["foo", "bar"]`, so _is no single way to write it that works for all callers, in all package type contexts, even though json imports (or any non-js import) are not package type dependent_.

On investigation, I find this state of affairs confusing.

This PR changes how we interpret `.d.*.ts` file module formats to _always_ be cjs-like. This means the correct way to write the declaration file for `["foo", "bar"]` is always
```ts
declare const _export: ["foo", "bar"];
export = _export;
```
and registers as importable by all import and require constructs in all package type contexts.