### PR TITLE
Tweak logic that chooses co- vs. contra-variant inferences when covariant inference is an empty object type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26989,7 +26989,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // Similarly ignore co-variant `any` inference when both are available as almost everything is assignable to it
                     // and it would spoil the overall inference.
                     const preferCovariantType = inferredCovariantType && (!inferredContravariantType ||
-                        !(inferredCovariantType.flags & (TypeFlags.Never | TypeFlags.Any)) &&
+                        !(inferredCovariantType.flags & (TypeFlags.Never | TypeFlags.Any) || isEmptyAnonymousObjectType(inferredCovariantType) && isWeakType(inferredContravariantType)) &&
                             some(inference.contraCandidates, t => isTypeAssignableTo(inferredCovariantType, t)) &&
                             every(context.inferences, other =>
                                 other !== inference && getConstraintOfTypeParameter(other.typeParameter) !== inference.typeParameter ||

--- a/tests/baselines/reference/coAndContraVariantInferences12.errors.txt
+++ b/tests/baselines/reference/coAndContraVariantInferences12.errors.txt
@@ -1,0 +1,39 @@
+coAndContraVariantInferences12.ts(18,19): error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
+coAndContraVariantInferences12.ts(21,18): error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+  Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
+
+
+==== coAndContraVariantInferences12.ts (2 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59765
+    
+    type FunctionComponent<P = any> = (props: P) => Element | null;
+    
+    interface ElementAttributes {
+      idomKey?: string | null | number;
+      children?: unknown;
+      skip?: boolean;
+    }
+    
+    declare function element<P>(
+      tag: FunctionComponent<P & ElementAttributes>,
+      attributes: P & ElementAttributes,
+    ): Element;
+    
+    declare function ElName(props: { name?: string }): Element;
+    element(ElName, {}); // ok
+    element(ElName, { age: 42 }); // error
+                      ~~~
+!!! error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
+    
+    declare function ElName2(props: { name: string }): Element;
+    element(ElName2, {}); // error
+                     ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+!!! error TS2345:   Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
+!!! related TS2728 coAndContraVariantInferences12.ts:20:35: 'name' is declared here.
+    
+    declare function ElEmpty(props: {}): Element;
+    element(ElEmpty, { name: "Trevor" }); // ok
+    declare const withOptionalName: { name?: string };
+    element(ElEmpty, withOptionalName); // ok
+    

--- a/tests/baselines/reference/coAndContraVariantInferences12.errors.txt
+++ b/tests/baselines/reference/coAndContraVariantInferences12.errors.txt
@@ -1,9 +1,12 @@
 coAndContraVariantInferences12.ts(18,19): error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
-coAndContraVariantInferences12.ts(21,18): error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+coAndContraVariantInferences12.ts(23,18): error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
   Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
+coAndContraVariantInferences12.ts(24,20): error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name: string; } & ElementAttributes'.
+coAndContraVariantInferences12.ts(25,18): error TS2345: Argument of type '{ idomKey: null; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+  Property 'name' is missing in type '{ idomKey: null; }' but required in type '{ name: string; }'.
 
 
-==== coAndContraVariantInferences12.ts (2 errors) ====
+==== coAndContraVariantInferences12.ts (4 errors) ====
     // https://github.com/microsoft/TypeScript/issues/59765
     
     type FunctionComponent<P = any> = (props: P) => Element | null;
@@ -24,16 +27,30 @@ coAndContraVariantInferences12.ts(21,18): error TS2345: Argument of type '{}' is
     element(ElName, { age: 42 }); // error
                       ~~~
 !!! error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
+    element(ElName, { idomKey: null }); // ok
+    element(ElName, { idomKey: null, name: "Trevor" }); // ok
     
     declare function ElName2(props: { name: string }): Element;
     element(ElName2, {}); // error
                      ~~
 !!! error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
 !!! error TS2345:   Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
-!!! related TS2728 coAndContraVariantInferences12.ts:20:35: 'name' is declared here.
+!!! related TS2728 coAndContraVariantInferences12.ts:22:35: 'name' is declared here.
+    element(ElName2, { age: 42 }); // error
+                       ~~~
+!!! error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name: string; } & ElementAttributes'.
+    element(ElName2, { idomKey: null }); // error
+                     ~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ idomKey: null; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+!!! error TS2345:   Property 'name' is missing in type '{ idomKey: null; }' but required in type '{ name: string; }'.
+!!! related TS2728 coAndContraVariantInferences12.ts:22:35: 'name' is declared here.
     
     declare function ElEmpty(props: {}): Element;
     element(ElEmpty, { name: "Trevor" }); // ok
+    element(ElEmpty, { age: 42 }); // ok
+    element(ElEmpty, { idomKey: null }); // ok
+    element(ElEmpty, { idomKey: null, name: "Trevor" }); // ok
     declare const withOptionalName: { name?: string };
     element(ElEmpty, withOptionalName); // ok
+    element(ElEmpty, { ...withOptionalName, idomKey: null }); // ok
     

--- a/tests/baselines/reference/coAndContraVariantInferences12.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences12.symbols
@@ -56,32 +56,75 @@ element(ElName, { age: 42 }); // error
 >ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
 >age : Symbol(age, Decl(coAndContraVariantInferences12.ts, 17, 17))
 
+element(ElName, { idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 18, 17))
+
+element(ElName, { idomKey: null, name: "Trevor" }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 19, 17))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 19, 32))
+
 declare function ElName2(props: { name: string }): Element;
->ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 17, 29))
->props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 19, 25))
->name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 19, 33))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 19, 51))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 21, 25))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 21, 33))
 >Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 
 element(ElName2, {}); // error
 >element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
->ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 17, 29))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 19, 51))
+
+element(ElName2, { age: 42 }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 19, 51))
+>age : Symbol(age, Decl(coAndContraVariantInferences12.ts, 23, 18))
+
+element(ElName2, { idomKey: null }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 19, 51))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 24, 18))
 
 declare function ElEmpty(props: {}): Element;
->ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
->props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 22, 25))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 26, 25))
 >Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 
 element(ElEmpty, { name: "Trevor" }); // ok
 >element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
->ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
->name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 23, 18))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 27, 18))
+
+element(ElEmpty, { age: 42 }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>age : Symbol(age, Decl(coAndContraVariantInferences12.ts, 28, 18))
+
+element(ElEmpty, { idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 29, 18))
+
+element(ElEmpty, { idomKey: null, name: "Trevor" }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 30, 18))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 30, 33))
 
 declare const withOptionalName: { name?: string };
->withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 24, 13))
->name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 24, 33))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 31, 13))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 31, 33))
 
 element(ElEmpty, withOptionalName); // ok
 >element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
->ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
->withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 24, 13))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 31, 13))
+
+element(ElEmpty, { ...withOptionalName, idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 24, 36))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 31, 13))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences12.ts, 33, 39))
 

--- a/tests/baselines/reference/coAndContraVariantInferences12.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences12.symbols
@@ -1,0 +1,87 @@
+//// [tests/cases/compiler/coAndContraVariantInferences12.ts] ////
+
+=== coAndContraVariantInferences12.ts ===
+// https://github.com/microsoft/TypeScript/issues/59765
+
+type FunctionComponent<P = any> = (props: P) => Element | null;
+>FunctionComponent : Symbol(FunctionComponent, Decl(coAndContraVariantInferences12.ts, 0, 0))
+>P : Symbol(P, Decl(coAndContraVariantInferences12.ts, 2, 23))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 2, 35))
+>P : Symbol(P, Decl(coAndContraVariantInferences12.ts, 2, 23))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+interface ElementAttributes {
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences12.ts, 2, 63))
+
+  idomKey?: string | null | number;
+>idomKey : Symbol(ElementAttributes.idomKey, Decl(coAndContraVariantInferences12.ts, 4, 29))
+
+  children?: unknown;
+>children : Symbol(ElementAttributes.children, Decl(coAndContraVariantInferences12.ts, 5, 35))
+
+  skip?: boolean;
+>skip : Symbol(ElementAttributes.skip, Decl(coAndContraVariantInferences12.ts, 6, 21))
+}
+
+declare function element<P>(
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>P : Symbol(P, Decl(coAndContraVariantInferences12.ts, 10, 25))
+
+  tag: FunctionComponent<P & ElementAttributes>,
+>tag : Symbol(tag, Decl(coAndContraVariantInferences12.ts, 10, 28))
+>FunctionComponent : Symbol(FunctionComponent, Decl(coAndContraVariantInferences12.ts, 0, 0))
+>P : Symbol(P, Decl(coAndContraVariantInferences12.ts, 10, 25))
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences12.ts, 2, 63))
+
+  attributes: P & ElementAttributes,
+>attributes : Symbol(attributes, Decl(coAndContraVariantInferences12.ts, 11, 48))
+>P : Symbol(P, Decl(coAndContraVariantInferences12.ts, 10, 25))
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences12.ts, 2, 63))
+
+): Element;
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+declare function ElName(props: { name?: string }): Element;
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 15, 24))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 15, 32))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElName, {}); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
+
+element(ElName, { age: 42 }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences12.ts, 13, 11))
+>age : Symbol(age, Decl(coAndContraVariantInferences12.ts, 17, 17))
+
+declare function ElName2(props: { name: string }): Element;
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 17, 29))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 19, 25))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 19, 33))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElName2, {}); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences12.ts, 17, 29))
+
+declare function ElEmpty(props: {}): Element;
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
+>props : Symbol(props, Decl(coAndContraVariantInferences12.ts, 22, 25))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElEmpty, { name: "Trevor" }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 23, 18))
+
+declare const withOptionalName: { name?: string };
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 24, 13))
+>name : Symbol(name, Decl(coAndContraVariantInferences12.ts, 24, 33))
+
+element(ElEmpty, withOptionalName); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences12.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences12.ts, 20, 21))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences12.ts, 24, 13))
+

--- a/tests/baselines/reference/coAndContraVariantInferences12.types
+++ b/tests/baselines/reference/coAndContraVariantInferences12.types
@@ -1,0 +1,125 @@
+//// [tests/cases/compiler/coAndContraVariantInferences12.ts] ////
+
+=== coAndContraVariantInferences12.ts ===
+// https://github.com/microsoft/TypeScript/issues/59765
+
+type FunctionComponent<P = any> = (props: P) => Element | null;
+>FunctionComponent : FunctionComponent<P>
+>                  : ^^^^^^^^^^^^^^^^^^^^
+>props : P
+>      : ^
+
+interface ElementAttributes {
+  idomKey?: string | null | number;
+>idomKey : string | number | null | undefined
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  children?: unknown;
+>children : unknown
+>         : ^^^^^^^
+
+  skip?: boolean;
+>skip : boolean | undefined
+>     : ^^^^^^^^^^^^^^^^^^^
+}
+
+declare function element<P>(
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+
+  tag: FunctionComponent<P & ElementAttributes>,
+>tag : FunctionComponent<P & ElementAttributes>
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  attributes: P & ElementAttributes,
+>attributes : P & ElementAttributes
+>           : ^^^^^^^^^^^^^^^^^^^^^
+
+): Element;
+
+declare function ElName(props: { name?: string }): Element;
+>ElName : (props: { name?: string; }) => Element
+>       : ^     ^^                  ^^^^^       
+>props : { name?: string; }
+>      : ^^^^^^^^^      ^^^
+>name : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+element(ElName, {}); // ok
+>element(ElName, {}) : Element
+>                    : ^^^^^^^
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+>ElName : (props: { name?: string; }) => Element
+>       : ^     ^^                  ^^^^^       
+>{} : {}
+>   : ^^
+
+element(ElName, { age: 42 }); // error
+>element(ElName, { age: 42 }) : Element
+>                             : ^^^^^^^
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+>ElName : (props: { name?: string; }) => Element
+>       : ^     ^^                  ^^^^^       
+>{ age: 42 } : { age: number; }
+>            : ^^^^^^^^^^^^^^^^
+>age : number
+>    : ^^^^^^
+>42 : 42
+>   : ^^
+
+declare function ElName2(props: { name: string }): Element;
+>ElName2 : (props: { name: string; }) => Element
+>        : ^     ^^                 ^^^^^       
+>props : { name: string; }
+>      : ^^^^^^^^      ^^^
+>name : string
+>     : ^^^^^^
+
+element(ElName2, {}); // error
+>element(ElName2, {}) : Element
+>                     : ^^^^^^^
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+>ElName2 : (props: { name: string; }) => Element
+>        : ^     ^^                 ^^^^^       
+>{} : {}
+>   : ^^
+
+declare function ElEmpty(props: {}): Element;
+>ElEmpty : (props: {}) => Element
+>        : ^     ^^  ^^^^^       
+>props : {}
+>      : ^^
+
+element(ElEmpty, { name: "Trevor" }); // ok
+>element(ElEmpty, { name: "Trevor" }) : Element
+>                                     : ^^^^^^^
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+>ElEmpty : (props: {}) => Element
+>        : ^     ^^  ^^^^^       
+>{ name: "Trevor" } : { name: string; }
+>                   : ^^^^^^^^^^^^^^^^^
+>name : string
+>     : ^^^^^^
+>"Trevor" : "Trevor"
+>         : ^^^^^^^^
+
+declare const withOptionalName: { name?: string };
+>withOptionalName : { name?: string; }
+>                 : ^^^^^^^^^      ^^^
+>name : string | undefined
+>     : ^^^^^^^^^^^^^^^^^^
+
+element(ElEmpty, withOptionalName); // ok
+>element(ElEmpty, withOptionalName) : Element
+>                                   : ^^^^^^^
+>element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
+>        : ^ ^^   ^^                                        ^^          ^^                     ^^^^^       
+>ElEmpty : (props: {}) => Element
+>        : ^     ^^  ^^^^^       
+>withOptionalName : { name?: string; }
+>                 : ^^^^^^^^^      ^^^
+

--- a/tests/baselines/reference/coAndContraVariantInferences13.errors.txt
+++ b/tests/baselines/reference/coAndContraVariantInferences13.errors.txt
@@ -1,0 +1,80 @@
+coAndContraVariantInferences13.ts(17,17): error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name?: string | undefined; } & ElementAttributes'.
+  Property 'idomKey' is missing in type '{}' but required in type 'ElementAttributes'.
+coAndContraVariantInferences13.ts(18,19): error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
+coAndContraVariantInferences13.ts(23,18): error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+  Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
+coAndContraVariantInferences13.ts(24,20): error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name: string; } & ElementAttributes'.
+coAndContraVariantInferences13.ts(25,18): error TS2345: Argument of type '{ idomKey: null; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+  Property 'name' is missing in type '{ idomKey: null; }' but required in type '{ name: string; }'.
+coAndContraVariantInferences13.ts(28,18): error TS2345: Argument of type '{ name: string; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+  Property 'idomKey' is missing in type '{ name: string; }' but required in type 'ElementAttributes'.
+coAndContraVariantInferences13.ts(29,18): error TS2345: Argument of type '{ age: number; }' is not assignable to parameter of type '{ age: number; } & ElementAttributes'.
+  Property 'idomKey' is missing in type '{ age: number; }' but required in type 'ElementAttributes'.
+coAndContraVariantInferences13.ts(33,18): error TS2345: Argument of type '{ name?: string | undefined; }' is not assignable to parameter of type '{ name?: string | undefined; } & ElementAttributes'.
+  Property 'idomKey' is missing in type '{ name?: string | undefined; }' but required in type 'ElementAttributes'.
+
+
+==== coAndContraVariantInferences13.ts (8 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/59765
+    
+    type FunctionComponent<P = any> = (props: P) => Element | null;
+    
+    interface ElementAttributes {
+      idomKey: string | null | number;
+      children?: unknown;
+      skip?: boolean;
+    }
+    
+    declare function element<P>(
+      tag: FunctionComponent<P & ElementAttributes>,
+      attributes: P & ElementAttributes,
+    ): Element;
+    
+    declare function ElName(props: { name?: string }): Element;
+    element(ElName, {}); // error
+                    ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name?: string | undefined; } & ElementAttributes'.
+!!! error TS2345:   Property 'idomKey' is missing in type '{}' but required in type 'ElementAttributes'.
+!!! related TS2728 coAndContraVariantInferences13.ts:6:3: 'idomKey' is declared here.
+    element(ElName, { age: 42 }); // error
+                      ~~~
+!!! error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name?: string | undefined; } & ElementAttributes'.
+    element(ElName, { idomKey: null }); // ok
+    element(ElName, { idomKey: null, name: "Trevor" }); // ok
+    
+    declare function ElName2(props: { name: string }): Element;
+    element(ElName2, {}); // error
+                     ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+!!! error TS2345:   Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
+!!! related TS2728 coAndContraVariantInferences13.ts:22:35: 'name' is declared here.
+    element(ElName2, { age: 42 }); // error
+                       ~~~
+!!! error TS2353: Object literal may only specify known properties, and 'age' does not exist in type '{ name: string; } & ElementAttributes'.
+    element(ElName2, { idomKey: null }); // error
+                     ~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ idomKey: null; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+!!! error TS2345:   Property 'name' is missing in type '{ idomKey: null; }' but required in type '{ name: string; }'.
+!!! related TS2728 coAndContraVariantInferences13.ts:22:35: 'name' is declared here.
+    
+    declare function ElEmpty(props: {}): Element;
+    element(ElEmpty, { name: "Trevor" }); // error
+                     ~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name: string; }' is not assignable to parameter of type '{ name: string; } & ElementAttributes'.
+!!! error TS2345:   Property 'idomKey' is missing in type '{ name: string; }' but required in type 'ElementAttributes'.
+!!! related TS2728 coAndContraVariantInferences13.ts:6:3: 'idomKey' is declared here.
+    element(ElEmpty, { age: 42 }); // error
+                     ~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ age: number; }' is not assignable to parameter of type '{ age: number; } & ElementAttributes'.
+!!! error TS2345:   Property 'idomKey' is missing in type '{ age: number; }' but required in type 'ElementAttributes'.
+!!! related TS2728 coAndContraVariantInferences13.ts:6:3: 'idomKey' is declared here.
+    element(ElEmpty, { idomKey: null }); // ok
+    element(ElEmpty, { idomKey: null, name: "Trevor" }); // ok
+    declare const withOptionalName: { name?: string };
+    element(ElEmpty, withOptionalName); // error
+                     ~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name?: string | undefined; }' is not assignable to parameter of type '{ name?: string | undefined; } & ElementAttributes'.
+!!! error TS2345:   Property 'idomKey' is missing in type '{ name?: string | undefined; }' but required in type 'ElementAttributes'.
+!!! related TS2728 coAndContraVariantInferences13.ts:6:3: 'idomKey' is declared here.
+    element(ElEmpty, { ...withOptionalName, idomKey: null }); // ok
+    

--- a/tests/baselines/reference/coAndContraVariantInferences13.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences13.symbols
@@ -1,0 +1,130 @@
+//// [tests/cases/compiler/coAndContraVariantInferences13.ts] ////
+
+=== coAndContraVariantInferences13.ts ===
+// https://github.com/microsoft/TypeScript/issues/59765
+
+type FunctionComponent<P = any> = (props: P) => Element | null;
+>FunctionComponent : Symbol(FunctionComponent, Decl(coAndContraVariantInferences13.ts, 0, 0))
+>P : Symbol(P, Decl(coAndContraVariantInferences13.ts, 2, 23))
+>props : Symbol(props, Decl(coAndContraVariantInferences13.ts, 2, 35))
+>P : Symbol(P, Decl(coAndContraVariantInferences13.ts, 2, 23))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+interface ElementAttributes {
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences13.ts, 2, 63))
+
+  idomKey: string | null | number;
+>idomKey : Symbol(ElementAttributes.idomKey, Decl(coAndContraVariantInferences13.ts, 4, 29))
+
+  children?: unknown;
+>children : Symbol(ElementAttributes.children, Decl(coAndContraVariantInferences13.ts, 5, 34))
+
+  skip?: boolean;
+>skip : Symbol(ElementAttributes.skip, Decl(coAndContraVariantInferences13.ts, 6, 21))
+}
+
+declare function element<P>(
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>P : Symbol(P, Decl(coAndContraVariantInferences13.ts, 10, 25))
+
+  tag: FunctionComponent<P & ElementAttributes>,
+>tag : Symbol(tag, Decl(coAndContraVariantInferences13.ts, 10, 28))
+>FunctionComponent : Symbol(FunctionComponent, Decl(coAndContraVariantInferences13.ts, 0, 0))
+>P : Symbol(P, Decl(coAndContraVariantInferences13.ts, 10, 25))
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences13.ts, 2, 63))
+
+  attributes: P & ElementAttributes,
+>attributes : Symbol(attributes, Decl(coAndContraVariantInferences13.ts, 11, 48))
+>P : Symbol(P, Decl(coAndContraVariantInferences13.ts, 10, 25))
+>ElementAttributes : Symbol(ElementAttributes, Decl(coAndContraVariantInferences13.ts, 2, 63))
+
+): Element;
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+declare function ElName(props: { name?: string }): Element;
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences13.ts, 13, 11))
+>props : Symbol(props, Decl(coAndContraVariantInferences13.ts, 15, 24))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 15, 32))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElName, {}); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences13.ts, 13, 11))
+
+element(ElName, { age: 42 }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences13.ts, 13, 11))
+>age : Symbol(age, Decl(coAndContraVariantInferences13.ts, 17, 17))
+
+element(ElName, { idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences13.ts, 13, 11))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 18, 17))
+
+element(ElName, { idomKey: null, name: "Trevor" }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName : Symbol(ElName, Decl(coAndContraVariantInferences13.ts, 13, 11))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 19, 17))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 19, 32))
+
+declare function ElName2(props: { name: string }): Element;
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences13.ts, 19, 51))
+>props : Symbol(props, Decl(coAndContraVariantInferences13.ts, 21, 25))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 21, 33))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElName2, {}); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences13.ts, 19, 51))
+
+element(ElName2, { age: 42 }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences13.ts, 19, 51))
+>age : Symbol(age, Decl(coAndContraVariantInferences13.ts, 23, 18))
+
+element(ElName2, { idomKey: null }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElName2 : Symbol(ElName2, Decl(coAndContraVariantInferences13.ts, 19, 51))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 24, 18))
+
+declare function ElEmpty(props: {}): Element;
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>props : Symbol(props, Decl(coAndContraVariantInferences13.ts, 26, 25))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+element(ElEmpty, { name: "Trevor" }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 27, 18))
+
+element(ElEmpty, { age: 42 }); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>age : Symbol(age, Decl(coAndContraVariantInferences13.ts, 28, 18))
+
+element(ElEmpty, { idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 29, 18))
+
+element(ElEmpty, { idomKey: null, name: "Trevor" }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 30, 18))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 30, 33))
+
+declare const withOptionalName: { name?: string };
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences13.ts, 31, 13))
+>name : Symbol(name, Decl(coAndContraVariantInferences13.ts, 31, 33))
+
+element(ElEmpty, withOptionalName); // error
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences13.ts, 31, 13))
+
+element(ElEmpty, { ...withOptionalName, idomKey: null }); // ok
+>element : Symbol(element, Decl(coAndContraVariantInferences13.ts, 8, 1))
+>ElEmpty : Symbol(ElEmpty, Decl(coAndContraVariantInferences13.ts, 24, 36))
+>withOptionalName : Symbol(withOptionalName, Decl(coAndContraVariantInferences13.ts, 31, 13))
+>idomKey : Symbol(idomKey, Decl(coAndContraVariantInferences13.ts, 33, 39))
+

--- a/tests/baselines/reference/coAndContraVariantInferences13.types
+++ b/tests/baselines/reference/coAndContraVariantInferences13.types
@@ -1,6 +1,6 @@
-//// [tests/cases/compiler/coAndContraVariantInferences12.ts] ////
+//// [tests/cases/compiler/coAndContraVariantInferences13.ts] ////
 
-=== coAndContraVariantInferences12.ts ===
+=== coAndContraVariantInferences13.ts ===
 // https://github.com/microsoft/TypeScript/issues/59765
 
 type FunctionComponent<P = any> = (props: P) => Element | null;
@@ -10,9 +10,9 @@ type FunctionComponent<P = any> = (props: P) => Element | null;
 >      : ^
 
 interface ElementAttributes {
-  idomKey?: string | null | number;
->idomKey : string | number | null | undefined
->        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  idomKey: string | null | number;
+>idomKey : string | number | null
+>        : ^^^^^^^^^^^^^^^^^^^^^^
 
   children?: unknown;
 >children : unknown
@@ -45,7 +45,7 @@ declare function ElName(props: { name?: string }): Element;
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
 
-element(ElName, {}); // ok
+element(ElName, {}); // error
 >element(ElName, {}) : Element
 >                    : ^^^^^^^
 >element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
@@ -147,7 +147,7 @@ declare function ElEmpty(props: {}): Element;
 >props : {}
 >      : ^^
 
-element(ElEmpty, { name: "Trevor" }); // ok
+element(ElEmpty, { name: "Trevor" }); // error
 >element(ElEmpty, { name: "Trevor" }) : Element
 >                                     : ^^^^^^^
 >element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
@@ -161,7 +161,7 @@ element(ElEmpty, { name: "Trevor" }); // ok
 >"Trevor" : "Trevor"
 >         : ^^^^^^^^
 
-element(ElEmpty, { age: 42 }); // ok
+element(ElEmpty, { age: 42 }); // error
 >element(ElEmpty, { age: 42 }) : Element
 >                              : ^^^^^^^
 >element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element
@@ -209,7 +209,7 @@ declare const withOptionalName: { name?: string };
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
 
-element(ElEmpty, withOptionalName); // ok
+element(ElEmpty, withOptionalName); // error
 >element(ElEmpty, withOptionalName) : Element
 >                                   : ^^^^^^^
 >element : <P>(tag: FunctionComponent<P & ElementAttributes>, attributes: P & ElementAttributes) => Element

--- a/tests/baselines/reference/coAndContraVariantInferences14.symbols
+++ b/tests/baselines/reference/coAndContraVariantInferences14.symbols
@@ -1,0 +1,47 @@
+//// [tests/cases/compiler/coAndContraVariantInferences14.ts] ////
+
+=== coAndContraVariantInferences14.ts ===
+interface Foo {
+>Foo : Symbol(Foo, Decl(coAndContraVariantInferences14.ts, 0, 0))
+
+  type: "foo";
+>type : Symbol(Foo.type, Decl(coAndContraVariantInferences14.ts, 0, 15))
+
+  optionalProp?: boolean;
+>optionalProp : Symbol(Foo.optionalProp, Decl(coAndContraVariantInferences14.ts, 1, 14))
+}
+
+type Consumer<T> = (arg: T) => void;
+>Consumer : Symbol(Consumer, Decl(coAndContraVariantInferences14.ts, 3, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 5, 14))
+>arg : Symbol(arg, Decl(coAndContraVariantInferences14.ts, 5, 20))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 5, 14))
+
+declare function someFunc<T extends Foo>(consumer: Consumer<T>, defaultT: T): T;
+>someFunc : Symbol(someFunc, Decl(coAndContraVariantInferences14.ts, 5, 36))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 7, 26))
+>Foo : Symbol(Foo, Decl(coAndContraVariantInferences14.ts, 0, 0))
+>consumer : Symbol(consumer, Decl(coAndContraVariantInferences14.ts, 7, 41))
+>Consumer : Symbol(Consumer, Decl(coAndContraVariantInferences14.ts, 3, 1))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 7, 26))
+>defaultT : Symbol(defaultT, Decl(coAndContraVariantInferences14.ts, 7, 63))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 7, 26))
+>T : Symbol(T, Decl(coAndContraVariantInferences14.ts, 7, 26))
+
+declare const fooConsumer: Consumer<Foo>;
+>fooConsumer : Symbol(fooConsumer, Decl(coAndContraVariantInferences14.ts, 9, 13))
+>Consumer : Symbol(Consumer, Decl(coAndContraVariantInferences14.ts, 3, 1))
+>Foo : Symbol(Foo, Decl(coAndContraVariantInferences14.ts, 0, 0))
+
+const result = someFunc(fooConsumer, { type: "foo", extra: "bar" });
+>result : Symbol(result, Decl(coAndContraVariantInferences14.ts, 11, 5))
+>someFunc : Symbol(someFunc, Decl(coAndContraVariantInferences14.ts, 5, 36))
+>fooConsumer : Symbol(fooConsumer, Decl(coAndContraVariantInferences14.ts, 9, 13))
+>type : Symbol(type, Decl(coAndContraVariantInferences14.ts, 11, 38))
+>extra : Symbol(extra, Decl(coAndContraVariantInferences14.ts, 11, 51))
+
+result.extra;
+>result.extra : Symbol(extra, Decl(coAndContraVariantInferences14.ts, 11, 51))
+>result : Symbol(result, Decl(coAndContraVariantInferences14.ts, 11, 5))
+>extra : Symbol(extra, Decl(coAndContraVariantInferences14.ts, 11, 51))
+

--- a/tests/baselines/reference/coAndContraVariantInferences14.types
+++ b/tests/baselines/reference/coAndContraVariantInferences14.types
@@ -1,0 +1,59 @@
+//// [tests/cases/compiler/coAndContraVariantInferences14.ts] ////
+
+=== coAndContraVariantInferences14.ts ===
+interface Foo {
+  type: "foo";
+>type : "foo"
+>     : ^^^^^
+
+  optionalProp?: boolean;
+>optionalProp : boolean | undefined
+>             : ^^^^^^^^^^^^^^^^^^^
+}
+
+type Consumer<T> = (arg: T) => void;
+>Consumer : Consumer<T>
+>         : ^^^^^^^^^^^
+>arg : T
+>    : ^
+
+declare function someFunc<T extends Foo>(consumer: Consumer<T>, defaultT: T): T;
+>someFunc : <T extends Foo>(consumer: Consumer<T>, defaultT: T) => T
+>         : ^ ^^^^^^^^^   ^^        ^^           ^^        ^^ ^^^^^ 
+>consumer : Consumer<T>
+>         : ^^^^^^^^^^^
+>defaultT : T
+>         : ^
+
+declare const fooConsumer: Consumer<Foo>;
+>fooConsumer : Consumer<Foo>
+>            : ^^^^^^^^^^^^^
+
+const result = someFunc(fooConsumer, { type: "foo", extra: "bar" });
+>result : { type: "foo"; extra: string; }
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>someFunc(fooConsumer, { type: "foo", extra: "bar" }) : { type: "foo"; extra: string; }
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>someFunc : <T extends Foo>(consumer: Consumer<T>, defaultT: T) => T
+>         : ^ ^^^^^^^^^   ^^        ^^           ^^        ^^ ^^^^^ 
+>fooConsumer : Consumer<Foo>
+>            : ^^^^^^^^^^^^^
+>{ type: "foo", extra: "bar" } : { type: "foo"; extra: string; }
+>                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "foo"
+>     : ^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+>extra : string
+>      : ^^^^^^
+>"bar" : "bar"
+>      : ^^^^^
+
+result.extra;
+>result.extra : string
+>             : ^^^^^^
+>result : { type: "foo"; extra: string; }
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>extra : string
+>      : ^^^^^^
+

--- a/tests/cases/compiler/coAndContraVariantInferences12.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences12.ts
@@ -1,0 +1,29 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59765
+
+type FunctionComponent<P = any> = (props: P) => Element | null;
+
+interface ElementAttributes {
+  idomKey?: string | null | number;
+  children?: unknown;
+  skip?: boolean;
+}
+
+declare function element<P>(
+  tag: FunctionComponent<P & ElementAttributes>,
+  attributes: P & ElementAttributes,
+): Element;
+
+declare function ElName(props: { name?: string }): Element;
+element(ElName, {}); // ok
+element(ElName, { age: 42 }); // error
+
+declare function ElName2(props: { name: string }): Element;
+element(ElName2, {}); // error
+
+declare function ElEmpty(props: {}): Element;
+element(ElEmpty, { name: "Trevor" }); // ok
+declare const withOptionalName: { name?: string };
+element(ElEmpty, withOptionalName); // ok

--- a/tests/cases/compiler/coAndContraVariantInferences13.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences13.ts
@@ -6,7 +6,7 @@
 type FunctionComponent<P = any> = (props: P) => Element | null;
 
 interface ElementAttributes {
-  idomKey?: string | null | number;
+  idomKey: string | null | number;
   children?: unknown;
   skip?: boolean;
 }
@@ -17,7 +17,7 @@ declare function element<P>(
 ): Element;
 
 declare function ElName(props: { name?: string }): Element;
-element(ElName, {}); // ok
+element(ElName, {}); // error
 element(ElName, { age: 42 }); // error
 element(ElName, { idomKey: null }); // ok
 element(ElName, { idomKey: null, name: "Trevor" }); // ok
@@ -28,10 +28,10 @@ element(ElName2, { age: 42 }); // error
 element(ElName2, { idomKey: null }); // error
 
 declare function ElEmpty(props: {}): Element;
-element(ElEmpty, { name: "Trevor" }); // ok
-element(ElEmpty, { age: 42 }); // ok
+element(ElEmpty, { name: "Trevor" }); // error
+element(ElEmpty, { age: 42 }); // error
 element(ElEmpty, { idomKey: null }); // ok
 element(ElEmpty, { idomKey: null, name: "Trevor" }); // ok
 declare const withOptionalName: { name?: string };
-element(ElEmpty, withOptionalName); // ok
+element(ElEmpty, withOptionalName); // error
 element(ElEmpty, { ...withOptionalName, idomKey: null }); // ok

--- a/tests/cases/compiler/coAndContraVariantInferences14.ts
+++ b/tests/cases/compiler/coAndContraVariantInferences14.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @noEmit: true
+
+interface Foo {
+  type: "foo";
+  optionalProp?: boolean;
+}
+
+type Consumer<T> = (arg: T) => void;
+
+declare function someFunc<T extends Foo>(consumer: Consumer<T>, defaultT: T): T;
+
+declare const fooConsumer: Consumer<Foo>;
+
+const result = someFunc(fooConsumer, { type: "foo", extra: "bar" });
+result.extra;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59765
cc @weswigham as the reviewer of https://github.com/microsoft/TypeScript/pull/57909 by which this got affected