### PR TITLE
Do not get awaited type of AsyncGenerator TNext

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38348,7 +38348,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const globalGeneratorType = resolver.getGlobalGeneratorType(/*reportErrors*/ false);
         yieldType = resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) || unknownType;
         returnType = resolver.resolveIterationType(returnType, /*errorNode*/ undefined) || unknownType;
-        nextType = resolver.resolveIterationType(nextType, /*errorNode*/ undefined) || unknownType;
         if (globalGeneratorType === emptyGenericType) {
             // Fall back to the global IterableIterator type.
             const globalIterableIteratorType = resolver.getGlobalIterableIteratorType(/*reportErrors*/ false);
@@ -40259,9 +40258,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const iterationTypes = returnType && getIterationTypesOfGeneratorFunctionReturnType(returnType, isAsync);
         const signatureYieldType = iterationTypes && iterationTypes.yieldType || anyType;
         const signatureNextType = iterationTypes && iterationTypes.nextType || anyType;
-        const resolvedSignatureNextType = isAsync ? getAwaitedType(signatureNextType) || anyType : signatureNextType;
         const yieldExpressionType = node.expression ? checkExpression(node.expression) : undefinedWideningType;
-        const yieldedType = getYieldedTypeOfYieldExpression(node, yieldExpressionType, resolvedSignatureNextType, isAsync);
+        const yieldedType = getYieldedTypeOfYieldExpression(node, yieldExpressionType, signatureNextType, isAsync);
         if (returnType && yieldedType) {
             checkTypeAssignableToAndOptionallyElaborate(yieldedType, signatureYieldType, node.expression || node, node.expression);
         }

--- a/tests/baselines/reference/asyncGeneratorPromiseNextType.symbols
+++ b/tests/baselines/reference/asyncGeneratorPromiseNextType.symbols
@@ -1,0 +1,75 @@
+//// [tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts] ////
+
+=== asyncGeneratorPromiseNextType.ts ===
+// https://github.com/microsoft/TypeScript/issues/44808
+
+type Result = {message: string}
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+>message : Symbol(message, Decl(asyncGeneratorPromiseNextType.ts, 2, 15))
+
+async function *saverGen(): AsyncGenerator<void, void, Promise<Result> | undefined> {
+>saverGen : Symbol(saverGen, Decl(asyncGeneratorPromiseNextType.ts, 2, 31))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+    let pending: Promise<Result>[] = [];
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 5, 7))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+    while (true) {
+        const p: Promise<Result> | undefined = yield;
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 7, 13))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+        if (p != null)
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 7, 13))
+
+            pending.push(p);
+>pending.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 5, 7))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 7, 13))
+
+        else {
+            const results = await Promise.all(pending);
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 11, 17))
+>Promise.all : Symbol(PromiseConstructor.all, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>all : Symbol(PromiseConstructor.all, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 5, 7))
+
+            pending = [];
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 5, 7))
+
+            console.log('Storing...');
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+            await storeResults(results);
+>storeResults : Symbol(storeResults, Decl(asyncGeneratorPromiseNextType.ts, 17, 1))
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 11, 17))
+        }
+    }
+}
+
+function storeResults(results: Result[]) {
+>storeResults : Symbol(storeResults, Decl(asyncGeneratorPromiseNextType.ts, 17, 1))
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 19, 22))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+    console.log(results);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 19, 22))
+
+    return Promise.resolve();
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/asyncGeneratorPromiseNextType.symbols
+++ b/tests/baselines/reference/asyncGeneratorPromiseNextType.symbols
@@ -73,3 +73,49 @@ function storeResults(results: Result[]) {
 >resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }
 
+async function *saverGen2() {
+>saverGen2 : Symbol(saverGen2, Decl(asyncGeneratorPromiseNextType.ts, 22, 1))
+
+    let pending: Promise<Result>[] = [];
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 25, 7))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+    while (true) {
+        const p: Promise<Result> | undefined = yield;
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 27, 13))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Result : Symbol(Result, Decl(asyncGeneratorPromiseNextType.ts, 0, 0))
+
+        if (p != null)
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 27, 13))
+
+            pending.push(p);
+>pending.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 25, 7))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>p : Symbol(p, Decl(asyncGeneratorPromiseNextType.ts, 27, 13))
+
+        else {
+            const results = await Promise.all(pending);
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 31, 17))
+>Promise.all : Symbol(PromiseConstructor.all, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>all : Symbol(PromiseConstructor.all, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 25, 7))
+
+            pending = [];
+>pending : Symbol(pending, Decl(asyncGeneratorPromiseNextType.ts, 25, 7))
+
+            console.log('Storing...');
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+            await storeResults(results);
+>storeResults : Symbol(storeResults, Decl(asyncGeneratorPromiseNextType.ts, 17, 1))
+>results : Symbol(results, Decl(asyncGeneratorPromiseNextType.ts, 31, 17))
+        }
+    }
+}
+

--- a/tests/baselines/reference/asyncGeneratorPromiseNextType.types
+++ b/tests/baselines/reference/asyncGeneratorPromiseNextType.types
@@ -126,3 +126,90 @@ function storeResults(results: Result[]) {
 >        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
 }
 
+async function *saverGen2() {
+>saverGen2 : () => AsyncGenerator<undefined, void, Promise<Result> | undefined>
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    let pending: Promise<Result>[] = [];
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    while (true) {
+>true : true
+>     : ^^^^
+
+        const p: Promise<Result> | undefined = yield;
+>p : Promise<Result> | undefined
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>yield : any
+
+        if (p != null)
+>p != null : boolean
+>          : ^^^^^^^
+>p : Promise<Result> | undefined
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+            pending.push(p);
+>pending.push(p) : number
+>                : ^^^^^^
+>pending.push : (...items: Promise<Result>[]) => number
+>             : ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^      
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>push : (...items: Promise<Result>[]) => number
+>     : ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^      
+>p : Promise<Result>
+>  : ^^^^^^^^^^^^^^^
+
+        else {
+            const results = await Promise.all(pending);
+>results : Result[]
+>        : ^^^^^^^^
+>await Promise.all(pending) : Result[]
+>                           : ^^^^^^^^
+>Promise.all(pending) : Promise<Result[]>
+>                     : ^^^^^^^^^^^^^^^^^
+>Promise.all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
+>            : ^^^ ^^      ^^                            ^^^                     ^^^ ^^^^^^^^^                       ^^      ^^ ^^^                                                     ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
+>    : ^^^ ^^      ^^                            ^^^                     ^^^ ^^^^^^^^^                       ^^      ^^ ^^^                                                     ^^^
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+
+            pending = [];
+>pending = [] : never[]
+>             : ^^^^^^^
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+            console.log('Storing...');
+>console.log('Storing...') : void
+>                          : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>'Storing...' : "Storing..."
+>             : ^^^^^^^^^^^^
+
+            await storeResults(results);
+>await storeResults(results) : void
+>                            : ^^^^
+>storeResults(results) : Promise<void>
+>                      : ^^^^^^^^^^^^^
+>storeResults : (results: Result[]) => Promise<void>
+>             : ^       ^^        ^^^^^^^^^^^^^^^^^^
+>results : Result[]
+>        : ^^^^^^^^
+        }
+    }
+}
+

--- a/tests/baselines/reference/asyncGeneratorPromiseNextType.types
+++ b/tests/baselines/reference/asyncGeneratorPromiseNextType.types
@@ -1,0 +1,128 @@
+//// [tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts] ////
+
+=== asyncGeneratorPromiseNextType.ts ===
+// https://github.com/microsoft/TypeScript/issues/44808
+
+type Result = {message: string}
+>Result : Result
+>       : ^^^^^^
+>message : string
+>        : ^^^^^^
+
+async function *saverGen(): AsyncGenerator<void, void, Promise<Result> | undefined> {
+>saverGen : () => AsyncGenerator<void, void, Promise<Result> | undefined>
+>         : ^^^^^^                                                       
+
+    let pending: Promise<Result>[] = [];
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    while (true) {
+>true : true
+>     : ^^^^
+
+        const p: Promise<Result> | undefined = yield;
+>p : Promise<Result> | undefined
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>yield : Promise<Result> | undefined
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        if (p != null)
+>p != null : boolean
+>          : ^^^^^^^
+>p : Promise<Result> | undefined
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+            pending.push(p);
+>pending.push(p) : number
+>                : ^^^^^^
+>pending.push : (...items: Promise<Result>[]) => number
+>             : ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^      
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>push : (...items: Promise<Result>[]) => number
+>     : ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^      
+>p : Promise<Result>
+>  : ^^^^^^^^^^^^^^^
+
+        else {
+            const results = await Promise.all(pending);
+>results : Result[]
+>        : ^^^^^^^^
+>await Promise.all(pending) : Result[]
+>                           : ^^^^^^^^
+>Promise.all(pending) : Promise<Result[]>
+>                     : ^^^^^^^^^^^^^^^^^
+>Promise.all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
+>            : ^^^ ^^      ^^                            ^^^                     ^^^ ^^^^^^^^^                       ^^      ^^ ^^^                                                     ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
+>    : ^^^ ^^      ^^                            ^^^                     ^^^ ^^^^^^^^^                       ^^      ^^ ^^^                                                     ^^^
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+
+            pending = [];
+>pending = [] : never[]
+>             : ^^^^^^^
+>pending : Promise<Result>[]
+>        : ^^^^^^^^^^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+            console.log('Storing...');
+>console.log('Storing...') : void
+>                          : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>'Storing...' : "Storing..."
+>             : ^^^^^^^^^^^^
+
+            await storeResults(results);
+>await storeResults(results) : void
+>                            : ^^^^
+>storeResults(results) : Promise<void>
+>                      : ^^^^^^^^^^^^^
+>storeResults : (results: Result[]) => Promise<void>
+>             : ^       ^^        ^^^^^^^^^^^^^^^^^^
+>results : Result[]
+>        : ^^^^^^^^
+        }
+    }
+}
+
+function storeResults(results: Result[]) {
+>storeResults : (results: Result[]) => Promise<void>
+>             : ^       ^^        ^^^^^^^^^^^^^^^^^^
+>results : Result[]
+>        : ^^^^^^^^
+
+    console.log(results);
+>console.log(results) : void
+>                     : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>results : Result[]
+>        : ^^^^^^^^
+
+    return Promise.resolve();
+>Promise.resolve() : Promise<void>
+>                  : ^^^^^^^^^^^^^
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>                : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+}
+

--- a/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
+++ b/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
@@ -1,0 +1,27 @@
+// @target: esnext
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/44808
+
+type Result = {message: string}
+
+async function *saverGen(): AsyncGenerator<void, void, Promise<Result> | undefined> {
+    let pending: Promise<Result>[] = [];
+    while (true) {
+        const p: Promise<Result> | undefined = yield;
+        if (p != null)
+            pending.push(p);
+        else {
+            const results = await Promise.all(pending);
+            pending = [];
+            console.log('Storing...');
+            await storeResults(results);
+        }
+    }
+}
+
+function storeResults(results: Result[]) {
+    console.log(results);
+    return Promise.resolve();
+}

--- a/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
+++ b/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
@@ -25,3 +25,18 @@ function storeResults(results: Result[]) {
     console.log(results);
     return Promise.resolve();
 }
+
+async function *saverGen2() {
+    let pending: Promise<Result>[] = [];
+    while (true) {
+        const p: Promise<Result> | undefined = yield;
+        if (p != null)
+            pending.push(p);
+        else {
+            const results = await Promise.all(pending);
+            pending = [];
+            console.log('Storing...');
+            await storeResults(results);
+        }
+    }
+}


### PR DESCRIPTION
We are incorrectly calling `getAwaitedType` on the `TNext` type of an async generator, despite the fact that the spec does not perform an Await.

- [27.6.1.2 %AsyncGeneratorPrototype%.next ( value )](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next)
- [27.6.3.7 AsyncGeneratorUnwrapYieldResumption ( resumptionValue )](https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption), Step 1

Our runtime emit looks to be correct, only checker appears to be wrong here.

Fixes #44808
