### PR TITLE
Fixed a crash when trying to find references on `NoSubstitutionTemplateLiteral` with `LiteralType` parent

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4226,7 +4226,9 @@ export function tryGetImportFromModuleSpecifier(node: StringLiteralLike): AnyVal
         case SyntaxKind.CallExpression:
             return isImportCall(node.parent) || isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false) ? node.parent as RequireOrImportCall : undefined;
         case SyntaxKind.LiteralType:
-            Debug.assert(isStringLiteral(node));
+            if (!isStringLiteral(node)) {
+                break;
+            }
             return tryCast(node.parent.parent, isImportTypeNode) as ValidImportTypeNode | undefined;
         default:
             return undefined;

--- a/tests/baselines/reference/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.baseline.jsonc
@@ -1,0 +1,23 @@
+// === findAllReferences ===
+// === /tests/cases/fourslash/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.ts ===
+// type Test = `[|{| isInString: true |}T|]/*FIND ALL REFS*/`;
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.ts ===
+  // type Test = `[|T|]/*FIND ALL REFS*/`;
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "var",
+    "name": "T",
+    "displayParts": [
+     {
+      "text": "`T`",
+      "kind": "stringLiteral"
+     }
+    ]
+   }
+  ]

--- a/tests/cases/fourslash/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.ts
+++ b/tests/cases/fourslash/findAllRefsNoSubstitutionTemplateLiteralNoCrash1.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+
+//// type Test = `T/*1*/`;
+
+verify.baselineFindAllReferences('1');


### PR DESCRIPTION
…

fixes https://github.com/microsoft/TypeScript/issues/59845