### PR TITLE
No contextual typing from return types for boolean literals deeper in instantiables

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32065,8 +32065,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // If the given contextual type contains instantiable types and if a mapper representing
     // return type inferences is available, instantiate those types using that mapper.
     function instantiateContextualType(contextualType: Type | undefined, node: Node, contextFlags: ContextFlags | undefined): Type | undefined {
-        if (contextualType && maybeTypeOfKind(contextualType, TypeFlags.Instantiable)) {
-            const inferenceContext = getInferenceContext(node);
+        if (!contextualType) {
+            return;
+        }
+        let inferenceContext: InferenceContext | undefined;
+        if (maybeTypeOfKind(contextualType, TypeFlags.Instantiable)) {
+            inferenceContext = getInferenceContext(node);
             // If no inferences have been made, and none of the type parameters for which we are inferring
             // specify default types, nothing is gained from instantiating as type parameters would just be
             // replaced with their constraints similar to the apparent type.
@@ -32077,16 +32081,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             if (inferenceContext?.returnMapper) {
                 // For other purposes (e.g. determining whether to produce literal types) we only
-                // incorporate inferences made from the return type in a function call. We remove
-                // the 'boolean' type from the contextual type such that contextually typed boolean
-                // literals actually end up widening to 'boolean' (see #48363).
-                const type = instantiateInstantiableTypes(contextualType, inferenceContext.returnMapper);
-                return type.flags & TypeFlags.Union && containsType((type as UnionType).types, regularFalseType) && containsType((type as UnionType).types, regularTrueType) ?
-                    filterType(type, t => t !== regularFalseType && t !== regularTrueType) :
-                    type;
+                // incorporate inferences made from the return type in a function call.
+                contextualType = instantiateInstantiableTypes(contextualType, inferenceContext.returnMapper);
             }
         }
-        return contextualType;
+
+        // We remove the 'boolean' type from the contextual type from return types such that contextually typed boolean
+        // literals actually end up widening to 'boolean' (see #48363).
+        return contextualType.flags & TypeFlags.Union && (inferenceContext ??= getInferenceContext(node))?.returnMapper && containsType((contextualType as UnionType).types, regularFalseType) && containsType((contextualType as UnionType).types, regularTrueType) ?
+            filterType(contextualType, t => t !== regularFalseType && t !== regularTrueType) :
+            contextualType;
     }
 
     // This function is similar to instantiateType, except that (a) it only instantiates types that

--- a/tests/baselines/reference/arrayLiteralInference.types
+++ b/tests/baselines/reference/arrayLiteralInference.types
@@ -190,8 +190,8 @@ let b1: { x: boolean }[] = foo({ x: true }, { x: false });
 >   : ^^^^^       ^^^^^
 >x : boolean
 >  : ^^^^^^^
->foo({ x: true }, { x: false }) : ({ x: true; } | { x: false; })[]
->                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>foo({ x: true }, { x: false }) : { x: boolean; }[]
+>                               : ^^^^^^^^^^^^^^^^^
 >foo : <T>(...args: T[]) => T[]
 >    : ^ ^^^^^    ^^   ^^^^^   
 >{ x: true } : { x: true; }
@@ -210,8 +210,8 @@ let b1: { x: boolean }[] = foo({ x: true }, { x: false });
 let b2: boolean[][] = foo([true], [false]);
 >b2 : boolean[][]
 >   : ^^^^^^^^^^^
->foo([true], [false]) : (true[] | false[])[]
->                     : ^^^^^^^^^^^^^^^^^^^^
+>foo([true], [false]) : boolean[][]
+>                     : ^^^^^^^^^^^
 >foo : <T>(...args: T[]) => T[]
 >    : ^ ^^^^^    ^^   ^^^^^   
 >[true] : true[]

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.errors.txt
@@ -1,0 +1,78 @@
+contextuallyTypedBooleanLiterals.ts(32,7): error TS2322: Type 'Box<{ prop: false; other: number; }>' is not assignable to type 'Box<{ prop: true; other: string; } | { prop: false; other: number; }>'.
+  Types of property 'set' are incompatible.
+    Type '(value: { prop: false; other: number; }) => void' is not assignable to type '(value: { prop: true; other: string; } | { prop: false; other: number; }) => void'.
+      Types of parameters 'value' and 'value' are incompatible.
+        Type '{ prop: true; other: string; } | { prop: false; other: number; }' is not assignable to type '{ prop: false; other: number; }'.
+          Type '{ prop: true; other: string; }' is not assignable to type '{ prop: false; other: number; }'.
+            Types of property 'prop' are incompatible.
+              Type 'true' is not assignable to type 'false'.
+
+
+==== contextuallyTypedBooleanLiterals.ts (1 errors) ====
+    // Repro from #48363
+    
+    type Box<T> = {
+      get: () => T;
+      set: (value: T) => void;
+    };
+    
+    declare function box<T>(value: T): Box<T>;
+    
+    const bn1 = box(0); // Box<number>
+    const bn2: Box<number> = box(0); // Ok, Box<number>
+    
+    const bb1 = box(false); // Box<boolean>
+    const bb2: Box<boolean> = box(false); // Ok, Box<boolean>
+    
+    // https://github.com/microsoft/TypeScript/issues/59754
+    
+    const bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+    const bn4: Box<{ prop: number }> = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+    
+    const bb3 = box({ prop: false }); // Box<boolean>
+    const bb4: Box<{ prop: boolean }> = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+    
+    const bn5 = box([0]); // Box<[number]>
+    const bn6: Box<[number]> = box([0]); // Ok, Box<[number]>
+    
+    const bb5 = box([false]); // Box<[boolean]>
+    const bb6: Box<[boolean]> = box([false]); // Ok, Box<[boolean]>
+    
+    const bb7: Box<{ deep: { prop: boolean } }> = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+    
+    const bb8: Box<{ prop: true; other: string } | { prop: false; other: number }> = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+          ~~~
+!!! error TS2322: Type 'Box<{ prop: false; other: number; }>' is not assignable to type 'Box<{ prop: true; other: string; } | { prop: false; other: number; }>'.
+!!! error TS2322:   Types of property 'set' are incompatible.
+!!! error TS2322:     Type '(value: { prop: false; other: number; }) => void' is not assignable to type '(value: { prop: true; other: string; } | { prop: false; other: number; }) => void'.
+!!! error TS2322:       Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2322:         Type '{ prop: true; other: string; } | { prop: false; other: number; }' is not assignable to type '{ prop: false; other: number; }'.
+!!! error TS2322:           Type '{ prop: true; other: string; }' is not assignable to type '{ prop: false; other: number; }'.
+!!! error TS2322:             Types of property 'prop' are incompatible.
+!!! error TS2322:               Type 'true' is not assignable to type 'false'.
+    
+    const bb9: Box<false> = box(false); // Ok, Box<false>
+    
+    const bb10: Box<{ prop: false }> = box({ prop: false }); // Ok, Box<{ prop: false }>
+    
+    type Box2<T> = {
+      get: () => T;
+    };
+    
+    const bb11: Box2<{ prop: true; other: string } | { prop: false; other: number }> = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
+    
+    declare function box2<T>(value: T): Box2<T>;
+    
+    // Repro from #48150
+    
+    interface Observable<T>
+    {
+      (): T;
+      (value: T): any;
+    }
+    
+    declare function observable<T>(value: T): Observable<T>;
+    
+    const x: Observable<boolean> = observable(false);
+    
+    

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.js
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.js
@@ -4,17 +4,47 @@
 // Repro from #48363
 
 type Box<T> = {
-    get: () => T,
-    set: (value: T) => void
-}
+  get: () => T;
+  set: (value: T) => void;
+};
 
 declare function box<T>(value: T): Box<T>;
 
-const bn1 = box(0);  // Box<number>
-const bn2: Box<number> = box(0);  // Ok
+const bn1 = box(0); // Box<number>
+const bn2: Box<number> = box(0); // Ok, Box<number>
 
-const bb1 = box(false);  // Box<boolean>
-const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+const bb1 = box(false); // Box<boolean>
+const bb2: Box<boolean> = box(false); // Ok, Box<boolean>
+
+// https://github.com/microsoft/TypeScript/issues/59754
+
+const bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+const bn4: Box<{ prop: number }> = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+
+const bb3 = box({ prop: false }); // Box<boolean>
+const bb4: Box<{ prop: boolean }> = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+
+const bn5 = box([0]); // Box<[number]>
+const bn6: Box<[number]> = box([0]); // Ok, Box<[number]>
+
+const bb5 = box([false]); // Box<[boolean]>
+const bb6: Box<[boolean]> = box([false]); // Ok, Box<[boolean]>
+
+const bb7: Box<{ deep: { prop: boolean } }> = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+
+const bb8: Box<{ prop: true; other: string } | { prop: false; other: number }> = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+
+const bb9: Box<false> = box(false); // Ok, Box<false>
+
+const bb10: Box<{ prop: false }> = box({ prop: false }); // Ok, Box<{ prop: false }>
+
+type Box2<T> = {
+  get: () => T;
+};
+
+const bb11: Box2<{ prop: true; other: string } | { prop: false; other: number }> = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
+
+declare function box2<T>(value: T): Box2<T>;
 
 // Repro from #48150
 
@@ -29,13 +59,28 @@ declare function observable<T>(value: T): Observable<T>;
 const x: Observable<boolean> = observable(false);
 
 
+
 //// [contextuallyTypedBooleanLiterals.js]
 "use strict";
 // Repro from #48363
 var bn1 = box(0); // Box<number>
-var bn2 = box(0); // Ok
+var bn2 = box(0); // Ok, Box<number>
 var bb1 = box(false); // Box<boolean>
-var bb2 = box(false); // Error, box<false> not assignable to Box<boolean>
+var bb2 = box(false); // Ok, Box<boolean>
+// https://github.com/microsoft/TypeScript/issues/59754
+var bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+var bn4 = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+var bb3 = box({ prop: false }); // Box<boolean>
+var bb4 = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+var bn5 = box([0]); // Box<[number]>
+var bn6 = box([0]); // Ok, Box<[number]>
+var bb5 = box([false]); // Box<[boolean]>
+var bb6 = box([false]); // Ok, Box<[boolean]>
+var bb7 = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+var bb8 = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+var bb9 = box(false); // Ok, Box<false>
+var bb10 = box({ prop: false }); // Ok, Box<{ prop: false }>
+var bb11 = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
 var x = observable(false);
 
 
@@ -49,6 +94,49 @@ declare const bn1: Box<number>;
 declare const bn2: Box<number>;
 declare const bb1: Box<boolean>;
 declare const bb2: Box<boolean>;
+declare const bn3: Box<{
+    prop: number;
+}>;
+declare const bn4: Box<{
+    prop: number;
+}>;
+declare const bb3: Box<{
+    prop: boolean;
+}>;
+declare const bb4: Box<{
+    prop: boolean;
+}>;
+declare const bn5: Box<number[]>;
+declare const bn6: Box<[number]>;
+declare const bb5: Box<boolean[]>;
+declare const bb6: Box<[boolean]>;
+declare const bb7: Box<{
+    deep: {
+        prop: boolean;
+    };
+}>;
+declare const bb8: Box<{
+    prop: true;
+    other: string;
+} | {
+    prop: false;
+    other: number;
+}>;
+declare const bb9: Box<false>;
+declare const bb10: Box<{
+    prop: false;
+}>;
+type Box2<T> = {
+    get: () => T;
+};
+declare const bb11: Box2<{
+    prop: true;
+    other: string;
+} | {
+    prop: false;
+    other: number;
+}>;
+declare function box2<T>(value: T): Box2<T>;
 interface Observable<T> {
     (): T;
     (value: T): any;

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.symbols
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.symbols
@@ -7,66 +7,173 @@ type Box<T> = {
 >Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
 
-    get: () => T,
+  get: () => T;
 >get : Symbol(get, Decl(contextuallyTypedBooleanLiterals.ts, 2, 15))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
 
-    set: (value: T) => void
->set : Symbol(set, Decl(contextuallyTypedBooleanLiterals.ts, 3, 17))
->value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 4, 10))
+  set: (value: T) => void;
+>set : Symbol(set, Decl(contextuallyTypedBooleanLiterals.ts, 3, 15))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 4, 8))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
-}
+
+};
 
 declare function box<T>(value: T): Box<T>;
->box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
 >value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 7, 24))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
 >Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
 >T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
 
-const bn1 = box(0);  // Box<number>
+const bn1 = box(0); // Box<number>
 >bn1 : Symbol(bn1, Decl(contextuallyTypedBooleanLiterals.ts, 9, 5))
->box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
 
-const bn2: Box<number> = box(0);  // Ok
+const bn2: Box<number> = box(0); // Ok, Box<number>
 >bn2 : Symbol(bn2, Decl(contextuallyTypedBooleanLiterals.ts, 10, 5))
 >Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
->box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
 
-const bb1 = box(false);  // Box<boolean>
+const bb1 = box(false); // Box<boolean>
 >bb1 : Symbol(bb1, Decl(contextuallyTypedBooleanLiterals.ts, 12, 5))
->box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
 
-const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+const bb2: Box<boolean> = box(false); // Ok, Box<boolean>
 >bb2 : Symbol(bb2, Decl(contextuallyTypedBooleanLiterals.ts, 13, 5))
 >Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
->box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+// https://github.com/microsoft/TypeScript/issues/59754
+
+const bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+>bn3 : Symbol(bn3, Decl(contextuallyTypedBooleanLiterals.ts, 17, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 17, 17))
+
+const bn4: Box<{ prop: number }> = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+>bn4 : Symbol(bn4, Decl(contextuallyTypedBooleanLiterals.ts, 18, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 18, 16))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 18, 40))
+
+const bb3 = box({ prop: false }); // Box<boolean>
+>bb3 : Symbol(bb3, Decl(contextuallyTypedBooleanLiterals.ts, 20, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 20, 17))
+
+const bb4: Box<{ prop: boolean }> = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+>bb4 : Symbol(bb4, Decl(contextuallyTypedBooleanLiterals.ts, 21, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 21, 16))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 21, 41))
+
+const bn5 = box([0]); // Box<[number]>
+>bn5 : Symbol(bn5, Decl(contextuallyTypedBooleanLiterals.ts, 23, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+const bn6: Box<[number]> = box([0]); // Ok, Box<[number]>
+>bn6 : Symbol(bn6, Decl(contextuallyTypedBooleanLiterals.ts, 24, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+const bb5 = box([false]); // Box<[boolean]>
+>bb5 : Symbol(bb5, Decl(contextuallyTypedBooleanLiterals.ts, 26, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+const bb6: Box<[boolean]> = box([false]); // Ok, Box<[boolean]>
+>bb6 : Symbol(bb6, Decl(contextuallyTypedBooleanLiterals.ts, 27, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+const bb7: Box<{ deep: { prop: boolean } }> = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+>bb7 : Symbol(bb7, Decl(contextuallyTypedBooleanLiterals.ts, 29, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>deep : Symbol(deep, Decl(contextuallyTypedBooleanLiterals.ts, 29, 16))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 29, 24))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>deep : Symbol(deep, Decl(contextuallyTypedBooleanLiterals.ts, 29, 51))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 29, 59))
+
+const bb8: Box<{ prop: true; other: string } | { prop: false; other: number }> = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+>bb8 : Symbol(bb8, Decl(contextuallyTypedBooleanLiterals.ts, 31, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 31, 16))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 31, 28))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 31, 48))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 31, 61))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 31, 86))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 31, 99))
+
+const bb9: Box<false> = box(false); // Ok, Box<false>
+>bb9 : Symbol(bb9, Decl(contextuallyTypedBooleanLiterals.ts, 33, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+
+const bb10: Box<{ prop: false }> = box({ prop: false }); // Ok, Box<{ prop: false }>
+>bb10 : Symbol(bb10, Decl(contextuallyTypedBooleanLiterals.ts, 35, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 35, 17))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 2))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 35, 40))
+
+type Box2<T> = {
+>Box2 : Symbol(Box2, Decl(contextuallyTypedBooleanLiterals.ts, 35, 56))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 37, 10))
+
+  get: () => T;
+>get : Symbol(get, Decl(contextuallyTypedBooleanLiterals.ts, 37, 16))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 37, 10))
+
+};
+
+const bb11: Box2<{ prop: true; other: string } | { prop: false; other: number }> = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
+>bb11 : Symbol(bb11, Decl(contextuallyTypedBooleanLiterals.ts, 41, 5))
+>Box2 : Symbol(Box2, Decl(contextuallyTypedBooleanLiterals.ts, 35, 56))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 41, 18))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 41, 30))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 41, 50))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 41, 63))
+>box2 : Symbol(box2, Decl(contextuallyTypedBooleanLiterals.ts, 41, 115))
+>prop : Symbol(prop, Decl(contextuallyTypedBooleanLiterals.ts, 41, 89))
+>other : Symbol(other, Decl(contextuallyTypedBooleanLiterals.ts, 41, 102))
+
+declare function box2<T>(value: T): Box2<T>;
+>box2 : Symbol(box2, Decl(contextuallyTypedBooleanLiterals.ts, 41, 115))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 43, 22))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 43, 25))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 43, 22))
+>Box2 : Symbol(Box2, Decl(contextuallyTypedBooleanLiterals.ts, 35, 56))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 43, 22))
 
 // Repro from #48150
 
 interface Observable<T>
->Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 43, 44))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 47, 21))
 {
   (): T;
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 47, 21))
 
   (value: T): any;
->value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 20, 3))
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 50, 3))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 47, 21))
 }
 
 declare function observable<T>(value: T): Observable<T>;
->observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 21, 1))
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
->value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 23, 31))
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
->Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
->T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
+>observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 51, 1))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 53, 28))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 53, 31))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 53, 28))
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 43, 44))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 53, 28))
 
 const x: Observable<boolean> = observable(false);
->x : Symbol(x, Decl(contextuallyTypedBooleanLiterals.ts, 25, 5))
->Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
->observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 21, 1))
+>x : Symbol(x, Decl(contextuallyTypedBooleanLiterals.ts, 55, 5))
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 43, 44))
+>observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 51, 1))
+
 

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.types
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.types
@@ -7,16 +7,17 @@ type Box<T> = {
 >Box : Box<T>
 >    : ^^^^^^
 
-    get: () => T,
+  get: () => T;
 >get : () => T
 >    : ^^^^^^ 
 
-    set: (value: T) => void
+  set: (value: T) => void;
 >set : (value: T) => void
 >    : ^     ^^ ^^^^^    
 >value : T
 >      : ^
-}
+
+};
 
 declare function box<T>(value: T): Box<T>;
 >box : <T>(value: T) => Box<T>
@@ -24,7 +25,7 @@ declare function box<T>(value: T): Box<T>;
 >value : T
 >      : ^
 
-const bn1 = box(0);  // Box<number>
+const bn1 = box(0); // Box<number>
 >bn1 : Box<number>
 >    : ^^^^^^^^^^^
 >box(0) : Box<number>
@@ -34,7 +35,7 @@ const bn1 = box(0);  // Box<number>
 >0 : 0
 >  : ^
 
-const bn2: Box<number> = box(0);  // Ok
+const bn2: Box<number> = box(0); // Ok, Box<number>
 >bn2 : Box<number>
 >    : ^^^^^^^^^^^
 >box(0) : Box<number>
@@ -44,7 +45,7 @@ const bn2: Box<number> = box(0);  // Ok
 >0 : 0
 >  : ^
 
-const bb1 = box(false);  // Box<boolean>
+const bb1 = box(false); // Box<boolean>
 >bb1 : Box<boolean>
 >    : ^^^^^^^^^^^^
 >box(false) : Box<boolean>
@@ -54,7 +55,7 @@ const bb1 = box(false);  // Box<boolean>
 >false : false
 >      : ^^^^^
 
-const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+const bb2: Box<boolean> = box(false); // Ok, Box<boolean>
 >bb2 : Box<boolean>
 >    : ^^^^^^^^^^^^
 >box(false) : Box<boolean>
@@ -63,6 +64,244 @@ const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Bo
 >    : ^ ^^     ^^ ^^^^^      
 >false : false
 >      : ^^^^^
+
+// https://github.com/microsoft/TypeScript/issues/59754
+
+const bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+>bn3 : Box<{ prop: number; }>
+>    : ^^^^^^^^^^^^^^^^^^^^^^
+>box({ prop: 0 }) : Box<{ prop: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: 0 } : { prop: number; }
+>            : ^^^^^^^^^^^^^^^^^
+>prop : number
+>     : ^^^^^^
+>0 : 0
+>  : ^
+
+const bn4: Box<{ prop: number }> = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+>bn4 : Box<{ prop: number; }>
+>    : ^^^^^^^^^^^^      ^^^^
+>prop : number
+>     : ^^^^^^
+>box({ prop: 0 }) : Box<{ prop: number; }>
+>                 : ^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: 0 } : { prop: number; }
+>            : ^^^^^^^^^^^^^^^^^
+>prop : number
+>     : ^^^^^^
+>0 : 0
+>  : ^
+
+const bb3 = box({ prop: false }); // Box<boolean>
+>bb3 : Box<{ prop: boolean; }>
+>    : ^^^^^^^^^^^^^^^^^^^^^^^
+>box({ prop: false }) : Box<{ prop: boolean; }>
+>                     : ^^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: false } : { prop: false; }
+>                : ^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+
+const bb4: Box<{ prop: boolean }> = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+>bb4 : Box<{ prop: boolean; }>
+>    : ^^^^^^^^^^^^       ^^^^
+>prop : boolean
+>     : ^^^^^^^
+>box({ prop: false }) : Box<{ prop: boolean; }>
+>                     : ^^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: false } : { prop: false; }
+>                : ^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+
+const bn5 = box([0]); // Box<[number]>
+>bn5 : Box<number[]>
+>    : ^^^^^^^^^^^^^
+>box([0]) : Box<number[]>
+>         : ^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>[0] : number[]
+>    : ^^^^^^^^
+>0 : 0
+>  : ^
+
+const bn6: Box<[number]> = box([0]); // Ok, Box<[number]>
+>bn6 : Box<[number]>
+>    : ^^^^^^^^^^^^^
+>box([0]) : Box<[number]>
+>         : ^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>[0] : [number]
+>    : ^^^^^^^^
+>0 : 0
+>  : ^
+
+const bb5 = box([false]); // Box<[boolean]>
+>bb5 : Box<boolean[]>
+>    : ^^^^^^^^^^^^^^
+>box([false]) : Box<boolean[]>
+>             : ^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>[false] : false[]
+>        : ^^^^^^^
+>false : false
+>      : ^^^^^
+
+const bb6: Box<[boolean]> = box([false]); // Ok, Box<[boolean]>
+>bb6 : Box<[boolean]>
+>    : ^^^^^^^^^^^^^^
+>box([false]) : Box<[boolean]>
+>             : ^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>[false] : [false]
+>        : ^^^^^^^
+>false : false
+>      : ^^^^^
+
+const bb7: Box<{ deep: { prop: boolean } }> = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+>bb7 : Box<{ deep: { prop: boolean; }; }>
+>    : ^^^^^^^^^^^^                  ^^^^
+>deep : { prop: boolean; }
+>     : ^^^^^^^^       ^^^
+>prop : boolean
+>     : ^^^^^^^
+>box({ deep: { prop: false } }) : Box<{ deep: { prop: boolean; }; }>
+>                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ deep: { prop: false } } : { deep: { prop: false; }; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>deep : { prop: false; }
+>     : ^^^^^^^^^^^^^^^^
+>{ prop: false } : { prop: false; }
+>                : ^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+
+const bb8: Box<{ prop: true; other: string } | { prop: false; other: number }> = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+>bb8 : Box<{ prop: true; other: string; } | { prop: false; other: number; }>
+>    : ^^^^^^^^^^^^    ^^^^^^^^^      ^^^^^^^^^^^^^^     ^^^^^^^^^      ^^^^
+>prop : true
+>     : ^^^^
+>true : true
+>     : ^^^^
+>other : string
+>      : ^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+>other : number
+>      : ^^^^^^
+>box({ prop: false, other: 0 }) : Box<{ prop: false; other: number; }>
+>                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: false, other: 0 } : { prop: false; other: number; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+>other : number
+>      : ^^^^^^
+>0 : 0
+>  : ^
+
+const bb9: Box<false> = box(false); // Ok, Box<false>
+>bb9 : Box<false>
+>    : ^^^^^^^^^^
+>false : false
+>      : ^^^^^
+>box(false) : Box<false>
+>           : ^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>false : false
+>      : ^^^^^
+
+const bb10: Box<{ prop: false }> = box({ prop: false }); // Ok, Box<{ prop: false }>
+>bb10 : Box<{ prop: false; }>
+>     : ^^^^^^^^^^^^     ^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+>box({ prop: false }) : Box<{ prop: false; }>
+>                     : ^^^^^^^^^^^^^^^^^^^^^
+>box : <T>(value: T) => Box<T>
+>    : ^ ^^     ^^ ^^^^^      
+>{ prop: false } : { prop: false; }
+>                : ^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+
+type Box2<T> = {
+>Box2 : Box2<T>
+>     : ^^^^^^^
+
+  get: () => T;
+>get : () => T
+>    : ^^^^^^ 
+
+};
+
+const bb11: Box2<{ prop: true; other: string } | { prop: false; other: number }> = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
+>bb11 : Box2<{ prop: true; other: string; } | { prop: false; other: number; }>
+>     : ^^^^^^^^^^^^^    ^^^^^^^^^      ^^^^^^^^^^^^^^     ^^^^^^^^^      ^^^^
+>prop : true
+>     : ^^^^
+>true : true
+>     : ^^^^
+>other : string
+>      : ^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+>other : number
+>      : ^^^^^^
+>box2({ prop: false, other: 0 }) : Box2<{ prop: false; other: number; }>
+>                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>box2 : <T>(value: T) => Box2<T>
+>     : ^ ^^     ^^ ^^^^^       
+>{ prop: false, other: 0 } : { prop: false; other: number; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>prop : false
+>     : ^^^^^
+>false : false
+>      : ^^^^^
+>other : number
+>      : ^^^^^^
+>0 : 0
+>  : ^
+
+declare function box2<T>(value: T): Box2<T>;
+>box2 : <T>(value: T) => Box2<T>
+>     : ^ ^^     ^^ ^^^^^       
+>value : T
+>      : ^
 
 // Repro from #48150
 
@@ -89,4 +328,5 @@ const x: Observable<boolean> = observable(false);
 >           : ^ ^^     ^^ ^^^^^             
 >false : false
 >      : ^^^^^
+
 

--- a/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
+++ b/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
@@ -7,17 +7,47 @@
 // Repro from #48363
 
 type Box<T> = {
-    get: () => T,
-    set: (value: T) => void
-}
+  get: () => T;
+  set: (value: T) => void;
+};
 
 declare function box<T>(value: T): Box<T>;
 
-const bn1 = box(0);  // Box<number>
-const bn2: Box<number> = box(0);  // Ok
+const bn1 = box(0); // Box<number>
+const bn2: Box<number> = box(0); // Ok, Box<number>
 
-const bb1 = box(false);  // Box<boolean>
-const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+const bb1 = box(false); // Box<boolean>
+const bb2: Box<boolean> = box(false); // Ok, Box<boolean>
+
+// https://github.com/microsoft/TypeScript/issues/59754
+
+const bn3 = box({ prop: 0 }); // Box<{ prop: number }>
+const bn4: Box<{ prop: number }> = box({ prop: 0 }); // Ok, Box<{ prop: number }>
+
+const bb3 = box({ prop: false }); // Box<boolean>
+const bb4: Box<{ prop: boolean }> = box({ prop: false }); // Ok, Box<{ prop: boolean }>
+
+const bn5 = box([0]); // Box<[number]>
+const bn6: Box<[number]> = box([0]); // Ok, Box<[number]>
+
+const bb5 = box([false]); // Box<[boolean]>
+const bb6: Box<[boolean]> = box([false]); // Ok, Box<[boolean]>
+
+const bb7: Box<{ deep: { prop: boolean } }> = box({ deep: { prop: false } }); // Ok, Box<{ deep: { prop: boolean } }>
+
+const bb8: Box<{ prop: true; other: string } | { prop: false; other: number }> = box({ prop: false, other: 0 }); // Error (T is invariant), Box<{ prop: false; other: number }>
+
+const bb9: Box<false> = box(false); // Ok, Box<false>
+
+const bb10: Box<{ prop: false }> = box({ prop: false }); // Ok, Box<{ prop: false }>
+
+type Box2<T> = {
+  get: () => T;
+};
+
+const bb11: Box2<{ prop: true; other: string } | { prop: false; other: number }> = box2({ prop: false, other: 0 }); // Ok, Box2<{ prop: false; other: number }>
+
+declare function box2<T>(value: T): Box2<T>;
 
 // Repro from #48150
 
@@ -30,3 +60,4 @@ interface Observable<T>
 declare function observable<T>(value: T): Observable<T>;
 
 const x: Observable<boolean> = observable(false);
+


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59754
this is an extension of https://github.com/microsoft/TypeScript/pull/48380