### PR TITLE
Fixed `.flowNode` binding on JSDoc nodes

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -534,6 +534,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
 
     // state used by control flow analysis
     var currentFlow: FlowNode;
+    var currentFlowJsDoc: FlowNode;
     var currentBreakTarget: FlowLabel | undefined;
     var currentContinueTarget: FlowLabel | undefined;
     var currentReturnTarget: FlowLabel | undefined;
@@ -2745,6 +2746,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         setParent(node, parent);
         if (tracing) (node as TracingNode).tracingPath = file.path;
         const saveInStrictMode = inStrictMode;
+        const saveCurrentFlowJsDoc = currentFlowJsDoc;
+        currentFlowJsDoc = currentFlow;
 
         // Even though in the AST the jsdoc @typedef node belongs to the current node,
         // its symbol might be in the same scope with the current node's symbol. Consider:
@@ -2791,14 +2794,18 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             parent = saveParent;
         }
         inStrictMode = saveInStrictMode;
+        currentFlowJsDoc = saveCurrentFlowJsDoc;
     }
 
     function bindJSDoc(node: Node) {
         if (hasJSDocNodes(node)) {
             if (isInJSFile(node)) {
+                const saveCurrentFlow = currentFlow;
+                currentFlow = currentFlowJsDoc;
                 for (const j of node.jsDoc!) {
                     bind(j);
                 }
+                currentFlow = saveCurrentFlow;
             }
             else {
                 for (const j of node.jsDoc!) {

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.types
@@ -59,16 +59,16 @@ const testFnTypes = {
 function testFn(input) {
 >testFn : (input: testFnTypes.input) => number | null
 >       : ^     ^^                 ^^^^^             
->input : import("file2").testFnTypes.input
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>input : testFnTypes.input
+>      : ^^^^^^^^^^^^^^^^^
 
     if (typeof input === 'number') {
 >typeof input === 'number' : boolean
 >                          : ^^^^^^^
 >typeof input : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->input : import("file2").testFnTypes.input
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>input : testFnTypes.input
+>      : ^^^^^^^^^^^^^^^^^
 >'number' : "number"
 >         : ^^^^^^^^
 
@@ -87,7 +87,7 @@ function testFn(input) {
 
 export {testFn, testFnTypes};
 >testFn : (input: testFnTypes.input) => number | null
->       : ^     ^^^^^^^^^^^^^^^^^^^^^^^^             
+>       : ^     ^^                 ^^^^^             
 >testFnTypes : { [x: string]: any; }
 >            : ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
@@ -35,16 +35,16 @@ const testFnTypes = {
 function testFn(input) {
 >testFn : (input: testFnTypes.input) => number | null
 >       : ^     ^^                 ^^^^^             
->input : boolean | myTypes.typeC
->      : ^^^^^^^^^^^^^^^^^^^^^^^
+>input : testFnTypes.input
+>      : ^^^^^^^^^^^^^^^^^
 
     if (typeof input === 'number') {
 >typeof input === 'number' : boolean
 >                          : ^^^^^^^
 >typeof input : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->input : boolean | myTypes.typeC
->      : ^^^^^^^^^^^^^^^^^^^^^^^
+>input : testFnTypes.input
+>      : ^^^^^^^^^^^^^^^^^
 >'number' : "number"
 >         : ^^^^^^^^
 
@@ -71,9 +71,9 @@ module.exports = {testFn, testFnTypes};
 >exports : typeof module.exports
 >        : ^^^^^^^^^^^^^^^^^^^^^
 >{testFn, testFnTypes} : { testFn: (input: testFnTypes.input) => number | null; testFnTypes: { [x: string]: any; }; }
->                      : ^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>                      : ^^^^^^^^^^^     ^^                 ^^^^^             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >testFn : (input: testFnTypes.input) => number | null
->       : ^     ^^^^^^^^^^^^^^^^^^^^^^^^             
+>       : ^     ^^                 ^^^^^             
 >testFnTypes : { [x: string]: any; }
 >            : ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/jsDocExtendsStaticBlockUsingCurrentClass1.symbols
+++ b/tests/baselines/reference/jsDocExtendsStaticBlockUsingCurrentClass1.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/jsdoc/jsDocExtendsStaticBlockUsingCurrentClass1.ts] ////
+
+=== a.js ===
+export class A {
+>A : Symbol(A, Decl(a.js, 0, 0))
+
+  static a() {}
+>a : Symbol(A.a, Decl(a.js, 0, 16))
+}
+
+=== b.js ===
+import { A } from "./a";
+>A : Symbol(A, Decl(b.js, 0, 8))
+
+/**
+ * @extends A
+ */
+export class B extends A {
+>B : Symbol(B, Decl(b.js, 0, 24))
+>A : Symbol(A, Decl(b.js, 0, 8))
+
+  static {
+    B.a();
+>B.a : Symbol(A.a, Decl(a.js, 0, 16))
+>B : Symbol(B, Decl(b.js, 0, 24))
+>a : Symbol(A.a, Decl(a.js, 0, 16))
+  }
+}

--- a/tests/baselines/reference/jsDocExtendsStaticBlockUsingCurrentClass1.types
+++ b/tests/baselines/reference/jsDocExtendsStaticBlockUsingCurrentClass1.types
@@ -1,0 +1,38 @@
+//// [tests/cases/conformance/jsdoc/jsDocExtendsStaticBlockUsingCurrentClass1.ts] ////
+
+=== a.js ===
+export class A {
+>A : A
+>  : ^
+
+  static a() {}
+>a : () => void
+>  : ^^^^^^^^^^
+}
+
+=== b.js ===
+import { A } from "./a";
+>A : typeof A
+>  : ^^^^^^^^
+
+/**
+ * @extends A
+ */
+export class B extends A {
+>B : B
+>  : ^
+>A : A
+>  : ^
+
+  static {
+    B.a();
+>B.a() : void
+>      : ^^^^
+>B.a : () => void
+>    : ^^^^^^^^^^
+>B : typeof B
+>  : ^^^^^^^^
+>a : () => void
+>  : ^^^^^^^^^^
+  }
+}

--- a/tests/cases/conformance/jsdoc/jsDocExtendsStaticBlockUsingCurrentClass1.ts
+++ b/tests/cases/conformance/jsdoc/jsDocExtendsStaticBlockUsingCurrentClass1.ts
@@ -1,0 +1,21 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: a.js
+export class A {
+  static a() {}
+}
+
+// @filename: b.js
+import { A } from "./a";
+
+/**
+ * @extends A
+ */
+export class B extends A {
+  static {
+    B.a();
+  }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/58943

quoting [my comment](https://github.com/microsoft/TypeScript/issues/58943#issuecomment-2323222122) there:
> JSDoc is bound as a child of its associated declaration and static block declarations are bound as immediately invoked when binding the declaration itself. So this @extends has a flow node pointing to the body of the static block. So when the class' type is requested it tries to resolve the flow node of the super class it received, which leads to resolving the type of the class' in the static block (this bit is circular here).