### PR TITLE
Sanitize version string for syntactically invalid buildinfo baselines

### DIFF
--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -1,7 +1,7 @@
 import { Baseline } from "../../_namespaces/Harness.js";
 import * as ts from "../../_namespaces/ts.js";
 import { jsonToReadableText } from "../helpers.js";
-import { patchHostForBuildInfoReadWrite } from "../helpers/baseline.js";
+import { fakeTsVersion, patchHostForBuildInfoReadWrite } from "../helpers/baseline.js";
 import { getTypeScriptLibTestLocation } from "../helpers/contents.js";
 import {
     getSysForSampleProjectReferences,
@@ -198,7 +198,10 @@ describe("unittests:: tsbuild:: on 'sample1' project", () => {
             commandLineArgs: ["--b", "-i", "-v"],
             edits: [{
                 caption: "tsbuildinfo written has error",
-                edit: sys => sys.prependFile("/home/src/workspaces/project/tsconfig.tsbuildinfo", "Some random string"),
+                edit: sys => {
+                    sys.prependFile("/home/src/workspaces/project/tsconfig.tsbuildinfo", "Some random string");
+                    sys.replaceFileText("/home/src/workspaces/project/tsconfig.tsbuildinfo", `"version":"${ts.version}"`, `"version":"${fakeTsVersion}"`); // build info won't parse, need to manually sterilize for baseline
+                },
             }],
         });
 

--- a/src/testRunner/unittests/tsc/incremental.ts
+++ b/src/testRunner/unittests/tsc/incremental.ts
@@ -1,6 +1,7 @@
 import * as ts from "../../_namespaces/ts.js";
 import { dedent } from "../../_namespaces/Utils.js";
 import { jsonToReadableText } from "../helpers.js";
+import { fakeTsVersion } from "../helpers/baseline.js";
 import { compilerOptionsToConfigJson } from "../helpers/contents.js";
 import {
     noChangeOnlyRuns,
@@ -100,7 +101,10 @@ describe("unittests:: tsc:: incremental::", () => {
         commandLineArgs: ["-i"],
         edits: [{
             caption: "tsbuildinfo written has error",
-            edit: sys => sys.prependFile("/home/src/workspaces/project/tsconfig.tsbuildinfo", "Some random string"),
+            edit: sys => {
+                sys.prependFile("/home/src/workspaces/project/tsconfig.tsbuildinfo", "Some random string");
+                sys.replaceFileText("/home/src/workspaces/project/tsconfig.tsbuildinfo", `"version":"${ts.version}"`, `"version":"${fakeTsVersion}"`); // build info won't parse, need to manually sterilize for baseline
+            },
         }],
     });
 

--- a/tests/baselines/reference/tsbuild/sample1/tsbuildinfo-has-error.js
+++ b/tests/baselines/reference/tsbuild/sample1/tsbuildinfo-has-error.js
@@ -84,7 +84,7 @@ Change:: tsbuildinfo written has error
 
 Input::
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo]
-Some random string{"fileNames":["../../tslibs/ts/lib/lib.d.ts","./main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-10726455937-export const x = 10;"],"root":[2],"version":"5.7.0-dev"}
+Some random string{"fileNames":["../../tslibs/ts/lib/lib.d.ts","./main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-10726455937-export const x = 10;"],"root":[2],"version":"FakeTSVersion"}
 
 
 /home/src/tslibs/TS/Lib/tsc.js --b -i -v

--- a/tests/baselines/reference/tsc/incremental/tsbuildinfo-has-error.js
+++ b/tests/baselines/reference/tsc/incremental/tsbuildinfo-has-error.js
@@ -77,7 +77,7 @@ Change:: tsbuildinfo written has error
 
 Input::
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo]
-Some random string{"fileNames":["../../tslibs/ts/lib/lib.d.ts","./main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-10726455937-export const x = 10;"],"root":[2],"version":"5.7.0-dev"}
+Some random string{"fileNames":["../../tslibs/ts/lib/lib.d.ts","./main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-10726455937-export const x = 10;"],"root":[2],"version":"FakeTSVersion"}
 
 
 /home/src/tslibs/TS/Lib/tsc.js -i


### PR DESCRIPTION
Nightlies haven't been publishing for [a few days](https://github.com/microsoft/TypeScript/actions/workflows/nightly.yaml) because some new baselines inadvertently captured the current ts version in them. The fancy automatic `.buildinfo` version stripping logic done by the builder baselines only applies to *syntactically valid* `.buildinfo` files, so these tests with _slightly invalid_ ones were inadvertently capturing the current version in the test baseline. Do note, with how the version removal machinery works, this extra ad-hoc sanitization is edit-order-dependent - if you try and make this edit *before* making the file syntactically invalid, the version-stripping-aware-sys will just add the current version right back to the file when it's re-read for the 2nd edit. 😅