### PR TITLE
Distribute mapped types over intersections with some array/tuple members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15030,14 +15030,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const modifiersType = getModifiersTypeFromMappedType(type);
             const baseConstraint = isGenericMappedType(modifiersType) ? getApparentTypeOfMappedType(modifiersType) : getBaseConstraintOfType(modifiersType);
             if (baseConstraint && everyType(baseConstraint, t => isArrayOrTupleType(t) || isArrayOrTupleOrIntersection(t))) {
-                return instantiateType(target, prependTypeMapping(typeVariable, baseConstraint, type.mapper));
+                const applicableConstraint = baseConstraint.flags & TypeFlags.Intersection ? getIntersectionType(filter((baseConstraint as IntersectionType).types, isArrayOrTupleType)) : baseConstraint;
+                return instantiateType(target, prependTypeMapping(typeVariable, applicableConstraint, type.mapper));
             }
         }
         return type;
     }
 
     function isArrayOrTupleOrIntersection(type: Type) {
-        return !!(type.flags & TypeFlags.Intersection) && every((type as IntersectionType).types, isArrayOrTupleType);
+        return !!(type.flags & TypeFlags.Intersection) && some((type as IntersectionType).types, isArrayOrTupleType);
     }
 
     function isMappedTypeGenericIndexedAccess(type: Type) {
@@ -20383,7 +20384,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return instantiateMappedTupleType(t, type, typeVariable!, mapper);
                     }
                     if (isArrayOrTupleOrIntersection(t)) {
-                        return getIntersectionType(map((t as IntersectionType).types, instantiateConstituent));
+                        return getIntersectionType(map(filter((t as IntersectionType).types, isArrayOrTupleType), instantiateConstituent));
                     }
                 }
                 return instantiateAnonymousType(type, prependTypeMapping(typeVariable!, t, mapper));

--- a/tests/baselines/reference/mappedArrayTupleIntersections.types
+++ b/tests/baselines/reference/mappedArrayTupleIntersections.types
@@ -28,8 +28,8 @@ type T4 = Boxify<string[] & [string, string]>;
 >   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 type T5 = Boxify<string[] & { x: string }>;
->T5 : Boxify<string[] & { x: string; }>
->   : ^^^^^^^^^^^^^^^^^^^^^^^      ^^^^
+>T5 : Box<string>[]
+>   : ^^^^^^^^^^^^^
 >x : string
 >  : ^^^^^^
 

--- a/tests/baselines/reference/mappedArrayTupleIntersections2.symbols
+++ b/tests/baselines/reference/mappedArrayTupleIntersections2.symbols
@@ -1,0 +1,62 @@
+//// [tests/cases/compiler/mappedArrayTupleIntersections2.ts] ////
+
+=== mappedArrayTupleIntersections2.ts ===
+// https://github.com/microsoft/TypeScript/issues/59849
+
+type IdentitySpread<t extends readonly unknown[]> = [...{ [i in keyof t]: t[i] }];
+>IdentitySpread : Symbol(IdentitySpread, Decl(mappedArrayTupleIntersections2.ts, 0, 0))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 2, 20))
+>i : Symbol(i, Decl(mappedArrayTupleIntersections2.ts, 2, 59))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 2, 20))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 2, 20))
+>i : Symbol(i, Decl(mappedArrayTupleIntersections2.ts, 2, 59))
+
+type Result1 = IdentitySpread<{ name: string } & string[]>;
+>Result1 : Symbol(Result1, Decl(mappedArrayTupleIntersections2.ts, 2, 82))
+>IdentitySpread : Symbol(IdentitySpread, Decl(mappedArrayTupleIntersections2.ts, 0, 0))
+>name : Symbol(name, Decl(mappedArrayTupleIntersections2.ts, 4, 31))
+
+type Result2 = IdentitySpread<(string | number)[] & ['foo', string, 42]>;
+>Result2 : Symbol(Result2, Decl(mappedArrayTupleIntersections2.ts, 4, 59))
+>IdentitySpread : Symbol(IdentitySpread, Decl(mappedArrayTupleIntersections2.ts, 0, 0))
+
+type Result3 = IdentitySpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+>Result3 : Symbol(Result3, Decl(mappedArrayTupleIntersections2.ts, 5, 73))
+>IdentitySpread : Symbol(IdentitySpread, Decl(mappedArrayTupleIntersections2.ts, 0, 0))
+
+type Result4 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>Result4 : Symbol(Result4, Decl(mappedArrayTupleIntersections2.ts, 6, 102))
+>IdentitySpread : Symbol(IdentitySpread, Decl(mappedArrayTupleIntersections2.ts, 0, 0))
+
+type Box<T> = { value: T };
+>Box : Symbol(Box, Decl(mappedArrayTupleIntersections2.ts, 7, 94))
+>T : Symbol(T, Decl(mappedArrayTupleIntersections2.ts, 9, 9))
+>value : Symbol(value, Decl(mappedArrayTupleIntersections2.ts, 9, 15))
+>T : Symbol(T, Decl(mappedArrayTupleIntersections2.ts, 9, 9))
+
+type BoxedSpread<t extends readonly unknown[]> = [...{ [i in keyof t]: Box<t[i]> }];
+>BoxedSpread : Symbol(BoxedSpread, Decl(mappedArrayTupleIntersections2.ts, 9, 27))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 10, 17))
+>i : Symbol(i, Decl(mappedArrayTupleIntersections2.ts, 10, 56))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 10, 17))
+>Box : Symbol(Box, Decl(mappedArrayTupleIntersections2.ts, 7, 94))
+>t : Symbol(t, Decl(mappedArrayTupleIntersections2.ts, 10, 17))
+>i : Symbol(i, Decl(mappedArrayTupleIntersections2.ts, 10, 56))
+
+type Result5 = BoxedSpread<{ name: string } & string[]>;
+>Result5 : Symbol(Result5, Decl(mappedArrayTupleIntersections2.ts, 10, 84))
+>BoxedSpread : Symbol(BoxedSpread, Decl(mappedArrayTupleIntersections2.ts, 9, 27))
+>name : Symbol(name, Decl(mappedArrayTupleIntersections2.ts, 12, 28))
+
+type Result6 = BoxedSpread<(string | number)[] & ['foo', string, 42]>;
+>Result6 : Symbol(Result6, Decl(mappedArrayTupleIntersections2.ts, 12, 56))
+>BoxedSpread : Symbol(BoxedSpread, Decl(mappedArrayTupleIntersections2.ts, 9, 27))
+
+type Result7 = BoxedSpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+>Result7 : Symbol(Result7, Decl(mappedArrayTupleIntersections2.ts, 13, 70))
+>BoxedSpread : Symbol(BoxedSpread, Decl(mappedArrayTupleIntersections2.ts, 9, 27))
+
+type Result8 = BoxedSpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>Result8 : Symbol(Result8, Decl(mappedArrayTupleIntersections2.ts, 14, 99))
+>BoxedSpread : Symbol(BoxedSpread, Decl(mappedArrayTupleIntersections2.ts, 9, 27))
+

--- a/tests/baselines/reference/mappedArrayTupleIntersections2.types
+++ b/tests/baselines/reference/mappedArrayTupleIntersections2.types
@@ -1,0 +1,55 @@
+//// [tests/cases/compiler/mappedArrayTupleIntersections2.ts] ////
+
+=== mappedArrayTupleIntersections2.ts ===
+// https://github.com/microsoft/TypeScript/issues/59849
+
+type IdentitySpread<t extends readonly unknown[]> = [...{ [i in keyof t]: t[i] }];
+>IdentitySpread : [...{ [i in keyof t]: t[i]; }]
+>               : ^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+
+type Result1 = IdentitySpread<{ name: string } & string[]>;
+>Result1 : string[]
+>        : ^^^^^^^^
+>name : string
+>     : ^^^^^^
+
+type Result2 = IdentitySpread<(string | number)[] & ['foo', string, 42]>;
+>Result2 : (string | 42)[]
+>        : ^^^^^^^^^^^^^^^
+
+type Result3 = IdentitySpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+>Result3 : (string | 43)[]
+>        : ^^^^^^^^^^^^^^^
+
+type Result4 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>Result4 : never
+>        : ^^^^^
+
+type Box<T> = { value: T };
+>Box : Box<T>
+>    : ^^^^^^
+>value : T
+>      : ^
+
+type BoxedSpread<t extends readonly unknown[]> = [...{ [i in keyof t]: Box<t[i]> }];
+>BoxedSpread : [...{ [i in keyof t]: Box<t[i]>; }]
+>            : ^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+type Result5 = BoxedSpread<{ name: string } & string[]>;
+>Result5 : Box<string>[]
+>        : ^^^^^^^^^^^^^
+>name : string
+>     : ^^^^^^
+
+type Result6 = BoxedSpread<(string | number)[] & ['foo', string, 42]>;
+>Result6 : (Box<string | number> & (Box<string> | Box<"foo"> | Box<42>))[]
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+type Result7 = BoxedSpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+>Result7 : ((Box<string | boolean> & Box<"foo">) | (Box<string | symbol> & Box<string>) | (Box<string | boolean> & Box<string>) | (Box<string | symbol> & Box<"foo">) | (Box<number> & Box<string>) | (Box<number> & Box<43>))[]
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+type Result8 = BoxedSpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>Result8 : never
+>        : ^^^^^
+

--- a/tests/cases/compiler/mappedArrayTupleIntersections2.ts
+++ b/tests/cases/compiler/mappedArrayTupleIntersections2.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59849
+
+type IdentitySpread<t extends readonly unknown[]> = [...{ [i in keyof t]: t[i] }];
+
+type Result1 = IdentitySpread<{ name: string } & string[]>;
+type Result2 = IdentitySpread<(string | number)[] & ['foo', string, 42]>;
+type Result3 = IdentitySpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+type Result4 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+
+type Box<T> = { value: T };
+type BoxedSpread<t extends readonly unknown[]> = [...{ [i in keyof t]: Box<t[i]> }];
+
+type Result5 = BoxedSpread<{ name: string } & string[]>;
+type Result6 = BoxedSpread<(string | number)[] & ['foo', string, 42]>;
+type Result7 = BoxedSpread<[string | boolean, string | symbol, ...number[]] & ['foo', string, 43]>;
+type Result8 = BoxedSpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59849
relates to https://github.com/microsoft/TypeScript/pull/57801 (cc @ahejlsberg)

reasoning behind the change explained [here](https://github.com/microsoft/TypeScript/issues/59849#issuecomment-2330976247)