### PR TITLE
Don't return `tags` when returning quick info for JSDoc nodes

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -13,6 +13,7 @@ import {
     EnumMember,
     ExportAssignment,
     find,
+    findAncestor,
     first,
     firstDefined,
     forEach,
@@ -50,6 +51,7 @@ import {
     isFunctionLike,
     isIdentifier,
     isInExpressionContext,
+    isJSDoc,
     isJsxOpeningLikeElement,
     isLet,
     isModuleWithStringLiteralName,
@@ -730,7 +732,7 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
         }
     }
 
-    if (tags.length === 0 && !hasMultipleSignatures) {
+    if (tags.length === 0 && !hasMultipleSignatures && !findAncestor(location, isJSDoc)) {
         tags = symbol.getContextualJsDocTags(enclosingDeclaration, typeChecker);
     }
 

--- a/tests/cases/fourslash/jsDocContextualTagsInJsDoc1.ts
+++ b/tests/cases/fourslash/jsDocContextualTagsInJsDoc1.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+//// /**
+////  * @param x/*1*/ Does the thing
+////  */
+//// function foo(x/*2*/) {}
+
+verify.quickInfoAt("1", "(parameter) x: any", "Does the thing", undefined);
+verify.quickInfoAt("2", "(parameter) x: any", "Does the thing", [{ name: "param", text: "x Does the thing" }]);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59402