### PR TITLE
Use a trie to quickly skip templates in union creation

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2590,3 +2590,96 @@ export function isNodeLikeSystem(): boolean {
         && !(process as any).browser
         && typeof require !== "undefined";
 }
+
+/** @internal */
+interface PrefixSuffixTrie<T extends {}> {
+    iterateAllMatches(input: string): Iterable<T>;
+    set(prefix: string, suffix: string, fn: (value: T | undefined) => T | undefined): void;
+    hasAnyMatch(input: string): boolean;
+}
+
+/** @internal */
+export function createPrefixSuffixTrie<T extends {}>(): PrefixSuffixTrie<T> {
+    interface Trie<T extends {}> {
+        children: Record<string, Trie<T>> | undefined;
+        value: T | undefined;
+    }
+
+    function createTrie<T extends {}>(): Trie<T> {
+        return {
+            children: undefined,
+            value: undefined,
+        };
+    }
+
+    const root = createTrie<Trie<T>>();
+
+    function* iterateAllMatches(input: string) {
+        let node = root;
+
+        if (node.value) {
+            yield* iterateSuffix(node.value, 0);
+        }
+
+        for (let i = 0; i < input.length; i++) {
+            const child = node.children?.[input[i]];
+            if (!child) break;
+            if (child.value) {
+                yield* iterateSuffix(child.value, i + 1);
+            }
+            node = child;
+        }
+
+        return;
+
+        function* iterateSuffix(node: Trie<T>, start: number) {
+            if (node.value) {
+                yield node.value;
+            }
+
+            for (let i = input.length - 1; i >= start; i--) {
+                const child = node.children?.[input[i]];
+                if (!child) break;
+                if (child.value) {
+                    yield child.value;
+                }
+                node = child;
+            }
+        }
+    }
+
+    function set(prefix: string, suffix: string, fn: (value: T | undefined) => T | undefined) {
+        let prefixNode = root;
+
+        for (let i = 0; i < prefix.length; i++) {
+            const char = prefix[i];
+            const children = prefixNode.children ??= {};
+            const child = children[char] ??= createTrie();
+            prefixNode = child;
+        }
+
+        let suffixNode = prefixNode.value ??= createTrie();
+
+        for (let i = suffix.length - 1; i >= 0; i--) {
+            const char = suffix[i];
+            const children = suffixNode.children ??= {};
+            const child = children[char] ??= createTrie();
+            suffixNode = child;
+        }
+
+        suffixNode.value = fn(suffixNode.value);
+    }
+
+    function hasAnyMatch(input: string) {
+        for (const _ of iterateAllMatches(input)) {
+            return true;
+        }
+        return false;
+    }
+
+    return {
+        iterateAllMatches,
+        set,
+        hasAnyMatch,
+    };
+}

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2592,7 +2592,7 @@ export function isNodeLikeSystem(): boolean {
 }
 
 /** @internal */
-interface PrefixSuffixTrie<T extends {}> {
+export interface PrefixSuffixTrie<T extends {}> {
     iterateAllMatches(input: string): Iterable<T>;
     set(prefix: string, suffix: string, fn: (value: T | undefined) => T | undefined): void;
     hasAnyMatch(input: string): boolean;


### PR DESCRIPTION
For #59655

Right now, `removeStringLiteralsMatchedByTemplateLiterals` iterates over the entire combinatorial explosion of string literals and templates in a union to ensure that any string literal already captured by a template is removed.

In #59655, we have 1,733 template literals and 626,376 string literals, which means quite literally a billion string literal to template literal inferences, all of which "fail" and don't end up removing anything.

My alternative PR #59705 simply says "no, this is too much work, error" like we do in subtype reduction. However, for this particular case, there are actually algorithmic changes we could make to go faster.

The thing that's actually taking the most time in #59655 is the _fast path_ (!!!) where we bail early if the string doesn't start/end with the first/last part of the template type. We're doing some billion `startsWith`/`endsWith`, where a significant number of those have common prefixes/suffixes such that we're scanning strings over and over and over.

There's a data structure which can help; the [trie](https://en.wikipedia.org/wiki/Trie). We can put all of our template literals into one trie, then walk it for each string literal. This lets us check every template literal in one traversal, skipping impossible paths to greatly reduce which template literals we'll have to do a full inference on.

Since a trie is just a prefix tree, this PR introduces a data structure which is actually a prefix trie of suffix tries; when walking down the prefix trie looking for potential matches, each of those nodes also contains a suffix trie which is walked down as well. This prevents us from having bad perf when it's actually the _suffixes_ that are long (and opens this to use in other contexts, see the end of this PR description).

For #59655, this nets:

```
Benchmark 1: node ~/work/TypeScript/built/local-old/tsc.js
  Time (mean ± σ):     72.882 s ±  1.093 s    [User: 77.298 s, System: 0.572 s]
  Range (min … max):   72.052 s … 75.183 s    10 runs
 
Benchmark 2: node ~/work/TypeScript/built/local/tsc.js
  Time (mean ± σ):     11.378 s ±  0.072 s    [User: 15.875 s, System: 0.521 s]
  Range (min … max):   11.291 s … 11.538 s    10 runs
 
Summary
  'node ~/work/TypeScript/built/local/tsc.js' ran
    6.41 ± 0.10 times faster than 'node ~/work/TypeScript/built/local-old/tsc.js'
```

This speeds up one of our slowest test cases:

```
Benchmark 1: node ./node_modules/mocha/bin/_mocha -g "templateLiteralTypes1" -t 40000 ./built/local-old/run.js
  Time (mean ± σ):      4.947 s ±  0.050 s    [User: 5.948 s, System: 0.410 s]
  Range (min … max):    4.897 s …  5.074 s    10 runs
 
Benchmark 2: node ./node_modules/mocha/bin/_mocha -g "templateLiteralTypes1" -t 40000 ./built/local/run.js
  Time (mean ± σ):      2.676 s ±  0.164 s    [User: 3.719 s, System: 0.335 s]
  Range (min … max):    2.580 s …  3.065 s    10 runs
 
Summary
  'node ./node_modules/mocha/bin/_mocha -g "templateLiteralTypes1" -t 40000 ./built/local/run.js' ran
    1.85 ± 0.11 times faster than 'node ./node_modules/mocha/bin/_mocha -g "templateLiteralTypes1" -t 40000 ./built/local-old/run.js'
```

TODO:

- [ ] Determine the cutoff point for when we should not bother to do this; building a trie is not free.
- [ ] Some sort of test like #59655 which takes a massively long time without this PR.

---

This two-way trie turns out to be exactly the data structure we'd need for #59058; our glob patterns are just a prefix and a suffix with a wildcard in the middle. The only difference is that while the template literal case needs to iterate through all possible matches, our file glob matching only needs to check if there's one match.

Though, paths/exports/etc are ordered, so it may still have to iterate all then sort by priority or something.