### PR TITLE
Handle delayed or missed watches for project updates

### DIFF
--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -21,6 +21,7 @@ import {
     FileWatcherCallback,
     FileWatcherEventKind,
     find,
+    forEachAncestorDirectory,
     getAllowJSCompilerOption,
     getBaseFileName,
     getDirectoryPath,
@@ -291,6 +292,13 @@ export function createCachedDirectoryStructureHost(host: DirectoryStructureHost,
         return host.realpath ? host.realpath(s) : s;
     }
 
+    function clearFirstAncestorEntry(fileOrDirectoryPath: Path) {
+        forEachAncestorDirectory(
+            getDirectoryPath(fileOrDirectoryPath),
+            ancestor => cachedReadDirectoryResult.delete(ensureTrailingDirectorySeparator(ancestor)) ? true : undefined,
+        );
+    }
+
     function addOrDeleteFileOrDirectory(fileOrDirectory: string, fileOrDirectoryPath: Path) {
         const existingResult = getCachedFileSystemEntries(fileOrDirectoryPath);
         if (existingResult !== undefined) {
@@ -302,6 +310,7 @@ export function createCachedDirectoryStructureHost(host: DirectoryStructureHost,
 
         const parentResult = getCachedFileSystemEntriesForBaseDir(fileOrDirectoryPath);
         if (!parentResult) {
+            clearFirstAncestorEntry(fileOrDirectoryPath);
             return undefined;
         }
 
@@ -338,6 +347,9 @@ export function createCachedDirectoryStructureHost(host: DirectoryStructureHost,
         const parentResult = getCachedFileSystemEntriesForBaseDir(filePath);
         if (parentResult) {
             updateFilesOfFileSystemEntry(parentResult, getBaseNameOfFileName(fileName), eventKind === FileWatcherEventKind.Created);
+        }
+        else {
+            clearFirstAncestorEntry(filePath);
         }
     }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -80,6 +80,7 @@ import {
     length,
     map,
     mapDefinedIterator,
+    memoize,
     missingFileModifiedTime,
     MultiMap,
     noop,
@@ -1910,6 +1911,11 @@ export class ProjectService {
             this.logger.info(`Config: ${configFileName} Detected new package.json: ${file}`);
             this.packageJsonCache.addOrUpdate(file, fileOrDirectoryPath);
             this.watchPackageJsonFile(file, fileOrDirectoryPath, wildCardWatcher);
+        }
+
+        if (!fsResult?.fileExists) {
+            // Ensure we send sourceFileChange
+            this.sendSourceFileChange(fileOrDirectoryPath);
         }
 
         const configuredProjectForConfig = this.findConfiguredProjectByProjectName(configFileName);
@@ -3838,6 +3844,34 @@ export class ProjectService {
         this.logger.close();
     }
 
+    private sendSourceFileChange(inPath: Path | undefined) {
+        this.filenameToScriptInfo.forEach(info => {
+            if (this.openFiles.has(info.path)) return; // Skip open files
+            if (!info.fileWatcher) return; // not watched file
+            const eventKind = memoize(() =>
+                this.host.fileExists(info.fileName) ?
+                    info.deferredDelete ?
+                        FileWatcherEventKind.Created :
+                        FileWatcherEventKind.Changed :
+                    FileWatcherEventKind.Deleted
+            );
+            if (inPath) {
+                // Skip node modules and files that are not in path
+                if (isScriptInfoWatchedFromNodeModules(info) || !info.path.startsWith(inPath)) return;
+                // If we are sending delete event and its already deleted, ignore
+                if (eventKind() === FileWatcherEventKind.Deleted && info.deferredDelete) return;
+                // In change cases, its hard to know if this is marked correctly across files and projects, so just send the event
+                this.logger.info(`Invoking sourceFileChange on ${info.fileName}:: ${eventKind()}`);
+            }
+
+            // Handle as if file is changed or deleted
+            this.onSourceFileChanged(
+                info,
+                eventKind(),
+            );
+        });
+    }
+
     /**
      * This function rebuilds the project for every file opened by the client
      * This does not reload contents of open files from disk. But we could do that if needed
@@ -3850,19 +3884,7 @@ export class ProjectService {
         // as there is no need to load contents of the files from the disk
 
         // Reload script infos
-        this.filenameToScriptInfo.forEach(info => {
-            if (this.openFiles.has(info.path)) return; // Skip open files
-            if (!info.fileWatcher) return; // not watched file
-            // Handle as if file is changed or deleted
-            this.onSourceFileChanged(
-                info,
-                this.host.fileExists(info.fileName) ?
-                    info.deferredDelete ?
-                        FileWatcherEventKind.Created :
-                        FileWatcherEventKind.Changed :
-                    FileWatcherEventKind.Deleted,
-            );
-        });
+        this.sendSourceFileChange(/*inPath*/ undefined);
         // Cancel all project updates since we will be updating them now
         this.pendingProjectUpdates.forEach((_project, projectName) => {
             this.throttledOperations.cancel(projectName);

--- a/src/testRunner/unittests/tsserver/getEditsForFileRename.ts
+++ b/src/testRunner/unittests/tsserver/getEditsForFileRename.ts
@@ -1,9 +1,12 @@
 import * as ts from "../../_namespaces/ts.js";
+import { dedent } from "../../_namespaces/Utils.js";
 import { jsonToReadableText } from "../helpers.js";
+import { libContent } from "../helpers/contents.js";
 import {
     baselineTsserverLogs,
     closeFilesForSession,
     openFilesForSession,
+    protocolTextSpanFromSubstring,
     TestSession,
     textSpanFromSubstring,
     verifyGetErrRequest,
@@ -205,6 +208,91 @@ describe("unittests:: tsserver:: getEditsForFileRename", () => {
                     baselineTsserverLogs("getEditsForFileRename", `works with when file is opened ${openedBeforeChange ? "before" : "after"} seeing file existance on the disk${closedBeforeChange ? " closed before change" : ""}${withUpdateOpen ? " with updateOpen" : ""}`, session);
                 });
             });
+        })
+    );
+
+    [true, false].forEach(canUseWatchEvents =>
+        it(`works when moving file to and from folder${canUseWatchEvents ? " canUseWatchEvents" : ""}`, () => {
+            const alertText = dedent`
+                export function alert(message: string) {
+                    console.log(\`ALERT: \${message}\`);
+                }
+            `;
+            const projectRootPath = "/home/src/myprojects/project";
+            const indexTs = `${projectRootPath}/index.ts`;
+            const indexFileText = dedent`
+                import { alert } from '@app/components/whatever/alert';
+                alert('Hello, world!');
+            `;
+            const componentsWhatever = `${projectRootPath}/components/whatever`;
+            const functionsWhatever = `${projectRootPath}/functions/whatever`;
+            const host = createServerHost({
+                "/home/src/myprojects/project/tsconfig.json": jsonToReadableText({
+                    compilerOptions: {
+                        target: "es2016",
+                        module: "commonjs",
+                        paths: {
+                            "@app/*": [
+                                "./*",
+                            ],
+                        },
+                        esModuleInterop: true,
+                        forceConsistentCasingInFileNames: true,
+                        strict: true,
+                        skipLibCheck: true,
+                    },
+                }),
+                [indexTs]: indexFileText,
+                [`${componentsWhatever}/alert.ts`]: alertText,
+                [`${functionsWhatever}/placeholder.txt`]: "",
+                "/a/lib/lib.es2016.full.d.ts": libContent,
+            });
+            const session = new TestSession({ host, canUseWatchEvents, canUseEvents: true });
+            openFilesForSession([{ file: indexTs, projectRootPath }], session);
+            host.renameFolder(componentsWhatever, functionsWhatever, /*skipFolderEntryWatches*/ true);
+            if (canUseWatchEvents) session.invokeWatchChanges();
+            openFilesForSession([{
+                file: `${functionsWhatever}/alert.ts`,
+                content: alertText,
+                projectRootPath,
+            }], session);
+            session.executeCommandSeq<ts.server.protocol.GetEditsForFileRenameRequest>({
+                command: ts.server.protocol.CommandTypes.GetEditsForFileRename,
+                arguments: { oldFilePath: componentsWhatever, newFilePath: functionsWhatever },
+            });
+            // Apply edit to index.ts
+            session.executeCommandSeq<ts.server.protocol.UpdateOpenRequest>({
+                command: ts.server.protocol.CommandTypes.UpdateOpen,
+                arguments: {
+                    changedFiles: [{
+                        fileName: indexTs,
+                        textChanges: [{
+                            ...protocolTextSpanFromSubstring(indexFileText, "@app/components/whatever/alert"),
+                            newText: "@app/functions/whatever/alert",
+                        }],
+                    }],
+                },
+            });
+            host.runQueuedTimeoutCallbacks();
+            host.renameFolder(functionsWhatever, componentsWhatever, /*skipFolderEntryWatches*/ true);
+            session.executeCommandSeq<ts.server.protocol.UpdateOpenRequest>({
+                command: ts.server.protocol.CommandTypes.UpdateOpen,
+                arguments: {
+                    openFiles: [{
+                        file: `${componentsWhatever}/alert.ts`,
+                        fileContent: alertText,
+                        projectRootPath,
+                    }],
+                    closedFiles: [`${functionsWhatever}/alert.ts`],
+                },
+            });
+            session.executeCommandSeq<ts.server.protocol.GetEditsForFileRenameRequest>({
+                command: ts.server.protocol.CommandTypes.GetEditsForFileRename,
+                arguments: { oldFilePath: functionsWhatever, newFilePath: componentsWhatever },
+            });
+            if (canUseWatchEvents) session.invokeWatchChanges();
+            host.runQueuedTimeoutCallbacks();
+            baselineTsserverLogs("getEditsForFileRename", `works when moving file to and from folder${canUseWatchEvents ? " canUseWatchEvents" : ""}`, session);
         })
     );
 });

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3318,6 +3318,7 @@ declare namespace ts {
             setHostConfiguration(args: protocol.ConfigureRequestArguments): void;
             private getWatchOptionsFromProjectWatchOptions;
             closeLog(): void;
+            private sendSourceFileChange;
             /**
              * This function rebuilds the project for every file opened by the client
              * This does not reload contents of open files from disk. But we could do that if needed

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
@@ -86,8 +86,8 @@ export {}
 //// [/user/username/projects/myproject/node_modules2/@types/qqq/index.d.ts] deleted
 
 Output::
-sysLog:: /user/username/projects/myproject/node_modules:: Changing watcher to PresentFileSystemEntryWatcher
 sysLog:: /user/username/projects/myproject/node_modules/@types:: Changing watcher to PresentFileSystemEntryWatcher
+sysLog:: /user/username/projects/myproject/node_modules:: Changing watcher to PresentFileSystemEntryWatcher
 
 
 PolledWatches::
@@ -115,14 +115,13 @@ FsWatchesRecursive::
   {}
 
 Timeout callback:: count: 2
-11: timerToUpdateProgram *new*
-13: timerToInvalidateFailedLookupResolutions *new*
+7: timerToUpdateProgram *new*
+10: timerToInvalidateFailedLookupResolutions *new*
 
 Before running Timeout callback:: count: 2
-11: timerToUpdateProgram
-13: timerToInvalidateFailedLookupResolutions
+7: timerToUpdateProgram
+10: timerToInvalidateFailedLookupResolutions
 
-Host is moving to new time
 After running Timeout callback:: count: 0
 Output::
 >> Screen clear
@@ -167,7 +166,7 @@ FsWatchesRecursive::
   {}
 
 Timeout callback:: count: 0
-13: timerToInvalidateFailedLookupResolutions *deleted*
+10: timerToInvalidateFailedLookupResolutions *deleted*
 
 
 Program root files: [

--- a/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder-canUseWatchEvents.js
+++ b/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder-canUseWatchEvents.js
@@ -347,20 +347,39 @@ Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Invoking sourceFileChange on /home/src/myprojects/project/components/whatever/alert.ts:: 2
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
 After request
 
 Timeout callback:: count: 2
-3: /home/src/myprojects/project/tsconfig.json *new*
-4: *ensureProjectForOpenFiles* *new*
+5: /home/src/myprojects/project/tsconfig.json *new*
+6: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 2 *changed*
     projectProgramVersion: 1
     dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *changed*
+    version: Text-1
+    pendingReloadFromDisk: true *changed*
+    deferredDelete: true *changed*
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
 
 Before request
 
@@ -380,27 +399,78 @@ Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, 
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 7,
+        "path": "/home/src/myprojects/project/components",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":7,"path":"/home/src/myprojects/project/components","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 8,
+        "path": "/home/src/myprojects/project/node_modules",
+        "recursive": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 9,
+        "path": "/home/src/myprojects/node_modules",
+        "recursive": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (4)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
-	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
 	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 
 
 	../../../../a/lib/lib.es2016.full.d.ts
 	  Default library for target 'es2016'
-	components/whatever/alert.ts
-	  Imported via '@app/components/whatever/alert' from file 'index.ts'
 	index.ts
 	  Matched by default include pattern '**/*'
 	functions/whatever/alert.ts
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 3
+      }
+    }
+Custom watchFile:: Close:: {"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (4)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -421,11 +491,35 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
+/home/src/myprojects/project/tsconfig.json:
+  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
+
+PolledWatches *deleted*::
+/home/src/myprojects/project/components/whatever/alert.ts:
+  {"event":{"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}}
+
+FsWatchesRecursive::
+/home/src/myprojects/node_modules: *new*
+  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
+/home/src/myprojects/node_modules/@types:
+  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project:
+  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/components: *new*
+  {"event":{"id":7,"path":"/home/src/myprojects/project/components","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules: *new*
+  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
+/home/src/myprojects/project/node_modules/@types:
+  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+
 Timeout callback:: count: 2
-3: /home/src/myprojects/project/tsconfig.json *deleted*
-4: *ensureProjectForOpenFiles* *deleted*
-5: /home/src/myprojects/project/tsconfig.json *new*
-6: *ensureProjectForOpenFiles* *new*
+5: /home/src/myprojects/project/tsconfig.json *deleted*
+6: *ensureProjectForOpenFiles* *deleted*
+7: /home/src/myprojects/project/tsconfig.json *new*
+8: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
@@ -438,10 +532,11 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
+/home/src/myprojects/project/components/whatever/alert.ts *deleted*
     version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
+    pendingReloadFromDisk: true
+    deferredDelete: true
+    containingProjects: 0
 /home/src/myprojects/project/functions/whatever/alert.ts (Open) *new*
     version: SVC-1-0
     containingProjects: 1
@@ -500,10 +595,6 @@ ScriptInfos::
     sourceMapFilePath: false *changed*
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
-    version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
 /home/src/myprojects/project/functions/whatever/alert.ts (Open)
     version: SVC-1-0
     containingProjects: 1
@@ -560,10 +651,6 @@ ScriptInfos::
     sourceMapFilePath: false
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
-    version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
 /home/src/myprojects/project/functions/whatever/alert.ts (Open)
     version: SVC-1-0
     containingProjects: 1
@@ -574,26 +661,53 @@ ScriptInfos::
         /home/src/myprojects/project/tsconfig.json *default*
 
 Before running Timeout callback:: count: 2
-5: /home/src/myprojects/project/tsconfig.json
-6: *ensureProjectForOpenFiles*
+7: /home/src/myprojects/project/tsconfig.json
+8: *ensureProjectForOpenFiles*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 7
+      }
+    }
+Custom watchDirectory:: Close:: {"id":7,"path":"/home/src/myprojects/project/components","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 8
+      }
+    }
+Custom watchDirectory:: Close:: {"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 9
+      }
+    }
+Custom watchDirectory:: Close:: {"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
 	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
-
-
-	../../../../a/lib/lib.es2016.full.d.ts
-	  Default library for target 'es2016'
-	functions/whatever/alert.ts
-	  Imported via '@app/functions/whatever/alert' from file 'index.ts'
-	  Matched by default include pattern '**/*'
-	index.ts
-	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
@@ -632,6 +746,28 @@ Info seq  [hh:mm:ss:mss] event:
     }
 After running Timeout callback:: count: 0
 
+PolledWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
+/home/src/myprojects/project/tsconfig.json:
+  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
+
+FsWatchesRecursive::
+/home/src/myprojects/node_modules/@types:
+  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project:
+  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules/@types:
+  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+
+FsWatchesRecursive *deleted*::
+/home/src/myprojects/node_modules:
+  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
+/home/src/myprojects/project/components:
+  {"event":{"id":7,"path":"/home/src/myprojects/project/components","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules:
+  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
+
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 3
@@ -639,25 +775,6 @@ Projects::
     dirty: false *changed*
     documentPositionMappers: 0 *changed*
         /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
-
-ScriptInfos::
-/a/lib/lib.es2016.full.d.ts
-    version: Text-1
-    sourceMapFilePath: false
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts *changed*
-    version: Text-1
-    containingProjects: 0 *changed*
-        /home/src/myprojects/project/tsconfig.json *deleted*
-/home/src/myprojects/project/functions/whatever/alert.ts (Open)
-    version: SVC-1-0
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json *default*
-/home/src/myprojects/project/index.ts (Open)
-    version: SVC-1-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json *default*
 
 Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/functions/whatever deleted
 Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/components/whatever created
@@ -690,19 +807,11 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 6,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 3
-      }
-    }
-Custom watchFile:: Close:: {"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Invoking /home/src/myprojects/project/tsconfig.json:: wildcard for open scriptInfo:: /home/src/myprojects/project/components/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
@@ -712,13 +821,13 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "createDirectoryWatcher",
       "body": {
-        "id": 7,
+        "id": 10,
         "path": "/home/src/myprojects/project/functions",
         "recursive": true,
         "ignoreUpdate": true
       }
     }
-Custom watchDirectory:: Added:: {"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}
+Custom watchDirectory:: Added:: {"id":10,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] event:
@@ -727,12 +836,12 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "createDirectoryWatcher",
       "body": {
-        "id": 8,
+        "id": 11,
         "path": "/home/src/myprojects/project/node_modules",
         "recursive": true
       }
     }
-Custom watchDirectory:: Added:: {"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}
+Custom watchDirectory:: Added:: {"id":11,"path":"/home/src/myprojects/project/node_modules","recursive":true}
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] event:
@@ -741,186 +850,38 @@ Info seq  [hh:mm:ss:mss] event:
       "type": "event",
       "event": "createDirectoryWatcher",
       "body": {
-        "id": 9,
+        "id": 12,
         "path": "/home/src/myprojects/node_modules",
         "recursive": true
       }
     }
-Custom watchDirectory:: Added:: {"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}
+Custom watchDirectory:: Added:: {"id":12,"path":"/home/src/myprojects/node_modules","recursive":true}
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions/whatever/alert.ts 500 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Missing file
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 10,
-        "path": "/home/src/myprojects/project/functions/whatever/alert.ts"
-      }
-    }
-Custom watchFile:: Added:: {"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
 	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+	/home/src/myprojects/project/components/whatever/alert.ts SVC-2-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 
 
 	../../../../a/lib/lib.es2016.full.d.ts
 	  Default library for target 'es2016'
 	index.ts
 	  Matched by default include pattern '**/*'
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/home/src/myprojects/project/components/whatever/alert.ts",
-        "configFile": "/home/src/myprojects/project/tsconfig.json",
-        "diagnostics": [
-          {
-            "text": "File '/home/src/myprojects/project/functions/whatever/alert.ts' not found.\n  The file is in the program because:\n    Matched by default include pattern '**/*'",
-            "code": 6053,
-            "category": "error"
-          }
-        ]
-      }
-    }
-Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/tsconfig.json ProjectRootPath: /home/src/myprojects/project:: Result: undefined
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 11,
-        "path": "/home/src/myprojects/project/components/whatever/tsconfig.json"
-      }
-    }
-Custom watchFile:: Added:: {"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 12,
-        "path": "/home/src/myprojects/project/components/whatever/jsconfig.json"
-      }
-    }
-Custom watchFile:: Added:: {"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 13,
-        "path": "/home/src/myprojects/project/components/tsconfig.json"
-      }
-    }
-Custom watchFile:: Added:: {"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 14,
-        "path": "/home/src/myprojects/project/components/jsconfig.json"
-      }
-    }
-Custom watchFile:: Added:: {"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 15,
-        "path": "/home/src/myprojects/project/jsconfig.json"
-      }
-    }
-Custom watchFile:: Added:: {"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}
-Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createFileWatcher",
-      "body": {
-        "id": 16,
-        "path": "/a/lib/lib.d.ts"
-      }
-    }
-Custom watchFile:: Added:: {"id":16,"path":"/a/lib/lib.d.ts"}
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createDirectoryWatcher",
-      "body": {
-        "id": 17,
-        "path": "/home/src/myprojects/project/components/whatever/node_modules/@types",
-        "recursive": true,
-        "ignoreUpdate": true
-      }
-    }
-Custom watchDirectory:: Added:: {"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "createDirectoryWatcher",
-      "body": {
-        "id": 18,
-        "path": "/home/src/myprojects/project/components/node_modules/@types",
-        "recursive": true,
-        "ignoreUpdate": true
-      }
-    }
-Custom watchDirectory:: Added:: {"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (1)
-	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
-
-
-	alert.ts
-	  Root file specified for compilation
+	components/whatever/alert.ts
+	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (1)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
 Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
-Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:
     {
       "response": true,
@@ -932,55 +893,30 @@ Info seq  [hh:mm:ss:mss] response:
 After request
 
 PolledWatches::
-/a/lib/lib.d.ts: *new*
-  {"event":{"id":16,"path":"/a/lib/lib.d.ts"}}
 /a/lib/lib.es2016.full.d.ts:
   {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
-/home/src/myprojects/project/components/jsconfig.json: *new*
-  {"event":{"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}}
-/home/src/myprojects/project/components/tsconfig.json: *new*
-  {"event":{"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}}
-/home/src/myprojects/project/components/whatever/jsconfig.json: *new*
-  {"event":{"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}}
-/home/src/myprojects/project/components/whatever/tsconfig.json: *new*
-  {"event":{"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}}
-/home/src/myprojects/project/functions/whatever/alert.ts: *new*
-  {"event":{"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}}
-/home/src/myprojects/project/jsconfig.json: *new*
-  {"event":{"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}}
 /home/src/myprojects/project/tsconfig.json:
   {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
 
-PolledWatches *deleted*::
-/home/src/myprojects/project/components/whatever/alert.ts:
-  {"event":{"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}}
-
 FsWatchesRecursive::
 /home/src/myprojects/node_modules: *new*
-  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
+  {"event":{"id":12,"path":"/home/src/myprojects/node_modules","recursive":true}}
 /home/src/myprojects/node_modules/@types:
   {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
 /home/src/myprojects/project:
   {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/components/node_modules/@types: *new*
-  {"event":{"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/components/whatever/node_modules/@types: *new*
-  {"event":{"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}}
 /home/src/myprojects/project/functions: *new*
-  {"event":{"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}}
+  {"event":{"id":10,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}}
 /home/src/myprojects/project/node_modules: *new*
-  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
+  {"event":{"id":11,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
 /home/src/myprojects/project/node_modules/@types:
   {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
 
 Timeout callback:: count: 2
-7: /home/src/myprojects/project/tsconfig.json *new*
-8: *ensureProjectForOpenFiles* *new*
+11: /home/src/myprojects/project/tsconfig.json *new*
+12: *ensureProjectForOpenFiles* *new*
 
 Projects::
-/dev/null/inferredProject1* (Inferred) *new*
-    projectStateVersion: 1
-    projectProgramVersion: 1
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 4 *changed*
     projectProgramVersion: 4 *changed*
@@ -991,11 +927,10 @@ ScriptInfos::
     sourceMapFilePath: false
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
-    open: true *changed*
-    version: Text-1
-    containingProjects: 1 *changed*
-        /dev/null/inferredProject1* *default* *new*
+/home/src/myprojects/project/components/whatever/alert.ts (Open) *new*
+    version: SVC-2-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
 /home/src/myprojects/project/functions/whatever/alert.ts *deleted*
     open: false *changed*
     version: SVC-1-0
@@ -1020,15 +955,29 @@ Info seq  [hh:mm:ss:mss] request:
     }
 Info seq  [hh:mm:ss:mss] response:
     {
-      "response": [],
+      "response": [
+        {
+          "fileName": "/home/src/myprojects/project/index.ts",
+          "textChanges": [
+            {
+              "start": {
+                "line": 1,
+                "offset": 24
+              },
+              "end": {
+                "line": 1,
+                "offset": 53
+              },
+              "newText": "@app/components/whatever/alert"
+            }
+          ]
+        }
+      ],
       "responseRequired": true
     }
 After request
 
 Projects::
-/dev/null/inferredProject1* (Inferred)
-    projectStateVersion: 1
-    projectProgramVersion: 1
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 4
     projectProgramVersion: 4
@@ -1063,127 +1012,29 @@ Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/s
 After request
 
 Timeout callback:: count: 2
-7: /home/src/myprojects/project/tsconfig.json *deleted*
-8: *ensureProjectForOpenFiles* *deleted*
-11: /home/src/myprojects/project/tsconfig.json *new*
-12: *ensureProjectForOpenFiles* *new*
+11: /home/src/myprojects/project/tsconfig.json *deleted*
+12: *ensureProjectForOpenFiles* *deleted*
+15: /home/src/myprojects/project/tsconfig.json *new*
+16: *ensureProjectForOpenFiles* *new*
 
 Projects::
-/dev/null/inferredProject1* (Inferred)
-    projectStateVersion: 1
-    projectProgramVersion: 1
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 5 *changed*
     projectProgramVersion: 4
     dirty: true *changed*
 
 Before running Timeout callback:: count: 2
-11: /home/src/myprojects/project/tsconfig.json
-12: *ensureProjectForOpenFiles*
+15: /home/src/myprojects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 11
-      }
-    }
-Custom watchFile:: Close:: {"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 12
-      }
-    }
-Custom watchFile:: Close:: {"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 13
-      }
-    }
-Custom watchFile:: Close:: {"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 14
-      }
-    }
-Custom watchFile:: Close:: {"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 15
-      }
-    }
-Custom watchFile:: Close:: {"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/functions/whatever/alert.ts 500 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Missing file
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 10
-      }
-    }
-Custom watchFile:: Close:: {"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 5 projectProgramVersion: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (3)
-	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
-	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
-	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
-
-
-	../../../../a/lib/lib.es2016.full.d.ts
-	  Default library for target 'es2016'
-	index.ts
-	  Matched by default include pattern '**/*'
-	components/whatever/alert.ts
-	  Matched by default include pattern '**/*'
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/home/src/myprojects/project/tsconfig.json",
-        "configFile": "/home/src/myprojects/project/tsconfig.json",
-        "diagnostics": []
-      }
-    }
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 5 projectProgramVersion: 4 structureChanged: false structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Same program as before
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (1)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -1191,32 +1042,9 @@ Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts Projec
 Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
 Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "closeFileWatcher",
-      "body": {
-        "id": 16
-      }
-    }
-Custom watchFile:: Close:: {"id":16,"path":"/a/lib/lib.d.ts"}
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (0)
-
-
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (0)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -1239,70 +1067,8 @@ Info seq  [hh:mm:ss:mss] event:
     }
 After running Timeout callback:: count: 0
 
-PolledWatches::
-/a/lib/lib.es2016.full.d.ts:
-  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
-/home/src/myprojects/project/tsconfig.json:
-  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
-
-PolledWatches *deleted*::
-/a/lib/lib.d.ts:
-  {"event":{"id":16,"path":"/a/lib/lib.d.ts"}}
-/home/src/myprojects/project/components/jsconfig.json:
-  {"event":{"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}}
-/home/src/myprojects/project/components/tsconfig.json:
-  {"event":{"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}}
-/home/src/myprojects/project/components/whatever/jsconfig.json:
-  {"event":{"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}}
-/home/src/myprojects/project/components/whatever/tsconfig.json:
-  {"event":{"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}}
-/home/src/myprojects/project/functions/whatever/alert.ts:
-  {"event":{"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}}
-/home/src/myprojects/project/jsconfig.json:
-  {"event":{"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}}
-
-FsWatchesRecursive::
-/home/src/myprojects/node_modules:
-  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
-/home/src/myprojects/node_modules/@types:
-  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project:
-  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/components/node_modules/@types:
-  {"event":{"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/components/whatever/node_modules/@types:
-  {"event":{"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/functions:
-  {"event":{"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}}
-/home/src/myprojects/project/node_modules:
-  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
-/home/src/myprojects/project/node_modules/@types:
-  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
-
 Projects::
-/dev/null/inferredProject1* (Inferred) *changed*
-    projectStateVersion: 2 *changed*
-    projectProgramVersion: 2 *changed*
-    isOrphan: true *changed*
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 5
-    projectProgramVersion: 5 *changed*
+    projectProgramVersion: 4
     dirty: false *changed*
-    documentPositionMappers: 0 *changed*
-        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
-
-ScriptInfos::
-/a/lib/lib.es2016.full.d.ts
-    version: Text-1
-    sourceMapFilePath: false
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
-    version: Text-1
-    containingProjects: 1 *changed*
-        /home/src/myprojects/project/tsconfig.json *default* *new*
-        /dev/null/inferredProject1* *deleted*
-/home/src/myprojects/project/index.ts (Open)
-    version: SVC-1-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json *default*

--- a/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder-canUseWatchEvents.js
+++ b/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder-canUseWatchEvents.js
@@ -1,0 +1,1308 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+Before request
+//// [/home/src/myprojects/project/tsconfig.json]
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "paths": {
+      "@app/*": [
+        "./*"
+      ]
+    },
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+
+//// [/home/src/myprojects/project/index.ts]
+import { alert } from '@app/components/whatever/alert';
+alert('Hello, world!');
+
+
+//// [/home/src/myprojects/project/components/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/functions/whatever/placeholder.txt]
+
+
+//// [/a/lib/lib.es2016.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/myprojects/project/index.ts",
+        "projectRootPath": "/home/src/myprojects/project"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/tsconfig.json 2000 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 1,
+        "path": "/home/src/myprojects/project/tsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/home/src/myprojects/project/tsconfig.json",
+        "reason": "Creating possible configured project for /home/src/myprojects/project/index.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /home/src/myprojects/project/tsconfig.json : {
+ "rootNames": [
+  "/home/src/myprojects/project/index.ts",
+  "/home/src/myprojects/project/components/whatever/alert.ts"
+ ],
+ "options": {
+  "target": 3,
+  "module": 1,
+  "paths": {
+   "@app/*": [
+    "./*"
+   ]
+  },
+  "esModuleInterop": true,
+  "forceConsistentCasingInFileNames": true,
+  "strict": true,
+  "skipLibCheck": true,
+  "pathsBasePath": "/home/src/myprojects/project",
+  "configFilePath": "/home/src/myprojects/project/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 2,
+        "path": "/home/src/myprojects/project",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 3,
+        "path": "/home/src/myprojects/project/components/whatever/alert.ts"
+      }
+    }
+Custom watchFile:: Added:: {"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.es2016.full.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 4,
+        "path": "/a/lib/lib.es2016.full.d.ts"
+      }
+    }
+Custom watchFile:: Added:: {"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 5,
+        "path": "/home/src/myprojects/project/node_modules/@types",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 6,
+        "path": "/home/src/myprojects/node_modules/@types",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	components/whatever/alert.ts
+	  Imported via '@app/components/whatever/alert' from file 'index.ts'
+	  Matched by default include pattern '**/*'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/home/src/myprojects/project/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "telemetry",
+      "body": {
+        "telemetryEventName": "projectInfo",
+        "payload": {
+          "projectId": "8eef2d0b8a0e9b1fea9cc093cf6e65a3858613760d59db089978dadbab81a1fb",
+          "fileStats": {
+            "js": 0,
+            "jsSize": 0,
+            "jsx": 0,
+            "jsxSize": 0,
+            "ts": 2,
+            "tsSize": 161,
+            "tsx": 0,
+            "tsxSize": 0,
+            "dts": 1,
+            "dtsSize": 413,
+            "deferred": 0,
+            "deferredSize": 0
+          },
+          "compilerOptions": {
+            "target": "es2016",
+            "module": "commonjs",
+            "paths": "",
+            "esModuleInterop": true,
+            "forceConsistentCasingInFileNames": true,
+            "strict": true,
+            "skipLibCheck": true
+          },
+          "typeAcquisition": {
+            "enable": false,
+            "include": false,
+            "exclude": false
+          },
+          "extends": false,
+          "files": false,
+          "include": false,
+          "exclude": false,
+          "compileOnSave": false,
+          "configFileName": "tsconfig.json",
+          "projectType": "configured",
+          "languageServiceEnabled": true,
+          "version": "FakeVersion"
+        }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/myprojects/project/index.ts",
+        "configFile": "/home/src/myprojects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "open",
+      "request_seq": 1,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+PolledWatches::
+/a/lib/lib.es2016.full.d.ts: *new*
+  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
+/home/src/myprojects/project/components/whatever/alert.ts: *new*
+  {"event":{"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}}
+/home/src/myprojects/project/tsconfig.json: *new*
+  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
+
+FsWatchesRecursive::
+/home/src/myprojects/node_modules/@types: *new*
+  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project: *new*
+  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules/@types: *new*
+  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/index.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/components/whatever deleted
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/functions/whatever created
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/functions/whatever updated
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/functions updated
+Before request
+//// [/home/src/myprojects/project/functions/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/components/whatever/alert.ts] deleted
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "watchChange",
+      "arguments": {
+        "id": 2,
+        "deleted": [
+          "/home/src/myprojects/project/components/whatever"
+        ],
+        "created": [
+          "/home/src/myprojects/project/functions/whatever"
+        ]
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+After request
+
+Timeout callback:: count: 2
+3: /home/src/myprojects/project/tsconfig.json *new*
+4: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/myprojects/project/functions/whatever/alert.ts",
+        "projectRootPath": "/home/src/myprojects/project",
+        "fileContent": "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Invoking /home/src/myprojects/project/tsconfig.json:: wildcard for open scriptInfo:: /home/src/myprojects/project/functions/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
+	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	components/whatever/alert.ts
+	  Imported via '@app/components/whatever/alert' from file 'index.ts'
+	index.ts
+	  Matched by default include pattern '**/*'
+	functions/whatever/alert.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "open",
+      "request_seq": 3,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+Timeout callback:: count: 2
+3: /home/src/myprojects/project/tsconfig.json *deleted*
+4: *ensureProjectForOpenFiles* *deleted*
+5: /home/src/myprojects/project/tsconfig.json *new*
+6: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2
+    projectProgramVersion: 2 *changed*
+    dirty: false *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "getEditsForFileRename",
+      "arguments": {
+        "oldFilePath": "/home/src/myprojects/project/components/whatever",
+        "newFilePath": "/home/src/myprojects/project/functions/whatever"
+      },
+      "seq": 4,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [
+        {
+          "fileName": "/home/src/myprojects/project/index.ts",
+          "textChanges": [
+            {
+              "start": {
+                "line": 1,
+                "offset": 24
+              },
+              "end": {
+                "line": 1,
+                "offset": 54
+              },
+              "newText": "@app/functions/whatever/alert"
+            }
+          ]
+        }
+      ],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2
+    projectProgramVersion: 2
+    documentPositionMappers: 1 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *new*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts *changed*
+    version: Text-1
+    sourceMapFilePath: false *changed*
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/myprojects/project/index.ts",
+            "textChanges": [
+              {
+                "start": {
+                  "line": 1,
+                  "offset": 24
+                },
+                "end": {
+                  "line": 1,
+                  "offset": 54
+                },
+                "newText": "@app/functions/whatever/alert"
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 5,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3 *changed*
+    projectProgramVersion: 2
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open) *changed*
+    version: SVC-1-1 *changed*
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before running Timeout callback:: count: 2
+5: /home/src/myprojects/project/tsconfig.json
+6: *ensureProjectForOpenFiles*
+
+Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	functions/whatever/alert.ts
+	  Imported via '@app/functions/whatever/alert' from file 'index.ts'
+	  Matched by default include pattern '**/*'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] got projects updated in background /home/src/myprojects/project/index.ts,/home/src/myprojects/project/functions/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectsUpdatedInBackground",
+      "body": {
+        "openFiles": [
+          "/home/src/myprojects/project/index.ts",
+          "/home/src/myprojects/project/functions/whatever/alert.ts"
+        ]
+      }
+    }
+After running Timeout callback:: count: 0
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3
+    projectProgramVersion: 3 *changed*
+    dirty: false *changed*
+    documentPositionMappers: 0 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *changed*
+    version: Text-1
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/functions/whatever deleted
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/components/whatever created
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/components/whatever updated
+Custom watchDirectory:: Triggered Ignored:: {"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}:: /home/src/myprojects/project/components updated
+Before request
+//// [/home/src/myprojects/project/components/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/functions/whatever/alert.ts] deleted
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "openFiles": [
+          {
+            "file": "/home/src/myprojects/project/components/whatever/alert.ts",
+            "fileContent": "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n",
+            "projectRootPath": "/home/src/myprojects/project"
+          }
+        ],
+        "closedFiles": [
+          "/home/src/myprojects/project/functions/whatever/alert.ts"
+        ]
+      },
+      "seq": 6,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 3
+      }
+    }
+Custom watchFile:: Close:: {"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 7,
+        "path": "/home/src/myprojects/project/functions",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 8,
+        "path": "/home/src/myprojects/project/node_modules",
+        "recursive": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 9,
+        "path": "/home/src/myprojects/node_modules",
+        "recursive": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions/whatever/alert.ts 500 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Missing file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 10,
+        "path": "/home/src/myprojects/project/functions/whatever/alert.ts"
+      }
+    }
+Custom watchFile:: Added:: {"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/myprojects/project/components/whatever/alert.ts",
+        "configFile": "/home/src/myprojects/project/tsconfig.json",
+        "diagnostics": [
+          {
+            "text": "File '/home/src/myprojects/project/functions/whatever/alert.ts' not found.\n  The file is in the program because:\n    Matched by default include pattern '**/*'",
+            "code": 6053,
+            "category": "error"
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/tsconfig.json ProjectRootPath: /home/src/myprojects/project:: Result: undefined
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 11,
+        "path": "/home/src/myprojects/project/components/whatever/tsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 12,
+        "path": "/home/src/myprojects/project/components/whatever/jsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 13,
+        "path": "/home/src/myprojects/project/components/tsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 14,
+        "path": "/home/src/myprojects/project/components/jsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 15,
+        "path": "/home/src/myprojects/project/jsconfig.json"
+      }
+    }
+Custom watchFile:: Added:: {"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createFileWatcher",
+      "body": {
+        "id": 16,
+        "path": "/a/lib/lib.d.ts"
+      }
+    }
+Custom watchFile:: Added:: {"id":16,"path":"/a/lib/lib.d.ts"}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 17,
+        "path": "/home/src/myprojects/project/components/whatever/node_modules/@types",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "createDirectoryWatcher",
+      "body": {
+        "id": 18,
+        "path": "/home/src/myprojects/project/components/node_modules/@types",
+        "recursive": true,
+        "ignoreUpdate": true
+      }
+    }
+Custom watchDirectory:: Added:: {"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+
+
+	alert.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+PolledWatches::
+/a/lib/lib.d.ts: *new*
+  {"event":{"id":16,"path":"/a/lib/lib.d.ts"}}
+/a/lib/lib.es2016.full.d.ts:
+  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
+/home/src/myprojects/project/components/jsconfig.json: *new*
+  {"event":{"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}}
+/home/src/myprojects/project/components/tsconfig.json: *new*
+  {"event":{"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}}
+/home/src/myprojects/project/components/whatever/jsconfig.json: *new*
+  {"event":{"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}}
+/home/src/myprojects/project/components/whatever/tsconfig.json: *new*
+  {"event":{"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}}
+/home/src/myprojects/project/functions/whatever/alert.ts: *new*
+  {"event":{"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}}
+/home/src/myprojects/project/jsconfig.json: *new*
+  {"event":{"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}}
+/home/src/myprojects/project/tsconfig.json:
+  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
+
+PolledWatches *deleted*::
+/home/src/myprojects/project/components/whatever/alert.ts:
+  {"event":{"id":3,"path":"/home/src/myprojects/project/components/whatever/alert.ts"}}
+
+FsWatchesRecursive::
+/home/src/myprojects/node_modules: *new*
+  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
+/home/src/myprojects/node_modules/@types:
+  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project:
+  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/components/node_modules/@types: *new*
+  {"event":{"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/components/whatever/node_modules/@types: *new*
+  {"event":{"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/functions: *new*
+  {"event":{"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules: *new*
+  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
+/home/src/myprojects/project/node_modules/@types:
+  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+
+Timeout callback:: count: 2
+7: /home/src/myprojects/project/tsconfig.json *new*
+8: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/dev/null/inferredProject1* (Inferred) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4 *changed*
+    projectProgramVersion: 4 *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
+    open: true *changed*
+    version: Text-1
+    containingProjects: 1 *changed*
+        /dev/null/inferredProject1* *default* *new*
+/home/src/myprojects/project/functions/whatever/alert.ts *deleted*
+    open: false *changed*
+    version: SVC-1-0
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "getEditsForFileRename",
+      "arguments": {
+        "oldFilePath": "/home/src/myprojects/project/functions/whatever",
+        "newFilePath": "/home/src/myprojects/project/components/whatever"
+      },
+      "seq": 7,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/dev/null/inferredProject1* (Inferred)
+    projectStateVersion: 1
+    projectProgramVersion: 1
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4
+    projectProgramVersion: 4
+    documentPositionMappers: 1 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *new*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "watchChange",
+      "arguments": {
+        "id": 2,
+        "deleted": [
+          "/home/src/myprojects/project/functions/whatever"
+        ],
+        "created": [
+          "/home/src/myprojects/project/components/whatever"
+        ]
+      },
+      "seq": 8,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+After request
+
+Timeout callback:: count: 2
+7: /home/src/myprojects/project/tsconfig.json *deleted*
+8: *ensureProjectForOpenFiles* *deleted*
+11: /home/src/myprojects/project/tsconfig.json *new*
+12: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/dev/null/inferredProject1* (Inferred)
+    projectStateVersion: 1
+    projectProgramVersion: 1
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 5 *changed*
+    projectProgramVersion: 4
+    dirty: true *changed*
+
+Before running Timeout callback:: count: 2
+11: /home/src/myprojects/project/tsconfig.json
+12: *ensureProjectForOpenFiles*
+
+Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 11
+      }
+    }
+Custom watchFile:: Close:: {"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 12
+      }
+    }
+Custom watchFile:: Close:: {"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 13
+      }
+    }
+Custom watchFile:: Close:: {"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 14
+      }
+    }
+Custom watchFile:: Close:: {"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 15
+      }
+    }
+Custom watchFile:: Close:: {"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/functions/whatever/alert.ts 500 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Missing file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 10
+      }
+    }
+Custom watchFile:: Close:: {"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 5 projectProgramVersion: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	index.ts
+	  Matched by default include pattern '**/*'
+	components/whatever/alert.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/myprojects/project/tsconfig.json",
+        "configFile": "/home/src/myprojects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "closeFileWatcher",
+      "body": {
+        "id": 16
+      }
+    }
+Custom watchFile:: Close:: {"id":16,"path":"/a/lib/lib.d.ts"}
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (0)
+
+
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (0)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] got projects updated in background /home/src/myprojects/project/index.ts,/home/src/myprojects/project/components/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectsUpdatedInBackground",
+      "body": {
+        "openFiles": [
+          "/home/src/myprojects/project/index.ts",
+          "/home/src/myprojects/project/components/whatever/alert.ts"
+        ]
+      }
+    }
+After running Timeout callback:: count: 0
+
+PolledWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {"event":{"id":4,"path":"/a/lib/lib.es2016.full.d.ts"}}
+/home/src/myprojects/project/tsconfig.json:
+  {"event":{"id":1,"path":"/home/src/myprojects/project/tsconfig.json"}}
+
+PolledWatches *deleted*::
+/a/lib/lib.d.ts:
+  {"event":{"id":16,"path":"/a/lib/lib.d.ts"}}
+/home/src/myprojects/project/components/jsconfig.json:
+  {"event":{"id":14,"path":"/home/src/myprojects/project/components/jsconfig.json"}}
+/home/src/myprojects/project/components/tsconfig.json:
+  {"event":{"id":13,"path":"/home/src/myprojects/project/components/tsconfig.json"}}
+/home/src/myprojects/project/components/whatever/jsconfig.json:
+  {"event":{"id":12,"path":"/home/src/myprojects/project/components/whatever/jsconfig.json"}}
+/home/src/myprojects/project/components/whatever/tsconfig.json:
+  {"event":{"id":11,"path":"/home/src/myprojects/project/components/whatever/tsconfig.json"}}
+/home/src/myprojects/project/functions/whatever/alert.ts:
+  {"event":{"id":10,"path":"/home/src/myprojects/project/functions/whatever/alert.ts"}}
+/home/src/myprojects/project/jsconfig.json:
+  {"event":{"id":15,"path":"/home/src/myprojects/project/jsconfig.json"}}
+
+FsWatchesRecursive::
+/home/src/myprojects/node_modules:
+  {"event":{"id":9,"path":"/home/src/myprojects/node_modules","recursive":true}}
+/home/src/myprojects/node_modules/@types:
+  {"event":{"id":6,"path":"/home/src/myprojects/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project:
+  {"event":{"id":2,"path":"/home/src/myprojects/project","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/components/node_modules/@types:
+  {"event":{"id":18,"path":"/home/src/myprojects/project/components/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/components/whatever/node_modules/@types:
+  {"event":{"id":17,"path":"/home/src/myprojects/project/components/whatever/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/functions:
+  {"event":{"id":7,"path":"/home/src/myprojects/project/functions","recursive":true,"ignoreUpdate":true}}
+/home/src/myprojects/project/node_modules:
+  {"event":{"id":8,"path":"/home/src/myprojects/project/node_modules","recursive":true}}
+/home/src/myprojects/project/node_modules/@types:
+  {"event":{"id":5,"path":"/home/src/myprojects/project/node_modules/@types","recursive":true,"ignoreUpdate":true}}
+
+Projects::
+/dev/null/inferredProject1* (Inferred) *changed*
+    projectStateVersion: 2 *changed*
+    projectProgramVersion: 2 *changed*
+    isOrphan: true *changed*
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 5
+    projectProgramVersion: 5 *changed*
+    dirty: false *changed*
+    documentPositionMappers: 0 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
+    version: Text-1
+    containingProjects: 1 *changed*
+        /home/src/myprojects/project/tsconfig.json *default* *new*
+        /dev/null/inferredProject1* *deleted*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*

--- a/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder.js
+++ b/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder.js
@@ -1,0 +1,801 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+Before request
+//// [/home/src/myprojects/project/tsconfig.json]
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "paths": {
+      "@app/*": [
+        "./*"
+      ]
+    },
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+
+//// [/home/src/myprojects/project/index.ts]
+import { alert } from '@app/components/whatever/alert';
+alert('Hello, world!');
+
+
+//// [/home/src/myprojects/project/components/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/functions/whatever/placeholder.txt]
+
+
+//// [/a/lib/lib.es2016.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/myprojects/project/index.ts",
+        "projectRootPath": "/home/src/myprojects/project"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/tsconfig.json 2000 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/home/src/myprojects/project/tsconfig.json",
+        "reason": "Creating possible configured project for /home/src/myprojects/project/index.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /home/src/myprojects/project/tsconfig.json : {
+ "rootNames": [
+  "/home/src/myprojects/project/index.ts",
+  "/home/src/myprojects/project/components/whatever/alert.ts"
+ ],
+ "options": {
+  "target": 3,
+  "module": 1,
+  "paths": {
+   "@app/*": [
+    "./*"
+   ]
+  },
+  "esModuleInterop": true,
+  "forceConsistentCasingInFileNames": true,
+  "strict": true,
+  "skipLibCheck": true,
+  "pathsBasePath": "/home/src/myprojects/project",
+  "configFilePath": "/home/src/myprojects/project/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.es2016.full.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules/@types 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	components/whatever/alert.ts
+	  Imported via '@app/components/whatever/alert' from file 'index.ts'
+	  Matched by default include pattern '**/*'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/home/src/myprojects/project/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "telemetry",
+      "body": {
+        "telemetryEventName": "projectInfo",
+        "payload": {
+          "projectId": "8eef2d0b8a0e9b1fea9cc093cf6e65a3858613760d59db089978dadbab81a1fb",
+          "fileStats": {
+            "js": 0,
+            "jsSize": 0,
+            "jsx": 0,
+            "jsxSize": 0,
+            "ts": 2,
+            "tsSize": 161,
+            "tsx": 0,
+            "tsxSize": 0,
+            "dts": 1,
+            "dtsSize": 413,
+            "deferred": 0,
+            "deferredSize": 0
+          },
+          "compilerOptions": {
+            "target": "es2016",
+            "module": "commonjs",
+            "paths": "",
+            "esModuleInterop": true,
+            "forceConsistentCasingInFileNames": true,
+            "strict": true,
+            "skipLibCheck": true
+          },
+          "typeAcquisition": {
+            "enable": false,
+            "include": false,
+            "exclude": false
+          },
+          "extends": false,
+          "files": false,
+          "include": false,
+          "exclude": false,
+          "compileOnSave": false,
+          "configFileName": "tsconfig.json",
+          "projectType": "configured",
+          "languageServiceEnabled": true,
+          "version": "FakeVersion"
+        }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/myprojects/project/index.ts",
+        "configFile": "/home/src/myprojects/project/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "open",
+      "request_seq": 1,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+PolledWatches::
+/home/src/myprojects/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.es2016.full.d.ts: *new*
+  {}
+/home/src/myprojects/project/components/whatever/alert.ts: *new*
+  {}
+/home/src/myprojects/project/tsconfig.json: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/myprojects/project: *new*
+  {}
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *new*
+    projectStateVersion: 1
+    projectProgramVersion: 1
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *new*
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/index.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Before request
+//// [/home/src/myprojects/project/functions/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/components/whatever/alert.ts] deleted
+
+Timeout callback:: count: 2
+3: /home/src/myprojects/project/tsconfig.json *new*
+4: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2 *changed*
+    projectProgramVersion: 1
+    dirty: true *changed*
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/myprojects/project/functions/whatever/alert.ts",
+        "projectRootPath": "/home/src/myprojects/project",
+        "fileContent": "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Invoking /home/src/myprojects/project/tsconfig.json:: wildcard for open scriptInfo:: /home/src/myprojects/project/functions/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
+	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	components/whatever/alert.ts
+	  Imported via '@app/components/whatever/alert' from file 'index.ts'
+	index.ts
+	  Matched by default include pattern '**/*'
+	functions/whatever/alert.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "open",
+      "request_seq": 2,
+      "success": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+Timeout callback:: count: 2
+3: /home/src/myprojects/project/tsconfig.json *deleted*
+4: *ensureProjectForOpenFiles* *deleted*
+5: /home/src/myprojects/project/tsconfig.json *new*
+6: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2
+    projectProgramVersion: 2 *changed*
+    dirty: false *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open) *new*
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "getEditsForFileRename",
+      "arguments": {
+        "oldFilePath": "/home/src/myprojects/project/components/whatever",
+        "newFilePath": "/home/src/myprojects/project/functions/whatever"
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [
+        {
+          "fileName": "/home/src/myprojects/project/index.ts",
+          "textChanges": [
+            {
+              "start": {
+                "line": 1,
+                "offset": 24
+              },
+              "end": {
+                "line": 1,
+                "offset": 54
+              },
+              "newText": "@app/functions/whatever/alert"
+            }
+          ]
+        }
+      ],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 2
+    projectProgramVersion: 2
+    documentPositionMappers: 1 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *new*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts *changed*
+    version: Text-1
+    sourceMapFilePath: false *changed*
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "/home/src/myprojects/project/index.ts",
+            "textChanges": [
+              {
+                "start": {
+                  "line": 1,
+                  "offset": 24
+                },
+                "end": {
+                  "line": 1,
+                  "offset": 54
+                },
+                "newText": "@app/functions/whatever/alert"
+              }
+            ]
+          }
+        ]
+      },
+      "seq": 4,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3 *changed*
+    projectProgramVersion: 2
+    dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open) *changed*
+    version: SVC-1-1 *changed*
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before running Timeout callback:: count: 2
+5: /home/src/myprojects/project/tsconfig.json
+6: *ensureProjectForOpenFiles*
+
+Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	functions/whatever/alert.ts
+	  Imported via '@app/functions/whatever/alert' from file 'index.ts'
+	  Matched by default include pattern '**/*'
+	index.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] got projects updated in background /home/src/myprojects/project/index.ts,/home/src/myprojects/project/functions/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectsUpdatedInBackground",
+      "body": {
+        "openFiles": [
+          "/home/src/myprojects/project/index.ts",
+          "/home/src/myprojects/project/functions/whatever/alert.ts"
+        ]
+      }
+    }
+After running Timeout callback:: count: 0
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 3
+    projectProgramVersion: 3 *changed*
+    dirty: false *changed*
+    documentPositionMappers: 0 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *changed*
+    version: Text-1
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/functions/whatever/alert.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Before request
+//// [/home/src/myprojects/project/components/whatever/alert.ts]
+export function alert(message: string) {
+    console.log(`ALERT: ${message}`);
+}
+
+
+//// [/home/src/myprojects/project/functions/whatever/alert.ts] deleted
+
+Timeout callback:: count: 2
+9: /home/src/myprojects/project/tsconfig.json *new*
+10: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4 *changed*
+    projectProgramVersion: 3
+    dirty: true *changed*
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "openFiles": [
+          {
+            "file": "/home/src/myprojects/project/components/whatever/alert.ts",
+            "fileContent": "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n",
+            "projectRootPath": "/home/src/myprojects/project"
+          }
+        ],
+        "closedFiles": [
+          "/home/src/myprojects/project/functions/whatever/alert.ts"
+        ]
+      },
+      "seq": 5,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/functions 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
+	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+
+
+	../../../../a/lib/lib.es2016.full.d.ts
+	  Default library for target 'es2016'
+	index.ts
+	  Matched by default include pattern '**/*'
+	components/whatever/alert.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true,
+      "performanceData": {
+        "updateGraphDurationMs": *
+      }
+    }
+After request
+
+PolledWatches::
+/home/src/myprojects/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/myprojects/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {}
+/home/src/myprojects/project/tsconfig.json:
+  {}
+
+FsWatches *deleted*::
+/home/src/myprojects/project/components/whatever/alert.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/myprojects/project:
+  {}
+/home/src/myprojects/project/functions: *new*
+  {}
+
+Timeout callback:: count: 2
+9: /home/src/myprojects/project/tsconfig.json *deleted*
+10: *ensureProjectForOpenFiles* *deleted*
+11: /home/src/myprojects/project/tsconfig.json *new*
+12: *ensureProjectForOpenFiles* *new*
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4
+    projectProgramVersion: 4 *changed*
+    dirty: false *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    sourceMapFilePath: false
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
+    open: true *changed*
+    version: Text-1
+    containingProjects: 1 *changed*
+        /home/src/myprojects/project/tsconfig.json *default* *new*
+/home/src/myprojects/project/functions/whatever/alert.ts *deleted*
+    open: false *changed*
+    version: SVC-1-0
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "getEditsForFileRename",
+      "arguments": {
+        "oldFilePath": "/home/src/myprojects/project/functions/whatever",
+        "newFilePath": "/home/src/myprojects/project/components/whatever"
+      },
+      "seq": 6,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": [
+        {
+          "fileName": "/home/src/myprojects/project/index.ts",
+          "textChanges": [
+            {
+              "start": {
+                "line": 1,
+                "offset": 24
+              },
+              "end": {
+                "line": 1,
+                "offset": 53
+              },
+              "newText": "@app/components/whatever/alert"
+            }
+          ]
+        }
+      ],
+      "responseRequired": true
+    }
+After request
+
+Projects::
+/home/src/myprojects/project/tsconfig.json (Configured) *changed*
+    projectStateVersion: 4
+    projectProgramVersion: 4
+    documentPositionMappers: 1 *changed*
+        /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *new*
+
+Before running Timeout callback:: count: 2
+11: /home/src/myprojects/project/tsconfig.json
+12: *ensureProjectForOpenFiles*
+
+Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/index.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] got projects updated in background /home/src/myprojects/project/index.ts,/home/src/myprojects/project/components/whatever/alert.ts
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectsUpdatedInBackground",
+      "body": {
+        "openFiles": [
+          "/home/src/myprojects/project/index.ts",
+          "/home/src/myprojects/project/components/whatever/alert.ts"
+        ]
+      }
+    }
+After running Timeout callback:: count: 0

--- a/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder.js
+++ b/tests/baselines/reference/tsserver/getEditsForFileRename/works-when-moving-file-to-and-from-folder.js
@@ -245,8 +245,11 @@ ScriptInfos::
         /home/src/myprojects/project/tsconfig.json *default*
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Invoking sourceFileChange on /home/src/myprojects/project/components/whatever/alert.ts:: 2
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/myprojects/project/components/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
@@ -262,14 +265,30 @@ export function alert(message: string) {
 //// [/home/src/myprojects/project/components/whatever/alert.ts] deleted
 
 Timeout callback:: count: 2
-3: /home/src/myprojects/project/tsconfig.json *new*
-4: *ensureProjectForOpenFiles* *new*
+5: /home/src/myprojects/project/tsconfig.json *new*
+6: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 2 *changed*
     projectProgramVersion: 1
     dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.es2016.full.d.ts
+    version: Text-1
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json
+/home/src/myprojects/project/components/whatever/alert.ts *changed*
+    version: Text-1
+    pendingReloadFromDisk: true *changed*
+    deferredDelete: true *changed*
+    containingProjects: 0 *changed*
+        /home/src/myprojects/project/tsconfig.json *deleted*
+/home/src/myprojects/project/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
 
 Info seq  [hh:mm:ss:mss] request:
     {
@@ -287,27 +306,31 @@ Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, 
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/functions/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 2 projectProgramVersion: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (4)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
-	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 	/home/src/myprojects/project/index.ts SVC-1-0 "import { alert } from '@app/components/whatever/alert';\nalert('Hello, world!');\n"
 	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 
 
 	../../../../a/lib/lib.es2016.full.d.ts
 	  Default library for target 'es2016'
-	components/whatever/alert.ts
-	  Imported via '@app/components/whatever/alert' from file 'index.ts'
 	index.ts
 	  Matched by default include pattern '**/*'
 	functions/whatever/alert.ts
 	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (4)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -328,11 +351,37 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/home/src/myprojects/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/myprojects/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {}
+/home/src/myprojects/project/tsconfig.json:
+  {}
+
+FsWatches *deleted*::
+/home/src/myprojects/project/components/whatever/alert.ts:
+  {}
+
+FsWatchesRecursive::
+/home/src/myprojects/project:
+  {}
+/home/src/myprojects/project/components: *new*
+  {}
+
 Timeout callback:: count: 2
-3: /home/src/myprojects/project/tsconfig.json *deleted*
-4: *ensureProjectForOpenFiles* *deleted*
-5: /home/src/myprojects/project/tsconfig.json *new*
-6: *ensureProjectForOpenFiles* *new*
+5: /home/src/myprojects/project/tsconfig.json *deleted*
+6: *ensureProjectForOpenFiles* *deleted*
+7: /home/src/myprojects/project/tsconfig.json *new*
+8: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
@@ -345,10 +394,11 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
+/home/src/myprojects/project/components/whatever/alert.ts *deleted*
     version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
+    pendingReloadFromDisk: true
+    deferredDelete: true
+    containingProjects: 0
 /home/src/myprojects/project/functions/whatever/alert.ts (Open) *new*
     version: SVC-1-0
     containingProjects: 1
@@ -407,10 +457,6 @@ ScriptInfos::
     sourceMapFilePath: false *changed*
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
-    version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
 /home/src/myprojects/project/functions/whatever/alert.ts (Open)
     version: SVC-1-0
     containingProjects: 1
@@ -467,10 +513,6 @@ ScriptInfos::
     sourceMapFilePath: false
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts
-    version: Text-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
 /home/src/myprojects/project/functions/whatever/alert.ts (Open)
     version: SVC-1-0
     containingProjects: 1
@@ -481,26 +523,23 @@ ScriptInfos::
         /home/src/myprojects/project/tsconfig.json *default*
 
 Before running Timeout callback:: count: 2
-5: /home/src/myprojects/project/tsconfig.json
-6: *ensureProjectForOpenFiles*
+7: /home/src/myprojects/project/tsconfig.json
+8: *ensureProjectForOpenFiles*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/project/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/myprojects/node_modules 1 undefined Project: /home/src/myprojects/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/myprojects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
 	/home/src/myprojects/project/functions/whatever/alert.ts SVC-1-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
-
-
-	../../../../a/lib/lib.es2016.full.d.ts
-	  Default library for target 'es2016'
-	functions/whatever/alert.ts
-	  Imported via '@app/functions/whatever/alert' from file 'index.ts'
-	  Matched by default include pattern '**/*'
-	index.ts
-	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
@@ -539,6 +578,32 @@ Info seq  [hh:mm:ss:mss] event:
     }
 After running Timeout callback:: count: 0
 
+PolledWatches::
+/home/src/myprojects/node_modules/@types:
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules/@types:
+  {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/home/src/myprojects/node_modules:
+  {"pollingInterval":500}
+/home/src/myprojects/project/node_modules:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.es2016.full.d.ts:
+  {}
+/home/src/myprojects/project/tsconfig.json:
+  {}
+
+FsWatchesRecursive::
+/home/src/myprojects/project:
+  {}
+
+FsWatchesRecursive *deleted*::
+/home/src/myprojects/project/components:
+  {}
+
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 3
@@ -546,25 +611,6 @@ Projects::
     dirty: false *changed*
     documentPositionMappers: 0 *changed*
         /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *deleted*
-
-ScriptInfos::
-/a/lib/lib.es2016.full.d.ts
-    version: Text-1
-    sourceMapFilePath: false
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts *changed*
-    version: Text-1
-    containingProjects: 0 *changed*
-        /home/src/myprojects/project/tsconfig.json *deleted*
-/home/src/myprojects/project/functions/whatever/alert.ts (Open)
-    version: SVC-1-0
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json *default*
-/home/src/myprojects/project/index.ts (Open)
-    version: SVC-1-1
-    containingProjects: 1
-        /home/src/myprojects/project/tsconfig.json *default*
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /home/src/myprojects/project/functions/whatever :: WatchInfo: /home/src/myprojects/project 1 undefined Config: /home/src/myprojects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json
@@ -584,8 +630,8 @@ export function alert(message: string) {
 //// [/home/src/myprojects/project/functions/whatever/alert.ts] deleted
 
 Timeout callback:: count: 2
-9: /home/src/myprojects/project/tsconfig.json *new*
-10: *ensureProjectForOpenFiles* *new*
+11: /home/src/myprojects/project/tsconfig.json *new*
+12: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
@@ -611,7 +657,9 @@ Info seq  [hh:mm:ss:mss] request:
       "seq": 5,
       "type": "request"
     }
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /home/src/myprojects/project/components/whatever/alert.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Invoking /home/src/myprojects/project/tsconfig.json:: wildcard for open scriptInfo:: /home/src/myprojects/project/components/whatever/alert.ts
 Info seq  [hh:mm:ss:mss] Scheduled: /home/src/myprojects/project/tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /home/src/myprojects/project/components/whatever/alert.ts ProjectRootPath: /home/src/myprojects/project:: Result: /home/src/myprojects/project/tsconfig.json
@@ -627,7 +675,7 @@ Info seq  [hh:mm:ss:mss] Project '/home/src/myprojects/project/tsconfig.json' (C
 Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.es2016.full.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
 	/home/src/myprojects/project/index.ts SVC-1-1 "import { alert } from '@app/functions/whatever/alert';\nalert('Hello, world!');\n"
-	/home/src/myprojects/project/components/whatever/alert.ts Text-1 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
+	/home/src/myprojects/project/components/whatever/alert.ts SVC-2-0 "export function alert(message: string) {\n    console.log(`ALERT: ${message}`);\n}\n"
 
 
 	../../../../a/lib/lib.es2016.full.d.ts
@@ -673,10 +721,6 @@ FsWatches::
 /home/src/myprojects/project/tsconfig.json:
   {}
 
-FsWatches *deleted*::
-/home/src/myprojects/project/components/whatever/alert.ts:
-  {}
-
 FsWatchesRecursive::
 /home/src/myprojects/project:
   {}
@@ -684,10 +728,10 @@ FsWatchesRecursive::
   {}
 
 Timeout callback:: count: 2
-9: /home/src/myprojects/project/tsconfig.json *deleted*
-10: *ensureProjectForOpenFiles* *deleted*
-11: /home/src/myprojects/project/tsconfig.json *new*
-12: *ensureProjectForOpenFiles* *new*
+11: /home/src/myprojects/project/tsconfig.json *deleted*
+12: *ensureProjectForOpenFiles* *deleted*
+15: /home/src/myprojects/project/tsconfig.json *new*
+16: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /home/src/myprojects/project/tsconfig.json (Configured) *changed*
@@ -701,11 +745,10 @@ ScriptInfos::
     sourceMapFilePath: false
     containingProjects: 1
         /home/src/myprojects/project/tsconfig.json
-/home/src/myprojects/project/components/whatever/alert.ts (Open) *changed*
-    open: true *changed*
-    version: Text-1
-    containingProjects: 1 *changed*
-        /home/src/myprojects/project/tsconfig.json *default* *new*
+/home/src/myprojects/project/components/whatever/alert.ts (Open) *new*
+    version: SVC-2-0
+    containingProjects: 1
+        /home/src/myprojects/project/tsconfig.json *default*
 /home/src/myprojects/project/functions/whatever/alert.ts *deleted*
     open: false *changed*
     version: SVC-1-0
@@ -760,8 +803,8 @@ Projects::
         /a/lib/lib.es2016.full.d.ts: identitySourceMapConsumer *new*
 
 Before running Timeout callback:: count: 2
-11: /home/src/myprojects/project/tsconfig.json
-12: *ensureProjectForOpenFiles*
+15: /home/src/myprojects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
 
 Info seq  [hh:mm:ss:mss] Running: /home/src/myprojects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*

--- a/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
@@ -338,17 +338,9 @@ Info seq  [hh:mm:ss:mss] event:
     }
 After running Immedidate callback:: count: 0
 
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts 2:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
-Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts 2:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
-Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
-Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms FileWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts 2:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
@@ -358,6 +350,14 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproje
 Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
 Before running Timeout callback:: count: 2
 10: /a/b/projects/myproject/tsconfig.json
 11: *ensureProjectForOpenFiles*

--- a/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
+++ b/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
@@ -469,6 +469,10 @@ Info seq  [hh:mm:ss:mss] event:
 After running Timeout callback:: count: 0
 
 Before request
+//// [/users/username/projects/project/sub/a.ts]
+export const a = 10;
+
+//// [/users/username/projects/project/a.ts] deleted
 
 Info seq  [hh:mm:ss:mss] request:
     {
@@ -542,65 +546,29 @@ Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /users/username/projec
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json projectStateVersion: 3 projectProgramVersion: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
 	/users/username/projects/project/b.ts SVC-1-0 "export const b = 10;"
+	/users/username/projects/project/sub/a.ts SVC-2-0 "export const a = 10;"
 
 
 	../../../../a/lib/lib.d.ts
 	  Default library for target 'es5'
 	b.ts
 	  Matched by default include pattern '**/*'
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] getConfigFileNameForFile:: File: /users/username/projects/project/tsconfig.json ProjectRootPath: /users/username/projects/project:: Result: undefined
-Info seq  [hh:mm:ss:mss] event:
-    {
-      "seq": 0,
-      "type": "event",
-      "event": "configFileDiag",
-      "body": {
-        "triggerFile": "/users/username/projects/project/sub/a.ts",
-        "configFile": "/users/username/projects/project/tsconfig.json",
-        "diagnostics": []
-      }
-    }
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /users/username/projects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* projectStateVersion: 1 projectProgramVersion: 0 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (2)
-	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
-	/users/username/projects/project/sub/a.ts SVC-2-0 ""
-
-
-	../../../../../a/lib/lib.d.ts
-	  Default library for target 'es5'
-	a.ts
-	  Root file specified for compilation
+	sub/a.ts
+	  Matched by default include pattern '**/*'
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (2)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
 Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
-Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] response:
     {
       "seq": 0,
@@ -614,30 +582,6 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
-PolledWatches::
-/users/username/projects/node_modules/@types:
-  {"pollingInterval":500}
-/users/username/projects/project/jsconfig.json: *new*
-  {"pollingInterval":2000}
-/users/username/projects/project/node_modules/@types:
-  {"pollingInterval":500}
-/users/username/projects/project/sub/jsconfig.json: *new*
-  {"pollingInterval":2000}
-/users/username/projects/project/sub/node_modules/@types: *new*
-  {"pollingInterval":500}
-/users/username/projects/project/sub/tsconfig.json: *new*
-  {"pollingInterval":2000}
-
-FsWatches::
-/a/lib/lib.d.ts:
-  {}
-/users/username/projects/project/tsconfig.json:
-  {}
-
-FsWatchesRecursive::
-/users/username/projects/project:
-  {}
-
 Timeout callback:: count: 2
 9: /users/username/projects/project/tsconfig.json *deleted*
 10: *ensureProjectForOpenFiles* *deleted*
@@ -645,20 +589,16 @@ Timeout callback:: count: 2
 12: *ensureProjectForOpenFiles* *new*
 
 Projects::
-/dev/null/inferredProject1* (Inferred) *new*
-    projectStateVersion: 1
-    projectProgramVersion: 1
 /users/username/projects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 3
     projectProgramVersion: 3 *changed*
     dirty: false *changed*
 
 ScriptInfos::
-/a/lib/lib.d.ts *changed*
+/a/lib/lib.d.ts
     version: Text-1
-    containingProjects: 2 *changed*
+    containingProjects: 1
         /users/username/projects/project/tsconfig.json
-        /dev/null/inferredProject1* *new*
 /users/username/projects/project/b.ts (Open)
     version: SVC-1-0
     containingProjects: 1
@@ -666,7 +606,7 @@ ScriptInfos::
 /users/username/projects/project/sub/a.ts (Open) *new*
     version: SVC-2-0
     containingProjects: 1
-        /dev/null/inferredProject1* *default*
+        /users/username/projects/project/tsconfig.json *default*
 
 Before running Timeout callback:: count: 2
 11: /users/username/projects/project/tsconfig.json
@@ -676,32 +616,24 @@ Info seq  [hh:mm:ss:mss] Running: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (2)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
 Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
-Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
 Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (2)
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
-Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
-Info seq  [hh:mm:ss:mss] 	Files (2)
+Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
 Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] 	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
-Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 		Projects: /users/username/projects/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] got projects updated in background /users/username/projects/project/b.ts,/users/username/projects/project/sub/a.ts
 Info seq  [hh:mm:ss:mss] event:
     {
@@ -726,23 +658,14 @@ Info seq  [hh:mm:ss:mss] Scheduled: /users/username/projects/project/tsconfig.js
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Scheduled: /users/username/projects/project/tsconfig.json, Cancelled earlier one
-Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
 Before request
-//// [/users/username/projects/project/sub/a.ts]
-export const a = 10;
-
-//// [/users/username/projects/project/a.ts] deleted
 
 Timeout callback:: count: 2
-17: /users/username/projects/project/tsconfig.json *new*
-18: *ensureProjectForOpenFiles* *new*
+15: /users/username/projects/project/tsconfig.json *new*
+16: *ensureProjectForOpenFiles* *new*
 
 Projects::
-/dev/null/inferredProject1* (Inferred)
-    projectStateVersion: 1
-    projectProgramVersion: 1
 /users/username/projects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 4 *changed*
     projectProgramVersion: 3
@@ -764,36 +687,19 @@ Info seq  [hh:mm:ss:mss] request:
 After request
 
 Timeout callback:: count: 3
-17: /users/username/projects/project/tsconfig.json
-18: *ensureProjectForOpenFiles*
-19: checkOne *new*
+15: /users/username/projects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
+17: checkOne *new*
 
 Before running Timeout callback:: count: 3
-17: /users/username/projects/project/tsconfig.json
-18: *ensureProjectForOpenFiles*
-19: checkOne
+15: /users/username/projects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
+17: checkOne
 
-Invoking Timeout callback:: timeoutId:: 19:: checkOne
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
-Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /users/username/projects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Invoking Timeout callback:: timeoutId:: 17:: checkOne
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
-Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
-Info seq  [hh:mm:ss:mss] Project '/users/username/projects/project/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (3)
-	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
-	/users/username/projects/project/b.ts SVC-1-0 "export const b = 10;"
-	/users/username/projects/project/sub/a.ts SVC-2-0 ""
-
-
-	../../../../a/lib/lib.d.ts
-	  Default library for target 'es5'
-	b.ts
-	  Matched by default include pattern '**/*'
-	sub/a.ts
-	  Matched by default include pattern '**/*'
-
-Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json projectStateVersion: 4 projectProgramVersion: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Same program as before
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,
@@ -806,61 +712,14 @@ Info seq  [hh:mm:ss:mss] event:
     }
 After running Timeout callback:: count: 2
 
-PolledWatches::
-/users/username/projects/node_modules/@types:
-  {"pollingInterval":500}
-/users/username/projects/project/node_modules/@types:
-  {"pollingInterval":500}
-/users/username/projects/project/sub/node_modules/@types:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/users/username/projects/project/jsconfig.json:
-  {"pollingInterval":2000}
-/users/username/projects/project/sub/jsconfig.json:
-  {"pollingInterval":2000}
-/users/username/projects/project/sub/tsconfig.json:
-  {"pollingInterval":2000}
-
-FsWatches::
-/a/lib/lib.d.ts:
-  {}
-/users/username/projects/project/tsconfig.json:
-  {}
-
-FsWatchesRecursive::
-/users/username/projects/project:
-  {}
-
 Immedidate callback:: count: 1
 1: semanticCheck *new*
 
 Projects::
-/dev/null/inferredProject1* (Inferred) *changed*
-    projectStateVersion: 2 *changed*
-    projectProgramVersion: 1
-    dirty: true *changed*
-    isOrphan: true *changed*
 /users/username/projects/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 4
-    projectProgramVersion: 4 *changed*
+    projectProgramVersion: 3
     dirty: false *changed*
-
-ScriptInfos::
-/a/lib/lib.d.ts
-    version: Text-1
-    containingProjects: 2
-        /users/username/projects/project/tsconfig.json
-        /dev/null/inferredProject1*
-/users/username/projects/project/b.ts (Open)
-    version: SVC-1-0
-    containingProjects: 1
-        /users/username/projects/project/tsconfig.json *default*
-/users/username/projects/project/sub/a.ts (Open) *changed*
-    version: SVC-2-0
-    containingProjects: 1 *changed*
-        /users/username/projects/project/tsconfig.json *default* *new*
-        /dev/null/inferredProject1* *deleted*
 
 Before running Immedidate callback:: count: 1
 1: semanticCheck
@@ -896,16 +755,16 @@ Info seq  [hh:mm:ss:mss] event:
 After running Immedidate callback:: count: 0
 
 Timeout callback:: count: 3
-17: /users/username/projects/project/tsconfig.json
-18: *ensureProjectForOpenFiles*
-20: checkOne *new*
+15: /users/username/projects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
+18: checkOne *new*
 
 Before running Timeout callback:: count: 3
-17: /users/username/projects/project/tsconfig.json
-18: *ensureProjectForOpenFiles*
-20: checkOne
+15: /users/username/projects/project/tsconfig.json
+16: *ensureProjectForOpenFiles*
+18: checkOne
 
-Invoking Timeout callback:: timeoutId:: 20:: checkOne
+Invoking Timeout callback:: timeoutId:: 18:: checkOne
 Info seq  [hh:mm:ss:mss] event:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/watchEnvironment/uses-dynamic-polling-when-file-is-added-to-subfolder.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/uses-dynamic-polling-when-file-is-added-to-subfolder.js
@@ -241,8 +241,11 @@ Before running Timeout callback:: count: 1
 
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project 1 {"synchronousWatchDirectory":true} Config: /a/username/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Invoking sourceFileChange on /a/username/project/src/file1.ts:: 1
 Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project 1 {"synchronousWatchDirectory":true} Config: /a/username/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project/src 1 {"synchronousWatchDirectory":true} Project: /a/username/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.jsonFailedLookupInvalidation
@@ -250,17 +253,32 @@ Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/user
 After running Timeout callback:: count: 5
 
 Timeout callback:: count: 5
-2: /a/username/project/tsconfig.json *new*
-3: *ensureProjectForOpenFiles* *new*
-4: /a/username/project/tsconfig.jsonFailedLookupInvalidation *new*
-5: pollLowPollingIntervalQueue *new*
-6: pollPollingIntervalQueue *new*
+4: /a/username/project/tsconfig.json *new*
+5: *ensureProjectForOpenFiles* *new*
+6: /a/username/project/tsconfig.jsonFailedLookupInvalidation *new*
+7: pollLowPollingIntervalQueue *new*
+8: pollPollingIntervalQueue *new*
 
 Projects::
 /a/username/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 2 *changed*
     projectProgramVersion: 1
     dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /a/username/project/tsconfig.json
+/a/username/project/src/file1.ts *changed*
+    version: Text-1
+    pendingReloadFromDisk: true *changed*
+    containingProjects: 1
+        /a/username/project/tsconfig.json
+/a/username/project/src/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /a/username/project/tsconfig.json *default*
 
 Before request
 
@@ -338,12 +356,12 @@ FsWatches::
   {"inode":7}
 
 Timeout callback:: count: 4
-3: *ensureProjectForOpenFiles* *deleted*
-4: /a/username/project/tsconfig.jsonFailedLookupInvalidation *deleted*
-2: /a/username/project/tsconfig.json
-5: pollLowPollingIntervalQueue
-6: pollPollingIntervalQueue
-7: *ensureProjectForOpenFiles* *new*
+5: *ensureProjectForOpenFiles* *deleted*
+6: /a/username/project/tsconfig.jsonFailedLookupInvalidation *deleted*
+4: /a/username/project/tsconfig.json
+7: pollLowPollingIntervalQueue
+8: pollPollingIntervalQueue
+9: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /a/username/project/tsconfig.json (Configured) *changed*
@@ -356,8 +374,9 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /a/username/project/tsconfig.json
-/a/username/project/src/file1.ts
+/a/username/project/src/file1.ts *changed*
     version: Text-1
+    pendingReloadFromDisk: false *changed*
     containingProjects: 1
         /a/username/project/tsconfig.json
 /a/username/project/src/file2.ts *new*

--- a/tests/baselines/reference/tsserver/watchEnvironment/uses-watchFile-when-file-is-added-to-subfolder.js
+++ b/tests/baselines/reference/tsserver/watchEnvironment/uses-watchFile-when-file-is-added-to-subfolder.js
@@ -240,30 +240,48 @@ Info seq  [hh:mm:ss:mss] response:
 After request
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project 1 {"synchronousWatchDirectory":true} Config: /a/username/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Invoking sourceFileChange on /a/username/project/src/file1.ts:: 1
 Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.json, Cancelled earlier one
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project 1 {"synchronousWatchDirectory":true} Config: /a/username/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project/src 1 {"synchronousWatchDirectory":true} Project: /a/username/project/tsconfig.json WatchType: Failed Lookup Locations
 Info seq  [hh:mm:ss:mss] Scheduled: /a/username/project/tsconfig.jsonFailedLookupInvalidation
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with /a/username/project/src :: WatchInfo: /a/username/project/src 1 {"synchronousWatchDirectory":true} Project: /a/username/project/tsconfig.json WatchType: Failed Lookup Locations
 Before running Timeout callback:: count: 3
-1: /a/username/project/tsconfig.json
-2: *ensureProjectForOpenFiles*
-3: /a/username/project/tsconfig.jsonFailedLookupInvalidation
+3: /a/username/project/tsconfig.json
+4: *ensureProjectForOpenFiles*
+5: /a/username/project/tsconfig.jsonFailedLookupInvalidation
 //// [/a/username/project/src/file2.ts] Inode:: 10
 
 
 
 Timeout callback:: count: 3
-1: /a/username/project/tsconfig.json *new*
-2: *ensureProjectForOpenFiles* *new*
-3: /a/username/project/tsconfig.jsonFailedLookupInvalidation *new*
+3: /a/username/project/tsconfig.json *new*
+4: *ensureProjectForOpenFiles* *new*
+5: /a/username/project/tsconfig.jsonFailedLookupInvalidation *new*
 
 Projects::
 /a/username/project/tsconfig.json (Configured) *changed*
     projectStateVersion: 2 *changed*
     projectProgramVersion: 1
     dirty: true *changed*
+
+ScriptInfos::
+/a/lib/lib.d.ts
+    version: Text-1
+    containingProjects: 1
+        /a/username/project/tsconfig.json
+/a/username/project/src/file1.ts *changed*
+    version: Text-1
+    pendingReloadFromDisk: true *changed*
+    containingProjects: 1
+        /a/username/project/tsconfig.json
+/a/username/project/src/index.ts (Open)
+    version: SVC-1-0
+    containingProjects: 1
+        /a/username/project/tsconfig.json *default*
 
 Info seq  [hh:mm:ss:mss] Running: /a/username/project/tsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
@@ -310,9 +328,9 @@ FsWatches::
   {"inode":7}
 
 Timeout callback:: count: 1
-2: *ensureProjectForOpenFiles* *deleted*
-3: /a/username/project/tsconfig.jsonFailedLookupInvalidation *deleted*
-4: *ensureProjectForOpenFiles* *new*
+4: *ensureProjectForOpenFiles* *deleted*
+5: /a/username/project/tsconfig.jsonFailedLookupInvalidation *deleted*
+6: *ensureProjectForOpenFiles* *new*
 
 Projects::
 /a/username/project/tsconfig.json (Configured) *changed*
@@ -325,8 +343,9 @@ ScriptInfos::
     version: Text-1
     containingProjects: 1
         /a/username/project/tsconfig.json
-/a/username/project/src/file1.ts
+/a/username/project/src/file1.ts *changed*
     version: Text-1
+    pendingReloadFromDisk: false *changed*
     containingProjects: 1
         /a/username/project/tsconfig.json
 /a/username/project/src/file2.ts *new*


### PR DESCRIPTION
This has two things:
- We invoke `sourceFileChange` when invoking wild card watcher to ensure fileExists status is updated. We do this because sometimes we only get "folder" added and deleted events and not actual file moved events. 
- In our cached directory structure, earlier we were ignoring events for files/folders whose parent didnt have cached entries. but in cases where we are getting say event for "folder/functions/whatever" while creating "functions/whatever", we would not cleanup structure for "folder" and hence it would still assume "functions" does not exist in "folder". This fixes it.
- 
This is kind of continuation of #59418 to deal with debounced watch events in a better way

Fixes repro reported in https://github.com/microsoft/TypeScript/issues/59603#issuecomment-2284919153