### PR TITLE
Improve generic type signature of Iterator.from()

### DIFF
--- a/src/lib/esnext.iterator.d.ts
+++ b/src/lib/esnext.iterator.d.ts
@@ -123,7 +123,7 @@ declare global {
          * Returns its input if the input already inherits from the built-in Iterator class.
          * @param value An iterator or iterable object to convert a native iterator.
          */
-        from<T>(value: Iterator<T, unknown, undefined> | Iterable<T, unknown, undefined>): IteratorObject<T, undefined, unknown>;
+        from<T, TReturn>(value: Iterator<T, TReturn, any> | Iterable<T, TReturn, any>): IteratorObject<T, TReturn, unknown>;
     }
 
     var Iterator: IteratorConstructor;


### PR DESCRIPTION
Fixes #59926

## Background

`Iterator.from` returns an iterator that passes along the return value of its wrapped iterator, but does NOT pass along the argument to its `next` method to the wrapped iterator. This behavior is observed in node.js 22 using the following scripts and I assume is the standard behavior:

* https://github.com/nikolaybotev/iteratorhelpersdemo/blob/main/helper-propagates-next.ts
* https://github.com/nikolaybotev/iteratorhelpersdemo/blob/main/helper-propagates-return.ts

## Problem

The current type signature for `Iterator.from` basically ignores the `TReturn` and `TNext` type arguments of the underlying `Iterator` protocol and make very hard assumptions about their values, which restrict certain valid code from passing typescript compilation, such as these two examples:

* https://github.com/nikolaybotev/iteratorhelpersdemo/blob/main/problems/from/helper-propagates-next.ts
* https://github.com/nikolaybotev/iteratorhelpersdemo/blob/main/problems/from/helper-propagates-return.ts

## Solution

Add the `TReturn` type argument to `Iterator.from` and reflect the observed behavior in the type signature of the argument and return value.

## Tests

Tested manually using the scripts linked above under the *Problem* section.
