### PR TITLE
Use correct line endings in built typesMap.json

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -607,7 +607,7 @@ export const generateTypesMap = task({
         const target = "built/local/typesMap.json";
         const contents = await fs.promises.readFile(source, "utf-8");
         JSON.parse(contents); // Validates that the JSON parses.
-        await fs.promises.writeFile(target, contents);
+        await fs.promises.writeFile(target, contents.replace(/\r\n/g, "\n"));
     },
 });
 


### PR DESCRIPTION
This is the one file in our entire package with CRLF line endings. I must have missed this when I refactored the build in 5.0 and corrected most of these problems.