### PR TITLE
Add an extra test case for narrowing of union containing a type parameter

### DIFF
--- a/tests/baselines/reference/controlFlowUnionContainingTypeParameter1.symbols
+++ b/tests/baselines/reference/controlFlowUnionContainingTypeParameter1.symbols
@@ -1,0 +1,105 @@
+//// [tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts] ////
+
+=== controlFlowUnionContainingTypeParameter1.ts ===
+// https://github.com/microsoft/TypeScript/issues/44814
+
+class TestClass<T> {
+>TestClass : Symbol(TestClass, Decl(controlFlowUnionContainingTypeParameter1.ts, 0, 0))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 16))
+
+  typeguard(val: unknown): val is T {
+>typeguard : Symbol(TestClass.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 20))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 3, 12))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 3, 12))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 16))
+
+    return true;
+  }
+  f(v: number): void {}
+>f : Symbol(TestClass.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 5, 3))
+>v : Symbol(v, Decl(controlFlowUnionContainingTypeParameter1.ts, 6, 4))
+
+  h(v: T): void {}
+>h : Symbol(TestClass.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 6, 23))
+>v : Symbol(v, Decl(controlFlowUnionContainingTypeParameter1.ts, 7, 4))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 16))
+
+  func(val: T | number): void {
+>func : Symbol(TestClass.func, Decl(controlFlowUnionContainingTypeParameter1.ts, 7, 18))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 8, 7))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 16))
+
+    if (this.typeguard(val)) {
+>this.typeguard : Symbol(TestClass.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 20))
+>this : Symbol(TestClass, Decl(controlFlowUnionContainingTypeParameter1.ts, 0, 0))
+>typeguard : Symbol(TestClass.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 2, 20))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 8, 7))
+
+      this.h(val);
+>this.h : Symbol(TestClass.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 6, 23))
+>this : Symbol(TestClass, Decl(controlFlowUnionContainingTypeParameter1.ts, 0, 0))
+>h : Symbol(TestClass.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 6, 23))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 8, 7))
+
+      return;
+    }
+    this.f(val);
+>this.f : Symbol(TestClass.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 5, 3))
+>this : Symbol(TestClass, Decl(controlFlowUnionContainingTypeParameter1.ts, 0, 0))
+>f : Symbol(TestClass.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 5, 3))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 8, 7))
+  }
+}
+
+class TestClass2<T extends Date> {
+>TestClass2 : Symbol(TestClass2, Decl(controlFlowUnionContainingTypeParameter1.ts, 15, 1))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 17))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+  typeguard(val: unknown): val is T {
+>typeguard : Symbol(TestClass2.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 34))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 18, 12))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 18, 12))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 17))
+
+    return true;
+  }
+  f(v: number): void {}
+>f : Symbol(TestClass2.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 20, 3))
+>v : Symbol(v, Decl(controlFlowUnionContainingTypeParameter1.ts, 21, 4))
+
+  h(v: T): void {}
+>h : Symbol(TestClass2.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 21, 23))
+>v : Symbol(v, Decl(controlFlowUnionContainingTypeParameter1.ts, 22, 4))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 17))
+
+  func(val: T | number): void {
+>func : Symbol(TestClass2.func, Decl(controlFlowUnionContainingTypeParameter1.ts, 22, 18))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 23, 7))
+>T : Symbol(T, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 17))
+
+    if (this.typeguard(val)) {
+>this.typeguard : Symbol(TestClass2.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 34))
+>this : Symbol(TestClass2, Decl(controlFlowUnionContainingTypeParameter1.ts, 15, 1))
+>typeguard : Symbol(TestClass2.typeguard, Decl(controlFlowUnionContainingTypeParameter1.ts, 17, 34))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 23, 7))
+
+      this.h(val);
+>this.h : Symbol(TestClass2.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 21, 23))
+>this : Symbol(TestClass2, Decl(controlFlowUnionContainingTypeParameter1.ts, 15, 1))
+>h : Symbol(TestClass2.h, Decl(controlFlowUnionContainingTypeParameter1.ts, 21, 23))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 23, 7))
+
+      return;
+    }
+    val;
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 23, 7))
+
+    this.f(val);
+>this.f : Symbol(TestClass2.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 20, 3))
+>this : Symbol(TestClass2, Decl(controlFlowUnionContainingTypeParameter1.ts, 15, 1))
+>f : Symbol(TestClass2.f, Decl(controlFlowUnionContainingTypeParameter1.ts, 20, 3))
+>val : Symbol(val, Decl(controlFlowUnionContainingTypeParameter1.ts, 23, 7))
+  }
+}
+

--- a/tests/baselines/reference/controlFlowUnionContainingTypeParameter1.types
+++ b/tests/baselines/reference/controlFlowUnionContainingTypeParameter1.types
@@ -1,0 +1,153 @@
+//// [tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts] ////
+
+=== controlFlowUnionContainingTypeParameter1.ts ===
+// https://github.com/microsoft/TypeScript/issues/44814
+
+class TestClass<T> {
+>TestClass : TestClass<T>
+>          : ^^^^^^^^^^^^
+
+  typeguard(val: unknown): val is T {
+>typeguard : (val: unknown) => val is T
+>          : ^   ^^       ^^^^^        
+>val : unknown
+>    : ^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+  }
+  f(v: number): void {}
+>f : (v: number) => void
+>  : ^ ^^      ^^^^^    
+>v : number
+>  : ^^^^^^
+
+  h(v: T): void {}
+>h : (v: T) => void
+>  : ^ ^^ ^^^^^    
+>v : T
+>  : ^
+
+  func(val: T | number): void {
+>func : (val: T | number) => void
+>     : ^   ^^          ^^^^^    
+>val : number | T
+>    : ^^^^^^^^^^
+
+    if (this.typeguard(val)) {
+>this.typeguard(val) : boolean
+>                    : ^^^^^^^
+>this.typeguard : (val: unknown) => val is T
+>               : ^   ^^       ^^^^^        
+>this : this
+>     : ^^^^
+>typeguard : (val: unknown) => val is T
+>          : ^   ^^       ^^^^^        
+>val : number | T
+>    : ^^^^^^^^^^
+
+      this.h(val);
+>this.h(val) : void
+>            : ^^^^
+>this.h : (v: T) => void
+>       : ^ ^^ ^^^^^    
+>this : this
+>     : ^^^^
+>h : (v: T) => void
+>  : ^ ^^ ^^^^^    
+>val : T
+>    : ^
+
+      return;
+    }
+    this.f(val);
+>this.f(val) : void
+>            : ^^^^
+>this.f : (v: number) => void
+>       : ^ ^^      ^^^^^    
+>this : this
+>     : ^^^^
+>f : (v: number) => void
+>  : ^ ^^      ^^^^^    
+>val : number
+>    : ^^^^^^
+  }
+}
+
+class TestClass2<T extends Date> {
+>TestClass2 : TestClass2<T>
+>           : ^^^^^^^^^^^^^
+
+  typeguard(val: unknown): val is T {
+>typeguard : (val: unknown) => val is T
+>          : ^   ^^       ^^^^^        
+>val : unknown
+>    : ^^^^^^^
+
+    return true;
+>true : true
+>     : ^^^^
+  }
+  f(v: number): void {}
+>f : (v: number) => void
+>  : ^ ^^      ^^^^^    
+>v : number
+>  : ^^^^^^
+
+  h(v: T): void {}
+>h : (v: T) => void
+>  : ^ ^^ ^^^^^    
+>v : T
+>  : ^
+
+  func(val: T | number): void {
+>func : (val: T | number) => void
+>     : ^   ^^          ^^^^^    
+>val : number | T
+>    : ^^^^^^^^^^
+
+    if (this.typeguard(val)) {
+>this.typeguard(val) : boolean
+>                    : ^^^^^^^
+>this.typeguard : (val: unknown) => val is T
+>               : ^   ^^       ^^^^^        
+>this : this
+>     : ^^^^
+>typeguard : (val: unknown) => val is T
+>          : ^   ^^       ^^^^^        
+>val : number | T
+>    : ^^^^^^^^^^
+
+      this.h(val);
+>this.h(val) : void
+>            : ^^^^
+>this.h : (v: T) => void
+>       : ^ ^^ ^^^^^    
+>this : this
+>     : ^^^^
+>h : (v: T) => void
+>  : ^ ^^ ^^^^^    
+>val : T
+>    : ^
+
+      return;
+    }
+    val;
+>val : number
+>    : ^^^^^^
+
+    this.f(val);
+>this.f(val) : void
+>            : ^^^^
+>this.f : (v: number) => void
+>       : ^ ^^      ^^^^^    
+>this : this
+>     : ^^^^
+>f : (v: number) => void
+>  : ^ ^^      ^^^^^    
+>val : number
+>    : ^^^^^^
+  }
+}
+

--- a/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
+++ b/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
@@ -1,0 +1,35 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/44814
+
+class TestClass<T> {
+  typeguard(val: unknown): val is T {
+    return true;
+  }
+  f(v: number): void {}
+  h(v: T): void {}
+  func(val: T | number): void {
+    if (this.typeguard(val)) {
+      this.h(val);
+      return;
+    }
+    this.f(val);
+  }
+}
+
+class TestClass2<T extends Date> {
+  typeguard(val: unknown): val is T {
+    return true;
+  }
+  f(v: number): void {}
+  h(v: T): void {}
+  func(val: T | number): void {
+    if (this.typeguard(val)) {
+      this.h(val);
+      return;
+    }
+    val;
+    this.f(val);
+  }
+}


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/44814
it was fixed https://github.com/microsoft/TypeScript/pull/41821 and specifically by the change in `getNarrowedType` [here](https://github.com/microsoft/TypeScript/pull/41821/files#diff-d9ab6589e714c71e657f601cf30ff51dfc607fc98419bf72e04f6b0fa92cc4b8R24495)