### PR TITLE
Add lint rule to prevent misuse of Comparison enum

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -156,6 +156,7 @@ export default tseslint.config(
             "local/jsdoc-format": "error",
             "local/js-extensions": "error",
             "local/no-array-mutating-method-expressions": "error",
+            "local/no-comparison-equality": "error",
         },
     },
     {

--- a/scripts/eslint/rules/no-comparison-equality.cjs
+++ b/scripts/eslint/rules/no-comparison-equality.cjs
@@ -1,0 +1,34 @@
+const { createRule } = require("./utils.cjs");
+
+/** @import { TSESTree } from "@typescript-eslint/utils" */
+void 0;
+
+module.exports = createRule({
+    name: "no-comparison-equality",
+    meta: {
+        docs: {
+            description: ``,
+        },
+        messages: {
+            noCompare: `Do not compare against {{comparison}} directly; compare against zero or Comparison.EqualTo instead.`,
+        },
+        schema: [],
+        type: "problem",
+    },
+    defaultOptions: [],
+
+    create(context) {
+        /** @type {(node: TSESTree.MemberExpression & { property: TSESTree.Identifier }) => void} */
+        const noCompare = node => {
+            if (node.property.name === "EqualTo") return;
+            context.report({ messageId: "noCompare", node, data: { comparison: context.sourceCode.getText(node) } });
+        };
+
+        const comparisonMemberExpression = "MemberExpression[object.name='Comparison']";
+
+        return {
+            [`SwitchCase > ${comparisonMemberExpression}`]: noCompare,
+            [`BinaryExpression[operator=/(===?|!==?)/] > ${comparisonMemberExpression}`]: noCompare,
+        };
+    },
+});

--- a/scripts/eslint/tests/no-comparison-equality.cjs
+++ b/scripts/eslint/tests/no-comparison-equality.cjs
@@ -1,0 +1,106 @@
+const { RuleTester } = require("./support/RuleTester.cjs");
+const rule = require("../rules/no-comparison-equality.cjs");
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        warnOnUnsupportedTypeScriptVersion: false,
+    },
+    parser: require.resolve("@typescript-eslint/parser"),
+});
+
+ruleTester.run("no-comparison-equality", rule, {
+    valid: [
+        {
+            code: `if (value > 0) {}`,
+        },
+        {
+            code: `
+if (value === Comparison.EqualTo) {}
+if (value !== Comparison.EqualTo) {}
+if (value == Comparison.EqualTo) {}
+if (value != Comparison.EqualTo) {}
+if (Comparison.EqualTo === value) {}
+if (Comparison.EqualTo !== value) {}
+if (Comparison.EqualTo == value) {}
+if (Comparison.EqualTo != value) {}
+            `,
+        },
+    ],
+
+    invalid: [
+        {
+            code: `
+switch (value) {
+    case Comparison.EqualTo:
+        break;
+    case Comparison.GreaterThan:
+        break;
+    case Comparison.LessThan:
+        break;
+}
+            `,
+            errors: [
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+            ],
+        },
+        {
+            code: `
+if (value === Comparison.LessThan) {}
+if (value !== Comparison.LessThan) {}
+if (value == Comparison.LessThan) {}
+if (value != Comparison.LessThan) {}
+if (Comparison.LessThan === value) {}
+if (Comparison.LessThan !== value) {}
+if (Comparison.LessThan == value) {}
+if (Comparison.LessThan != value) {}
+            `,
+            errors: [
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+            ],
+        },
+        {
+            code: `
+if (value === Comparison.GreaterThan) {}
+if (value !== Comparison.GreaterThan) {}
+if (value == Comparison.GreaterThan) {}
+if (value != Comparison.GreaterThan) {}
+if (Comparison.GreaterThan === value) {}
+if (Comparison.GreaterThan !== value) {}
+if (Comparison.GreaterThan == value) {}
+if (Comparison.GreaterThan != value) {}
+            `,
+            errors: [
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+            ],
+        },
+        {
+            code: `
+if (value === Comparison.Something) {}
+if (value !== Comparison.Something) {}
+if (value == Comparison.Something) {}
+if (value != Comparison.Something) {}
+            `,
+            errors: [
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+                { messageId: "noCompare" },
+            ],
+        },
+    ],
+});

--- a/scripts/eslint/tests/no-comparison-equality.cjs
+++ b/scripts/eslint/tests/no-comparison-equality.cjs
@@ -2,10 +2,11 @@ const { RuleTester } = require("./support/RuleTester.cjs");
 const rule = require("../rules/no-comparison-equality.cjs");
 
 const ruleTester = new RuleTester({
-    parserOptions: {
-        warnOnUnsupportedTypeScriptVersion: false,
+    languageOptions: {
+        parserOptions: {
+            warnOnUnsupportedTypeScriptVersion: false,
+        },
     },
-    parser: require.resolve("@typescript-eslint/parser"),
 });
 
 ruleTester.run("no-comparison-equality", rule, {


### PR DESCRIPTION
Alternative to #52897 to say to never ever try and equate Comparison values