### PR TITLE
Fixed symbol lookup for binding expando properties in nested blocks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -482,7 +482,7 @@ import {
     isBindingPattern,
     isBlock,
     isBlockOrCatchScoped,
-    isBlockScopedContainerTopLevel,
+    isBlockScopedOrTopLevelContainer,
     isBooleanLiteral,
     isCallChain,
     isCallExpression,
@@ -49600,7 +49600,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const inLoopInitializer = isIterationStatement(container, /*lookInLabeledStatements*/ false);
                         const inLoopBodyBlock = container.kind === SyntaxKind.Block && isIterationStatement(container.parent, /*lookInLabeledStatements*/ false);
 
-                        links.isDeclarationWithCollidingName = !isBlockScopedContainerTopLevel(container) && (!isDeclaredInLoop || (!inLoopInitializer && !inLoopBodyBlock));
+                        links.isDeclarationWithCollidingName = !isBlockScopedOrTopLevelContainer(container) && (!isDeclaredInLoop || (!inLoopInitializer && !inLoopBodyBlock));
                     }
                     else {
                         links.isDeclarationWithCollidingName = false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1966,7 +1966,7 @@ function isShorthandAmbientModule(node: Node | undefined): boolean {
 }
 
 /** @internal */
-export function isBlockScopedContainerTopLevel(node: Node): boolean {
+export function isBlockScopedOrTopLevelContainer(node: Node): boolean {
     return node.kind === SyntaxKind.SourceFile ||
         node.kind === SyntaxKind.ModuleDeclaration ||
         isFunctionLikeOrClassStaticBlockDeclaration(node);

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1658,12 +1658,12 @@ export function isFunctionLike(node: Node | undefined): node is SignatureDeclara
 
 /** @internal */
 export function isFunctionLikeOrClassStaticBlockDeclaration(node: Node | undefined): node is SignatureDeclaration | ClassStaticBlockDeclaration {
-    return !!node && (isFunctionLikeKind(node.kind) || isClassStaticBlockDeclaration(node));
+    return !!node && (isFunctionLikeDeclaration(node) || isClassStaticBlockDeclaration(node));
 }
 
 /** @internal */
-export function isFunctionLikeDeclaration(node: Node): node is FunctionLikeDeclaration {
-    return node && isFunctionLikeDeclarationKind(node.kind);
+export function isFunctionLikeDeclaration(node: Node | undefined): node is FunctionLikeDeclaration {
+    return !!node && isFunctionLikeDeclarationKind(node.kind);
 }
 
 /** @internal */

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -1104,7 +1104,7 @@ function moveStatementsToTargetFile(changes: textChanges.ChangeTracker, program:
     }
 }
 
-function getOverloadRangeToMove(sourceFile: SourceFile, statement: Statement) {
+function getOverloadRangeToMove(sourceFile: SourceFile, statement: Statement | undefined) {
     if (isFunctionLikeDeclaration(statement)) {
         const declarations = statement.symbol.declarations;
         if (declarations === undefined || length(declarations) <= 1 || !contains(declarations, statement)) {

--- a/tests/baselines/reference/expandoFunctionBlockShadowing2.js
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing2.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing2.ts] ////
+
+//// [index.js]
+export function X() {}
+if (Math.random()) {
+  /** @type {{ test?: any }} */
+  const X = {};
+  Object.defineProperty(X, "test", { value: 1 });
+}
+
+export function Y() {}
+Object.defineProperty(Y, "test", { value: "foo" });
+const aliasTopY = Y;
+if (Math.random()) {
+  const Y = function Y() {}
+  Object.defineProperty(Y, "test", { value: 42 });
+
+  /** @type {{ (): void; test: string }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ (): void; test: number }} */
+  const blockYcheck = Y;
+}
+
+
+
+
+//// [index.d.ts]
+export function X(): void;
+export function Y(): void;
+export namespace Y {
+    let test: string;
+}

--- a/tests/baselines/reference/expandoFunctionBlockShadowing2.symbols
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing2.symbols
@@ -1,0 +1,67 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing2.ts] ////
+
+=== src/index.js ===
+export function X() {}
+>X : Symbol(X, Decl(index.js, 0, 0))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  /** @type {{ test?: any }} */
+  const X = {};
+>X : Symbol(X, Decl(index.js, 3, 7))
+
+  Object.defineProperty(X, "test", { value: 1 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>X : Symbol(X, Decl(index.js, 3, 7))
+>"test" : Symbol(X.test, Decl(index.js, 3, 15))
+>value : Symbol(value, Decl(index.js, 4, 36))
+}
+
+export function Y() {}
+>Y : Symbol(Y, Decl(index.js, 5, 1), Decl(index.js, 8, 22))
+
+Object.defineProperty(Y, "test", { value: "foo" });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Y : Symbol(Y, Decl(index.js, 5, 1), Decl(index.js, 8, 22))
+>"test" : Symbol(Y.test, Decl(index.js, 7, 22))
+>value : Symbol(value, Decl(index.js, 8, 34))
+
+const aliasTopY = Y;
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 9, 5))
+>Y : Symbol(Y, Decl(index.js, 5, 1), Decl(index.js, 8, 22))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const Y = function Y() {}
+>Y : Symbol(Y, Decl(index.js, 11, 7))
+>Y : Symbol(Y, Decl(index.js, 11, 11))
+
+  Object.defineProperty(Y, "test", { value: 42 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Y : Symbol(Y, Decl(index.js, 11, 7))
+>"test" : Symbol(Y.test, Decl(index.js, 11, 27))
+>value : Symbol(value, Decl(index.js, 12, 36))
+
+  /** @type {{ (): void; test: string }} */
+  const topYcheck = aliasTopY;
+>topYcheck : Symbol(topYcheck, Decl(index.js, 15, 7))
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 9, 5))
+
+  /** @type {{ (): void; test: number }} */
+  const blockYcheck = Y;
+>blockYcheck : Symbol(blockYcheck, Decl(index.js, 17, 7))
+>Y : Symbol(Y, Decl(index.js, 11, 7))
+}
+

--- a/tests/baselines/reference/expandoFunctionBlockShadowing2.types
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing2.types
@@ -1,0 +1,128 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing2.ts] ////
+
+=== src/index.js ===
+export function X() {}
+>X : () => void
+>  : ^^^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  /** @type {{ test?: any }} */
+  const X = {};
+>X : { test?: any; }
+>  : ^^^^^^^^^   ^^^
+>{} : {}
+>   : ^^
+
+  Object.defineProperty(X, "test", { value: 1 });
+>Object.defineProperty(X, "test", { value: 1 }) : { test?: any; }
+>                                               : ^^^^^^^^^   ^^^
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>X : { test?: any; }
+>  : ^^^^^^^^^   ^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: 1 } : { value: number; }
+>             : ^^^^^^^^^^^^^^^^^^
+>value : number
+>      : ^^^^^^
+>1 : 1
+>  : ^
+}
+
+export function Y() {}
+>Y : typeof Y
+>  : ^^^^^^^^
+
+Object.defineProperty(Y, "test", { value: "foo" });
+>Object.defineProperty(Y, "test", { value: "foo" }) : typeof Y
+>                                                   : ^^^^^^^^
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Y : typeof Y
+>  : ^^^^^^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: "foo" } : { value: string; }
+>                 : ^^^^^^^^^^^^^^^^^^
+>value : string
+>      : ^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const aliasTopY = Y;
+>aliasTopY : typeof Y
+>          : ^^^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const Y = function Y() {}
+>Y : { (): void; readonly test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function Y() {} : { (): void; readonly test: number; }
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Y : { (): void; readonly test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Object.defineProperty(Y, "test", { value: 42 });
+>Object.defineProperty(Y, "test", { value: 42 }) : { (): void; readonly test: number; }
+>                                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Y : { (): void; readonly test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: 42 } : { value: number; }
+>              : ^^^^^^^^^^^^^^^^^^
+>value : number
+>      : ^^^^^^
+>42 : 42
+>   : ^^
+
+  /** @type {{ (): void; test: string }} */
+  const topYcheck = aliasTopY;
+>topYcheck : { (): void; test: string; }
+>          : ^^^^^^    ^^^^^^^^      ^^^
+>aliasTopY : typeof import("src/index").Y
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  /** @type {{ (): void; test: number }} */
+  const blockYcheck = Y;
+>blockYcheck : { (): void; test: number; }
+>            : ^^^^^^    ^^^^^^^^      ^^^
+>Y : { (): void; readonly test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+

--- a/tests/baselines/reference/expandoFunctionBlockShadowing3.js
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing3.js
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing3.ts] ////
+
+//// [expandoFunctionBlockShadowing3.ts]
+export function Z() {}
+Z.test = "foo";
+const aliasTopZ = Z;
+if (Math.random()) {
+  const Z = function Z() {};
+  if (Math.random()) {
+    Z.test = 42;
+  }
+
+  const topZcheck: { (): void; test: string } = aliasTopZ;
+  const blockZcheck: { (): void; test: number } = Z;
+}
+
+
+
+
+//// [expandoFunctionBlockShadowing3.d.ts]
+export declare function Z(): void;
+export declare namespace Z {
+    var test: string;
+}

--- a/tests/baselines/reference/expandoFunctionBlockShadowing3.symbols
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing3.symbols
@@ -1,0 +1,46 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing3.ts] ////
+
+=== expandoFunctionBlockShadowing3.ts ===
+export function Z() {}
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 0, 0), Decl(expandoFunctionBlockShadowing3.ts, 0, 22))
+
+Z.test = "foo";
+>Z.test : Symbol(Z.test, Decl(expandoFunctionBlockShadowing3.ts, 0, 22))
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 0, 0), Decl(expandoFunctionBlockShadowing3.ts, 0, 22))
+>test : Symbol(Z.test, Decl(expandoFunctionBlockShadowing3.ts, 0, 22))
+
+const aliasTopZ = Z;
+>aliasTopZ : Symbol(aliasTopZ, Decl(expandoFunctionBlockShadowing3.ts, 2, 5))
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 0, 0), Decl(expandoFunctionBlockShadowing3.ts, 0, 22))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const Z = function Z() {};
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 4, 7))
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 4, 11))
+
+  if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+    Z.test = 42;
+>Z.test : Symbol(Z.test, Decl(expandoFunctionBlockShadowing3.ts, 5, 22))
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 4, 7))
+>test : Symbol(Z.test, Decl(expandoFunctionBlockShadowing3.ts, 5, 22))
+  }
+
+  const topZcheck: { (): void; test: string } = aliasTopZ;
+>topZcheck : Symbol(topZcheck, Decl(expandoFunctionBlockShadowing3.ts, 9, 7))
+>test : Symbol(test, Decl(expandoFunctionBlockShadowing3.ts, 9, 30))
+>aliasTopZ : Symbol(aliasTopZ, Decl(expandoFunctionBlockShadowing3.ts, 2, 5))
+
+  const blockZcheck: { (): void; test: number } = Z;
+>blockZcheck : Symbol(blockZcheck, Decl(expandoFunctionBlockShadowing3.ts, 10, 7))
+>test : Symbol(test, Decl(expandoFunctionBlockShadowing3.ts, 10, 32))
+>Z : Symbol(Z, Decl(expandoFunctionBlockShadowing3.ts, 4, 7))
+}
+

--- a/tests/baselines/reference/expandoFunctionBlockShadowing3.types
+++ b/tests/baselines/reference/expandoFunctionBlockShadowing3.types
@@ -1,0 +1,83 @@
+//// [tests/cases/compiler/expandoFunctionBlockShadowing3.ts] ////
+
+=== expandoFunctionBlockShadowing3.ts ===
+export function Z() {}
+>Z : typeof Z
+>  : ^^^^^^^^
+
+Z.test = "foo";
+>Z.test = "foo" : "foo"
+>               : ^^^^^
+>Z.test : string
+>       : ^^^^^^
+>Z : typeof Z
+>  : ^^^^^^^^
+>test : string
+>     : ^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const aliasTopZ = Z;
+>aliasTopZ : typeof Z
+>          : ^^^^^^^^
+>Z : typeof Z
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const Z = function Z() {};
+>Z : { (): void; test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function Z() {} : { (): void; test: number; }
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Z : { (): void; test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+    Z.test = 42;
+>Z.test = 42 : 42
+>            : ^^
+>Z.test : number
+>       : ^^^^^^
+>Z : { (): void; test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>test : number
+>     : ^^^^^^
+>42 : 42
+>   : ^^
+  }
+
+  const topZcheck: { (): void; test: string } = aliasTopZ;
+>topZcheck : { (): void; test: string; }
+>          : ^^^^^^    ^^^^^^^^      ^^^
+>test : string
+>     : ^^^^^^
+>aliasTopZ : typeof import("expandoFunctionBlockShadowing3").Z
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  const blockZcheck: { (): void; test: number } = Z;
+>blockZcheck : { (): void; test: number; }
+>            : ^^^^^^    ^^^^^^^^      ^^^
+>test : number
+>     : ^^^^^^
+>Z : { (): void; test: number; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+

--- a/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.js
+++ b/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/javascriptDefinePropertyPrototypeBlockShadowing1.ts] ////
+
+//// [index.js]
+export function X() {}
+if (Math.random()) {
+  const X = function() {}
+  Object.defineProperty(X.prototype, "test", { value: 1 });
+}
+
+export function Y() {}
+Object.defineProperty(Y.prototype, "test", { value: "foo" });
+const AliasTopY = Y;
+if (Math.random()) {
+  const Y = function Y() {}
+  Object.defineProperty(Y.prototype, "test", { value: 42 });
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+}
+
+
+
+
+//// [index.d.ts]
+export function X(): void;
+export function Y(): void;
+export class Y {
+    readonly test: string;
+}

--- a/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.symbols
+++ b/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.symbols
@@ -1,0 +1,72 @@
+//// [tests/cases/compiler/javascriptDefinePropertyPrototypeBlockShadowing1.ts] ////
+
+=== src/index.js ===
+export function X() {}
+>X : Symbol(X, Decl(index.js, 0, 0))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const X = function() {}
+>X : Symbol(X, Decl(index.js, 2, 7))
+
+  Object.defineProperty(X.prototype, "test", { value: 1 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>X.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>X : Symbol(X, Decl(index.js, 2, 7))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>"test" : Symbol(X.test, Decl(index.js, 2, 25))
+>value : Symbol(value, Decl(index.js, 3, 46))
+}
+
+export function Y() {}
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+
+Object.defineProperty(Y.prototype, "test", { value: "foo" });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Y.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>"test" : Symbol(Y.test, Decl(index.js, 6, 22))
+>value : Symbol(value, Decl(index.js, 7, 44))
+
+const AliasTopY = Y;
+>AliasTopY : Symbol(AliasTopY, Decl(index.js, 8, 5))
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const Y = function Y() {}
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+>Y : Symbol(Y, Decl(index.js, 10, 11))
+
+  Object.defineProperty(Y.prototype, "test", { value: 42 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Y.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>"test" : Symbol(Y.test, Decl(index.js, 10, 27))
+>value : Symbol(value, Decl(index.js, 11, 46))
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+>topYcheck : Symbol(topYcheck, Decl(index.js, 14, 7))
+>AliasTopY : Symbol(AliasTopY, Decl(index.js, 8, 5))
+
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+>blockYcheck : Symbol(blockYcheck, Decl(index.js, 16, 7))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+}
+

--- a/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.types
+++ b/tests/baselines/reference/javascriptDefinePropertyPrototypeBlockShadowing1.types
@@ -1,0 +1,137 @@
+//// [tests/cases/compiler/javascriptDefinePropertyPrototypeBlockShadowing1.ts] ////
+
+=== src/index.js ===
+export function X() {}
+>X : () => void
+>  : ^^^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const X = function() {}
+>X : typeof X
+>  : ^^^^^^^^
+>function() {} : typeof X
+>              : ^^^^^^^^
+
+  Object.defineProperty(X.prototype, "test", { value: 1 });
+>Object.defineProperty(X.prototype, "test", { value: 1 }) : any
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>X.prototype : any
+>X : typeof X
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: 1 } : { value: number; }
+>             : ^^^^^^^^^^^^^^^^^^
+>value : number
+>      : ^^^^^^
+>1 : 1
+>  : ^
+}
+
+export function Y() {}
+>Y : typeof Y
+>  : ^^^^^^^^
+
+Object.defineProperty(Y.prototype, "test", { value: "foo" });
+>Object.defineProperty(Y.prototype, "test", { value: "foo" }) : any
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Y.prototype : any
+>Y : typeof Y
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: "foo" } : { value: string; }
+>                 : ^^^^^^^^^^^^^^^^^^
+>value : string
+>      : ^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const AliasTopY = Y;
+>AliasTopY : typeof Y
+>          : ^^^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const Y = function Y() {}
+>Y : typeof Y
+>  : ^^^^^^^^
+>function Y() {} : typeof Y
+>                : ^^^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+
+  Object.defineProperty(Y.prototype, "test", { value: 42 });
+>Object.defineProperty(Y.prototype, "test", { value: 42 }) : any
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Y.prototype : any
+>Y : typeof Y
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>"test" : "test"
+>       : ^^^^^^
+>{ value: 42 } : { value: number; }
+>              : ^^^^^^^^^^^^^^^^^^
+>value : number
+>      : ^^^^^^
+>42 : 42
+>   : ^^
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+>topYcheck : { test: string; }
+>          : ^^^^^^^^      ^^^
+>new AliasTopY() : import("src/index").Y
+>                : ^^^^^^^^^^^^^^^^^^^^^
+>AliasTopY : typeof import("src/index").Y
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+>blockYcheck : { test: number; }
+>            : ^^^^^^^^      ^^^
+>new Y() : Y
+>        : ^
+>Y : typeof Y
+>  : ^^^^^^^^
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing1.js
+++ b/tests/baselines/reference/specialPropertyBlockShadowing1.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing1.ts] ////
+
+//// [index.js]
+export const X = {};
+if (Math.random()) {
+  const X = {};
+  X.test = 1;
+}
+
+export const Y = {};
+Y.test = "foo";
+const aliasTopY = Y;
+if (Math.random()) {
+  const Y = {};
+  Y.test = 42;
+
+  /** @type {{ test: string }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ test: number }} */
+  const blockYcheck = Y;
+}
+
+
+
+
+//// [index.d.ts]
+export const X: {};
+export namespace Y {
+    let test: string;
+}

--- a/tests/baselines/reference/specialPropertyBlockShadowing1.symbols
+++ b/tests/baselines/reference/specialPropertyBlockShadowing1.symbols
@@ -1,0 +1,56 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing1.ts] ////
+
+=== src/index.js ===
+export const X = {};
+>X : Symbol(X, Decl(index.js, 0, 12))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const X = {};
+>X : Symbol(X, Decl(index.js, 2, 7))
+
+  X.test = 1;
+>X.test : Symbol(X.test, Decl(index.js, 2, 15))
+>X : Symbol(X, Decl(index.js, 2, 7))
+>test : Symbol(X.test, Decl(index.js, 2, 15))
+}
+
+export const Y = {};
+>Y : Symbol(Y, Decl(index.js, 6, 12), Decl(index.js, 6, 20))
+
+Y.test = "foo";
+>Y.test : Symbol(Y.test, Decl(index.js, 6, 20))
+>Y : Symbol(Y, Decl(index.js, 6, 12), Decl(index.js, 6, 20))
+>test : Symbol(Y.test, Decl(index.js, 6, 20))
+
+const aliasTopY = Y;
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 8, 5))
+>Y : Symbol(Y, Decl(index.js, 6, 12), Decl(index.js, 6, 20))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const Y = {};
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+
+  Y.test = 42;
+>Y.test : Symbol(Y.test, Decl(index.js, 10, 15))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+>test : Symbol(Y.test, Decl(index.js, 10, 15))
+
+  /** @type {{ test: string }} */
+  const topYcheck = aliasTopY;
+>topYcheck : Symbol(topYcheck, Decl(index.js, 14, 7))
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 8, 5))
+
+  /** @type {{ test: number }} */
+  const blockYcheck = Y;
+>blockYcheck : Symbol(blockYcheck, Decl(index.js, 16, 7))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing1.types
+++ b/tests/baselines/reference/specialPropertyBlockShadowing1.types
@@ -1,0 +1,105 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing1.ts] ////
+
+=== src/index.js ===
+export const X = {};
+>X : {}
+>  : ^^
+>{} : {}
+>   : ^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const X = {};
+>X : { test: number; }
+>  : ^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  X.test = 1;
+>X.test = 1 : 1
+>           : ^
+>X.test : number
+>       : ^^^^^^
+>X : { test: number; }
+>  : ^^^^^^^^^^^^^^^^^
+>test : number
+>     : ^^^^^^
+>1 : 1
+>  : ^
+}
+
+export const Y = {};
+>Y : typeof Y
+>  : ^^^^^^^^
+>{} : {}
+>   : ^^
+
+Y.test = "foo";
+>Y.test = "foo" : "foo"
+>               : ^^^^^
+>Y.test : string
+>       : ^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+>test : string
+>     : ^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const aliasTopY = Y;
+>aliasTopY : typeof Y
+>          : ^^^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const Y = {};
+>Y : { test: number; }
+>  : ^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  Y.test = 42;
+>Y.test = 42 : 42
+>            : ^^
+>Y.test : number
+>       : ^^^^^^
+>Y : { test: number; }
+>  : ^^^^^^^^^^^^^^^^^
+>test : number
+>     : ^^^^^^
+>42 : 42
+>   : ^^
+
+  /** @type {{ test: string }} */
+  const topYcheck = aliasTopY;
+>topYcheck : { test: string; }
+>          : ^^^^^^^^      ^^^
+>aliasTopY : typeof import("src/index").Y
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  /** @type {{ test: number }} */
+  const blockYcheck = Y;
+>blockYcheck : { test: number; }
+>            : ^^^^^^^^      ^^^
+>Y : { test: number; }
+>  : ^^^^^^^^^^^^^^^^^
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing2.errors.txt
+++ b/tests/baselines/reference/specialPropertyBlockShadowing2.errors.txt
@@ -1,0 +1,41 @@
+src/index.js(4,43): error TS2339: Property 'test' does not exist on type 'X'.
+src/index.js(12,43): error TS2339: Property 'test' does not exist on type 'Y'.
+src/index.js(15,9): error TS2322: Type 'Y' is not assignable to type '{ test: string; }'.
+  Types of property 'test' are incompatible.
+    Type 'string | number | undefined' is not assignable to type 'string'.
+      Type 'undefined' is not assignable to type 'string'.
+src/index.js(17,9): error TS2741: Property 'test' is missing in type 'Y' but required in type '{ test: number; }'.
+
+
+==== src/index.js (4 errors) ====
+    export function X() { };
+    if (Math.random()) {
+      const X = function () { };
+      X.prototype.method = function () { this.test = 1 };
+                                              ~~~~
+!!! error TS2339: Property 'test' does not exist on type 'X'.
+    }
+    
+    export function Y() { };
+    Y.prototype.method = function () { this.test = "foo" };
+    const AliasTopY = Y;
+    if (Math.random()) {
+      const Y = function () { };
+      Y.prototype.method = function () { this.test = 42 };
+                                              ~~~~
+!!! error TS2339: Property 'test' does not exist on type 'Y'.
+    
+      /** @type {{ test: string }} */
+      const topYcheck = new AliasTopY();
+            ~~~~~~~~~
+!!! error TS2322: Type 'Y' is not assignable to type '{ test: string; }'.
+!!! error TS2322:   Types of property 'test' are incompatible.
+!!! error TS2322:     Type 'string | number | undefined' is not assignable to type 'string'.
+!!! error TS2322:       Type 'undefined' is not assignable to type 'string'.
+      /** @type {{ test: number }} */
+      const blockYcheck = new Y();
+            ~~~~~~~~~~~
+!!! error TS2741: Property 'test' is missing in type 'Y' but required in type '{ test: number; }'.
+!!! related TS2728 src/index.js:16:16: 'test' is declared here.
+    }
+    

--- a/tests/baselines/reference/specialPropertyBlockShadowing2.js
+++ b/tests/baselines/reference/specialPropertyBlockShadowing2.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing2.ts] ////
+
+//// [index.js]
+export function X() { };
+if (Math.random()) {
+  const X = function () { };
+  X.prototype.method = function () { this.test = 1 };
+}
+
+export function Y() { };
+Y.prototype.method = function () { this.test = "foo" };
+const AliasTopY = Y;
+if (Math.random()) {
+  const Y = function () { };
+  Y.prototype.method = function () { this.test = 42 };
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+}
+
+
+
+
+//// [index.d.ts]
+export function X(): void;
+export class X {
+    test: number | undefined;
+}
+export function Y(): void;
+export class Y {
+    method(): void;
+    test: string | number | undefined;
+}

--- a/tests/baselines/reference/specialPropertyBlockShadowing2.symbols
+++ b/tests/baselines/reference/specialPropertyBlockShadowing2.symbols
@@ -1,0 +1,66 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing2.ts] ////
+
+=== src/index.js ===
+export function X() { };
+>X : Symbol(X, Decl(index.js, 0, 0))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const X = function () { };
+>X : Symbol(X, Decl(index.js, 2, 7))
+
+  X.prototype.method = function () { this.test = 1 };
+>X.prototype : Symbol(X.method, Decl(index.js, 2, 28))
+>X : Symbol(X, Decl(index.js, 2, 7))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>method : Symbol(X.method, Decl(index.js, 2, 28))
+>this : Symbol(X, Decl(index.js, 2, 11))
+>test : Symbol(X.test, Decl(index.js, 3, 36))
+}
+
+export function Y() { };
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+
+Y.prototype.method = function () { this.test = "foo" };
+>Y.prototype : Symbol(Y.method, Decl(index.js, 6, 24))
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>method : Symbol(Y.method, Decl(index.js, 6, 24))
+>this.test : Symbol(Y.test, Decl(index.js, 7, 34), Decl(index.js, 11, 36))
+>this : Symbol(Y, Decl(index.js, 4, 1))
+>test : Symbol(Y.test, Decl(index.js, 7, 34), Decl(index.js, 11, 36))
+
+const AliasTopY = Y;
+>AliasTopY : Symbol(AliasTopY, Decl(index.js, 8, 5))
+>Y : Symbol(Y, Decl(index.js, 4, 1))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const Y = function () { };
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+
+  Y.prototype.method = function () { this.test = 42 };
+>Y.prototype : Symbol(Y.method, Decl(index.js, 10, 28))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>method : Symbol(Y.method, Decl(index.js, 10, 28))
+>this : Symbol(Y, Decl(index.js, 10, 11))
+>test : Symbol(Y.test, Decl(index.js, 7, 34), Decl(index.js, 11, 36))
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+>topYcheck : Symbol(topYcheck, Decl(index.js, 14, 7))
+>AliasTopY : Symbol(AliasTopY, Decl(index.js, 8, 5))
+
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+>blockYcheck : Symbol(blockYcheck, Decl(index.js, 16, 7))
+>Y : Symbol(Y, Decl(index.js, 10, 7))
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing2.types
+++ b/tests/baselines/reference/specialPropertyBlockShadowing2.types
@@ -1,0 +1,147 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing2.ts] ////
+
+=== src/index.js ===
+export function X() { };
+>X : typeof X
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const X = function () { };
+>X : typeof X
+>  : ^^^^^^^^
+>function () { } : typeof X
+>                : ^^^^^^^^
+
+  X.prototype.method = function () { this.test = 1 };
+>X.prototype.method = function () { this.test = 1 } : () => void
+>                                                   : ^^^^^^^^^^
+>X.prototype.method : any
+>                   : ^^^
+>X.prototype : any
+>            : ^^^
+>X : typeof X
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>method : any
+>       : ^^^
+>function () { this.test = 1 } : () => void
+>                              : ^^^^^^^^^^
+>this.test = 1 : 1
+>              : ^
+>this.test : any
+>          : ^^^
+>this : this
+>     : ^^^^
+>test : any
+>     : ^^^
+>1 : 1
+>  : ^
+}
+
+export function Y() { };
+>Y : typeof Y
+>  : ^^^^^^^^
+
+Y.prototype.method = function () { this.test = "foo" };
+>Y.prototype.method = function () { this.test = "foo" } : () => void
+>                                                       : ^^^^^^^^^^
+>Y.prototype.method : any
+>                   : ^^^
+>Y.prototype : any
+>            : ^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>method : any
+>       : ^^^
+>function () { this.test = "foo" } : () => void
+>                                  : ^^^^^^^^^^
+>this.test = "foo" : "foo"
+>                  : ^^^^^
+>this.test : string | number | undefined
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : this
+>     : ^^^^
+>test : string | number | undefined
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const AliasTopY = Y;
+>AliasTopY : typeof Y
+>          : ^^^^^^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const Y = function () { };
+>Y : typeof Y
+>  : ^^^^^^^^
+>function () { } : typeof Y
+>                : ^^^^^^^^
+
+  Y.prototype.method = function () { this.test = 42 };
+>Y.prototype.method = function () { this.test = 42 } : () => void
+>                                                    : ^^^^^^^^^^
+>Y.prototype.method : any
+>                   : ^^^
+>Y.prototype : any
+>            : ^^^
+>Y : typeof Y
+>  : ^^^^^^^^
+>prototype : any
+>          : ^^^
+>method : any
+>       : ^^^
+>function () { this.test = 42 } : () => void
+>                               : ^^^^^^^^^^
+>this.test = 42 : 42
+>               : ^^
+>this.test : any
+>          : ^^^
+>this : this
+>     : ^^^^
+>test : any
+>     : ^^^
+>42 : 42
+>   : ^^
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+>topYcheck : { test: string; }
+>          : ^^^^^^^^      ^^^
+>new AliasTopY() : import("src/index").Y
+>                : ^^^^^^^^^^^^^^^^^^^^^
+>AliasTopY : typeof import("src/index").Y
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+>blockYcheck : { test: number; }
+>            : ^^^^^^^^      ^^^
+>new Y() : Y
+>        : ^
+>Y : typeof Y
+>  : ^^^^^^^^
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing3.js
+++ b/tests/baselines/reference/specialPropertyBlockShadowing3.js
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing3.ts] ////
+
+//// [index.js]
+export const x = {};
+x.inner = {};
+if (Math.random()) {
+  const x = {};
+  x.inner = {};
+  x.inner.test = 1;
+}
+
+export const y = {};
+y.inner = {};
+y.inner.test = "foo";
+
+const aliasTopY = y;
+if (Math.random()) {
+  const y = {};
+  y.inner = {};
+  y.inner.test = 42;
+
+  /** @type {{ inner: { test: string } }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ inner: { test: number } }} */
+  const blockYcheck = y;
+}
+
+
+
+
+//// [index.d.ts]
+export namespace x {
+    let inner: {};
+}
+export namespace y {
+    namespace inner {
+        let test: string;
+    }
+}

--- a/tests/baselines/reference/specialPropertyBlockShadowing3.symbols
+++ b/tests/baselines/reference/specialPropertyBlockShadowing3.symbols
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing3.ts] ////
+
+=== src/index.js ===
+export const x = {};
+>x : Symbol(x, Decl(index.js, 0, 12), Decl(index.js, 0, 20))
+
+x.inner = {};
+>x.inner : Symbol(x.inner, Decl(index.js, 0, 20))
+>x : Symbol(x, Decl(index.js, 0, 12), Decl(index.js, 0, 20))
+>inner : Symbol(x.inner, Decl(index.js, 0, 20))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const x = {};
+>x : Symbol(x, Decl(index.js, 3, 7))
+
+  x.inner = {};
+>x.inner : Symbol(x.inner, Decl(index.js, 3, 15))
+>x : Symbol(x, Decl(index.js, 3, 7))
+>inner : Symbol(x.inner, Decl(index.js, 3, 15))
+
+  x.inner.test = 1;
+>x.inner.test : Symbol(x.inner.test, Decl(index.js, 4, 15))
+>x.inner : Symbol(x.inner, Decl(index.js, 3, 15))
+>x : Symbol(x, Decl(index.js, 3, 7))
+>inner : Symbol(x.inner, Decl(index.js, 3, 15))
+>test : Symbol(x.inner.test, Decl(index.js, 4, 15))
+}
+
+export const y = {};
+>y : Symbol(y, Decl(index.js, 8, 12), Decl(index.js, 8, 20), Decl(index.js, 9, 13))
+
+y.inner = {};
+>y.inner : Symbol(y.inner, Decl(index.js, 8, 20), Decl(index.js, 10, 2))
+>y : Symbol(y, Decl(index.js, 8, 12), Decl(index.js, 8, 20), Decl(index.js, 9, 13))
+>inner : Symbol(y.inner, Decl(index.js, 8, 20), Decl(index.js, 10, 2))
+
+y.inner.test = "foo";
+>y.inner.test : Symbol(y.inner.test, Decl(index.js, 9, 13))
+>y.inner : Symbol(y.inner, Decl(index.js, 8, 20), Decl(index.js, 10, 2))
+>y : Symbol(y, Decl(index.js, 8, 12), Decl(index.js, 8, 20), Decl(index.js, 9, 13))
+>inner : Symbol(y.inner, Decl(index.js, 8, 20), Decl(index.js, 10, 2))
+>test : Symbol(y.inner.test, Decl(index.js, 9, 13))
+
+const aliasTopY = y;
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 12, 5))
+>y : Symbol(y, Decl(index.js, 8, 12), Decl(index.js, 8, 20), Decl(index.js, 9, 13))
+
+if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+  const y = {};
+>y : Symbol(y, Decl(index.js, 14, 7))
+
+  y.inner = {};
+>y.inner : Symbol(y.inner, Decl(index.js, 14, 15))
+>y : Symbol(y, Decl(index.js, 14, 7))
+>inner : Symbol(y.inner, Decl(index.js, 14, 15))
+
+  y.inner.test = 42;
+>y.inner.test : Symbol(y.inner.test, Decl(index.js, 15, 15))
+>y.inner : Symbol(y.inner, Decl(index.js, 14, 15))
+>y : Symbol(y, Decl(index.js, 14, 7))
+>inner : Symbol(y.inner, Decl(index.js, 14, 15))
+>test : Symbol(y.inner.test, Decl(index.js, 15, 15))
+
+  /** @type {{ inner: { test: string } }} */
+  const topYcheck = aliasTopY;
+>topYcheck : Symbol(topYcheck, Decl(index.js, 19, 7))
+>aliasTopY : Symbol(aliasTopY, Decl(index.js, 12, 5))
+
+  /** @type {{ inner: { test: number } }} */
+  const blockYcheck = y;
+>blockYcheck : Symbol(blockYcheck, Decl(index.js, 21, 7))
+>y : Symbol(y, Decl(index.js, 14, 7))
+}
+

--- a/tests/baselines/reference/specialPropertyBlockShadowing3.types
+++ b/tests/baselines/reference/specialPropertyBlockShadowing3.types
@@ -1,0 +1,165 @@
+//// [tests/cases/compiler/specialPropertyBlockShadowing3.ts] ////
+
+=== src/index.js ===
+export const x = {};
+>x : typeof x
+>  : ^^^^^^^^
+>{} : {}
+>   : ^^
+
+x.inner = {};
+>x.inner = {} : {}
+>             : ^^
+>x.inner : {}
+>        : ^^
+>x : typeof x
+>  : ^^^^^^^^
+>inner : {}
+>      : ^^
+>{} : {}
+>   : ^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const x = {};
+>x : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  x.inner = {};
+>x.inner = {} : { test: number; }
+>             : ^^^^^^^^^^^^^^^^^
+>x.inner : { test: number; }
+>        : ^^^^^^^^^^^^^^^^^
+>x : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>inner : { test: number; }
+>      : ^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  x.inner.test = 1;
+>x.inner.test = 1 : 1
+>                 : ^
+>x.inner.test : number
+>             : ^^^^^^
+>x.inner : { test: number; }
+>        : ^^^^^^^^^^^^^^^^^
+>x : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>inner : { test: number; }
+>      : ^^^^^^^^^^^^^^^^^
+>test : number
+>     : ^^^^^^
+>1 : 1
+>  : ^
+}
+
+export const y = {};
+>y : typeof y
+>  : ^^^^^^^^
+>{} : {}
+>   : ^^
+
+y.inner = {};
+>y.inner = {} : typeof y.inner
+>             : ^^^^^^^^^^^^^^
+>y.inner : typeof y.inner
+>        : ^^^^^^^^^^^^^^
+>y : typeof y
+>  : ^^^^^^^^
+>inner : typeof y.inner
+>      : ^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+y.inner.test = "foo";
+>y.inner.test = "foo" : "foo"
+>                     : ^^^^^
+>y.inner.test : string
+>             : ^^^^^^
+>y.inner : typeof y.inner
+>        : ^^^^^^^^^^^^^^
+>y : typeof y
+>  : ^^^^^^^^
+>inner : typeof y.inner
+>      : ^^^^^^^^^^^^^^
+>test : string
+>     : ^^^^^^
+>"foo" : "foo"
+>      : ^^^^^
+
+const aliasTopY = y;
+>aliasTopY : typeof y
+>          : ^^^^^^^^
+>y : typeof y
+>  : ^^^^^^^^
+
+if (Math.random()) {
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+
+  const y = {};
+>y : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  y.inner = {};
+>y.inner = {} : { test: number; }
+>             : ^^^^^^^^^^^^^^^^^
+>y.inner : { test: number; }
+>        : ^^^^^^^^^^^^^^^^^
+>y : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>inner : { test: number; }
+>      : ^^^^^^^^^^^^^^^^^
+>{} : {}
+>   : ^^
+
+  y.inner.test = 42;
+>y.inner.test = 42 : 42
+>                  : ^^
+>y.inner.test : number
+>             : ^^^^^^
+>y.inner : { test: number; }
+>        : ^^^^^^^^^^^^^^^^^
+>y : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>inner : { test: number; }
+>      : ^^^^^^^^^^^^^^^^^
+>test : number
+>     : ^^^^^^
+>42 : 42
+>   : ^^
+
+  /** @type {{ inner: { test: string } }} */
+  const topYcheck = aliasTopY;
+>topYcheck : { inner: { test: string; }; }
+>          : ^^^^^^^^^                 ^^^
+>aliasTopY : typeof import("src/index").y
+>          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  /** @type {{ inner: { test: number } }} */
+  const blockYcheck = y;
+>blockYcheck : { inner: { test: number; }; }
+>            : ^^^^^^^^^                 ^^^
+>y : { inner: { test: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+

--- a/tests/cases/compiler/expandoFunctionBlockShadowing2.ts
+++ b/tests/cases/compiler/expandoFunctionBlockShadowing2.ts
@@ -1,0 +1,28 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: dist
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: src/index.js
+
+export function X() {}
+if (Math.random()) {
+  /** @type {{ test?: any }} */
+  const X = {};
+  Object.defineProperty(X, "test", { value: 1 });
+}
+
+export function Y() {}
+Object.defineProperty(Y, "test", { value: "foo" });
+const aliasTopY = Y;
+if (Math.random()) {
+  const Y = function Y() {}
+  Object.defineProperty(Y, "test", { value: 42 });
+
+  /** @type {{ (): void; test: string }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ (): void; test: number }} */
+  const blockYcheck = Y;
+}

--- a/tests/cases/compiler/expandoFunctionBlockShadowing3.ts
+++ b/tests/cases/compiler/expandoFunctionBlockShadowing3.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @declaration: true
+// @emitDeclarationOnly: true
+
+export function Z() {}
+Z.test = "foo";
+const aliasTopZ = Z;
+if (Math.random()) {
+  const Z = function Z() {};
+  if (Math.random()) {
+    Z.test = 42;
+  }
+
+  const topZcheck: { (): void; test: string } = aliasTopZ;
+  const blockZcheck: { (): void; test: number } = Z;
+}

--- a/tests/cases/compiler/javascriptDefinePropertyPrototypeBlockShadowing1.ts
+++ b/tests/cases/compiler/javascriptDefinePropertyPrototypeBlockShadowing1.ts
@@ -1,0 +1,27 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: dist
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: src/index.js
+
+export function X() {}
+if (Math.random()) {
+  const X = function() {}
+  Object.defineProperty(X.prototype, "test", { value: 1 });
+}
+
+export function Y() {}
+Object.defineProperty(Y.prototype, "test", { value: "foo" });
+const AliasTopY = Y;
+if (Math.random()) {
+  const Y = function Y() {}
+  Object.defineProperty(Y.prototype, "test", { value: 42 });
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+}

--- a/tests/cases/compiler/specialPropertyBlockShadowing1.ts
+++ b/tests/cases/compiler/specialPropertyBlockShadowing1.ts
@@ -1,0 +1,27 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: dist
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: src/index.js
+
+export const X = {};
+if (Math.random()) {
+  const X = {};
+  X.test = 1;
+}
+
+export const Y = {};
+Y.test = "foo";
+const aliasTopY = Y;
+if (Math.random()) {
+  const Y = {};
+  Y.test = 42;
+
+  /** @type {{ test: string }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ test: number }} */
+  const blockYcheck = Y;
+}

--- a/tests/cases/compiler/specialPropertyBlockShadowing2.ts
+++ b/tests/cases/compiler/specialPropertyBlockShadowing2.ts
@@ -1,0 +1,27 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: dist
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: src/index.js
+
+export function X() { };
+if (Math.random()) {
+  const X = function () { };
+  X.prototype.method = function () { this.test = 1 };
+}
+
+export function Y() { };
+Y.prototype.method = function () { this.test = "foo" };
+const AliasTopY = Y;
+if (Math.random()) {
+  const Y = function () { };
+  Y.prototype.method = function () { this.test = 42 };
+
+  /** @type {{ test: string }} */
+  const topYcheck = new AliasTopY();
+  /** @type {{ test: number }} */
+  const blockYcheck = new Y();
+}

--- a/tests/cases/compiler/specialPropertyBlockShadowing3.ts
+++ b/tests/cases/compiler/specialPropertyBlockShadowing3.ts
@@ -1,0 +1,32 @@
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: dist
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: src/index.js
+
+export const x = {};
+x.inner = {};
+if (Math.random()) {
+  const x = {};
+  x.inner = {};
+  x.inner.test = 1;
+}
+
+export const y = {};
+y.inner = {};
+y.inner.test = "foo";
+
+const aliasTopY = y;
+if (Math.random()) {
+  const y = {};
+  y.inner = {};
+  y.inner.test = 42;
+
+  /** @type {{ inner: { test: string } }} */
+  const topYcheck = aliasTopY;
+  /** @type {{ inner: { test: number } }} */
+  const blockYcheck = y;
+}


### PR DESCRIPTION
fixes more issues like https://github.com/microsoft/TypeScript/issues/56538
I realized that my PR ( https://github.com/microsoft/TypeScript/pull/56552 ) that fixed that issue missed quite a bit of cases, cc @weswigham (as the reviewer of that previous PR)

1. This PR fixes lookup in nested blocks - when the expando is meant to be bound to a symbol in some outer block, between the current block and its enclosing container
2. It also fixes the a block/container lookup in more cases related to special properties, expando prototypes, auto this properties and `Object.defineProperty` expando members