### PR TITLE
fix(59769): remapped properties ObjectLiteralMethodSnippet completion

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -7,12 +7,11 @@ import {
     Block,
     CallExpression,
     CharacterCodes,
-    CheckFlags,
     ClassLikeDeclaration,
     CodeFixContextBase,
     combine,
+    createDeclarationName,
     Debug,
-    Declaration,
     Diagnostics,
     emptyArray,
     EntityName,
@@ -25,14 +24,11 @@ import {
     FunctionExpression,
     GetAccessorDeclaration,
     getAllAccessorDeclarations,
-    getCheckFlags,
     getEffectiveModifierFlags,
     getEmitScriptTarget,
     getFirstIdentifier,
     getModuleSpecifierResolverHost,
     getNameForExportedSymbol,
-    getNameOfDeclaration,
-    getPropertyNameFromType,
     getQuotePreference,
     getSetAccessorValueParameter,
     getSynthesizedDeepClone,
@@ -59,7 +55,6 @@ import {
     isSetAccessorDeclaration,
     isStringLiteral,
     isTypeNode,
-    isTypeUsableAsPropertyName,
     isYieldExpression,
     LanguageServiceHost,
     length,
@@ -98,7 +93,6 @@ import {
     textChanges,
     TextSpan,
     textSpanEnd,
-    TransientSymbol,
     tryCast,
     TsConfigSourceFile,
     Type,
@@ -107,12 +101,11 @@ import {
     TypeNode,
     TypeParameterDeclaration,
     TypePredicate,
-    unescapeLeadingUnderscores,
     UnionType,
     UserPreferences,
     visitEachChild,
     visitNode,
-    visitNodes,
+    visitNodes
 } from "../_namespaces/ts.js";
 
 /**
@@ -358,16 +351,6 @@ export function addNewNodeForMemberSymbol(
 
     function createTypeNode(typeNode: TypeNode | undefined) {
         return getSynthesizedDeepClone(typeNode, /*includeTrivia*/ false);
-    }
-
-    function createDeclarationName(symbol: Symbol, declaration: Declaration | undefined): PropertyName {
-        if (getCheckFlags(symbol) & CheckFlags.Mapped) {
-            const nameType = (symbol as TransientSymbol).links.nameType;
-            if (nameType && isTypeUsableAsPropertyName(nameType)) {
-                return factory.createIdentifier(unescapeLeadingUnderscores(getPropertyNameFromType(nameType)));
-            }
-        }
-        return getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
     }
 }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -38,6 +38,7 @@ import {
     ConstructorDeclaration,
     ContextFlags,
     countWhere,
+    createDeclarationName,
     createModuleSpecifierResolutionHost,
     createPackageJsonImportFilter,
     createPrinter,
@@ -112,7 +113,6 @@ import {
     getSourceFileOfModule,
     getSwitchedType,
     getSymbolId,
-    getSynthesizedDeepClone,
     getTokenAtPosition,
     getTouchingPropertyName,
     hasDocComment,
@@ -328,7 +328,6 @@ import {
     programContainsModules,
     PropertyAccessExpression,
     PropertyDeclaration,
-    PropertyName,
     PropertySignature,
     PseudoBigInt,
     pseudoBigIntToString,
@@ -394,7 +393,7 @@ import {
     UnionType,
     UserPreferences,
     VariableDeclaration,
-    walkUpParenthesizedExpressions,
+    walkUpParenthesizedExpressions
 } from "./_namespaces/ts.js";
 
 // Exported only for tests
@@ -2309,7 +2308,7 @@ function createObjectLiteralMethod(
     }
     const checker = program.getTypeChecker();
     const declaration = declarations[0];
-    const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
+    const name = createDeclarationName(symbol, declaration);
     const type = checker.getWidenedType(checker.getTypeOfSymbolAtLocation(symbol, enclosingDeclaration));
     const quotePreference = getQuotePreference(sourceFile, preferences);
     const builderFlags = NodeBuilderFlags.OmitThisParameter | (quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : NodeBuilderFlags.None);
@@ -4371,7 +4370,7 @@ function getCompletionData(
             // dprint-ignore
             switch (tokenKind) {
                 case SyntaxKind.CommaToken:
-                    switch (containingNodeKind) {    
+                    switch (containingNodeKind) {
                         case SyntaxKind.CallExpression:                                               // func( a, |
                         case SyntaxKind.NewExpression: {                                              // new C(a, |
                             const expression = (contextToken.parent as CallExpression | NewExpression).expression;
@@ -4454,7 +4453,7 @@ function getCompletionData(
                     }
 
                 case SyntaxKind.TemplateHead:
-                    return { 
+                    return {
                         defaultCommitCharacters: allCommitCharacters,
                         isNewIdentifierLocation: containingNodeKind === SyntaxKind.TemplateExpression // `aa ${|
                     };

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -17,6 +17,7 @@ import {
     cast,
     CatchClause,
     CharacterCodes,
+    CheckFlags,
     ClassDeclaration,
     ClassExpression,
     clone,
@@ -90,6 +91,7 @@ import {
     FutureSourceFile,
     getAssignmentDeclarationKind,
     getBaseFileName,
+    getCheckFlags,
     getCombinedNodeFlagsAlwaysIncludeJSDoc,
     getDirectoryPath,
     getEmitModuleKind,
@@ -110,6 +112,7 @@ import {
     getOriginalNode,
     getPackageNameFromTypesPackageName,
     getPathComponents,
+    getPropertyNameFromType,
     getRootDeclaration,
     getSourceFileOfNode,
     getSpanOfTokenAtPosition,
@@ -258,6 +261,7 @@ import {
     isTypeOperatorNode,
     isTypeParameterDeclaration,
     isTypeReferenceNode,
+    isTypeUsableAsPropertyName,
     isVarConst,
     isVariableDeclarationList,
     isVoidExpression,
@@ -372,6 +376,7 @@ import {
     tokenToString,
     toPath,
     toSorted,
+    TransientSymbol,
     tryCast,
     tryParseJson,
     Type,
@@ -4316,4 +4321,17 @@ export function createFutureSourceFile(fileName: string, syntaxModuleIndicator: 
         statements: emptyArray,
         imports: emptyArray,
     };
+}
+
+/**
+ * @internal
+ */
+export function createDeclarationName(symbol: Symbol, declaration: Declaration | undefined): PropertyName {
+    if (getCheckFlags(symbol) & CheckFlags.Mapped) {
+        const nameType = (symbol as TransientSymbol).links.nameType;
+        if (nameType && isTypeUsableAsPropertyName(nameType)) {
+            return factory.createIdentifier(unescapeLeadingUnderscores(getPropertyNameFromType(nameType)));
+        }
+    }
+    return getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
 }

--- a/tests/cases/fourslash/suggestMappedProperties.ts
+++ b/tests/cases/fourslash/suggestMappedProperties.ts
@@ -1,0 +1,45 @@
+/// <reference path="fourslash.ts" />
+
+////type ListenerTemplate<T, S extends string, I extends string = "${1}"> = {
+////    [K in keyof T as K extends string
+////        ? S extends `${infer F}${I}${infer R}` ? `${F}${K}${R}` : K : K]
+////        : (listener: (payload: T[K]) => void) => void;
+////};
+////type ListenActionable<E> = ListenerTemplate<E, "add*Listener" | "remove*Listener", "*">;
+////type ClickEventSupport = ListenActionable<{ Click: 'some-click-event-payload' }>;
+////
+////const foo = (): ClickEventSupport => {
+////    [|return|] { /*1*/ }
+////}
+
+verify.completions({
+    marker: '1',
+    exact: [{
+        name: 'addClickListener',
+        sortText: completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, 'addClickListener')
+    }, {
+        source: completion.CompletionSource.ObjectLiteralMethodSnippet,
+        isSnippet: true,
+        name: 'addClickListener(listener)',
+        insertText: `addClickListener(listener) {
+    $0
+},`,
+        sortText: completion.SortText.SortBelow(completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, 'addClickListener'))
+    }, {
+        name: 'removeClickListener',
+        sortText: completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, 'removeClickListener')
+    }, {
+        source: completion.CompletionSource.ObjectLiteralMethodSnippet,
+        isSnippet: true,
+        name: 'removeClickListener(listener)',
+        insertText: `removeClickListener(listener) {
+    $0
+},`,
+        sortText: completion.SortText.SortBelow(completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, 'removeClickListener'))
+    }],
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: true,
+        includeCompletionsWithObjectLiteralMethodSnippets: true,
+    }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #59769

Also there is issue with error message: 
`Type '{}' is missing the following properties from type 'ListenerTemplate<{ Click: "some-click-event-payload"; }, "add*Listener" | "remove*Listener", "*">': Click, Click`

But I don't know how to fix it.


