### PR TITLE
 Don't generalize when assigment target is never (fix: #41707) 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22056,7 +22056,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const [sourceType, targetType] = getTypeNamesForErrorDisplay(source, target);
             let generalizedSource = source;
             let generalizedSourceType = sourceType;
-
+            
+            // Don't generalize on 'never' - we really want the original type
+            // to be displayed for use-cases like 'assertNever'.
             if (!(target.flags & TypeFlags.Never) && isLiteralType(source) && !typeCouldHaveTopLevelSingletonTypes(target)) {
                 generalizedSource = getBaseTypeOfLiteralType(source);
                 Debug.assert(!isTypeAssignableTo(generalizedSource, target), "generalized source shouldn't be assignable");

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22057,7 +22057,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let generalizedSource = source;
             let generalizedSourceType = sourceType;
 
-            if (isLiteralType(source) && !typeCouldHaveTopLevelSingletonTypes(target)) {
+            if (isLiteralType(source) && (!typeCouldHaveTopLevelSingletonTypes(target) && !(target.flags & TypeFlags.Never))) {
                 generalizedSource = getBaseTypeOfLiteralType(source);
                 Debug.assert(!isTypeAssignableTo(generalizedSource, target), "generalized source shouldn't be assignable");
                 generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22057,7 +22057,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let generalizedSource = source;
             let generalizedSourceType = sourceType;
 
-            if (isLiteralType(source) && (!typeCouldHaveTopLevelSingletonTypes(target) && !(target.flags & TypeFlags.Never))) {
+            if (!(target.flags & TypeFlags.Never) && isLiteralType(source) && !typeCouldHaveTopLevelSingletonTypes(target)) {
                 generalizedSource = getBaseTypeOfLiteralType(source);
                 Debug.assert(!isTypeAssignableTo(generalizedSource, target), "generalized source shouldn't be assignable");
                 generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);

--- a/tests/baselines/reference/controlFlowArrayErrors.errors.txt
+++ b/tests/baselines/reference/controlFlowArrayErrors.errors.txt
@@ -6,7 +6,7 @@ controlFlowArrayErrors.ts(19,9): error TS7034: Variable 'x' implicitly has type 
 controlFlowArrayErrors.ts(22,9): error TS7005: Variable 'x' implicitly has an 'any[]' type.
 controlFlowArrayErrors.ts(29,12): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string | number'.
 controlFlowArrayErrors.ts(34,12): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string | number'.
-controlFlowArrayErrors.ts(48,12): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+controlFlowArrayErrors.ts(48,12): error TS2345: Argument of type '99' is not assignable to parameter of type 'never'.
 controlFlowArrayErrors.ts(56,12): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
 controlFlowArrayErrors.ts(60,11): error TS7034: Variable 'x' implicitly has type 'any[]' in some locations where its type cannot be determined.
 controlFlowArrayErrors.ts(63,9): error TS7005: Variable 'x' implicitly has an 'any[]' type.
@@ -78,7 +78,7 @@ controlFlowArrayErrors.ts(63,9): error TS7005: Variable 'x' implicitly has an 'a
         x;           // boolean[] | (string | number)[]
         x.push(99);  // Error
                ~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '99' is not assignable to parameter of type 'never'.
     }
     
     function f7() {

--- a/tests/baselines/reference/dependentDestructuredVariables.errors.txt
+++ b/tests/baselines/reference/dependentDestructuredVariables.errors.txt
@@ -1,6 +1,6 @@
 dependentDestructuredVariables.ts(334,5): error TS7022: 'value1' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
 dependentDestructuredVariables.ts(334,5): error TS7031: Binding element 'value1' implicitly has an 'any' type.
-dependentDestructuredVariables.ts(431,15): error TS2322: Type 'number' is not assignable to type 'never'.
+dependentDestructuredVariables.ts(431,15): error TS2322: Type '1' is not assignable to type 'never'.
 
 
 ==== dependentDestructuredVariables.ts (3 errors) ====
@@ -440,7 +440,7 @@ dependentDestructuredVariables.ts(431,15): error TS2322: Type 'number' is not as
         if (y === undefined) {
             const shouldNotBeOk: never = x;  // Error
                   ~~~~~~~~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
         }
     }
     

--- a/tests/baselines/reference/errorOnFunctionReturnType.errors.txt
+++ b/tests/baselines/reference/errorOnFunctionReturnType.errors.txt
@@ -5,7 +5,7 @@ foo.js(16,60): error TS2355: A function whose declared type is neither 'undefine
 foo.js(21,20): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 foo.js(31,10): error TS2534: A function returning 'never' cannot have a reachable end point.
 foo.js(35,12): error TS1065: The return type of an async function or method must be the global Promise<T> type.
-foo.js(37,5): error TS2322: Type 'string' is not assignable to type 'never'.
+foo.js(37,5): error TS2322: Type '"asd"' is not assignable to type 'never'.
 foo.js(40,56): error TS2534: A function returning 'never' cannot have a reachable end point.
 foo.js(45,18): error TS2534: A function returning 'never' cannot have a reachable end point.
 
@@ -64,7 +64,7 @@ foo.js(45,18): error TS2534: A function returning 'never' cannot have a reachabl
     async function testNever2() {
         return "asd";
         ~~~~~~
-!!! error TS2322: Type 'string' is not assignable to type 'never'.
+!!! error TS2322: Type '"asd"' is not assignable to type 'never'.
     }
     
     var testNever3 = /** @type {FunctionReturningNever} */ function() {

--- a/tests/baselines/reference/exhaustiveSwitchCheckCircularity.errors.txt
+++ b/tests/baselines/reference/exhaustiveSwitchCheckCircularity.errors.txt
@@ -1,4 +1,4 @@
-exhaustiveSwitchCheckCircularity.ts(14,26): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+exhaustiveSwitchCheckCircularity.ts(14,26): error TS2345: Argument of type '"bbb"' is not assignable to parameter of type 'never'.
 
 
 ==== exhaustiveSwitchCheckCircularity.ts (1 errors) ====
@@ -17,7 +17,7 @@ exhaustiveSwitchCheckCircularity.ts(14,26): error TS2345: Argument of type 'stri
             }
             else if (isNever(foo)) {  // Error expected
                              ~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"bbb"' is not assignable to parameter of type 'never'.
                 break;
             }
         }

--- a/tests/baselines/reference/extractInferenceImprovement.errors.txt
+++ b/tests/baselines/reference/extractInferenceImprovement.errors.txt
@@ -1,4 +1,4 @@
-extractInferenceImprovement.ts(26,26): error TS2345: Argument of type 'typeof s' is not assignable to parameter of type 'never'.
+extractInferenceImprovement.ts(26,26): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type 'never'.
 extractInferenceImprovement.ts(28,1): error TS2322: Type 'string | number' is not assignable to type 'string'.
   Type 'number' is not assignable to type 'string'.
 extractInferenceImprovement.ts(28,26): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"first" | "second"'.
@@ -32,7 +32,7 @@ extractInferenceImprovement.ts(28,26): error TS2345: Argument of type 'unique sy
     // Should fail
     prop = getProperty2(obj, s);
                              ~
-!!! error TS2345: Argument of type 'typeof s' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type 'never'.
     
     prop = getProperty3(obj, s);
     ~~~~

--- a/tests/baselines/reference/functionCallOnConstrainedTypeVariable.errors.txt
+++ b/tests/baselines/reference/functionCallOnConstrainedTypeVariable.errors.txt
@@ -1,6 +1,6 @@
-functionCallOnConstrainedTypeVariable.ts(11,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
-functionCallOnConstrainedTypeVariable.ts(15,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
-functionCallOnConstrainedTypeVariable.ts(18,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+functionCallOnConstrainedTypeVariable.ts(11,7): error TS2345: Argument of type '"s"' is not assignable to parameter of type 'never'.
+functionCallOnConstrainedTypeVariable.ts(15,7): error TS2345: Argument of type '"s"' is not assignable to parameter of type 'never'.
+functionCallOnConstrainedTypeVariable.ts(18,5): error TS2345: Argument of type '""' is not assignable to parameter of type 'never'.
 functionCallOnConstrainedTypeVariable.ts(19,9): error TS2554: Expected 1 arguments, but got 4.
 
 
@@ -17,18 +17,18 @@ functionCallOnConstrainedTypeVariable.ts(19,9): error TS2554: Expected 1 argumen
     function call0(p: A | B) { 
       p.a("s"); // Error
           ~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"s"' is not assignable to parameter of type 'never'.
     }
     
     function callN<T extends A | B>(p: T) {
       p.a("s"); // Error
           ~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"s"' is not assignable to parameter of type 'never'.
       
       var a: T["a"] = p.a;
       a(""); // Error
         ~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '""' is not assignable to parameter of type 'never'.
       a("", "", "", ""); // Error
             ~~~~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 4.

--- a/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
@@ -1,9 +1,9 @@
 keyofAndIndexedAccess2.ts(4,5): error TS2322: Type 'string' is not assignable to type 'number'.
 keyofAndIndexedAccess2.ts(6,5): error TS2322: Type '2' is not assignable to type '0 | 1'.
 keyofAndIndexedAccess2.ts(7,5): error TS2322: Type '"x"' is not assignable to type '0 | 1'.
-keyofAndIndexedAccess2.ts(8,5): error TS2322: Type 'number' is not assignable to type 'never'.
-keyofAndIndexedAccess2.ts(9,5): error TS2322: Type 'number' is not assignable to type 'never'.
-keyofAndIndexedAccess2.ts(10,5): error TS2322: Type 'string' is not assignable to type 'never'.
+keyofAndIndexedAccess2.ts(8,5): error TS2322: Type '1' is not assignable to type 'never'.
+keyofAndIndexedAccess2.ts(9,5): error TS2322: Type '2' is not assignable to type 'never'.
+keyofAndIndexedAccess2.ts(10,5): error TS2322: Type '"x"' is not assignable to type 'never'.
 keyofAndIndexedAccess2.ts(14,5): error TS2739: Type '{ [key: string]: number; }' is missing the following properties from type '{ x: number; y: number; }': x, y
 keyofAndIndexedAccess2.ts(15,5): error TS2322: Type 'T' is not assignable to type '{ x: number; y: number; }'.
   Type '{ [key: string]: number; }' is missing the following properties from type '{ x: number; y: number; }': x, y
@@ -18,7 +18,7 @@ keyofAndIndexedAccess2.ts(31,5): error TS2322: Type '{ [key: string]: number; }'
 keyofAndIndexedAccess2.ts(38,5): error TS2322: Type '{ [x: string]: number; }' is not assignable to type '{ [P in K]: number; }'.
 keyofAndIndexedAccess2.ts(50,3): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Item'.
   No index signature with a parameter of type 'string' was found on type 'Item'.
-keyofAndIndexedAccess2.ts(51,3): error TS2322: Type 'number' is not assignable to type 'never'.
+keyofAndIndexedAccess2.ts(51,3): error TS2322: Type '123' is not assignable to type 'never'.
 keyofAndIndexedAccess2.ts(52,3): error TS2322: Type 'number' is not assignable to type 'T[keyof T]'.
   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'number'.
 keyofAndIndexedAccess2.ts(53,3): error TS2322: Type 'number' is not assignable to type 'T[K]'.
@@ -30,7 +30,7 @@ keyofAndIndexedAccess2.ts(67,3): error TS2322: Type 'number' is not assignable t
 keyofAndIndexedAccess2.ts(68,3): error TS2322: Type 'number' is not assignable to type 'T[K]'.
   'number' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'number'.
 keyofAndIndexedAccess2.ts(108,5): error TS2322: Type '123' is not assignable to type 'Type[K]'.
-  Type 'number' is not assignable to type 'never'.
+  Type '123' is not assignable to type 'never'.
 
 
 ==== keyofAndIndexedAccess2.ts (23 errors) ====
@@ -49,13 +49,13 @@ keyofAndIndexedAccess2.ts(108,5): error TS2322: Type '123' is not assignable to 
 !!! error TS2322: Type '"x"' is not assignable to type '0 | 1'.
         obj[k2] = 1;    // Error
         ~~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
         obj[k2] = 2;    // Error
         ~~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '2' is not assignable to type 'never'.
         obj[k2] = 'x';  // Error
         ~~~~~~~
-!!! error TS2322: Type 'string' is not assignable to type 'never'.
+!!! error TS2322: Type '"x"' is not assignable to type 'never'.
     }
     
     function f2<T extends { [key: string]: number }>(a: { x: number, y: number }, b: { [key: string]: number }, c: T, k: keyof T) {
@@ -121,7 +121,7 @@ keyofAndIndexedAccess2.ts(108,5): error TS2322: Type '123' is not assignable to 
 !!! error TS7053:   No index signature with a parameter of type 'string' was found on type 'Item'.
       obj[k2] = 123;  // Error
       ~~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '123' is not assignable to type 'never'.
       obj[k3] = 123;  // Error
       ~~~~~~~
 !!! error TS2322: Type 'number' is not assignable to type 'T[keyof T]'.
@@ -197,7 +197,7 @@ keyofAndIndexedAccess2.ts(108,5): error TS2322: Type '123' is not assignable to 
         return 123;  // Error
         ~~~~~~
 !!! error TS2322: Type '123' is not assignable to type 'Type[K]'.
-!!! error TS2322:   Type 'number' is not assignable to type 'never'.
+!!! error TS2322:   Type '123' is not assignable to type 'never'.
     }
     
     // Repro from #30920

--- a/tests/baselines/reference/logicalAssignment6(target=es2015).errors.txt
+++ b/tests/baselines/reference/logicalAssignment6(target=es2015).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment6.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment6.ts(10,42): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment6.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                              ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment6(target=es2020).errors.txt
+++ b/tests/baselines/reference/logicalAssignment6(target=es2020).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment6.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment6.ts(10,42): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment6.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                              ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment6(target=es2021).errors.txt
+++ b/tests/baselines/reference/logicalAssignment6(target=es2021).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment6.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment6.ts(10,42): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment6.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                              ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment6(target=esnext).errors.txt
+++ b/tests/baselines/reference/logicalAssignment6(target=esnext).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment6.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment6.ts(10,42): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment6.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment6.ts(10,42): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                              ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment7(target=es2015).errors.txt
+++ b/tests/baselines/reference/logicalAssignment7(target=es2015).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment7.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment7.ts(10,40): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment7.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment7(target=es2020).errors.txt
+++ b/tests/baselines/reference/logicalAssignment7(target=es2020).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment7.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment7.ts(10,40): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment7.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment7(target=es2021).errors.txt
+++ b/tests/baselines/reference/logicalAssignment7(target=es2021).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment7.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment7.ts(10,40): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment7.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/logicalAssignment7(target=esnext).errors.txt
+++ b/tests/baselines/reference/logicalAssignment7(target=esnext).errors.txt
@@ -1,5 +1,5 @@
 logicalAssignment7.ts(10,5): error TS2532: Object is possibly 'undefined'.
-logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+logicalAssignment7.ts(10,40): error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
 
 
 ==== logicalAssignment7.ts (2 errors) ====
@@ -16,6 +16,6 @@ logicalAssignment7.ts(10,40): error TS2345: Argument of type 'number' is not ass
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '100' is not assignable to parameter of type 'never'.
     }
     

--- a/tests/baselines/reference/narrowingUnionToNeverAssigment.errors.txt
+++ b/tests/baselines/reference/narrowingUnionToNeverAssigment.errors.txt
@@ -1,0 +1,19 @@
+narrowingUnionToNeverAssigment.ts(8,15): error TS2322: Type '"c" | "d"' is not assignable to type 'never'.
+  Type '"c"' is not assignable to type 'never'.
+
+
+==== narrowingUnionToNeverAssigment.ts (1 errors) ====
+    type Variants = "a" | "b" | "c" | "d";
+    
+    
+    function fx1(x: Variants) {
+        if (x === "a" || x === "b") {        
+        }
+        else {
+            const y: never = x;
+                  ~
+!!! error TS2322: Type '"c" | "d"' is not assignable to type 'never'.
+!!! error TS2322:   Type '"c"' is not assignable to type 'never'.
+        }
+    }
+    

--- a/tests/baselines/reference/narrowingUnionToNeverAssigment.js
+++ b/tests/baselines/reference/narrowingUnionToNeverAssigment.js
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/narrowingUnionToNeverAssigment.ts] ////
+
+//// [narrowingUnionToNeverAssigment.ts]
+type Variants = "a" | "b" | "c" | "d";
+
+
+function fx1(x: Variants) {
+    if (x === "a" || x === "b") {        
+    }
+    else {
+        const y: never = x;
+    }
+}
+
+
+//// [narrowingUnionToNeverAssigment.js]
+"use strict";
+function fx1(x) {
+    if (x === "a" || x === "b") {
+    }
+    else {
+        var y = x;
+    }
+}

--- a/tests/baselines/reference/narrowingUnionToNeverAssigment.symbols
+++ b/tests/baselines/reference/narrowingUnionToNeverAssigment.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/narrowingUnionToNeverAssigment.ts] ////
+
+=== narrowingUnionToNeverAssigment.ts ===
+type Variants = "a" | "b" | "c" | "d";
+>Variants : Symbol(Variants, Decl(narrowingUnionToNeverAssigment.ts, 0, 0))
+
+
+function fx1(x: Variants) {
+>fx1 : Symbol(fx1, Decl(narrowingUnionToNeverAssigment.ts, 0, 38))
+>x : Symbol(x, Decl(narrowingUnionToNeverAssigment.ts, 3, 13))
+>Variants : Symbol(Variants, Decl(narrowingUnionToNeverAssigment.ts, 0, 0))
+
+    if (x === "a" || x === "b") {        
+>x : Symbol(x, Decl(narrowingUnionToNeverAssigment.ts, 3, 13))
+>x : Symbol(x, Decl(narrowingUnionToNeverAssigment.ts, 3, 13))
+    }
+    else {
+        const y: never = x;
+>y : Symbol(y, Decl(narrowingUnionToNeverAssigment.ts, 7, 13))
+>x : Symbol(x, Decl(narrowingUnionToNeverAssigment.ts, 3, 13))
+    }
+}
+

--- a/tests/baselines/reference/narrowingUnionToNeverAssigment.types
+++ b/tests/baselines/reference/narrowingUnionToNeverAssigment.types
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/narrowingUnionToNeverAssigment.ts] ////
+
+=== narrowingUnionToNeverAssigment.ts ===
+type Variants = "a" | "b" | "c" | "d";
+>Variants : Variants
+>         : ^^^^^^^^
+
+
+function fx1(x: Variants) {
+>fx1 : (x: Variants) => void
+>    : ^ ^^        ^^^^^^^^^
+>x : Variants
+>  : ^^^^^^^^
+
+    if (x === "a" || x === "b") {        
+>x === "a" || x === "b" : boolean
+>                       : ^^^^^^^
+>x === "a" : boolean
+>          : ^^^^^^^
+>x : Variants
+>  : ^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>x === "b" : boolean
+>          : ^^^^^^^
+>x : "b" | "c" | "d"
+>  : ^^^^^^^^^^^^^^^
+>"b" : "b"
+>    : ^^^
+    }
+    else {
+        const y: never = x;
+>y : never
+>  : ^^^^^
+>x : "c" | "d"
+>  : ^^^^^^^^^
+    }
+}
+

--- a/tests/baselines/reference/neverTypeErrors1.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors1.errors.txt
@@ -1,13 +1,13 @@
-neverTypeErrors1.ts(3,5): error TS2322: Type 'number' is not assignable to type 'never'.
-neverTypeErrors1.ts(4,5): error TS2322: Type 'string' is not assignable to type 'never'.
-neverTypeErrors1.ts(5,5): error TS2322: Type 'boolean' is not assignable to type 'never'.
+neverTypeErrors1.ts(3,5): error TS2322: Type '1' is not assignable to type 'never'.
+neverTypeErrors1.ts(4,5): error TS2322: Type '"abc"' is not assignable to type 'never'.
+neverTypeErrors1.ts(5,5): error TS2322: Type 'false' is not assignable to type 'never'.
 neverTypeErrors1.ts(6,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 neverTypeErrors1.ts(7,5): error TS2322: Type 'null' is not assignable to type 'never'.
 neverTypeErrors1.ts(8,5): error TS2322: Type '{}' is not assignable to type 'never'.
 neverTypeErrors1.ts(9,5): error TS2349: This expression is not callable.
   Type 'never' has no call signatures.
 neverTypeErrors1.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
-neverTypeErrors1.ts(17,5): error TS2322: Type 'number' is not assignable to type 'never'.
+neverTypeErrors1.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 neverTypeErrors1.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
 neverTypeErrors1.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
 neverTypeErrors1.ts(24,17): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
@@ -18,13 +18,13 @@ neverTypeErrors1.ts(24,17): error TS2407: The right-hand side of a 'for...in' st
         let x: never;
         x = 1;
         ~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
         x = "abc";
         ~
-!!! error TS2322: Type 'string' is not assignable to type 'never'.
+!!! error TS2322: Type '"abc"' is not assignable to type 'never'.
         x = false;
         ~
-!!! error TS2322: Type 'boolean' is not assignable to type 'never'.
+!!! error TS2322: Type 'false' is not assignable to type 'never'.
         x = undefined;
         ~
 !!! error TS2322: Type 'undefined' is not assignable to type 'never'.
@@ -49,7 +49,7 @@ neverTypeErrors1.ts(24,17): error TS2407: The right-hand side of a 'for...in' st
     function f3(): never {
         return 1;
         ~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
     }
     
     function f4(): never {

--- a/tests/baselines/reference/neverTypeErrors2.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors2.errors.txt
@@ -1,13 +1,13 @@
-neverTypeErrors2.ts(3,5): error TS2322: Type 'number' is not assignable to type 'never'.
-neverTypeErrors2.ts(4,5): error TS2322: Type 'string' is not assignable to type 'never'.
-neverTypeErrors2.ts(5,5): error TS2322: Type 'boolean' is not assignable to type 'never'.
+neverTypeErrors2.ts(3,5): error TS2322: Type '1' is not assignable to type 'never'.
+neverTypeErrors2.ts(4,5): error TS2322: Type '"abc"' is not assignable to type 'never'.
+neverTypeErrors2.ts(5,5): error TS2322: Type 'false' is not assignable to type 'never'.
 neverTypeErrors2.ts(6,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 neverTypeErrors2.ts(7,5): error TS2322: Type 'null' is not assignable to type 'never'.
 neverTypeErrors2.ts(8,5): error TS2322: Type '{}' is not assignable to type 'never'.
 neverTypeErrors2.ts(9,5): error TS2349: This expression is not callable.
   Type 'never' has no call signatures.
 neverTypeErrors2.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
-neverTypeErrors2.ts(17,5): error TS2322: Type 'number' is not assignable to type 'never'.
+neverTypeErrors2.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 neverTypeErrors2.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
 neverTypeErrors2.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
 neverTypeErrors2.ts(24,17): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
@@ -18,13 +18,13 @@ neverTypeErrors2.ts(24,17): error TS2407: The right-hand side of a 'for...in' st
         let x: never;
         x = 1;
         ~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
         x = "abc";
         ~
-!!! error TS2322: Type 'string' is not assignable to type 'never'.
+!!! error TS2322: Type '"abc"' is not assignable to type 'never'.
         x = false;
         ~
-!!! error TS2322: Type 'boolean' is not assignable to type 'never'.
+!!! error TS2322: Type 'false' is not assignable to type 'never'.
         x = undefined;
         ~
 !!! error TS2322: Type 'undefined' is not assignable to type 'never'.
@@ -49,7 +49,7 @@ neverTypeErrors2.ts(24,17): error TS2407: The right-hand side of a 'for...in' st
     function f3(): never {
         return 1;
         ~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'never'.
+!!! error TS2322: Type '1' is not assignable to type 'never'.
     }
     
     function f4(): never {

--- a/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
@@ -1,4 +1,4 @@
-nonPrimitiveUnionIntersection.ts(1,5): error TS2322: Type 'string' is not assignable to type 'never'.
+nonPrimitiveUnionIntersection.ts(1,5): error TS2322: Type '""' is not assignable to type 'never'.
 nonPrimitiveUnionIntersection.ts(3,5): error TS2322: Type 'number' is not assignable to type 'object'.
 nonPrimitiveUnionIntersection.ts(4,1): error TS2322: Type 'string' is not assignable to type 'never'.
 nonPrimitiveUnionIntersection.ts(8,38): error TS2353: Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
@@ -7,7 +7,7 @@ nonPrimitiveUnionIntersection.ts(8,38): error TS2353: Object literal may only sp
 ==== nonPrimitiveUnionIntersection.ts (4 errors) ====
     var a: object & string = ""; // error
         ~
-!!! error TS2322: Type 'string' is not assignable to type 'never'.
+!!! error TS2322: Type '""' is not assignable to type 'never'.
     var b: object | string = ""; // ok
     var c: object & {} = 123; // error
         ~

--- a/tests/baselines/reference/tsxUnionElementType1.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType1.errors.txt
@@ -1,4 +1,4 @@
-file.tsx(12,10): error TS2322: Type 'boolean' is not assignable to type 'never'.
+file.tsx(12,10): error TS2322: Type 'true' is not assignable to type 'never'.
 
 
 ==== file.tsx (1 errors) ====
@@ -15,4 +15,4 @@ file.tsx(12,10): error TS2322: Type 'boolean' is not assignable to type 'never'.
     var SFCComp = SFC1 || SFC2;
     <SFCComp x />
              ~
-!!! error TS2322: Type 'boolean' is not assignable to type 'never'.
+!!! error TS2322: Type 'true' is not assignable to type 'never'.

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -1,4 +1,4 @@
-file.tsx(32,17): error TS2322: Type 'boolean' is not assignable to type 'never'.
+file.tsx(32,17): error TS2322: Type 'true' is not assignable to type 'never'.
 file.tsx(33,21): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
 file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
@@ -39,7 +39,7 @@ file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 
     // Error
     let a = <RCComp x />;
                     ~
-!!! error TS2322: Type 'boolean' is not assignable to type 'never'.
+!!! error TS2322: Type 'true' is not assignable to type 'never'.
 !!! related TS6500 file.tsx:3:36: The expected type comes from property 'x' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC1 | RC2> & { x: number; } & { children?: ReactNode; } & { x: string; } & { children?: ReactNode; }'
     let b = <PartRCComp x={10} />
                         ~

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -12,8 +12,8 @@ unionTypeCallSignatures.ts(15,29): error TS2769: No overload matches this call.
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
     Argument of type 'boolean' is not assignable to parameter of type 'string'.
 unionTypeCallSignatures.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
-unionTypeCallSignatures.ts(19,32): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
-unionTypeCallSignatures.ts(20,32): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+unionTypeCallSignatures.ts(19,32): error TS2345: Argument of type '10' is not assignable to parameter of type 'never'.
+unionTypeCallSignatures.ts(20,32): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'never'.
 unionTypeCallSignatures.ts(21,1): error TS2554: Expected 1 arguments, but got 0.
 unionTypeCallSignatures.ts(24,1): error TS2554: Expected 1 arguments, but got 0.
 unionTypeCallSignatures.ts(26,36): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
@@ -78,10 +78,10 @@ unionTypeCallSignatures.ts(73,12): error TS2554: Expected 2 arguments, but got 1
     var unionOfDifferentParameterTypes: { (a: number): number; } | { (a: string): Date; };
     unionOfDifferentParameterTypes(10);// error - no call signatures
                                    ~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '10' is not assignable to parameter of type 'never'.
     unionOfDifferentParameterTypes("hello");// error - no call signatures
                                    ~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'never'.
     unionOfDifferentParameterTypes();// error - no call signatures
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 0.

--- a/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
@@ -12,8 +12,8 @@ unionTypeConstructSignatures.ts(15,33): error TS2769: No overload matches this c
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
     Argument of type 'boolean' is not assignable to parameter of type 'string'.
 unionTypeConstructSignatures.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
-unionTypeConstructSignatures.ts(19,36): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
-unionTypeConstructSignatures.ts(20,36): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+unionTypeConstructSignatures.ts(19,36): error TS2345: Argument of type '10' is not assignable to parameter of type 'never'.
+unionTypeConstructSignatures.ts(20,36): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'never'.
 unionTypeConstructSignatures.ts(21,1): error TS2554: Expected 1 arguments, but got 0.
 unionTypeConstructSignatures.ts(24,1): error TS2554: Expected 1 arguments, but got 0.
 unionTypeConstructSignatures.ts(26,40): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
@@ -78,10 +78,10 @@ unionTypeConstructSignatures.ts(73,1): error TS2511: Cannot create an instance o
     var unionOfDifferentParameterTypes: { new (a: number): number; } | { new (a: string): Date; };
     new unionOfDifferentParameterTypes(10);// error - no call signatures
                                        ~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '10' is not assignable to parameter of type 'never'.
     new unionOfDifferentParameterTypes("hello");// error - no call signatures
                                        ~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'never'.
     new unionOfDifferentParameterTypes();// error - no call signatures
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 0.

--- a/tests/baselines/reference/unionTypeInference.errors.txt
+++ b/tests/baselines/reference/unionTypeInference.errors.txt
@@ -1,5 +1,5 @@
 unionTypeInference.ts(13,24): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
-unionTypeInference.ts(31,15): error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+unionTypeInference.ts(31,15): error TS2345: Argument of type '42' is not assignable to parameter of type 'never'.
 
 
 ==== unionTypeInference.ts (2 errors) ====
@@ -37,7 +37,7 @@ unionTypeInference.ts(31,15): error TS2345: Argument of type 'number' is not ass
     const d2 = f4(s);
     const d3 = f4(42);  // Error
                   ~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '42' is not assignable to parameter of type 'never'.
     
     export interface Foo<T> {
         then<U>(f: (x: T) => U | Foo<U>, g: U): Foo<U>;

--- a/tests/baselines/reference/unknownControlFlow.errors.txt
+++ b/tests/baselines/reference/unknownControlFlow.errors.txt
@@ -1,6 +1,6 @@
 unknownControlFlow.ts(18,9): error TS2322: Type 'unknown' is not assignable to type '{}'.
 unknownControlFlow.ts(283,5): error TS2536: Type 'keyof (T & {})' cannot be used to index type 'T'.
-unknownControlFlow.ts(290,11): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+unknownControlFlow.ts(290,11): error TS2345: Argument of type '"foo"' is not assignable to parameter of type 'never'.
 unknownControlFlow.ts(291,5): error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
 unknownControlFlow.ts(293,5): error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
 unknownControlFlow.ts(323,9): error TS2367: This comparison appears to be unintentional because the types 'T' and 'number' have no overlap.
@@ -303,7 +303,7 @@ unknownControlFlow.ts(341,9): error TS2367: This comparison appears to be uninte
     
     ff1(null, 'foo');  // Error
               ~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '"foo"' is not assignable to parameter of type 'never'.
     ff2(null, 'foo');  // Error
         ~~~~
 !!! error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.

--- a/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
+++ b/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
@@ -1,0 +1,12 @@
+// @strict: true
+
+type Variants = "a" | "b" | "c" | "d";
+
+
+function fx1(x: Variants) {
+    if (x === "a" || x === "b") {        
+    }
+    else {
+        const y: never = x;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #41707

Added a condition that when the expected type is "never," the checker should not generalize the literal type. It might not be the best solution, but it's definitely the easiest one. Another idea that I've considered was to check if the "source" type is narrowed and skip generalization for narrowed types, but I'm not sure how to do it properly and if it OK solution.