### PR TITLE
Add missing test case for assertion functions with `PropertySignature` declarations

### DIFF
--- a/tests/baselines/reference/assertionTypePredicates1.errors.txt
+++ b/tests/baselines/reference/assertionTypePredicates1.errors.txt
@@ -13,9 +13,10 @@ assertionTypePredicates1.ts(165,15): error TS1228: A type predicate is only allo
 assertionTypePredicates1.ts(170,5): error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
 assertionTypePredicates1.ts(172,5): error TS2776: Assertions require the call target to be an identifier or qualified name.
 assertionTypePredicates1.ts(174,5): error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
+assertionTypePredicates1.ts(200,5): error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
 
 
-==== assertionTypePredicates1.ts (15 errors) ====
+==== assertionTypePredicates1.ts (16 errors) ====
     declare function isString(value: unknown): value is string;
     declare function isArrayOfStrings(value: unknown): value is string[];
     
@@ -242,5 +243,70 @@ assertionTypePredicates1.ts(174,5): error TS2775: Assertions require every name 
             thing.isGood();
             thing.good;
         }
+    }
+    
+    class TestPropertyDeclaration1 {
+      assert = (value: unknown): asserts value => {};
+      other(x: unknown) {
+        this.assert(x); // error
+        ~~~~~~~~~~~
+!!! error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
+!!! related TS2782 assertionTypePredicates1.ts:198:3: 'assert' needs an explicit type annotation.
+        x;
+      }
+    }
+    
+    class TestPropertyDeclaration2 {
+      assert: (v: unknown) => asserts v = (value) => {};
+      other(x: unknown) {
+        this.assert(x); // ok
+        x;
+      }
+    }
+    
+    declare class ParentInheritedPropertyDeclaration {
+      assert: (value: unknown) => asserts value;
+    }
+    class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+      other(x: unknown) {
+        this.assert(x); // ok
+        x;
+      }
+    }
+    
+    interface TestPropertySignature {
+      assert: (value: unknown) => asserts value;
+    }
+    function testPropertySignature(
+      x: TestPropertySignature,
+      y: unknown,
+    ) {
+      x.assert(y); // ok
+      x;
+    }
+    function testFunctionThisParameter1(
+      this: TestPropertySignature,
+      x: unknown,
+    ) {
+      this.assert(x); // ok
+      x;
+    }
+    
+    interface TestMethodSignature {
+      assert(value: unknown): asserts value;
+    }
+    function testMethodSignature(
+      x: TestMethodSignature,
+      y: unknown,
+    ) {
+      x.assert(y); // ok
+      x;
+    }
+    function testFunctionThisParameter2(
+      this: TestMethodSignature,
+      x: unknown,
+    ) {
+      this.assert(x); // ok
+      x;
     }
     

--- a/tests/baselines/reference/assertionTypePredicates1.js
+++ b/tests/baselines/reference/assertionTypePredicates1.js
@@ -197,6 +197,68 @@ function example1(things: Thing[]) {
     }
 }
 
+class TestPropertyDeclaration1 {
+  assert = (value: unknown): asserts value => {};
+  other(x: unknown) {
+    this.assert(x); // error
+    x;
+  }
+}
+
+class TestPropertyDeclaration2 {
+  assert: (v: unknown) => asserts v = (value) => {};
+  other(x: unknown) {
+    this.assert(x); // ok
+    x;
+  }
+}
+
+declare class ParentInheritedPropertyDeclaration {
+  assert: (value: unknown) => asserts value;
+}
+class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+  other(x: unknown) {
+    this.assert(x); // ok
+    x;
+  }
+}
+
+interface TestPropertySignature {
+  assert: (value: unknown) => asserts value;
+}
+function testPropertySignature(
+  x: TestPropertySignature,
+  y: unknown,
+) {
+  x.assert(y); // ok
+  x;
+}
+function testFunctionThisParameter1(
+  this: TestPropertySignature,
+  x: unknown,
+) {
+  this.assert(x); // ok
+  x;
+}
+
+interface TestMethodSignature {
+  assert(value: unknown): asserts value;
+}
+function testMethodSignature(
+  x: TestMethodSignature,
+  y: unknown,
+) {
+  x.assert(y); // ok
+  x;
+}
+function testFunctionThisParameter2(
+  this: TestMethodSignature,
+  x: unknown,
+) {
+  this.assert(x); // ok
+  x;
+}
+
 
 //// [assertionTypePredicates1.js]
 "use strict";
@@ -386,6 +448,53 @@ function example1(things) {
         thing.good;
     }
 }
+var TestPropertyDeclaration1 = /** @class */ (function () {
+    function TestPropertyDeclaration1() {
+        this.assert = function (value) { };
+    }
+    TestPropertyDeclaration1.prototype.other = function (x) {
+        this.assert(x); // error
+        x;
+    };
+    return TestPropertyDeclaration1;
+}());
+var TestPropertyDeclaration2 = /** @class */ (function () {
+    function TestPropertyDeclaration2() {
+        this.assert = function (value) { };
+    }
+    TestPropertyDeclaration2.prototype.other = function (x) {
+        this.assert(x); // ok
+        x;
+    };
+    return TestPropertyDeclaration2;
+}());
+var ChildInheritedPropertyDeclaration = /** @class */ (function (_super) {
+    __extends(ChildInheritedPropertyDeclaration, _super);
+    function ChildInheritedPropertyDeclaration() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    ChildInheritedPropertyDeclaration.prototype.other = function (x) {
+        this.assert(x); // ok
+        x;
+    };
+    return ChildInheritedPropertyDeclaration;
+}(ParentInheritedPropertyDeclaration));
+function testPropertySignature(x, y) {
+    x.assert(y); // ok
+    x;
+}
+function testFunctionThisParameter1(x) {
+    this.assert(x); // ok
+    x;
+}
+function testMethodSignature(x, y) {
+    x.assert(y); // ok
+    x;
+}
+function testFunctionThisParameter2(x) {
+    this.assert(x); // ok
+    x;
+}
 
 
 //// [assertionTypePredicates1.d.ts]
@@ -438,3 +547,27 @@ interface GoodThing {
     good: true;
 }
 declare function example1(things: Thing[]): void;
+declare class TestPropertyDeclaration1 {
+    assert: (value: unknown) => asserts value;
+    other(x: unknown): void;
+}
+declare class TestPropertyDeclaration2 {
+    assert: (v: unknown) => asserts v;
+    other(x: unknown): void;
+}
+declare class ParentInheritedPropertyDeclaration {
+    assert: (value: unknown) => asserts value;
+}
+declare class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+    other(x: unknown): void;
+}
+interface TestPropertySignature {
+    assert: (value: unknown) => asserts value;
+}
+declare function testPropertySignature(x: TestPropertySignature, y: unknown): void;
+declare function testFunctionThisParameter1(this: TestPropertySignature, x: unknown): void;
+interface TestMethodSignature {
+    assert(value: unknown): asserts value;
+}
+declare function testMethodSignature(x: TestMethodSignature, y: unknown): void;
+declare function testFunctionThisParameter2(this: TestMethodSignature, x: unknown): void;

--- a/tests/baselines/reference/assertionTypePredicates1.symbols
+++ b/tests/baselines/reference/assertionTypePredicates1.symbols
@@ -551,3 +551,175 @@ function example1(things: Thing[]) {
     }
 }
 
+class TestPropertyDeclaration1 {
+>TestPropertyDeclaration1 : Symbol(TestPropertyDeclaration1, Decl(assertionTypePredicates1.ts, 194, 1))
+
+  assert = (value: unknown): asserts value => {};
+>assert : Symbol(TestPropertyDeclaration1.assert, Decl(assertionTypePredicates1.ts, 196, 32))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 197, 12))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 197, 12))
+
+  other(x: unknown) {
+>other : Symbol(TestPropertyDeclaration1.other, Decl(assertionTypePredicates1.ts, 197, 49))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 198, 8))
+
+    this.assert(x); // error
+>this.assert : Symbol(TestPropertyDeclaration1.assert, Decl(assertionTypePredicates1.ts, 196, 32))
+>this : Symbol(TestPropertyDeclaration1, Decl(assertionTypePredicates1.ts, 194, 1))
+>assert : Symbol(TestPropertyDeclaration1.assert, Decl(assertionTypePredicates1.ts, 196, 32))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 198, 8))
+
+    x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 198, 8))
+  }
+}
+
+class TestPropertyDeclaration2 {
+>TestPropertyDeclaration2 : Symbol(TestPropertyDeclaration2, Decl(assertionTypePredicates1.ts, 202, 1))
+
+  assert: (v: unknown) => asserts v = (value) => {};
+>assert : Symbol(TestPropertyDeclaration2.assert, Decl(assertionTypePredicates1.ts, 204, 32))
+>v : Symbol(v, Decl(assertionTypePredicates1.ts, 205, 11))
+>v : Symbol(v, Decl(assertionTypePredicates1.ts, 205, 11))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 205, 39))
+
+  other(x: unknown) {
+>other : Symbol(TestPropertyDeclaration2.other, Decl(assertionTypePredicates1.ts, 205, 52))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 206, 8))
+
+    this.assert(x); // ok
+>this.assert : Symbol(TestPropertyDeclaration2.assert, Decl(assertionTypePredicates1.ts, 204, 32))
+>this : Symbol(TestPropertyDeclaration2, Decl(assertionTypePredicates1.ts, 202, 1))
+>assert : Symbol(TestPropertyDeclaration2.assert, Decl(assertionTypePredicates1.ts, 204, 32))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 206, 8))
+
+    x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 206, 8))
+  }
+}
+
+declare class ParentInheritedPropertyDeclaration {
+>ParentInheritedPropertyDeclaration : Symbol(ParentInheritedPropertyDeclaration, Decl(assertionTypePredicates1.ts, 210, 1))
+
+  assert: (value: unknown) => asserts value;
+>assert : Symbol(ParentInheritedPropertyDeclaration.assert, Decl(assertionTypePredicates1.ts, 212, 50))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 213, 11))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 213, 11))
+}
+class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+>ChildInheritedPropertyDeclaration : Symbol(ChildInheritedPropertyDeclaration, Decl(assertionTypePredicates1.ts, 214, 1))
+>ParentInheritedPropertyDeclaration : Symbol(ParentInheritedPropertyDeclaration, Decl(assertionTypePredicates1.ts, 210, 1))
+
+  other(x: unknown) {
+>other : Symbol(ChildInheritedPropertyDeclaration.other, Decl(assertionTypePredicates1.ts, 215, 84))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 216, 8))
+
+    this.assert(x); // ok
+>this.assert : Symbol(ParentInheritedPropertyDeclaration.assert, Decl(assertionTypePredicates1.ts, 212, 50))
+>this : Symbol(ChildInheritedPropertyDeclaration, Decl(assertionTypePredicates1.ts, 214, 1))
+>assert : Symbol(ParentInheritedPropertyDeclaration.assert, Decl(assertionTypePredicates1.ts, 212, 50))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 216, 8))
+
+    x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 216, 8))
+  }
+}
+
+interface TestPropertySignature {
+>TestPropertySignature : Symbol(TestPropertySignature, Decl(assertionTypePredicates1.ts, 220, 1))
+
+  assert: (value: unknown) => asserts value;
+>assert : Symbol(TestPropertySignature.assert, Decl(assertionTypePredicates1.ts, 222, 33))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 223, 11))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 223, 11))
+}
+function testPropertySignature(
+>testPropertySignature : Symbol(testPropertySignature, Decl(assertionTypePredicates1.ts, 224, 1))
+
+  x: TestPropertySignature,
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 225, 31))
+>TestPropertySignature : Symbol(TestPropertySignature, Decl(assertionTypePredicates1.ts, 220, 1))
+
+  y: unknown,
+>y : Symbol(y, Decl(assertionTypePredicates1.ts, 226, 27))
+
+) {
+  x.assert(y); // ok
+>x.assert : Symbol(TestPropertySignature.assert, Decl(assertionTypePredicates1.ts, 222, 33))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 225, 31))
+>assert : Symbol(TestPropertySignature.assert, Decl(assertionTypePredicates1.ts, 222, 33))
+>y : Symbol(y, Decl(assertionTypePredicates1.ts, 226, 27))
+
+  x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 225, 31))
+}
+function testFunctionThisParameter1(
+>testFunctionThisParameter1 : Symbol(testFunctionThisParameter1, Decl(assertionTypePredicates1.ts, 231, 1))
+
+  this: TestPropertySignature,
+>this : Symbol(this, Decl(assertionTypePredicates1.ts, 232, 36))
+>TestPropertySignature : Symbol(TestPropertySignature, Decl(assertionTypePredicates1.ts, 220, 1))
+
+  x: unknown,
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 233, 30))
+
+) {
+  this.assert(x); // ok
+>this.assert : Symbol(TestPropertySignature.assert, Decl(assertionTypePredicates1.ts, 222, 33))
+>this : Symbol(this, Decl(assertionTypePredicates1.ts, 232, 36))
+>assert : Symbol(TestPropertySignature.assert, Decl(assertionTypePredicates1.ts, 222, 33))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 233, 30))
+
+  x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 233, 30))
+}
+
+interface TestMethodSignature {
+>TestMethodSignature : Symbol(TestMethodSignature, Decl(assertionTypePredicates1.ts, 238, 1))
+
+  assert(value: unknown): asserts value;
+>assert : Symbol(TestMethodSignature.assert, Decl(assertionTypePredicates1.ts, 240, 31))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 241, 9))
+>value : Symbol(value, Decl(assertionTypePredicates1.ts, 241, 9))
+}
+function testMethodSignature(
+>testMethodSignature : Symbol(testMethodSignature, Decl(assertionTypePredicates1.ts, 242, 1))
+
+  x: TestMethodSignature,
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 243, 29))
+>TestMethodSignature : Symbol(TestMethodSignature, Decl(assertionTypePredicates1.ts, 238, 1))
+
+  y: unknown,
+>y : Symbol(y, Decl(assertionTypePredicates1.ts, 244, 25))
+
+) {
+  x.assert(y); // ok
+>x.assert : Symbol(TestMethodSignature.assert, Decl(assertionTypePredicates1.ts, 240, 31))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 243, 29))
+>assert : Symbol(TestMethodSignature.assert, Decl(assertionTypePredicates1.ts, 240, 31))
+>y : Symbol(y, Decl(assertionTypePredicates1.ts, 244, 25))
+
+  x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 243, 29))
+}
+function testFunctionThisParameter2(
+>testFunctionThisParameter2 : Symbol(testFunctionThisParameter2, Decl(assertionTypePredicates1.ts, 249, 1))
+
+  this: TestMethodSignature,
+>this : Symbol(this, Decl(assertionTypePredicates1.ts, 250, 36))
+>TestMethodSignature : Symbol(TestMethodSignature, Decl(assertionTypePredicates1.ts, 238, 1))
+
+  x: unknown,
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 251, 28))
+
+) {
+  this.assert(x); // ok
+>this.assert : Symbol(TestMethodSignature.assert, Decl(assertionTypePredicates1.ts, 240, 31))
+>this : Symbol(this, Decl(assertionTypePredicates1.ts, 250, 36))
+>assert : Symbol(TestMethodSignature.assert, Decl(assertionTypePredicates1.ts, 240, 31))
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 251, 28))
+
+  x;
+>x : Symbol(x, Decl(assertionTypePredicates1.ts, 251, 28))
+}
+

--- a/tests/baselines/reference/assertionTypePredicates1.types
+++ b/tests/baselines/reference/assertionTypePredicates1.types
@@ -1076,3 +1076,249 @@ function example1(things: Thing[]) {
     }
 }
 
+class TestPropertyDeclaration1 {
+>TestPropertyDeclaration1 : TestPropertyDeclaration1
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  assert = (value: unknown): asserts value => {};
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>(value: unknown): asserts value => {} : (value: unknown) => asserts value
+>                                      : ^     ^^       ^^^^^             
+>value : unknown
+>      : ^^^^^^^
+
+  other(x: unknown) {
+>other : (x: unknown) => void
+>      : ^ ^^       ^^^^^^^^^
+>x : unknown
+>  : ^^^^^^^
+
+    this.assert(x); // error
+>this.assert(x) : void
+>               : ^^^^
+>this.assert : (value: unknown) => asserts value
+>            : ^     ^^       ^^^^^             
+>this : this
+>     : ^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>x : unknown
+>  : ^^^^^^^
+
+    x;
+>x : unknown
+>  : ^^^^^^^
+  }
+}
+
+class TestPropertyDeclaration2 {
+>TestPropertyDeclaration2 : TestPropertyDeclaration2
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  assert: (v: unknown) => asserts v = (value) => {};
+>assert : (v: unknown) => asserts v
+>       : ^ ^^       ^^^^^         
+>v : unknown
+>  : ^^^^^^^
+>(value) => {} : (value: unknown) => void
+>              : ^     ^^^^^^^^^^^^^^^^^^
+>value : unknown
+>      : ^^^^^^^
+
+  other(x: unknown) {
+>other : (x: unknown) => void
+>      : ^ ^^       ^^^^^^^^^
+>x : unknown
+>  : ^^^^^^^
+
+    this.assert(x); // ok
+>this.assert(x) : void
+>               : ^^^^
+>this.assert : (v: unknown) => asserts v
+>            : ^ ^^       ^^^^^         
+>this : this
+>     : ^^^^
+>assert : (v: unknown) => asserts v
+>       : ^ ^^       ^^^^^         
+>x : unknown
+>  : ^^^^^^^
+
+    x;
+>x : {}
+>  : ^^
+  }
+}
+
+declare class ParentInheritedPropertyDeclaration {
+>ParentInheritedPropertyDeclaration : ParentInheritedPropertyDeclaration
+>                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  assert: (value: unknown) => asserts value;
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>value : unknown
+>      : ^^^^^^^
+}
+class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+>ChildInheritedPropertyDeclaration : ChildInheritedPropertyDeclaration
+>                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ParentInheritedPropertyDeclaration : ParentInheritedPropertyDeclaration
+>                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  other(x: unknown) {
+>other : (x: unknown) => void
+>      : ^ ^^       ^^^^^^^^^
+>x : unknown
+>  : ^^^^^^^
+
+    this.assert(x); // ok
+>this.assert(x) : void
+>               : ^^^^
+>this.assert : (value: unknown) => asserts value
+>            : ^     ^^       ^^^^^             
+>this : this
+>     : ^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>x : unknown
+>  : ^^^^^^^
+
+    x;
+>x : {}
+>  : ^^
+  }
+}
+
+interface TestPropertySignature {
+  assert: (value: unknown) => asserts value;
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>value : unknown
+>      : ^^^^^^^
+}
+function testPropertySignature(
+>testPropertySignature : (x: TestPropertySignature, y: unknown) => void
+>                      : ^ ^^                     ^^ ^^       ^^^^^^^^^
+
+  x: TestPropertySignature,
+>x : TestPropertySignature
+>  : ^^^^^^^^^^^^^^^^^^^^^
+
+  y: unknown,
+>y : unknown
+>  : ^^^^^^^
+
+) {
+  x.assert(y); // ok
+>x.assert(y) : void
+>            : ^^^^
+>x.assert : (value: unknown) => asserts value
+>         : ^     ^^       ^^^^^             
+>x : TestPropertySignature
+>  : ^^^^^^^^^^^^^^^^^^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>y : unknown
+>  : ^^^^^^^
+
+  x;
+>x : TestPropertySignature
+>  : ^^^^^^^^^^^^^^^^^^^^^
+}
+function testFunctionThisParameter1(
+>testFunctionThisParameter1 : (this: TestPropertySignature, x: unknown) => void
+>                           : ^    ^^                     ^^ ^^       ^^^^^^^^^
+
+  this: TestPropertySignature,
+>this : TestPropertySignature
+>     : ^^^^^^^^^^^^^^^^^^^^^
+
+  x: unknown,
+>x : unknown
+>  : ^^^^^^^
+
+) {
+  this.assert(x); // ok
+>this.assert(x) : void
+>               : ^^^^
+>this.assert : (value: unknown) => asserts value
+>            : ^     ^^       ^^^^^             
+>this : TestPropertySignature
+>     : ^^^^^^^^^^^^^^^^^^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>x : unknown
+>  : ^^^^^^^
+
+  x;
+>x : {}
+>  : ^^
+}
+
+interface TestMethodSignature {
+  assert(value: unknown): asserts value;
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>value : unknown
+>      : ^^^^^^^
+}
+function testMethodSignature(
+>testMethodSignature : (x: TestMethodSignature, y: unknown) => void
+>                    : ^ ^^                   ^^ ^^       ^^^^^^^^^
+
+  x: TestMethodSignature,
+>x : TestMethodSignature
+>  : ^^^^^^^^^^^^^^^^^^^
+
+  y: unknown,
+>y : unknown
+>  : ^^^^^^^
+
+) {
+  x.assert(y); // ok
+>x.assert(y) : void
+>            : ^^^^
+>x.assert : (value: unknown) => asserts value
+>         : ^     ^^       ^^^^^             
+>x : TestMethodSignature
+>  : ^^^^^^^^^^^^^^^^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>y : unknown
+>  : ^^^^^^^
+
+  x;
+>x : TestMethodSignature
+>  : ^^^^^^^^^^^^^^^^^^^
+}
+function testFunctionThisParameter2(
+>testFunctionThisParameter2 : (this: TestMethodSignature, x: unknown) => void
+>                           : ^    ^^                   ^^ ^^       ^^^^^^^^^
+
+  this: TestMethodSignature,
+>this : TestMethodSignature
+>     : ^^^^^^^^^^^^^^^^^^^
+
+  x: unknown,
+>x : unknown
+>  : ^^^^^^^
+
+) {
+  this.assert(x); // ok
+>this.assert(x) : void
+>               : ^^^^
+>this.assert : (value: unknown) => asserts value
+>            : ^     ^^       ^^^^^             
+>this : TestMethodSignature
+>     : ^^^^^^^^^^^^^^^^^^^
+>assert : (value: unknown) => asserts value
+>       : ^     ^^       ^^^^^             
+>x : unknown
+>  : ^^^^^^^
+
+  x;
+>x : {}
+>  : ^^
+}
+

--- a/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
+++ b/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
@@ -197,3 +197,65 @@ function example1(things: Thing[]) {
         thing.good;
     }
 }
+
+class TestPropertyDeclaration1 {
+  assert = (value: unknown): asserts value => {};
+  other(x: unknown) {
+    this.assert(x); // error
+    x;
+  }
+}
+
+class TestPropertyDeclaration2 {
+  assert: (v: unknown) => asserts v = (value) => {};
+  other(x: unknown) {
+    this.assert(x); // ok
+    x;
+  }
+}
+
+declare class ParentInheritedPropertyDeclaration {
+  assert: (value: unknown) => asserts value;
+}
+class ChildInheritedPropertyDeclaration extends ParentInheritedPropertyDeclaration {
+  other(x: unknown) {
+    this.assert(x); // ok
+    x;
+  }
+}
+
+interface TestPropertySignature {
+  assert: (value: unknown) => asserts value;
+}
+function testPropertySignature(
+  x: TestPropertySignature,
+  y: unknown,
+) {
+  x.assert(y); // ok
+  x;
+}
+function testFunctionThisParameter1(
+  this: TestPropertySignature,
+  x: unknown,
+) {
+  this.assert(x); // ok
+  x;
+}
+
+interface TestMethodSignature {
+  assert(value: unknown): asserts value;
+}
+function testMethodSignature(
+  x: TestMethodSignature,
+  y: unknown,
+) {
+  x.assert(y); // ok
+  x;
+}
+function testFunctionThisParameter2(
+  this: TestMethodSignature,
+  x: unknown,
+) {
+  this.assert(x); // ok
+  x;
+}


### PR DESCRIPTION
I was looking into `isDeclarationWithExplicitTypeAnnotation` to assess if it's not missing `MethodSignature` handling. I couldn't come up with a test case that would prove it is. I think that case is always handled by an early check for `SymbolFlags.Method` in `getExplicitTypeOfSymbol` (and that's the only caller of `isDeclarationWithExplicitTypeAnnotation`).

In the process, I found out that there was no test case for the `isPropertySignature` check in `isDeclarationWithExplicitTypeAnnotation`. So here it is (plus some extras) 😉 
