### PR TITLE
Use ProjectService for linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,7 @@ export default tseslint.config(
             parserOptions: {
                 warnOnUnsupportedTypeScriptVersion: false,
                 projectService: true,
+                tsconfigRootDir: __dirname,
                 defaultProject: "./scripts/tsconfig.json",
                 allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,10 +51,11 @@ export default tseslint.config(
         languageOptions: {
             parserOptions: {
                 warnOnUnsupportedTypeScriptVersion: false,
-                projectService: true,
                 tsconfigRootDir: __dirname,
-                defaultProject: "./scripts/tsconfig.json",
-                allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
+                projectService: {
+                    defaultProject: "./scripts/tsconfig.json",
+                    allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
+                },
             },
             globals: globals.node,
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,7 +53,8 @@ export default tseslint.config(
                 warnOnUnsupportedTypeScriptVersion: false,
                 tsconfigRootDir: __dirname,
                 projectService: {
-                    defaultProject: path.join(__dirname, "scripts", "tsconfig.json"),
+                    // This is a reasonable config to use for loose files.
+                    defaultProject: "./scripts/tsconfig.json",
                     allowDefaultProject: ["*.js", "*.cjs", "*.mjs"].map(p => [p, `.${p}`]).flat(),
                 },
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,9 +51,10 @@ export default tseslint.config(
         languageOptions: {
             parserOptions: {
                 warnOnUnsupportedTypeScriptVersion: false,
+                tsconfigRootDir: __dirname,
                 projectService: {
                     defaultProject: path.join(__dirname, "scripts", "tsconfig.json"),
-                    allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
+                    allowDefaultProject: ["*.js", "*.cjs", "*.mjs"].map(p => [p, `.${p}`]).flat(),
                 },
             },
             globals: globals.node,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,9 @@ export default tseslint.config(
         languageOptions: {
             parserOptions: {
                 warnOnUnsupportedTypeScriptVersion: false,
+                projectService: true,
+                defaultProject: "./scripts/tsconfig.json",
+                allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
             },
             globals: globals.node,
         },
@@ -170,24 +173,6 @@ export default tseslint.config(
                 { name: "module" },
                 { name: "exports" },
             ],
-        },
-    },
-    {
-        files: ["src/**"],
-        languageOptions: {
-            parserOptions: {
-                tsconfigRootDir: __dirname,
-                project: "./src/tsconfig-eslint.json",
-            },
-        },
-    },
-    {
-        files: ["scripts/**"],
-        languageOptions: {
-            parserOptions: {
-                tsconfigRootDir: __dirname,
-                project: "./scripts/tsconfig.json",
-            },
         },
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,9 +51,8 @@ export default tseslint.config(
         languageOptions: {
             parserOptions: {
                 warnOnUnsupportedTypeScriptVersion: false,
-                tsconfigRootDir: __dirname,
                 projectService: {
-                    defaultProject: "./scripts/tsconfig.json",
+                    defaultProject: path.join(__dirname, "scripts", "tsconfig.json"),
                     allowDefaultProject: ["*.js", "*.cjs", "*.mjs"],
                 },
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
                 "@types/node": "latest",
                 "@types/source-map-support": "^0.5.10",
                 "@types/which": "^3.0.4",
-                "@typescript-eslint/rule-tester": "^8.1.0",
-                "@typescript-eslint/type-utils": "^8.1.0",
-                "@typescript-eslint/utils": "^8.1.0",
+                "@typescript-eslint/rule-tester": "^8.2.0",
+                "@typescript-eslint/type-utils": "^8.2.0",
+                "@typescript-eslint/utils": "^8.2.0",
                 "azure-devops-node-api": "^14.0.2",
                 "c8": "^10.1.2",
                 "chai": "^4.5.0",
@@ -56,7 +56,7 @@
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.6.3",
                 "typescript": "^5.5.4",
-                "typescript-eslint": "^8.1.0",
+                "typescript-eslint": "^8.2.0",
                 "which": "^3.0.1"
             },
             "engines": {
@@ -1066,16 +1066,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
-            "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.2.0.tgz",
+            "integrity": "sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/type-utils": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/type-utils": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1099,15 +1099,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
-            "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.2.0.tgz",
+            "integrity": "sha512-j3Di+o0lHgPrb7FxL3fdEy6LJ/j2NE8u+AP/5cQ9SKb+JLH6V6UHDqJ+e0hXBkHP1wn1YDFjYCS9LBQsZDlDEg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1127,13 +1127,13 @@
             }
         },
         "node_modules/@typescript-eslint/rule-tester": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.1.0.tgz",
-            "integrity": "sha512-shzRkkwKoCUCV1lttzqMFsKnbsOWQ0vjfxe1q3kDjrqdhKkQ/t3t3GwHk0QqjYQd7NUjKk2EB+nNaNI//0IL7Q==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.2.0.tgz",
+            "integrity": "sha512-+nolUggnH/VhAzzQEI2DKkDk5dopcrrwE/9MKTgV+bYojqTMrI9poYF0zjXtQdWmIhI4o5qJC5AO0ozmDR9OTA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
                 "ajv": "^6.12.6",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "4.6.2",
@@ -1147,18 +1147,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@eslint/eslintrc": ">=2",
                 "eslint": "^8.57.0 || ^9.0.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
-            "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.2.0.tgz",
+            "integrity": "sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0"
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1169,13 +1168,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
-            "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.2.0.tgz",
+            "integrity": "sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -1193,9 +1192,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
-            "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.2.0.tgz",
+            "integrity": "sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1206,13 +1205,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
-            "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.2.0.tgz",
+            "integrity": "sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1258,15 +1257,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
-            "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
+            "integrity": "sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/typescript-estree": "8.1.0"
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1280,12 +1279,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
-            "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.2.0.tgz",
+            "integrity": "sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.1.0",
+                "@typescript-eslint/types": "8.2.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -4509,14 +4508,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.1.0.tgz",
-            "integrity": "sha512-prB2U3jXPJLpo1iVLN338Lvolh6OrcCZO+9Yv6AR+tvegPPptYCDBIHiEEUdqRi8gAv2bXNKfMUrgAd2ejn/ow==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.2.0.tgz",
+            "integrity": "sha512-DmnqaPcML0xYwUzgNbM1XaKXpEb7BShYf2P1tkUmmcl8hyeG7Pj08Er7R9bNy6AufabywzJcOybQAtnD/c9DGw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.1.0",
-                "@typescript-eslint/parser": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0"
+                "@typescript-eslint/eslint-plugin": "8.2.0",
+                "@typescript-eslint/parser": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5471,16 +5470,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
-            "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.2.0.tgz",
+            "integrity": "sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/type-utils": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/type-utils": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -5488,26 +5487,26 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
-            "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.2.0.tgz",
+            "integrity": "sha512-j3Di+o0lHgPrb7FxL3fdEy6LJ/j2NE8u+AP/5cQ9SKb+JLH6V6UHDqJ+e0hXBkHP1wn1YDFjYCS9LBQsZDlDEg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/rule-tester": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.1.0.tgz",
-            "integrity": "sha512-shzRkkwKoCUCV1lttzqMFsKnbsOWQ0vjfxe1q3kDjrqdhKkQ/t3t3GwHk0QqjYQd7NUjKk2EB+nNaNI//0IL7Q==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.2.0.tgz",
+            "integrity": "sha512-+nolUggnH/VhAzzQEI2DKkDk5dopcrrwE/9MKTgV+bYojqTMrI9poYF0zjXtQdWmIhI4o5qJC5AO0ozmDR9OTA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
                 "ajv": "^6.12.6",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "4.6.2",
@@ -5515,41 +5514,41 @@
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
-            "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.2.0.tgz",
+            "integrity": "sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0"
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
-            "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.2.0.tgz",
+            "integrity": "sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
-            "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.2.0.tgz",
+            "integrity": "sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
-            "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.2.0.tgz",
+            "integrity": "sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/visitor-keys": "8.1.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -5579,24 +5578,24 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
-            "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
+            "integrity": "sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.1.0",
-                "@typescript-eslint/types": "8.1.0",
-                "@typescript-eslint/typescript-estree": "8.1.0"
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
-            "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.2.0.tgz",
+            "integrity": "sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "8.1.0",
+                "@typescript-eslint/types": "8.2.0",
                 "eslint-visitor-keys": "^3.4.3"
             }
         },
@@ -7888,14 +7887,14 @@
             "dev": true
         },
         "typescript-eslint": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.1.0.tgz",
-            "integrity": "sha512-prB2U3jXPJLpo1iVLN338Lvolh6OrcCZO+9Yv6AR+tvegPPptYCDBIHiEEUdqRi8gAv2bXNKfMUrgAd2ejn/ow==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.2.0.tgz",
+            "integrity": "sha512-DmnqaPcML0xYwUzgNbM1XaKXpEb7BShYf2P1tkUmmcl8hyeG7Pj08Er7R9bNy6AufabywzJcOybQAtnD/c9DGw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/eslint-plugin": "8.1.0",
-                "@typescript-eslint/parser": "8.1.0",
-                "@typescript-eslint/utils": "8.1.0"
+                "@typescript-eslint/eslint-plugin": "8.2.0",
+                "@typescript-eslint/parser": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0"
             }
         },
         "typical": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
         "@types/node": "latest",
         "@types/source-map-support": "^0.5.10",
         "@types/which": "^3.0.4",
-        "@typescript-eslint/rule-tester": "^8.1.0",
-        "@typescript-eslint/type-utils": "^8.1.0",
-        "@typescript-eslint/utils": "^8.1.0",
+        "@typescript-eslint/rule-tester": "^8.2.0",
+        "@typescript-eslint/type-utils": "^8.2.0",
+        "@typescript-eslint/utils": "^8.2.0",
         "azure-devops-node-api": "^14.0.2",
         "c8": "^10.1.2",
         "chai": "^4.5.0",
@@ -82,7 +82,7 @@
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.3",
         "typescript": "^5.5.4",
-        "typescript-eslint": "^8.1.0",
+        "typescript-eslint": "^8.2.0",
         "which": "^3.0.1"
     },
     "overrides": {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,6 +3,7 @@
         "lib": [
             "es2018"
         ],
+        "types": ["node"],
         "module": "Node16",
         "moduleResolution": "Node16",
         "target": "es2018",

--- a/src/tsconfig-eslint.json
+++ b/src/tsconfig-eslint.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig-base",
-    "compilerOptions": {
-        "types": ["node", "mocha", "chai"]
-    }
-}


### PR DESCRIPTION
This simplifies things, and lets us dogfood the experience.

```console
$  hyperfine -w 3 -n 'before' -p 'git switch main' 'node ./node_modules/eslint/bin/eslint.js .' -n 'after' -p 'git switch eslint-project-service' 'node ./node_modules/eslint/bin/eslint.js .'
Benchmark 1: before
  Time (mean ± σ):     26.980 s ±  0.523 s    [User: 42.924 s, System: 1.743 s]
  Range (min … max):   26.235 s … 28.133 s    10 runs

Benchmark 2: after
  Time (mean ± σ):     27.924 s ±  0.322 s    [User: 44.788 s, System: 1.784 s]
  Range (min … max):   27.451 s … 28.619 s    10 runs

Summary
  'before' ran
    1.04 ± 0.02 times faster than 'after'
```

Slower, but we also have technically enabled typed linting on a handful of new files?