### PR TITLE
Fixed an issue with mapped property symbol not displaying added `| undefined` when its origin symbol was optional

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8378,8 +8378,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (declWithExistingAnnotation && !isFunctionLikeDeclaration(declWithExistingAnnotation) && !isGetAccessorDeclaration(declWithExistingAnnotation)) {
                     // try to reuse the existing annotation
                     const existing = getNonlocalEffectiveTypeAnnotationNode(declWithExistingAnnotation)!;
-                    // explicitly add `| undefined` to optional mapped properties whose type contains `undefined` (and not `missing`)
-                    const addUndefined = addUndefinedForParameter || !!(symbol.flags & SymbolFlags.Property && symbol.flags & SymbolFlags.Optional && isOptionalDeclaration(declWithExistingAnnotation) && (symbol as MappedSymbol).links?.mappedType && containsNonMissingUndefinedType(type));
+                    // explicitly add `| undefined` to mapped properties whose type contains `undefined` (and not `missing`)
+                    const addUndefined = addUndefinedForParameter || !!(symbol.flags & SymbolFlags.Property && (symbol as MappedSymbol).links?.mappedType && containsNonMissingUndefinedType(type));
                     const result = !isTypePredicateNode(existing) && tryReuseExistingTypeNode(context, existing, type, declWithExistingAnnotation, addUndefined);
                     if (result) {
                         restoreFlags();

--- a/tests/cases/fourslash/quickInfoMappedPropertyUnionUndefined1.ts
+++ b/tests/cases/fourslash/quickInfoMappedPropertyUnionUndefined1.ts
@@ -1,0 +1,29 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @exactOptionalPropertyTypes: true
+
+// https://github.com/microsoft/TypeScript/issues/59948
+
+//// type OptionalToUnionWithUndefined<T> = {
+////   [K in keyof T]: T extends Record<K, T[K]> ? T[K] : T[K] | undefined;
+//// };
+////
+//// type Intermidiate/*1*/ = OptionalToUnionWithUndefined<{ a?: string }>;
+//// type Literal/*2*/ = { a?: string | undefined };
+////
+//// type Res1/*3*/ = Required<Intermidiate>;
+//// type Res2/*4*/ = Required<Literal>;
+
+verify.quickInfoAt("1", `type Intermidiate = {
+    a?: string | undefined;
+}`);
+verify.quickInfoAt("2", `type Literal = {
+    a?: string | undefined;
+}`);
+verify.quickInfoAt("3", `type Res1 = {
+    a: string | undefined;
+}`);
+verify.quickInfoAt("4", `type Res2 = {
+    a: string | undefined;
+}`);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59948