### PR TITLE
On macOS prevent inadvertent watchDirectory(~/Library, WatchType.FailedLookupLocations) due to globalTypingsCacheLocation

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -299,7 +299,6 @@ export function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPa
     // Paths like /Users/username/Library
     if (
         !isDosStyle &&
-        length > indexAfterOsRoot &&
         pathComponents[indexAfterOsRoot] === "Library"
     ) {
         indexAfterOsRoot += 1;
@@ -308,7 +307,6 @@ export function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPa
     // Paths like /Users/username/Library/Caches
     if (
         !isDosStyle &&
-        length > indexAfterOsRoot &&
         pathComponents[indexAfterOsRoot] === "Caches"
     ) {
         indexAfterOsRoot += 1;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -302,14 +302,11 @@ export function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPa
         pathComponents[indexAfterOsRoot] === "Library"
     ) {
         indexAfterOsRoot += 1;
-    }
 
-    // Paths like /Users/username/Library/Caches
-    if (
-        !isDosStyle &&
-        pathComponents[indexAfterOsRoot] === "Caches"
-    ) {
-        indexAfterOsRoot += 1;
+        // Paths like /Users/username/Library/Caches
+        if (pathComponents[indexAfterOsRoot] === "Caches") {
+            indexAfterOsRoot += 1;
+        }
     }
 
     return indexAfterOsRoot;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -263,7 +263,8 @@ export function removeIgnoredPath(path: Path): Path | undefined {
         path;
 }
 
-function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathComponents>, length: number) {
+/** @internal */
+export function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathComponents>, length: number) {
     // Ignore "/", "c:/"
     if (length <= 1) return 1;
     let indexAfterOsRoot = 1;
@@ -295,13 +296,22 @@ function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathCompo
     // Paths like: c:/users/username or /home/username
     indexAfterOsRoot += 2;
 
+    // Paths like /Users/username/Library
+    if (
+        !isDosStyle &&
+        length > indexAfterOsRoot &&
+        pathComponents[indexAfterOsRoot] === "Library"
+    ) {
+        indexAfterOsRoot += 1;
+    }
+
     // Paths like /Users/username/Library/Caches
     if (
         !isDosStyle &&
-        pathComponents[indexAfterOsRoot] === "Library" &&
-        pathComponents[indexAfterOsRoot + 1] === "Caches"
+        length > indexAfterOsRoot &&
+        pathComponents[indexAfterOsRoot] === "Caches"
     ) {
-        return indexAfterOsRoot + 2;
+        indexAfterOsRoot += 1;
     }
 
     return indexAfterOsRoot;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -293,7 +293,18 @@ function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathCompo
     }
 
     // Paths like: c:/users/username or /home/username
-    return indexAfterOsRoot + 2;
+    indexAfterOsRoot += 2;
+
+    // Paths like /Users/username/Library/Caches
+    if (
+        !isDosStyle &&
+        pathComponents[indexAfterOsRoot] === "Library" &&
+        pathComponents[indexAfterOsRoot + 1] === "Caches"
+    ) {
+        return indexAfterOsRoot + 2;
+    }
+
+    return indexAfterOsRoot;
 }
 
 /**

--- a/src/testRunner/tests.ts
+++ b/src/testRunner/tests.ts
@@ -48,6 +48,7 @@ export * from "./unittests/printer.js";
 export * from "./unittests/programApi.js";
 export * from "./unittests/publicApi.js";
 export * from "./unittests/regExpScannerRecovery.js";
+export * from "./unittests/resolutionCache.js";
 export * from "./unittests/reuseProgramStructure.js";
 export * from "./unittests/semver.js";
 export * from "./unittests/services/cancellableLanguageServiceOperations.js";

--- a/src/testRunner/unittests/resolutionCache.ts
+++ b/src/testRunner/unittests/resolutionCache.ts
@@ -1,0 +1,16 @@
+import * as ts from "../_namespaces/ts.js";
+
+describe("unittests:: resolution cache ", () => {
+    it("perceivedOsRootLengthForWatching", () => {
+        const toPathComp = (path: string) => ts.getPathComponents(ts.toPath(path, undefined, (f: string) => f));
+        const osRootBase = (path: string) => {
+            let pathComp = toPathComp(path);
+            let idx = ts.perceivedOsRootLengthForWatching(pathComp, pathComp.length);
+            return pathComp[idx];
+        };
+        assert.strictEqual(osRootBase("/Users/username"), undefined);
+        assert.strictEqual(osRootBase("/Users/username/Library"), undefined);
+        assert.strictEqual(osRootBase("/Users/username/Library/Caches"), undefined);
+        assert.strictEqual(osRootBase("/Users/username/Library/Caches/typescript/5.5/package.json"), "typescript");
+    });
+});

--- a/src/testRunner/unittests/resolutionCache.ts
+++ b/src/testRunner/unittests/resolutionCache.ts
@@ -11,5 +11,6 @@ describe("unittests:: resolution cache ", () => {
         assert.isUndefined(osRootBase("/Users/username/Library"));
         assert.isUndefined(osRootBase("/Users/username/Library/Caches"));
         assert.strictEqual(osRootBase("/Users/username/Library/Caches/typescript/5.5/package.json"), "typescript");
+        assert.strictEqual(osRootBase("/home/user/Caches"), "Caches");
     });
 });

--- a/src/testRunner/unittests/resolutionCache.ts
+++ b/src/testRunner/unittests/resolutionCache.ts
@@ -2,15 +2,14 @@ import * as ts from "../_namespaces/ts.js";
 
 describe("unittests:: resolution cache ", () => {
     it("perceivedOsRootLengthForWatching", () => {
-        const toPathComp = (path: string) => ts.getPathComponents(ts.toPath(path, undefined, (f: string) => f));
         const osRootBase = (path: string) => {
-            let pathComp = toPathComp(path);
-            let idx = ts.perceivedOsRootLengthForWatching(pathComp, pathComp.length);
+            const pathComp = ts.getPathComponents(ts.toPath(path, /*basePath*/ undefined, (f: string) => f));
+            const idx = ts.perceivedOsRootLengthForWatching(pathComp, pathComp.length);
             return pathComp[idx];
         };
-        assert.strictEqual(osRootBase("/Users/username"), undefined);
-        assert.strictEqual(osRootBase("/Users/username/Library"), undefined);
-        assert.strictEqual(osRootBase("/Users/username/Library/Caches"), undefined);
+        assert.isUndefined(osRootBase("/Users/username"));
+        assert.isUndefined(osRootBase("/Users/username/Library"));
+        assert.isUndefined(osRootBase("/Users/username/Library/Caches"));
         assert.strictEqual(osRootBase("/Users/username/Library/Caches/typescript/5.5/package.json"), "typescript");
     });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/59831
