### PR TITLE
fix Set().entries() inference

### DIFF
--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -181,7 +181,7 @@ interface Set<T> {
     /**
      * Returns an iterable of [v,v] pairs for every value `v` in the set.
      */
-    entries(): SetIterator<[T, T]>;
+    entries(): SetIterator<T extends string | number | symbol ? { [K in T]: [K, K]; }[T] : [T, T]>;
     /**
      * Despite its name, returns an iterable of the values in the set.
      */
@@ -200,7 +200,7 @@ interface ReadonlySet<T> {
     /**
      * Returns an iterable of [v,v] pairs for every value `v` in the set.
      */
-    entries(): SetIterator<[T, T]>;
+    entries(): SetIterator<T extends string | number | symbol ? { [K in T]: [K, K]; }[T] : [T, T]>;
 
     /**
      * Despite its name, returns an iterable of the values in the set.


### PR DESCRIPTION
Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Fixes #

If someone can point me to where I can write a test for this, happy to do so.

the updates I've made solve for this case:

```ts
type Actual = Set<'foo' | 'bar'>['entries'];
// ^? () => IterableIterator<['foo' | 'bar', 'foo' | 'bar']>
type Expected = () => IterableIterator<["foo", "foo"] | ["bar", "bar"]>;
```