### PR TITLE
Report implict any error when widening null/undefined in presence of …

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25513,7 +25513,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ArrowFunction:
                 if (noImplicitAny && !(declaration as NamedDeclaration).name) {
                     if (wideningKind === WideningKind.GeneratorYield) {
-                        error(declaration, Diagnostics.Generator_implicitly_has_yield_type_0_because_it_does_not_yield_any_values_Consider_supplying_a_return_type_annotation, typeAsString);
+                        error(declaration, Diagnostics.Generator_implicitly_has_yield_type_0_Consider_supplying_a_return_type_annotation, typeAsString);
                     }
                     else {
                         error(declaration, Diagnostics.Function_expression_which_lacks_return_type_annotation_implicitly_has_an_0_return_type, typeAsString);
@@ -25535,12 +25535,40 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         errorOrSuggestion(noImplicitAny, declaration, diagnostic, declarationNameToString(getNameOfDeclaration(declaration)), typeAsString);
     }
 
+    function reportErrorsFromWideningWithContextualSignature(declaration: FunctionLikeDeclaration, wideningKind: WideningKind) {
+        const signature = getContextualSignatureForFunctionLikeDeclaration(declaration);
+        if (!signature) {
+            return true;
+        }
+        let returnType = getReturnTypeOfSignature(signature);
+        const flags = getFunctionFlags(declaration);
+        switch (wideningKind) {
+            case WideningKind.FunctionReturn:
+                if (flags & FunctionFlags.Generator) {
+                    returnType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, !!(flags & FunctionFlags.Async)) ?? returnType;
+                }
+                else if (flags & FunctionFlags.Async) {
+                    returnType = getAwaitedTypeNoAlias(returnType) ?? returnType;
+                }
+                return isGenericType(returnType);
+            case WideningKind.GeneratorYield:
+                const yieldType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Yield, returnType, !!(flags & FunctionFlags.Async));
+                return !!yieldType && isGenericType(yieldType);
+            case WideningKind.GeneratorNext:
+                const nextType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Next, returnType, !!(flags & FunctionFlags.Async));
+                return !!nextType && isGenericType(nextType);
+        }
+        return false;
+    }
+
     function reportErrorsFromWidening(declaration: Declaration, type: Type, wideningKind?: WideningKind) {
         addLazyDiagnostic(() => {
-            if (noImplicitAny && getObjectFlags(type) & ObjectFlags.ContainsWideningType && (!wideningKind || !getContextualSignatureForFunctionLikeDeclaration(declaration as FunctionLikeDeclaration))) {
-                // Report implicit any error within type if possible, otherwise report error on declaration
-                if (!reportWideningErrorsInType(type)) {
-                    reportImplicitAny(declaration, type, wideningKind);
+            if (noImplicitAny && getObjectFlags(type) & ObjectFlags.ContainsWideningType) {
+                if (!wideningKind || isFunctionLikeDeclaration(declaration) && reportErrorsFromWideningWithContextualSignature(declaration, wideningKind)) {
+                    // Report implicit any error within type if possible, otherwise report error on declaration
+                    if (!reportWideningErrorsInType(type)) {
+                        reportImplicitAny(declaration, type, wideningKind);
+                    }
                 }
             }
         });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25535,7 +25535,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         errorOrSuggestion(noImplicitAny, declaration, diagnostic, declarationNameToString(getNameOfDeclaration(declaration)), typeAsString);
     }
 
-    function reportErrorsFromWideningWithContextualSignature(declaration: FunctionLikeDeclaration, wideningKind: WideningKind) {
+    function shouldReportErrorsFromWideningWithContextualSignature(declaration: FunctionLikeDeclaration, wideningKind: WideningKind) {
         const signature = getContextualSignatureForFunctionLikeDeclaration(declaration);
         if (!signature) {
             return true;
@@ -25564,7 +25564,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function reportErrorsFromWidening(declaration: Declaration, type: Type, wideningKind?: WideningKind) {
         addLazyDiagnostic(() => {
             if (noImplicitAny && getObjectFlags(type) & ObjectFlags.ContainsWideningType) {
-                if (!wideningKind || isFunctionLikeDeclaration(declaration) && reportErrorsFromWideningWithContextualSignature(declaration, wideningKind)) {
+                if (!wideningKind || isFunctionLikeDeclaration(declaration) && shouldReportErrorsFromWideningWithContextualSignature(declaration, wideningKind)) {
                     // Report implicit any error within type if possible, otherwise report error on declaration
                     if (!reportWideningErrorsInType(type)) {
                         reportImplicitAny(declaration, type, wideningKind);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6626,7 +6626,7 @@
         "category": "Error",
         "code": 7024
     },
-    "Generator implicitly has yield type '{0}' because it does not yield any values. Consider supplying a return type annotation.": {
+    "Generator implicitly has yield type '{0}'. Consider supplying a return type annotation.": {
         "category": "Error",
         "code": 7025
     },

--- a/tests/baselines/reference/generatorReturnTypeInferenceNonStrict.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeInferenceNonStrict.errors.txt
@@ -4,7 +4,7 @@ generatorReturnTypeInferenceNonStrict.ts(74,15): error TS7057: 'yield' expressio
 generatorReturnTypeInferenceNonStrict.ts(79,11): error TS7055: 'g301', which lacks return-type annotation, implicitly has an 'any' yield type.
 generatorReturnTypeInferenceNonStrict.ts(89,11): error TS7055: 'g303', which lacks return-type annotation, implicitly has an 'any' yield type.
 generatorReturnTypeInferenceNonStrict.ts(126,11): error TS7055: 'g310', which lacks return-type annotation, implicitly has an 'any' yield type.
-generatorReturnTypeInferenceNonStrict.ts(131,10): error TS7025: Generator implicitly has yield type 'any' because it does not yield any values. Consider supplying a return type annotation.
+generatorReturnTypeInferenceNonStrict.ts(131,10): error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
 
 
 ==== generatorReturnTypeInferenceNonStrict.ts (7 errors) ====
@@ -152,7 +152,7 @@ generatorReturnTypeInferenceNonStrict.ts(131,10): error TS7025: Generator implic
     function* g311() { // Generator<any (implicit), void, string>
     	yield* (function*() {
     	        ~~~~~~~~
-!!! error TS7025: Generator implicitly has yield type 'any' because it does not yield any values. Consider supplying a return type annotation.
+!!! error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
     		const y: string = yield;
     	})();
     }

--- a/tests/baselines/reference/generatorTypeCheck62.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck62.errors.txt
@@ -12,9 +12,10 @@ generatorTypeCheck62.ts(32,62): error TS2345: Argument of type '(state: State) =
         Type 'IteratorReturnResult<State>' is not assignable to type 'IteratorResult<any, void>'.
           Type 'IteratorReturnResult<State>' is not assignable to type 'IteratorReturnResult<void>'.
             Type 'State' is not assignable to type 'void'.
+generatorTypeCheck62.ts(32,62): error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
 
 
-==== generatorTypeCheck62.ts (2 errors) ====
+==== generatorTypeCheck62.ts (3 errors) ====
     export interface StrategicState {
         lastStrategyApplied?: string;
     }
@@ -63,6 +64,8 @@ generatorTypeCheck62.ts(32,62): error TS2345: Argument of type '(state: State) =
 !!! error TS2345:         Type 'IteratorReturnResult<State>' is not assignable to type 'IteratorResult<any, void>'.
 !!! error TS2345:           Type 'IteratorReturnResult<State>' is not assignable to type 'IteratorReturnResult<void>'.
 !!! error TS2345:             Type 'State' is not assignable to type 'void'.
+                                                                 ~~~~~~~~
+!!! error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
         yield ;
         return state; // `return`/`TReturn` isn't supported by `strategy`, so this should error.
     });

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.errors.txt
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.errors.txt
@@ -4,9 +4,11 @@ implicitAnyGenericTypeInference.ts(16,4): error TS7025: Generator implicitly has
 implicitAnyGenericTypeInference.ts(19,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
 implicitAnyGenericTypeInference.ts(22,4): error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
 implicitAnyGenericTypeInference.ts(25,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+implicitAnyGenericTypeInference.ts(28,25): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+implicitAnyGenericTypeInference.ts(29,24): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
 
 
-==== implicitAnyGenericTypeInference.ts (6 errors) ====
+==== implicitAnyGenericTypeInference.ts (8 errors) ====
     interface Comparer<T> {
         compareTo<U>(x: T, y: U): U;
     }
@@ -43,4 +45,12 @@ implicitAnyGenericTypeInference.ts(25,4): error TS7011: Function expression, whi
     declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
     f6(async function* () { return null; });
        ~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    
+    // https://github.com/microsoft/TypeScript/issues/44913
+    Promise.resolve().catch(e => null);
+                            ~~~~~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    Promise.resolve().then(v => null);
+                           ~~~~~~~~~
 !!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.errors.txt
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.errors.txt
@@ -1,0 +1,46 @@
+implicitAnyGenericTypeInference.ts(10,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+implicitAnyGenericTypeInference.ts(13,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+implicitAnyGenericTypeInference.ts(16,4): error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
+implicitAnyGenericTypeInference.ts(19,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+implicitAnyGenericTypeInference.ts(22,4): error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
+implicitAnyGenericTypeInference.ts(25,4): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+
+
+==== implicitAnyGenericTypeInference.ts (6 errors) ====
+    interface Comparer<T> {
+        compareTo<U>(x: T, y: U): U;
+    }
+    
+    var c: Comparer<any>;
+    c = { compareTo: (x, y) => { return y; } };
+    var r = c.compareTo(1, '');
+    
+    declare function f1<T>(cb: () => T): void;
+    f1(() => null);
+       ~~~~~~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    
+    declare function f2<T>(cb: () => PromiseLike<T>): void;
+    f2(async () => null);
+       ~~~~~~~~~~~~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    
+    declare function f3<T>(cb: () => Generator<T>): void;
+    f3(function* () { yield null; });
+       ~~~~~~~~
+!!! error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
+    
+    declare function f4<T>(cb: () => Generator<unknown, T>): void;
+    f4(function* () { return null; });
+       ~~~~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    
+    declare function f5<T>(cb: () => AsyncGenerator<T>): void;
+    f5(async function* () { yield null; });
+       ~~~~~
+!!! error TS7025: Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
+    
+    declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
+    f6(async function* () { return null; });
+       ~~~~~
+!!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.js
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.js
@@ -27,6 +27,10 @@ f5(async function* () { yield null; });
 declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
 f6(async function* () { return null; });
 
+// https://github.com/microsoft/TypeScript/issues/44913
+Promise.resolve().catch(e => null);
+Promise.resolve().then(v => null);
+
 //// [implicitAnyGenericTypeInference.js]
 var c;
 c = { compareTo: (x, y) => { return y; } };
@@ -37,3 +41,6 @@ f3(function* () { yield null; });
 f4(function* () { return null; });
 f5(async function* () { yield null; });
 f6(async function* () { return null; });
+// https://github.com/microsoft/TypeScript/issues/44913
+Promise.resolve().catch(e => null);
+Promise.resolve().then(v => null);

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.js
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.js
@@ -9,7 +9,31 @@ var c: Comparer<any>;
 c = { compareTo: (x, y) => { return y; } };
 var r = c.compareTo(1, '');
 
+declare function f1<T>(cb: () => T): void;
+f1(() => null);
+
+declare function f2<T>(cb: () => PromiseLike<T>): void;
+f2(async () => null);
+
+declare function f3<T>(cb: () => Generator<T>): void;
+f3(function* () { yield null; });
+
+declare function f4<T>(cb: () => Generator<unknown, T>): void;
+f4(function* () { return null; });
+
+declare function f5<T>(cb: () => AsyncGenerator<T>): void;
+f5(async function* () { yield null; });
+
+declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
+f6(async function* () { return null; });
+
 //// [implicitAnyGenericTypeInference.js]
 var c;
-c = { compareTo: function (x, y) { return y; } };
+c = { compareTo: (x, y) => { return y; } };
 var r = c.compareTo(1, '');
+f1(() => null);
+f2(async () => null);
+f3(function* () { yield null; });
+f4(function* () { return null; });
+f5(async function* () { yield null; });
+f6(async function* () { return null; });

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.symbols
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.symbols
@@ -91,3 +91,20 @@ declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
 f6(async function* () { return null; });
 >f6 : Symbol(f6, Decl(implicitAnyGenericTypeInference.ts, 21, 39))
 
+// https://github.com/microsoft/TypeScript/issues/44913
+Promise.resolve().catch(e => null);
+>Promise.resolve().catch : Symbol(Promise.catch, Decl(lib.es5.d.ts, --, --))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>catch : Symbol(Promise.catch, Decl(lib.es5.d.ts, --, --))
+>e : Symbol(e, Decl(implicitAnyGenericTypeInference.ts, 27, 24))
+
+Promise.resolve().then(v => null);
+>Promise.resolve().then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
+>v : Symbol(v, Decl(implicitAnyGenericTypeInference.ts, 28, 23))
+

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.symbols
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.symbols
@@ -32,3 +32,62 @@ var r = c.compareTo(1, '');
 >c : Symbol(c, Decl(implicitAnyGenericTypeInference.ts, 4, 3))
 >compareTo : Symbol(Comparer.compareTo, Decl(implicitAnyGenericTypeInference.ts, 0, 23))
 
+declare function f1<T>(cb: () => T): void;
+>f1 : Symbol(f1, Decl(implicitAnyGenericTypeInference.ts, 6, 27))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 8, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 8, 23))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 8, 20))
+
+f1(() => null);
+>f1 : Symbol(f1, Decl(implicitAnyGenericTypeInference.ts, 6, 27))
+
+declare function f2<T>(cb: () => PromiseLike<T>): void;
+>f2 : Symbol(f2, Decl(implicitAnyGenericTypeInference.ts, 9, 15))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 11, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 11, 23))
+>PromiseLike : Symbol(PromiseLike, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 11, 20))
+
+f2(async () => null);
+>f2 : Symbol(f2, Decl(implicitAnyGenericTypeInference.ts, 9, 15))
+
+declare function f3<T>(cb: () => Generator<T>): void;
+>f3 : Symbol(f3, Decl(implicitAnyGenericTypeInference.ts, 12, 21))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 14, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 14, 23))
+>Generator : Symbol(Generator, Decl(lib.es2015.generator.d.ts, --, --))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 14, 20))
+
+f3(function* () { yield null; });
+>f3 : Symbol(f3, Decl(implicitAnyGenericTypeInference.ts, 12, 21))
+
+declare function f4<T>(cb: () => Generator<unknown, T>): void;
+>f4 : Symbol(f4, Decl(implicitAnyGenericTypeInference.ts, 15, 33))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 17, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 17, 23))
+>Generator : Symbol(Generator, Decl(lib.es2015.generator.d.ts, --, --))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 17, 20))
+
+f4(function* () { return null; });
+>f4 : Symbol(f4, Decl(implicitAnyGenericTypeInference.ts, 15, 33))
+
+declare function f5<T>(cb: () => AsyncGenerator<T>): void;
+>f5 : Symbol(f5, Decl(implicitAnyGenericTypeInference.ts, 18, 34))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 20, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 20, 23))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 20, 20))
+
+f5(async function* () { yield null; });
+>f5 : Symbol(f5, Decl(implicitAnyGenericTypeInference.ts, 18, 34))
+
+declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
+>f6 : Symbol(f6, Decl(implicitAnyGenericTypeInference.ts, 21, 39))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 23, 20))
+>cb : Symbol(cb, Decl(implicitAnyGenericTypeInference.ts, 23, 23))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(implicitAnyGenericTypeInference.ts, 23, 20))
+
+f6(async function* () { return null; });
+>f6 : Symbol(f6, Decl(implicitAnyGenericTypeInference.ts, 21, 39))
+

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.types
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.types
@@ -1,5 +1,9 @@
 //// [tests/cases/compiler/implicitAnyGenericTypeInference.ts] ////
 
+=== Performance Stats ===
+Type Count: 1,000
+Instantiation count: 2,500
+
 === implicitAnyGenericTypeInference.ts ===
 interface Comparer<T> {
     compareTo<U>(x: T, y: U): U;
@@ -27,6 +31,7 @@ c = { compareTo: (x, y) => { return y; } };
 >(x, y) => { return y; } : <U>(x: any, y: U) => U
 >                        : ^ ^^ ^^^^^^^ ^^^^^^^^^
 >x : any
+>  : ^^^
 >y : U
 >  : ^
 >y : U
@@ -47,4 +52,92 @@ var r = c.compareTo(1, '');
 >  : ^
 >'' : ""
 >   : ^^
+
+declare function f1<T>(cb: () => T): void;
+>f1 : <T>(cb: () => T) => void
+>   : ^ ^^  ^^       ^^^^^    
+>cb : () => T
+>   : ^^^^^^ 
+
+f1(() => null);
+>f1(() => null) : void
+>               : ^^^^
+>f1 : <T>(cb: () => T) => void
+>   : ^ ^^  ^^       ^^^^^    
+>() => null : () => any
+>           : ^^^^^^^^^
+
+declare function f2<T>(cb: () => PromiseLike<T>): void;
+>f2 : <T>(cb: () => PromiseLike<T>) => void
+>   : ^ ^^  ^^                    ^^^^^    
+>cb : () => PromiseLike<T>
+>   : ^^^^^^              
+
+f2(async () => null);
+>f2(async () => null) : void
+>                     : ^^^^
+>f2 : <T>(cb: () => PromiseLike<T>) => void
+>   : ^ ^^  ^^                    ^^^^^    
+>async () => null : () => Promise<any>
+>                 : ^^^^^^^^^^^^^^^^^^
+
+declare function f3<T>(cb: () => Generator<T>): void;
+>f3 : <T>(cb: () => Generator<T>) => void
+>   : ^ ^^  ^^                  ^^^^^    
+>cb : () => Generator<T>
+>   : ^^^^^^            
+
+f3(function* () { yield null; });
+>f3(function* () { yield null; }) : void
+>                                 : ^^^^
+>f3 : <T>(cb: () => Generator<T>) => void
+>   : ^ ^^  ^^                  ^^^^^    
+>function* () { yield null; } : () => Generator<any, void, any>
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>yield null : any
+>           : ^^^
+
+declare function f4<T>(cb: () => Generator<unknown, T>): void;
+>f4 : <T>(cb: () => Generator<unknown, T>) => void
+>   : ^ ^^  ^^                           ^^^^^    
+>cb : () => Generator<unknown, T>
+>   : ^^^^^^                     
+
+f4(function* () { return null; });
+>f4(function* () { return null; }) : void
+>                                  : ^^^^
+>f4 : <T>(cb: () => Generator<unknown, T>) => void
+>   : ^ ^^  ^^                           ^^^^^    
+>function* () { return null; } : () => Generator<never, any, any>
+>                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+declare function f5<T>(cb: () => AsyncGenerator<T>): void;
+>f5 : <T>(cb: () => AsyncGenerator<T>) => void
+>   : ^ ^^  ^^                       ^^^^^    
+>cb : () => AsyncGenerator<T>
+>   : ^^^^^^                 
+
+f5(async function* () { yield null; });
+>f5(async function* () { yield null; }) : void
+>                                       : ^^^^
+>f5 : <T>(cb: () => AsyncGenerator<T>) => void
+>   : ^ ^^  ^^                       ^^^^^    
+>async function* () { yield null; } : () => AsyncGenerator<any, void, any>
+>                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>yield null : any
+>           : ^^^
+
+declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
+>f6 : <T>(cb: () => AsyncGenerator<unknown, T>) => void
+>   : ^ ^^  ^^                                ^^^^^    
+>cb : () => AsyncGenerator<unknown, T>
+>   : ^^^^^^                          
+
+f6(async function* () { return null; });
+>f6(async function* () { return null; }) : void
+>                                        : ^^^^
+>f6 : <T>(cb: () => AsyncGenerator<unknown, T>) => void
+>   : ^ ^^  ^^                                ^^^^^    
+>async function* () { return null; } : () => AsyncGenerator<never, any, any>
+>                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/implicitAnyGenericTypeInference.types
+++ b/tests/baselines/reference/implicitAnyGenericTypeInference.types
@@ -141,3 +141,44 @@ f6(async function* () { return null; });
 >async function* () { return null; } : () => AsyncGenerator<never, any, any>
 >                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+// https://github.com/microsoft/TypeScript/issues/44913
+Promise.resolve().catch(e => null);
+>Promise.resolve().catch(e => null) : Promise<any>
+>                                   : ^^^^^^^^^^^^
+>Promise.resolve().catch : <TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>) => Promise<void | TResult>
+>                        : ^       ^^^^^^^^^^          ^^^^      ^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Promise.resolve() : Promise<void>
+>                  : ^^^^^^^^^^^^^
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>                : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>catch : <TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>) => Promise<void | TResult>
+>      : ^       ^^^^^^^^^^          ^^^^      ^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>e => null : (e: any) => any
+>          : ^ ^^^^^^^^^^^^^
+>e : any
+>  : ^^^
+
+Promise.resolve().then(v => null);
+>Promise.resolve().then(v => null) : Promise<any>
+>                                  : ^^^^^^^^^^^^
+>Promise.resolve().then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>                       : ^        ^^^^^^^^^        ^^^^^^^^^^           ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^^^^      ^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Promise.resolve() : Promise<void>
+>                  : ^^^^^^^^^^^^^
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>                : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>Promise : PromiseConstructor
+>        : ^^^^^^^^^^^^^^^^^^
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>        : ^^^^^^             ^^^ ^^     ^^ ^^^                   ^^^ ^^     ^^                  ^^^                   ^^^
+>then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>     : ^        ^^^^^^^^^        ^^^^^^^^^^           ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^^^^      ^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>v => null : (v: void) => any
+>          : ^ ^^^^^^^^^^^^^^
+>v : void
+>  : ^^^^
+

--- a/tests/cases/compiler/implicitAnyGenericTypeInference.ts
+++ b/tests/cases/compiler/implicitAnyGenericTypeInference.ts
@@ -1,4 +1,5 @@
 // @noimplicitany: true
+// @target: esnext
 
 interface Comparer<T> {
     compareTo<U>(x: T, y: U): U;
@@ -7,3 +8,21 @@ interface Comparer<T> {
 var c: Comparer<any>;
 c = { compareTo: (x, y) => { return y; } };
 var r = c.compareTo(1, '');
+
+declare function f1<T>(cb: () => T): void;
+f1(() => null);
+
+declare function f2<T>(cb: () => PromiseLike<T>): void;
+f2(async () => null);
+
+declare function f3<T>(cb: () => Generator<T>): void;
+f3(function* () { yield null; });
+
+declare function f4<T>(cb: () => Generator<unknown, T>): void;
+f4(function* () { return null; });
+
+declare function f5<T>(cb: () => AsyncGenerator<T>): void;
+f5(async function* () { yield null; });
+
+declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
+f6(async function* () { return null; });

--- a/tests/cases/compiler/implicitAnyGenericTypeInference.ts
+++ b/tests/cases/compiler/implicitAnyGenericTypeInference.ts
@@ -26,3 +26,7 @@ f5(async function* () { yield null; });
 
 declare function f6<T>(cb: () => AsyncGenerator<unknown, T>): void;
 f6(async function* () { return null; });
+
+// https://github.com/microsoft/TypeScript/issues/44913
+Promise.resolve().catch(e => null);
+Promise.resolve().then(v => null);


### PR DESCRIPTION
This adds a missing implicit-any error when we would infer `any` from the body of a function as the result of widening when that function has a contextual signature whose return type is generic.

This is intended to catch cases like the following:

```ts
// @strictNullChecks: false
// @noImplicitAny: true
declare var p: Promise<number>;
const p2 = p.catch(() => null);
//    ^? p2: Promise<any>;
```

Fixes #44913
