### PR TITLE
Experiment: Always report `useDefineForClassFields`-related errors even when disabled

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34198,7 +34198,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             && !(isAccessExpression(node) && isAccessExpression(node.expression))
             && !isBlockScopedNameDeclaredBeforeUse(valueDeclaration, right)
             && !(isMethodDeclaration(valueDeclaration) && getCombinedModifierFlagsCached(valueDeclaration) & ModifierFlags.Static)
-            && (useDefineForClassFields || !isPropertyDeclaredInAncestorClass(prop))
         ) {
             diagnosticMessage = error(right, Diagnostics.Property_0_is_used_before_its_initialization, declarationName);
         }


### PR DESCRIPTION
This is an experiment to establish a rough estimate of how frequently projects in the wild depend on the initializer order for TypeScript "Parameter Property Initializers" feature when used in conjunction with `useDefineForClassFields: false`.

Note that this will only catch cases where projects have an ordering dependency that would be reported as a use-before-definition error by the compiler when `useDefineForClassFields` is enabled.
