### PR TITLE
Provide string literal completions for flow properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -769,6 +769,7 @@ import {
     isTypeReferenceType,
     isTypeUsableAsPropertyName,
     isUMDExportSymbol,
+    isUnaryTupleTypeNode,
     isValidBigIntString,
     isValidESSymbolDeclaration,
     isValidTypeOnlyAliasUseSite,
@@ -16709,17 +16710,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return isNoInferType(substitutionType) ? substitutionType.baseType : getIntersectionType([substitutionType.constraint, substitutionType.baseType]);
     }
 
-    function isUnaryTupleTypeNode(node: TypeNode) {
-        return node.kind === SyntaxKind.TupleType && (node as TupleTypeNode).elements.length === 1;
-    }
-
     function getImpliedConstraint(type: Type, checkNode: TypeNode, extendsNode: TypeNode): Type | undefined {
         return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(type, (checkNode as TupleTypeNode).elements[0], (extendsNode as TupleTypeNode).elements[0]) :
             getActualTypeVariable(getTypeFromTypeNode(checkNode)) === getActualTypeVariable(type) ? getTypeFromTypeNode(extendsNode) :
             undefined;
     }
 
-    function getConditionalFlowTypeOfType(type: Type, node: Node) {
+    function getFlowTypeOfType(type: Type, node: Node) {
         let constraints: Type[] | undefined;
         let covariant = true;
         while (node && !isStatement(node) && node.kind !== SyntaxKind.JSDoc) {
@@ -19893,7 +19890,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeFromTypeNode(node: TypeNode): Type {
-        return getConditionalFlowTypeOfType(getTypeFromTypeNodeWorker(node), node);
+        return getFlowTypeOfType(getTypeFromTypeNodeWorker(node), node);
     }
 
     function getTypeFromTypeNodeWorker(node: TypeNode): Type {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -11918,3 +11918,8 @@ export const nodeCoreModules = new Set([
     ...unprefixedNodeCoreModulesList.map(name => `node:${name}`),
     ...exclusivelyPrefixedNodeCoreModules,
 ]);
+
+/** @internal */
+export function isUnaryTupleTypeNode(node: TypeNode) {
+    return node.kind === SyntaxKind.TupleType && (node as TupleTypeNode).elements.length === 1;
+}

--- a/tests/cases/fourslash/stringLiteralCompletionsFlowPropertiesIndexedAccess1.ts
+++ b/tests/cases/fourslash/stringLiteralCompletionsFlowPropertiesIndexedAccess1.ts
@@ -1,0 +1,39 @@
+/// <reference path="fourslash.ts" />
+
+//// type Test1<T> = "foo" extends keyof T ? T["/*1*/"] : never;
+//// 
+//// type A = { bar: string };
+//// type Test2 = "foo" extends keyof A ? A["/*2*/"] : never;
+////
+//// type Test3<T> = "foo" extends keyof T ? "bar" extends keyof T ? T["/*3*/"] : never : never;
+////
+//// type Test4<T extends { foo?: string }> = "foo" extends keyof T ? T["/*4*/"] : never;
+////
+//// type Test5<T> = "foo" extends keyof T ? "foo" extends keyof T ? T["/*5*/"] : never : never;
+////
+//// type Test6<T> = ["foo"] extends [keyof T] ? T["/*6*/"] : never;
+////
+//// type Test7<T extends { foo: string }> = "bar" extends keyof T ? T["/*7*/"] : never;
+////
+//// type Test8<T> = "foo" | "bar" extends keyof T ? T["/*8*/"] : never;
+////
+//// type Test9<T, T2> = "foo" & T2 extends keyof T ? T["/*9*/"] : never;
+////
+//// type Test10<T, T2> = "foo" extends keyof T & T2 ? T["/*10*/"] : never;
+////
+//// type Test11<T, T2> = "foo" extends keyof T | T2 ? T["/*11*/"] : never;
+////
+//// type Test12<T, T2> = "foo" extends keyof T2 ? T["/*12*/"] : never;
+
+verify.completions({ marker: ["1"], exact: ["foo"] });
+verify.completions({ marker: ["2"], excludes: ["foo"] });
+verify.completions({ marker: ["3"], exact: ["bar", "foo"] });
+verify.completions({ marker: ["4"], exact: ["foo"] });
+verify.completions({ marker: ["5"], exact: ["foo"] });
+verify.completions({ marker: ["6"], exact: ["foo"] });
+verify.completions({ marker: ["7"], exact: ["bar", "foo"] });
+verify.completions({ marker: ["8"], excludes: ["bar", "foo"] });
+verify.completions({ marker: ["9"], excludes: ["foo"] });
+verify.completions({ marker: ["10"], exact: ["foo"] });
+verify.completions({ marker: ["11"], excludes: ["foo"] });
+verify.completions({ marker: ["12"], excludes: ["foo"] });


### PR DESCRIPTION
I noticed that even though this type checks OK:
```ts
type Test1<T> = "foo" extends keyof T ? T["foo"] : never;
```

completions do not suggest the `"foo"` property. This PR fixes that :)