### PR TITLE
Do not overwrite original pointer when indirectly points to location

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6063,7 +6063,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!location) {
                 return range;
             }
-            // Don't overwrite the original node if `range` has an `original` node that points either directly or indirectly to `location` 
+            // Don't overwrite the original node if `range` has an `original` node that points either directly or indirectly to `location`
             let original = range.original;
             while (original && original !== location) {
                 original = original.original;


### PR DESCRIPTION
Due to the complicated machinery in `setTextRange` and `deepCloneOrReuseNode` as part of the `NodeBuilder`, it was possible that the node we are updating might be a clone of a node that already has an `original` pointer.

In `setTextRange(context, range, location)`, we are given two nodes relevant to this issue:

- `range` - the node for which we are setting the text range
- `location` the node from which we are copying the text range, and which would be set as the `original`

In this case, we end up cloning `range` via `factory.cloneNode()`. Clones created from `factory.cloneNode()` will already have their `original` pointer set to the node being cloned.

Later in the function, we call `setOriginalNode` on the cloned range, but `setOriginalNode` only shallowly checks whether `node.original` has already been set to the provided original node. In this case, we have a clone of `range` whose `original` points to `range`, which in turn has an `original` that points to `location`. As far as `setOriginalNode` is concerned, we should overwrite the `original` pointer and merge emit nodes. However, the clone of `range` already has the leading synthetic comments from `location`, so we add them again.

This changes the algorithm in `setTextRange` to skip the call to `setOriginalNode` when `location` may indirectly be an original node for `range`. We don't do this in `setOriginalNode` as it is called fairly frequently and walking up all of the `original` pointers for every call to `setOriginalNode` would be fairly expensive.

Related #59613
Related #59332
