### PR TITLE
Normalize variadic tuples with reduced never element type to never

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17455,6 +17455,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // Spread variadic elements with tuple types into the resulting tuple.
                     forEach(elements, (t, n) => addElement(t, type.target.elementFlags[n], type.target.labeledElementDeclarations?.[n]));
                 }
+                else if (getReducedApparentType(type).flags & TypeFlags.Never) {
+                    return neverType;
+                }
                 else {
                     // Treat everything else as an array type and create a rest element.
                     addElement(isArrayLikeType(type) && getIndexTypeOfType(type, numberType) || errorType, ElementFlags.Rest, target.labeledElementDeclarations?.[i]);

--- a/tests/baselines/reference/variadicTuples1.errors.txt
+++ b/tests/baselines/reference/variadicTuples1.errors.txt
@@ -543,3 +543,9 @@ variadicTuples1.ts(411,7): error TS2322: Type '[boolean, false]' is not assignab
     
     type AnyArr = [...any];
     
+    type NeverSpread1 = [...never];
+    type IdentitySpread<T extends readonly unknown[]> = [...T];
+    type NeverSpread2 = IdentitySpread<never>;
+    type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+    type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+    

--- a/tests/baselines/reference/variadicTuples1.js
+++ b/tests/baselines/reference/variadicTuples1.js
@@ -424,6 +424,12 @@ type ToStringLength2<T extends any[]> = `${[...T]['length']}`;
 
 type AnyArr = [...any];
 
+type NeverSpread1 = [...never];
+type IdentitySpread<T extends readonly unknown[]> = [...T];
+type NeverSpread2 = IdentitySpread<never>;
+type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+
 
 //// [variadicTuples1.js]
 "use strict";
@@ -833,6 +839,11 @@ type U3 = [...[string, number], boolean];
 type ToStringLength1<T extends any[]> = `${T['length']}`;
 type ToStringLength2<T extends any[]> = `${[...T]['length']}`;
 type AnyArr = [...any];
+type NeverSpread1 = [...never];
+type IdentitySpread<T extends readonly unknown[]> = [...T];
+type NeverSpread2 = IdentitySpread<never>;
+type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
 
 
 !!!! File variadicTuples1.d.ts differs from original emit in noCheck emit

--- a/tests/baselines/reference/variadicTuples1.symbols
+++ b/tests/baselines/reference/variadicTuples1.symbols
@@ -1419,3 +1419,23 @@ type ToStringLength2<T extends any[]> = `${[...T]['length']}`;
 type AnyArr = [...any];
 >AnyArr : Symbol(AnyArr, Decl(variadicTuples1.ts, 419, 62))
 
+type NeverSpread1 = [...never];
+>NeverSpread1 : Symbol(NeverSpread1, Decl(variadicTuples1.ts, 421, 23))
+
+type IdentitySpread<T extends readonly unknown[]> = [...T];
+>IdentitySpread : Symbol(IdentitySpread, Decl(variadicTuples1.ts, 423, 31))
+>T : Symbol(T, Decl(variadicTuples1.ts, 424, 20))
+>T : Symbol(T, Decl(variadicTuples1.ts, 424, 20))
+
+type NeverSpread2 = IdentitySpread<never>;
+>NeverSpread2 : Symbol(NeverSpread2, Decl(variadicTuples1.ts, 424, 59))
+>IdentitySpread : Symbol(IdentitySpread, Decl(variadicTuples1.ts, 423, 31))
+
+type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+>ReducedNeverSpread1 : Symbol(ReducedNeverSpread1, Decl(variadicTuples1.ts, 425, 42))
+>IdentitySpread : Symbol(IdentitySpread, Decl(variadicTuples1.ts, 423, 31))
+
+type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>ReducedNeverSpread2 : Symbol(ReducedNeverSpread2, Decl(variadicTuples1.ts, 426, 57))
+>IdentitySpread : Symbol(IdentitySpread, Decl(variadicTuples1.ts, 423, 31))
+

--- a/tests/baselines/reference/variadicTuples1.types
+++ b/tests/baselines/reference/variadicTuples1.types
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/types/tuple/variadicTuples1.ts] ////
 
 === Performance Stats ===
-Type Count: 1,000
+Type Count: 1,000 -> 2,500
 Instantiation count: 2,500
 
 === variadicTuples1.ts ===
@@ -2303,4 +2303,24 @@ type ToStringLength2<T extends any[]> = `${[...T]['length']}`;
 type AnyArr = [...any];
 >AnyArr : any[]
 >       : ^^^^^
+
+type NeverSpread1 = [...never];
+>NeverSpread1 : never
+>             : ^^^^^
+
+type IdentitySpread<T extends readonly unknown[]> = [...T];
+>IdentitySpread : [...T]
+>               : ^^^^^^
+
+type NeverSpread2 = IdentitySpread<never>;
+>NeverSpread2 : never
+>             : ^^^^^
+
+type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+>ReducedNeverSpread1 : never
+>                    : ^^^^^
+
+type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;
+>ReducedNeverSpread2 : never
+>                    : ^^^^^
 

--- a/tests/cases/conformance/types/tuple/variadicTuples1.ts
+++ b/tests/cases/conformance/types/tuple/variadicTuples1.ts
@@ -423,3 +423,9 @@ type ToStringLength1<T extends any[]> = `${T['length']}`;
 type ToStringLength2<T extends any[]> = `${[...T]['length']}`;
 
 type AnyArr = [...any];
+
+type NeverSpread1 = [...never];
+type IdentitySpread<T extends readonly unknown[]> = [...T];
+type NeverSpread2 = IdentitySpread<never>;
+type ReducedNeverSpread1 = IdentitySpread<[] & [string]>;
+type ReducedNeverSpread2 = IdentitySpread<[string | boolean, boolean, ...number[]] & ['foo', string, 44]>;


### PR DESCRIPTION
an issue observed while investigating another one, see [here](https://github.com/microsoft/TypeScript/issues/59849#issuecomment-2330976247)

This solves an inconsistency problem that can be seen here ([TS playground](https://www.typescriptlang.org/play/?ts=5.7.0-dev.20240904#code/C4TwDgpgBAQghgZwgGwJYDtoF4oG0B0hmAbhAE4C6A3AFAD0dUTAegPw02iRQAqECwADw8oEAB7AI6ACYIoAV3QBrdAHsA7ulwUAfFBwFCPap3DQAkujDzg+vBSgAyPALIYA5iYZMobU9wAlfnlkWxw+AUFLa2AdWm8WdiA)):
```ts
type Baseline = [...never];
//   ^? type Baseline = never

type Test<T extends unknown[]> = [...T];
type Input = [] & [string];
//   ^? type Input = never
type Result = Test<Input>;
//   ^? type Result = any[]
```

`Baseline` and `Result` should both be `never`.
