### PR TITLE
Fix Set of one string literal bug in openExternalProject

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -4959,7 +4959,7 @@ export class ProjectService {
         if (cleanupAfter) {
             this.cleanupConfiguredProjects(
                 configuredProjects,
-                new Set(proj.projectFileName),
+                new Set([proj.projectFileName]),
             );
             this.printProjects();
         }


### PR DESCRIPTION
No test changed, which is... interesting.

Noted in https://github.com/microsoft/TypeScript/pull/59683#issuecomment-2297157267