### PR TITLE
`this` can be nullish

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39818,6 +39818,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.NewExpression:
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.YieldExpression:
+            case SyntaxKind.ThisKeyword:
                 return PredicateSemantics.Sometimes;
             case SyntaxKind.BinaryExpression:
                 // List of operators that can produce null/undefined:

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -9,10 +9,9 @@ predicateSemantics.ts(33,8): error TS2872: This kind of expression is always tru
 predicateSemantics.ts(34,11): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(35,8): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(36,8): error TS2872: This kind of expression is always truthy.
-predicateSemantics.ts(43,12): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 
 
-==== predicateSemantics.ts (12 errors) ====
+==== predicateSemantics.ts (11 errors) ====
     declare let cond: any;
     
     // OK: One or other operand is possibly nullish
@@ -78,6 +77,4 @@ predicateSemantics.ts(43,12): error TS2869: Right operand of ?? is unreachable b
     function foo(this: Object | undefined) {
         // Should be OK
         return this ?? 0;
-               ~~~~
-!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
     }

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -9,9 +9,10 @@ predicateSemantics.ts(33,8): error TS2872: This kind of expression is always tru
 predicateSemantics.ts(34,11): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(35,8): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(36,8): error TS2872: This kind of expression is always truthy.
+predicateSemantics.ts(43,12): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 
 
-==== predicateSemantics.ts (11 errors) ====
+==== predicateSemantics.ts (12 errors) ====
     declare let cond: any;
     
     // OK: One or other operand is possibly nullish
@@ -74,3 +75,9 @@ predicateSemantics.ts(36,8): error TS2872: This kind of expression is always tru
     // Should be OK
     console.log((cond || undefined) && 1 / cond);
     
+    function foo(this: Object | undefined) {
+        // Should be OK
+        return this ?? 0;
+               ~~~~
+!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+    }

--- a/tests/baselines/reference/predicateSemantics.js
+++ b/tests/baselines/reference/predicateSemantics.js
@@ -41,6 +41,10 @@ while ((({}))) { }
 // Should be OK
 console.log((cond || undefined) && 1 / cond);
 
+function foo(this: Object | undefined) {
+    // Should be OK
+    return this ?? 0;
+}
 
 //// [predicateSemantics.js]
 var _a, _b, _c, _d, _e, _f;
@@ -80,3 +84,7 @@ while (({})) { }
 while ((({}))) { }
 // Should be OK
 console.log((cond || undefined) && 1 / cond);
+function foo() {
+    // Should be OK
+    return this !== null && this !== void 0 ? this : 0;
+}

--- a/tests/baselines/reference/predicateSemantics.symbols
+++ b/tests/baselines/reference/predicateSemantics.symbols
@@ -70,3 +70,12 @@ console.log((cond || undefined) && 1 / cond);
 >undefined : Symbol(undefined)
 >cond : Symbol(cond, Decl(predicateSemantics.ts, 0, 11))
 
+function foo(this: Object | undefined) {
+>foo : Symbol(foo, Decl(predicateSemantics.ts, 38, 45))
+>this : Symbol(this, Decl(predicateSemantics.ts, 40, 13))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    // Should be OK
+    return this ?? 0;
+>this : Symbol(this, Decl(predicateSemantics.ts, 40, 13))
+}

--- a/tests/baselines/reference/predicateSemantics.types
+++ b/tests/baselines/reference/predicateSemantics.types
@@ -219,3 +219,18 @@ console.log((cond || undefined) && 1 / cond);
 >cond : any
 >     : ^^^
 
+function foo(this: Object | undefined) {
+>foo : (this: Object | undefined) => Object | 0
+>    : ^    ^^                  ^^^^^^^^^^^^^^^
+>this : Object
+>     : ^^^^^^
+
+    // Should be OK
+    return this ?? 0;
+>this ?? 0 : 0 | Object
+>          : ^^^^^^^^^^
+>this : Object
+>     : ^^^^^^
+>0 : 0
+>  : ^
+}

--- a/tests/cases/compiler/predicateSemantics.ts
+++ b/tests/cases/compiler/predicateSemantics.ts
@@ -37,3 +37,8 @@ while ((({}))) { }
 
 // Should be OK
 console.log((cond || undefined) && 1 / cond);
+
+function foo(this: Object | undefined) {
+    // Should be OK
+    return this ?? 0;
+}


### PR DESCRIPTION
`this` keyword wasn't categorized as possibly nullish, but it is.

Fixes #59755