### PR TITLE
Improve logic that chooses co- vs. contra-variant return type inferences

### DIFF
--- a/tests/baselines/reference/coAndContraVariantInferences10.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences10.symbols
@@ -1,0 +1,216 @@
+//// [tests/cases/compiler/coAndContraVariantInferences10.ts] ////
+
+=== coAndContraVariantInferences10.ts ===
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 2, 21))
+
+  pipe: <A>(op: (source: Observable<T>) => Observable<A>) => Observable<A>;
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>A : Symbol(A, Decl(coAndContraVariantInferences10.ts, 3, 9))
+>op : Symbol(op, Decl(coAndContraVariantInferences10.ts, 3, 12))
+>source : Symbol(source, Decl(coAndContraVariantInferences10.ts, 3, 17))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 2, 21))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>A : Symbol(A, Decl(coAndContraVariantInferences10.ts, 3, 9))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>A : Symbol(A, Decl(coAndContraVariantInferences10.ts, 3, 9))
+
+  _v: T;
+>_v : Symbol(Observable._v, Decl(coAndContraVariantInferences10.ts, 3, 75))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 2, 21))
+}
+declare function tap<T>(
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 6, 21))
+
+  next: (value: T) => void,
+>next : Symbol(next, Decl(coAndContraVariantInferences10.ts, 6, 24))
+>value : Symbol(value, Decl(coAndContraVariantInferences10.ts, 7, 9))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 6, 21))
+
+): (source: Observable<T>) => Observable<T>;
+>source : Symbol(source, Decl(coAndContraVariantInferences10.ts, 8, 4))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 6, 21))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences10.ts, 6, 21))
+
+declare const obs1: Observable<{
+>obs1 : Symbol(obs1, Decl(coAndContraVariantInferences10.ts, 10, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 10, 32))
+
+}>;
+function test1(): Observable<{}> {
+>test1 : Symbol(test1, Decl(coAndContraVariantInferences10.ts, 12, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  return obs1.pipe(tap((arg) => {}));
+>obs1.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs1 : Symbol(obs1, Decl(coAndContraVariantInferences10.ts, 10, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 14, 24))
+}
+
+declare const obs2: Observable<{
+>obs2 : Symbol(obs2, Decl(coAndContraVariantInferences10.ts, 17, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 17, 32))
+
+}>;
+function test2(): Observable<{}> {
+>test2 : Symbol(test2, Decl(coAndContraVariantInferences10.ts, 19, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  return obs2.pipe(tap((arg) => {}));
+>obs2.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs2 : Symbol(obs2, Decl(coAndContraVariantInferences10.ts, 17, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 21, 24))
+}
+
+declare const obs3: Observable<{
+>obs3 : Symbol(obs3, Decl(coAndContraVariantInferences10.ts, 24, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 24, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences10.ts, 25, 15))
+
+}>;
+function test3(): Observable<{}> {
+>test3 : Symbol(test3, Decl(coAndContraVariantInferences10.ts, 27, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  return obs3.pipe(tap((arg) => {}));
+>obs3.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs3 : Symbol(obs3, Decl(coAndContraVariantInferences10.ts, 24, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 29, 24))
+}
+
+declare const obs4: Observable<{
+>obs4 : Symbol(obs4, Decl(coAndContraVariantInferences10.ts, 32, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 32, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences10.ts, 33, 16))
+
+}>;
+function test4(): Observable<{ prop?: string }> {
+>test4 : Symbol(test4, Decl(coAndContraVariantInferences10.ts, 35, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 36, 30))
+
+  return obs4.pipe(tap((arg) => {}));
+>obs4.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs4 : Symbol(obs4, Decl(coAndContraVariantInferences10.ts, 32, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 37, 24))
+}
+
+declare const obs5: Observable<{
+>obs5 : Symbol(obs5, Decl(coAndContraVariantInferences10.ts, 40, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 40, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences10.ts, 41, 15))
+
+}>;
+function test5(): Observable<{ prop: string }> {
+>test5 : Symbol(test5, Decl(coAndContraVariantInferences10.ts, 43, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 44, 30))
+
+  return obs5.pipe(tap((arg) => {}));
+>obs5.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs5 : Symbol(obs5, Decl(coAndContraVariantInferences10.ts, 40, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 45, 24))
+}
+
+declare const obs6: Observable<{
+>obs6 : Symbol(obs6, Decl(coAndContraVariantInferences10.ts, 48, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 48, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences10.ts, 49, 15))
+
+}>;
+function test6(): Observable<{ prop2?: number }> {
+>test6 : Symbol(test6, Decl(coAndContraVariantInferences10.ts, 51, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences10.ts, 52, 30))
+
+  return obs6.pipe(tap((arg) => {}));
+>obs6.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs6 : Symbol(obs6, Decl(coAndContraVariantInferences10.ts, 48, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 53, 24))
+}
+
+declare const obs7: Observable<{
+>obs7 : Symbol(obs7, Decl(coAndContraVariantInferences10.ts, 56, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 56, 32))
+
+}>;
+function test7(): Observable<any> {
+>test7 : Symbol(test7, Decl(coAndContraVariantInferences10.ts, 58, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  return obs7.pipe(tap((arg) => {}));
+>obs7.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs7 : Symbol(obs7, Decl(coAndContraVariantInferences10.ts, 56, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 60, 24))
+}
+
+declare const obs8: Observable<{
+>obs8 : Symbol(obs8, Decl(coAndContraVariantInferences10.ts, 63, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences10.ts, 63, 32))
+
+}>;
+function test8(): Observable<unknown> {
+>test8 : Symbol(test8, Decl(coAndContraVariantInferences10.ts, 65, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences10.ts, 0, 0))
+
+  return obs8.pipe(tap((arg) => {}));
+>obs8.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>obs8 : Symbol(obs8, Decl(coAndContraVariantInferences10.ts, 63, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences10.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences10.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences10.ts, 67, 24))
+}
+

--- a/tests/baselines/reference/coAndContraVariantInferences10.types
+++ b/tests/baselines/reference/coAndContraVariantInferences10.types
@@ -1,0 +1,310 @@
+//// [tests/cases/compiler/coAndContraVariantInferences10.ts] ////
+
+=== coAndContraVariantInferences10.ts ===
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+  pipe: <A>(op: (source: Observable<T>) => Observable<A>) => Observable<A>;
+>pipe : <A>(op: (source: Observable<T>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^                                        ^^^^^             
+>op : (source: Observable<T>) => Observable<A>
+>   : ^      ^^             ^^^^^             
+>source : Observable<T>
+>       : ^^^^^^^^^^^^^
+
+  _v: T;
+>_v : T
+>   : ^
+}
+declare function tap<T>(
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+
+  next: (value: T) => void,
+>next : (value: T) => void
+>     : ^     ^^ ^^^^^    
+>value : T
+>      : ^
+
+): (source: Observable<T>) => Observable<T>;
+>source : Observable<T>
+>       : ^^^^^^^^^^^^^
+
+declare const obs1: Observable<{
+>obs1 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test1(): Observable<{}> {
+>test1 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs1.pipe(tap((arg) => {}));
+>obs1.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs1.pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs1 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop?: string; }>) => Observable<{ prop?: string; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const obs2: Observable<{
+>obs2 : Observable<{ prop: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+}>;
+function test2(): Observable<{}> {
+>test2 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs2.pipe(tap((arg) => {}));
+>obs2.pipe(tap((arg) => {})) : Observable<{ prop: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs2.pipe : <A>(op: (source: Observable<{ prop: string; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs2 : Observable<{ prop: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop: string; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop: string; }>) => Observable<{ prop: string; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop: string; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; }
+>    : ^^^^^^^^      ^^^
+}
+
+declare const obs3: Observable<{
+>obs3 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test3(): Observable<{}> {
+>test3 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs3.pipe(tap((arg) => {}));
+>obs3.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs3.pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs3 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop: string; prop2?: number; }>) => Observable<{ prop: string; prop2?: number; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs4: Observable<{
+>obs4 : Observable<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test4(): Observable<{ prop?: string }> {
+>test4 : () => Observable<{ prop?: string; }>
+>      : ^^^^^^                              
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  return obs4.pipe(tap((arg) => {}));
+>obs4.pipe(tap((arg) => {})) : Observable<{ prop?: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs4.pipe : <A>(op: (source: Observable<{ prop?: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs4 : Observable<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop?: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop?: string; prop2?: number; }>) => Observable<{ prop?: string; prop2?: number; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop?: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; prop2?: number; }
+>    : ^^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs5: Observable<{
+>obs5 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test5(): Observable<{ prop: string }> {
+>test5 : () => Observable<{ prop: string; }>
+>      : ^^^^^^                             
+>prop : string
+>     : ^^^^^^
+
+  return obs5.pipe(tap((arg) => {}));
+>obs5.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs5.pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs5 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop: string; prop2?: number; }>) => Observable<{ prop: string; prop2?: number; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs6: Observable<{
+>obs6 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test6(): Observable<{ prop2?: number }> {
+>test6 : () => Observable<{ prop2?: number; }>
+>      : ^^^^^^                               
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+  return obs6.pipe(tap((arg) => {}));
+>obs6.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs6.pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs6 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop: string; prop2?: number; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop: string; prop2?: number; }>) => Observable<{ prop: string; prop2?: number; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs7: Observable<{
+>obs7 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test7(): Observable<any> {
+>test7 : () => Observable<any>
+>      : ^^^^^^               
+
+  return obs7.pipe(tap((arg) => {}));
+>obs7.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs7.pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs7 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop?: string; }>) => Observable<{ prop?: string; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const obs8: Observable<{
+>obs8 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test8(): Observable<unknown> {
+>test8 : () => Observable<unknown>
+>      : ^^^^^^                   
+
+  return obs8.pipe(tap((arg) => {}));
+>obs8.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs8.pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>          : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs8 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: (source: Observable<{ prop?: string; }>) => Observable<A>) => Observable<A>
+>     : ^ ^^  ^^^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: Observable<{ prop?: string; }>) => Observable<{ prop?: string; }>
+>                 : ^      ^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => (source: Observable<T>) => Observable<T>
+>    : ^ ^^    ^^                  ^^^^^                                        
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+

--- a/tests/baselines/reference/coAndContraVariantInferences11.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences11.symbols
@@ -1,0 +1,199 @@
+//// [tests/cases/compiler/coAndContraVariantInferences11.ts] ////
+
+=== coAndContraVariantInferences11.ts ===
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Box<T> {
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 2, 14))
+
+  select: <A>(op: (source: T) => A) => A;
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>A : Symbol(A, Decl(coAndContraVariantInferences11.ts, 3, 11))
+>op : Symbol(op, Decl(coAndContraVariantInferences11.ts, 3, 14))
+>source : Symbol(source, Decl(coAndContraVariantInferences11.ts, 3, 19))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 2, 14))
+>A : Symbol(A, Decl(coAndContraVariantInferences11.ts, 3, 11))
+>A : Symbol(A, Decl(coAndContraVariantInferences11.ts, 3, 11))
+
+  _v: T;
+>_v : Symbol(Box._v, Decl(coAndContraVariantInferences11.ts, 3, 41))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 2, 14))
+}
+declare function tap<T>(next: (value: T) => void): (source: T) => T;
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 6, 21))
+>next : Symbol(next, Decl(coAndContraVariantInferences11.ts, 6, 24))
+>value : Symbol(value, Decl(coAndContraVariantInferences11.ts, 6, 31))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 6, 21))
+>source : Symbol(source, Decl(coAndContraVariantInferences11.ts, 6, 52))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 6, 21))
+>T : Symbol(T, Decl(coAndContraVariantInferences11.ts, 6, 21))
+
+declare const box1: Box<{
+>box1 : Symbol(box1, Decl(coAndContraVariantInferences11.ts, 8, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 8, 25))
+
+}>;
+function test1(): {} {
+>test1 : Symbol(test1, Decl(coAndContraVariantInferences11.ts, 10, 3))
+
+  return box1.select(tap((arg) => {}));
+>box1.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box1 : Symbol(box1, Decl(coAndContraVariantInferences11.ts, 8, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 12, 26))
+}
+
+declare const box2: Box<{
+>box2 : Symbol(box2, Decl(coAndContraVariantInferences11.ts, 15, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 15, 25))
+
+}>;
+function test2(): {} {
+>test2 : Symbol(test2, Decl(coAndContraVariantInferences11.ts, 17, 3))
+
+  return box2.select(tap((arg) => {}));
+>box2.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box2 : Symbol(box2, Decl(coAndContraVariantInferences11.ts, 15, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 19, 26))
+}
+
+declare const box3: Box<{
+>box3 : Symbol(box3, Decl(coAndContraVariantInferences11.ts, 22, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 22, 25))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences11.ts, 23, 15))
+
+}>;
+function test3(): {} {
+>test3 : Symbol(test3, Decl(coAndContraVariantInferences11.ts, 25, 3))
+
+  return box3.select(tap((arg) => {}));
+>box3.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box3 : Symbol(box3, Decl(coAndContraVariantInferences11.ts, 22, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 27, 26))
+}
+
+declare const box4: Box<{
+>box4 : Symbol(box4, Decl(coAndContraVariantInferences11.ts, 30, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 30, 25))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences11.ts, 31, 16))
+
+}>;
+function test4(): { prop?: string } {
+>test4 : Symbol(test4, Decl(coAndContraVariantInferences11.ts, 33, 3))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 34, 19))
+
+  return box4.select(tap((arg) => {}));
+>box4.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box4 : Symbol(box4, Decl(coAndContraVariantInferences11.ts, 30, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 35, 26))
+}
+
+declare const box5: Box<{
+>box5 : Symbol(box5, Decl(coAndContraVariantInferences11.ts, 38, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 38, 25))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences11.ts, 39, 15))
+
+}>;
+function test5(): { prop: string } {
+>test5 : Symbol(test5, Decl(coAndContraVariantInferences11.ts, 41, 3))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 42, 19))
+
+  return box5.select(tap((arg) => {}));
+>box5.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box5 : Symbol(box5, Decl(coAndContraVariantInferences11.ts, 38, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 43, 26))
+}
+
+declare const box6: Box<{
+>box6 : Symbol(box6, Decl(coAndContraVariantInferences11.ts, 46, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 46, 25))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences11.ts, 47, 15))
+
+}>;
+function test6(): { prop2?: number } {
+>test6 : Symbol(test6, Decl(coAndContraVariantInferences11.ts, 49, 3))
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences11.ts, 50, 19))
+
+  return box6.select(tap((arg) => {}));
+>box6.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box6 : Symbol(box6, Decl(coAndContraVariantInferences11.ts, 46, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 51, 26))
+}
+
+declare const box7: Box<{
+>box7 : Symbol(box7, Decl(coAndContraVariantInferences11.ts, 54, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 54, 25))
+
+}>;
+function test7(): any {
+>test7 : Symbol(test7, Decl(coAndContraVariantInferences11.ts, 56, 3))
+
+  return box7.select(tap((arg) => {}));
+>box7.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box7 : Symbol(box7, Decl(coAndContraVariantInferences11.ts, 54, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 58, 26))
+}
+
+declare const box8: Box<{
+>box8 : Symbol(box8, Decl(coAndContraVariantInferences11.ts, 61, 13))
+>Box : Symbol(Box, Decl(coAndContraVariantInferences11.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences11.ts, 61, 25))
+
+}>;
+function test8(): unknown {
+>test8 : Symbol(test8, Decl(coAndContraVariantInferences11.ts, 63, 3))
+
+  return box8.select(tap((arg) => {}));
+>box8.select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>box8 : Symbol(box8, Decl(coAndContraVariantInferences11.ts, 61, 13))
+>select : Symbol(Box.select, Decl(coAndContraVariantInferences11.ts, 2, 18))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences11.ts, 5, 1))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences11.ts, 65, 26))
+}
+

--- a/tests/baselines/reference/coAndContraVariantInferences11.types
+++ b/tests/baselines/reference/coAndContraVariantInferences11.types
@@ -1,0 +1,306 @@
+//// [tests/cases/compiler/coAndContraVariantInferences11.ts] ////
+
+=== coAndContraVariantInferences11.ts ===
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Box<T> {
+  select: <A>(op: (source: T) => A) => A;
+>select : <A>(op: (source: T) => A) => A
+>       : ^ ^^  ^^                ^^^^^ 
+>op : (source: T) => A
+>   : ^      ^^ ^^^^^ 
+>source : T
+>       : ^
+
+  _v: T;
+>_v : T
+>   : ^
+}
+declare function tap<T>(next: (value: T) => void): (source: T) => T;
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>next : (value: T) => void
+>     : ^     ^^ ^^^^^    
+>value : T
+>      : ^
+>source : T
+>       : ^
+
+declare const box1: Box<{
+>box1 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test1(): {} {
+>test1 : () => {}
+>      : ^^^^^^  
+
+  return box1.select(tap((arg) => {}));
+>box1.select(tap((arg) => {})) : { prop?: string; }
+>                              : ^^^^^^^^^      ^^^
+>box1.select : <A>(op: (source: { prop?: string; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box1 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop?: string; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop?: string; }) => { prop?: string; }
+>                 : ^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const box2: Box<{
+>box2 : Box<{ prop: string; }>
+>     : ^^^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+}>;
+function test2(): {} {
+>test2 : () => {}
+>      : ^^^^^^  
+
+  return box2.select(tap((arg) => {}));
+>box2.select(tap((arg) => {})) : { prop: string; }
+>                              : ^^^^^^^^      ^^^
+>box2.select : <A>(op: (source: { prop: string; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box2 : Box<{ prop: string; }>
+>     : ^^^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop: string; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop: string; }) => { prop: string; }
+>                 : ^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop: string; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; }
+>    : ^^^^^^^^      ^^^
+}
+
+declare const box3: Box<{
+>box3 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test3(): {} {
+>test3 : () => {}
+>      : ^^^^^^  
+
+  return box3.select(tap((arg) => {}));
+>box3.select(tap((arg) => {})) : { prop: string; prop2?: number; }
+>                              : ^^^^^^^^      ^^^^^^^^^^      ^^^
+>box3.select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box3 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop: string; prop2?: number; }) => { prop: string; prop2?: number; }
+>                 : ^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const box4: Box<{
+>box4 : Box<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test4(): { prop?: string } {
+>test4 : () => { prop?: string; }
+>      : ^^^^^^                  
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  return box4.select(tap((arg) => {}));
+>box4.select(tap((arg) => {})) : { prop?: string; prop2?: number; }
+>                              : ^^^^^^^^^      ^^^^^^^^^^      ^^^
+>box4.select : <A>(op: (source: { prop?: string; prop2?: number; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box4 : Box<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop?: string; prop2?: number; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop?: string; prop2?: number; }) => { prop?: string; prop2?: number; }
+>                 : ^      ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop?: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; prop2?: number; }
+>    : ^^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const box5: Box<{
+>box5 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test5(): { prop: string } {
+>test5 : () => { prop: string; }
+>      : ^^^^^^                 
+>prop : string
+>     : ^^^^^^
+
+  return box5.select(tap((arg) => {}));
+>box5.select(tap((arg) => {})) : { prop: string; prop2?: number; }
+>                              : ^^^^^^^^      ^^^^^^^^^^      ^^^
+>box5.select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box5 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop: string; prop2?: number; }) => { prop: string; prop2?: number; }
+>                 : ^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const box6: Box<{
+>box6 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test6(): { prop2?: number } {
+>test6 : () => { prop2?: number; }
+>      : ^^^^^^                   
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+  return box6.select(tap((arg) => {}));
+>box6.select(tap((arg) => {})) : { prop: string; prop2?: number; }
+>                              : ^^^^^^^^      ^^^^^^^^^^      ^^^
+>box6.select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box6 : Box<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop: string; prop2?: number; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop: string; prop2?: number; }) => { prop: string; prop2?: number; }
+>                 : ^      ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const box7: Box<{
+>box7 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test7(): any {
+>test7 : () => any
+>      : ^^^^^^   
+
+  return box7.select(tap((arg) => {}));
+>box7.select(tap((arg) => {})) : { prop?: string; }
+>                              : ^^^^^^^^^      ^^^
+>box7.select : <A>(op: (source: { prop?: string; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box7 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop?: string; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop?: string; }) => { prop?: string; }
+>                 : ^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const box8: Box<{
+>box8 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test8(): unknown {
+>test8 : () => unknown
+>      : ^^^^^^       
+
+  return box8.select(tap((arg) => {}));
+>box8.select(tap((arg) => {})) : { prop?: string; }
+>                              : ^^^^^^^^^      ^^^
+>box8.select : <A>(op: (source: { prop?: string; }) => A) => A
+>            : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>box8 : Box<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^      ^^^^
+>select : <A>(op: (source: { prop?: string; }) => A) => A
+>       : ^ ^^  ^^^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+>tap((arg) => {}) : (source: { prop?: string; }) => { prop?: string; }
+>                 : ^      ^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^      ^^^
+>tap : <T>(next: (value: T) => void) => (source: T) => T
+>    : ^ ^^    ^^                  ^^^^^                
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+

--- a/tests/baselines/reference/coAndContraVariantInferences9.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences9.symbols
@@ -1,0 +1,232 @@
+//// [tests/cases/compiler/coAndContraVariantInferences9.ts] ////
+
+=== coAndContraVariantInferences9.ts ===
+// https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 2, 21))
+
+  pipe<A>(op: OperatorFunction<T, A>): Observable<A>;
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>A : Symbol(A, Decl(coAndContraVariantInferences9.ts, 3, 7))
+>op : Symbol(op, Decl(coAndContraVariantInferences9.ts, 3, 10))
+>OperatorFunction : Symbol(OperatorFunction, Decl(coAndContraVariantInferences9.ts, 7, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 2, 21))
+>A : Symbol(A, Decl(coAndContraVariantInferences9.ts, 3, 7))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>A : Symbol(A, Decl(coAndContraVariantInferences9.ts, 3, 7))
+}
+interface UnaryFunction<T, R> {
+>UnaryFunction : Symbol(UnaryFunction, Decl(coAndContraVariantInferences9.ts, 4, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 5, 24))
+>R : Symbol(R, Decl(coAndContraVariantInferences9.ts, 5, 26))
+
+  (source: T): R;
+>source : Symbol(source, Decl(coAndContraVariantInferences9.ts, 6, 3))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 5, 24))
+>R : Symbol(R, Decl(coAndContraVariantInferences9.ts, 5, 26))
+}
+interface OperatorFunction<T, R>
+>OperatorFunction : Symbol(OperatorFunction, Decl(coAndContraVariantInferences9.ts, 7, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 8, 27))
+>R : Symbol(R, Decl(coAndContraVariantInferences9.ts, 8, 29))
+
+  extends UnaryFunction<Observable<T>, Observable<R>> {}
+>UnaryFunction : Symbol(UnaryFunction, Decl(coAndContraVariantInferences9.ts, 4, 1))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 8, 27))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>R : Symbol(R, Decl(coAndContraVariantInferences9.ts, 8, 29))
+
+interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
+>MonoTypeOperatorFunction : Symbol(MonoTypeOperatorFunction, Decl(coAndContraVariantInferences9.ts, 9, 56))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 10, 35))
+>OperatorFunction : Symbol(OperatorFunction, Decl(coAndContraVariantInferences9.ts, 7, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 10, 35))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 10, 35))
+
+declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 11, 21))
+>next : Symbol(next, Decl(coAndContraVariantInferences9.ts, 11, 24))
+>value : Symbol(value, Decl(coAndContraVariantInferences9.ts, 11, 31))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 11, 21))
+>MonoTypeOperatorFunction : Symbol(MonoTypeOperatorFunction, Decl(coAndContraVariantInferences9.ts, 9, 56))
+>T : Symbol(T, Decl(coAndContraVariantInferences9.ts, 11, 21))
+
+declare const obs1: Observable<{
+>obs1 : Symbol(obs1, Decl(coAndContraVariantInferences9.ts, 13, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 13, 32))
+
+}>;
+function test1(): Observable<{}> {
+>test1 : Symbol(test1, Decl(coAndContraVariantInferences9.ts, 15, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  return obs1.pipe(tap((arg) => {}));
+>obs1.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs1 : Symbol(obs1, Decl(coAndContraVariantInferences9.ts, 13, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 17, 24))
+}
+
+declare const obs2: Observable<{
+>obs2 : Symbol(obs2, Decl(coAndContraVariantInferences9.ts, 20, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 20, 32))
+
+}>;
+function test2(): Observable<{}> {
+>test2 : Symbol(test2, Decl(coAndContraVariantInferences9.ts, 22, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  return obs2.pipe(tap((arg) => {}));
+>obs2.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs2 : Symbol(obs2, Decl(coAndContraVariantInferences9.ts, 20, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 24, 24))
+}
+
+declare const obs3: Observable<{
+>obs3 : Symbol(obs3, Decl(coAndContraVariantInferences9.ts, 27, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 27, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences9.ts, 28, 15))
+
+}>;
+function test3(): Observable<{}> {
+>test3 : Symbol(test3, Decl(coAndContraVariantInferences9.ts, 30, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  return obs3.pipe(tap((arg) => {}));
+>obs3.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs3 : Symbol(obs3, Decl(coAndContraVariantInferences9.ts, 27, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 32, 24))
+}
+
+declare const obs4: Observable<{
+>obs4 : Symbol(obs4, Decl(coAndContraVariantInferences9.ts, 35, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 35, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences9.ts, 36, 16))
+
+}>;
+function test4(): Observable<{ prop?: string }> {
+>test4 : Symbol(test4, Decl(coAndContraVariantInferences9.ts, 38, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 39, 30))
+
+  return obs4.pipe(tap((arg) => {}));
+>obs4.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs4 : Symbol(obs4, Decl(coAndContraVariantInferences9.ts, 35, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 40, 24))
+}
+
+declare const obs5: Observable<{
+>obs5 : Symbol(obs5, Decl(coAndContraVariantInferences9.ts, 43, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 43, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences9.ts, 44, 15))
+
+}>;
+function test5(): Observable<{ prop: string }> {
+>test5 : Symbol(test5, Decl(coAndContraVariantInferences9.ts, 46, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 47, 30))
+
+  return obs5.pipe(tap((arg) => {}));
+>obs5.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs5 : Symbol(obs5, Decl(coAndContraVariantInferences9.ts, 43, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 48, 24))
+}
+
+declare const obs6: Observable<{
+>obs6 : Symbol(obs6, Decl(coAndContraVariantInferences9.ts, 51, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 51, 32))
+
+  prop2?: number;
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences9.ts, 52, 15))
+
+}>;
+function test6(): Observable<{ prop2?: number }> {
+>test6 : Symbol(test6, Decl(coAndContraVariantInferences9.ts, 54, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+>prop2 : Symbol(prop2, Decl(coAndContraVariantInferences9.ts, 55, 30))
+
+  return obs6.pipe(tap((arg) => {}));
+>obs6.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs6 : Symbol(obs6, Decl(coAndContraVariantInferences9.ts, 51, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 56, 24))
+}
+
+declare const obs7: Observable<{
+>obs7 : Symbol(obs7, Decl(coAndContraVariantInferences9.ts, 59, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 59, 32))
+
+}>;
+function test7(): Observable<any> {
+>test7 : Symbol(test7, Decl(coAndContraVariantInferences9.ts, 61, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  return obs7.pipe(tap((arg) => {}));
+>obs7.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs7 : Symbol(obs7, Decl(coAndContraVariantInferences9.ts, 59, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 63, 24))
+}
+
+declare const obs8: Observable<{
+>obs8 : Symbol(obs8, Decl(coAndContraVariantInferences9.ts, 66, 13))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  prop?: string;
+>prop : Symbol(prop, Decl(coAndContraVariantInferences9.ts, 66, 32))
+
+}>;
+function test8(): Observable<unknown> {
+>test8 : Symbol(test8, Decl(coAndContraVariantInferences9.ts, 68, 3))
+>Observable : Symbol(Observable, Decl(coAndContraVariantInferences9.ts, 0, 0))
+
+  return obs8.pipe(tap((arg) => {}));
+>obs8.pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>obs8 : Symbol(obs8, Decl(coAndContraVariantInferences9.ts, 66, 13))
+>pipe : Symbol(Observable.pipe, Decl(coAndContraVariantInferences9.ts, 2, 25))
+>tap : Symbol(tap, Decl(coAndContraVariantInferences9.ts, 10, 71))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences9.ts, 70, 24))
+}
+

--- a/tests/baselines/reference/coAndContraVariantInferences9.types
+++ b/tests/baselines/reference/coAndContraVariantInferences9.types
@@ -1,0 +1,306 @@
+//// [tests/cases/compiler/coAndContraVariantInferences9.ts] ////
+
+=== coAndContraVariantInferences9.ts ===
+// https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+  pipe<A>(op: OperatorFunction<T, A>): Observable<A>;
+>pipe : <A>(op: OperatorFunction<T, A>) => Observable<A>
+>     : ^ ^^  ^^                      ^^^^^             
+>op : OperatorFunction<T, A>
+>   : ^^^^^^^^^^^^^^^^^^^^^^
+}
+interface UnaryFunction<T, R> {
+  (source: T): R;
+>source : T
+>       : ^
+}
+interface OperatorFunction<T, R>
+  extends UnaryFunction<Observable<T>, Observable<R>> {}
+interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
+declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>next : (value: T) => void
+>     : ^     ^^ ^^^^^    
+>value : T
+>      : ^
+
+declare const obs1: Observable<{
+>obs1 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test1(): Observable<{}> {
+>test1 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs1.pipe(tap((arg) => {}));
+>obs1.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs1.pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs1 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop?: string; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const obs2: Observable<{
+>obs2 : Observable<{ prop: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+}>;
+function test2(): Observable<{}> {
+>test2 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs2.pipe(tap((arg) => {}));
+>obs2.pipe(tap((arg) => {})) : Observable<{ prop: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs2.pipe : <A>(op: OperatorFunction<{ prop: string; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs2 : Observable<{ prop: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop: string; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop: string; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop: string; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; }
+>    : ^^^^^^^^      ^^^
+}
+
+declare const obs3: Observable<{
+>obs3 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test3(): Observable<{}> {
+>test3 : () => Observable<{}>
+>      : ^^^^^^              
+
+  return obs3.pipe(tap((arg) => {}));
+>obs3.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs3.pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs3 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop: string; prop2?: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs4: Observable<{
+>obs4 : Observable<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test4(): Observable<{ prop?: string }> {
+>test4 : () => Observable<{ prop?: string; }>
+>      : ^^^^^^                              
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+  return obs4.pipe(tap((arg) => {}));
+>obs4.pipe(tap((arg) => {})) : Observable<{ prop?: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs4.pipe : <A>(op: OperatorFunction<{ prop?: string; prop2?: number; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs4 : Observable<{ prop?: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop?: string; prop2?: number; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop?: string; prop2?: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop?: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; prop2?: number; }
+>    : ^^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs5: Observable<{
+>obs5 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test5(): Observable<{ prop: string }> {
+>test5 : () => Observable<{ prop: string; }>
+>      : ^^^^^^                             
+>prop : string
+>     : ^^^^^^
+
+  return obs5.pipe(tap((arg) => {}));
+>obs5.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs5.pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs5 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop: string; prop2?: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs6: Observable<{
+>obs6 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+
+  prop: string;
+>prop : string
+>     : ^^^^^^
+
+  prop2?: number;
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test6(): Observable<{ prop2?: number }> {
+>test6 : () => Observable<{ prop2?: number; }>
+>      : ^^^^^^                               
+>prop2 : number | undefined
+>      : ^^^^^^^^^^^^^^^^^^
+
+  return obs6.pipe(tap((arg) => {}));
+>obs6.pipe(tap((arg) => {})) : Observable<{ prop: string; prop2?: number; }>
+>                            : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>obs6.pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs6 : Observable<{ prop: string; prop2?: number; }>
+>     : ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop: string; prop2?: number; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop: string; prop2?: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop: string; prop2?: number; }) => void
+>            : ^   ^^^^^^^^^^      ^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop: string; prop2?: number; }
+>    : ^^^^^^^^      ^^^^^^^^^^      ^^^
+}
+
+declare const obs7: Observable<{
+>obs7 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test7(): Observable<any> {
+>test7 : () => Observable<any>
+>      : ^^^^^^               
+
+  return obs7.pipe(tap((arg) => {}));
+>obs7.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs7.pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs7 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop?: string; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+
+declare const obs8: Observable<{
+>obs8 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+
+  prop?: string;
+>prop : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+}>;
+function test8(): Observable<unknown> {
+>test8 : () => Observable<unknown>
+>      : ^^^^^^                   
+
+  return obs8.pipe(tap((arg) => {}));
+>obs8.pipe(tap((arg) => {})) : Observable<{ prop?: string; }>
+>                            : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>obs8.pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>          : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>obs8 : Observable<{ prop?: string; }>
+>     : ^^^^^^^^^^^^^^^^^^^^      ^^^^
+>pipe : <A>(op: OperatorFunction<{ prop?: string; }, A>) => Observable<A>
+>     : ^ ^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^^^^^^^^^^
+>tap((arg) => {}) : MonoTypeOperatorFunction<{ prop?: string; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>tap : <T>(next: (value: T) => void) => MonoTypeOperatorFunction<T>
+>    : ^ ^^    ^^                  ^^^^^                           
+>(arg) => {} : (arg: { prop?: string; }) => void
+>            : ^   ^^^^^^^^^^^      ^^^^^^^^^^^^
+>arg : { prop?: string; }
+>    : ^^^^^^^^^      ^^^
+}
+

--- a/tests/cases/compiler/coAndContraVariantInferences10.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences10.ts
@@ -1,0 +1,72 @@
+// @strict: true
+// @noEmit: true
+
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+  pipe: <A>(op: (source: Observable<T>) => Observable<A>) => Observable<A>;
+  _v: T;
+}
+declare function tap<T>(
+  next: (value: T) => void,
+): (source: Observable<T>) => Observable<T>;
+
+declare const obs1: Observable<{
+  prop?: string;
+}>;
+function test1(): Observable<{}> {
+  return obs1.pipe(tap((arg) => {}));
+}
+
+declare const obs2: Observable<{
+  prop: string;
+}>;
+function test2(): Observable<{}> {
+  return obs2.pipe(tap((arg) => {}));
+}
+
+declare const obs3: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test3(): Observable<{}> {
+  return obs3.pipe(tap((arg) => {}));
+}
+
+declare const obs4: Observable<{
+  prop?: string;
+  prop2?: number;
+}>;
+function test4(): Observable<{ prop?: string }> {
+  return obs4.pipe(tap((arg) => {}));
+}
+
+declare const obs5: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test5(): Observable<{ prop: string }> {
+  return obs5.pipe(tap((arg) => {}));
+}
+
+declare const obs6: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test6(): Observable<{ prop2?: number }> {
+  return obs6.pipe(tap((arg) => {}));
+}
+
+declare const obs7: Observable<{
+  prop?: string;
+}>;
+function test7(): Observable<any> {
+  return obs7.pipe(tap((arg) => {}));
+}
+
+declare const obs8: Observable<{
+  prop?: string;
+}>;
+function test8(): Observable<unknown> {
+  return obs8.pipe(tap((arg) => {}));
+}

--- a/tests/cases/compiler/coAndContraVariantInferences11.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences11.ts
@@ -1,0 +1,70 @@
+// @strict: true
+// @noEmit: true
+
+// based on https://github.com/microsoft/TypeScript/issues/59656
+
+interface Box<T> {
+  select: <A>(op: (source: T) => A) => A;
+  _v: T;
+}
+declare function tap<T>(next: (value: T) => void): (source: T) => T;
+
+declare const box1: Box<{
+  prop?: string;
+}>;
+function test1(): {} {
+  return box1.select(tap((arg) => {}));
+}
+
+declare const box2: Box<{
+  prop: string;
+}>;
+function test2(): {} {
+  return box2.select(tap((arg) => {}));
+}
+
+declare const box3: Box<{
+  prop: string;
+  prop2?: number;
+}>;
+function test3(): {} {
+  return box3.select(tap((arg) => {}));
+}
+
+declare const box4: Box<{
+  prop?: string;
+  prop2?: number;
+}>;
+function test4(): { prop?: string } {
+  return box4.select(tap((arg) => {}));
+}
+
+declare const box5: Box<{
+  prop: string;
+  prop2?: number;
+}>;
+function test5(): { prop: string } {
+  return box5.select(tap((arg) => {}));
+}
+
+declare const box6: Box<{
+  prop: string;
+  prop2?: number;
+}>;
+function test6(): { prop2?: number } {
+  return box6.select(tap((arg) => {}));
+}
+
+declare const box7: Box<{
+  prop?: string;
+}>;
+function test7(): any {
+  return box7.select(tap((arg) => {}));
+}
+
+declare const box8: Box<{
+  prop?: string;
+}>;
+function test8(): unknown {
+  return box8.select(tap((arg) => {}));
+}

--- a/tests/cases/compiler/coAndContraVariantInferences9.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences9.ts
@@ -1,0 +1,75 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59656
+
+interface Observable<T> {
+  pipe<A>(op: OperatorFunction<T, A>): Observable<A>;
+}
+interface UnaryFunction<T, R> {
+  (source: T): R;
+}
+interface OperatorFunction<T, R>
+  extends UnaryFunction<Observable<T>, Observable<R>> {}
+interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
+declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
+
+declare const obs1: Observable<{
+  prop?: string;
+}>;
+function test1(): Observable<{}> {
+  return obs1.pipe(tap((arg) => {}));
+}
+
+declare const obs2: Observable<{
+  prop: string;
+}>;
+function test2(): Observable<{}> {
+  return obs2.pipe(tap((arg) => {}));
+}
+
+declare const obs3: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test3(): Observable<{}> {
+  return obs3.pipe(tap((arg) => {}));
+}
+
+declare const obs4: Observable<{
+  prop?: string;
+  prop2?: number;
+}>;
+function test4(): Observable<{ prop?: string }> {
+  return obs4.pipe(tap((arg) => {}));
+}
+
+declare const obs5: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test5(): Observable<{ prop: string }> {
+  return obs5.pipe(tap((arg) => {}));
+}
+
+declare const obs6: Observable<{
+  prop: string;
+  prop2?: number;
+}>;
+function test6(): Observable<{ prop2?: number }> {
+  return obs6.pipe(tap((arg) => {}));
+}
+
+declare const obs7: Observable<{
+  prop?: string;
+}>;
+function test7(): Observable<any> {
+  return obs7.pipe(tap((arg) => {}));
+}
+
+declare const obs8: Observable<{
+  prop?: string;
+}>;
+function test8(): Observable<unknown> {
+  return obs8.pipe(tap((arg) => {}));
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59656
cc @weswigham as the reviewer of https://github.com/microsoft/TypeScript/pull/57909 by which this got affected