### PR TITLE
Only pad initializer types for parameters without annotations and contextual signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40553,7 +40553,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             checkExpressionCached(initializer, checkMode));
 
         const rootDeclaration = getRootDeclaration(declaration);
-        if (isParameter(rootDeclaration) && !getEffectiveTypeAnnotationNode(rootDeclaration)) {
+        if (isParameter(rootDeclaration) && !getEffectiveTypeAnnotationNode(rootDeclaration) && (!isFunctionLikeDeclaration(rootDeclaration.parent) || !getContextualSignatureForFunctionLikeDeclaration(rootDeclaration.parent))) {
             if (declaration.name.kind === SyntaxKind.ObjectBindingPattern && isObjectLiteralType(type)) {
                 return padObjectLiteralType(type as ObjectType, declaration.name);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40551,7 +40551,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const type = getQuickTypeOfExpression(initializer) || (contextualType ?
             checkExpressionWithContextualType(initializer, contextualType, /*inferenceContext*/ undefined, checkMode || CheckMode.Normal) :
             checkExpressionCached(initializer, checkMode));
-        if (isParameter(isBindingElement(declaration) ? walkUpBindingElementsAndPatterns(declaration) : declaration)) {
+
+        const rootDeclaration = getRootDeclaration(declaration);
+        if (isParameter(rootDeclaration) && !getEffectiveTypeAnnotationNode(rootDeclaration)) {
             if (declaration.name.kind === SyntaxKind.ObjectBindingPattern && isObjectLiteralType(type)) {
                 return padObjectLiteralType(type as ObjectType, declaration.name);
             }

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts] ////
+
+=== destructuringParameterDeclaration10.ts ===
+export function prepareConfig({
+>prepareConfig : Symbol(prepareConfig, Decl(destructuringParameterDeclaration10.ts, 0, 0))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 4, 4))
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 1, 22))
+
+    } = {}
+}: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 4, 4))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+} = {}) {
+    json // string[]
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 1, 22))
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : Symbol(prepareConfigWithoutAnnotation, Decl(destructuringParameterDeclaration10.ts, 8, 1))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles)
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
+
+    } = {}
+} = {}) {
+    json
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).symbols
@@ -37,3 +37,25 @@ export function prepareConfigWithoutAnnotation({
 >json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
 }
 
+export const prepareConfigWithContextualSignature: (param:{
+>prepareConfigWithContextualSignature : Symbol(prepareConfigWithContextualSignature, Decl(destructuringParameterDeclaration10.ts, 18, 12))
+>param : Symbol(param, Decl(destructuringParameterDeclaration10.ts, 18, 52))
+
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 18, 59))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+}) => void = ({
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 18, 59))
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 21, 22))
+
+    } = {}
+} = {}) => {
+    json // string[]
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 21, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).types
@@ -60,3 +60,40 @@ export function prepareConfigWithoutAnnotation({
 >     : ^^^^^
 }
 
+export const prepareConfigWithContextualSignature: (param:{
+>prepareConfigWithContextualSignature : (param: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                     : ^     ^^                                                                            ^^^^^    
+>param : { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }
+>      : ^^^^^^^^^^^^^^^^^^^^                                                     ^^^
+
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Partial<Record<"json" | "jsonc" | "json5", string[]>>
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+}) => void = ({
+>({    additionalFiles: {        json = []    } = {}} = {}) => {    json // string[]} : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                                                                     : ^                             ^^^^^^^^^^^^^^^^^^^^^^^                                                     ^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) => {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=false).types
@@ -1,0 +1,62 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts] ////
+
+=== destructuringParameterDeclaration10.ts ===
+export function prepareConfig({
+>prepareConfig : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>              : ^                             ^^^                                                                            ^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+}: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Partial<Record<"json" | "jsonc" | "json5", string[]>>
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : ({ additionalFiles: { json } }?: { additionalFiles?: { json?: any[]; }; }) => void
+>                               : ^                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : any[]
+>     : ^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json
+>json : any[]
+>     : ^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts] ////
+
+=== destructuringParameterDeclaration10.ts ===
+export function prepareConfig({
+>prepareConfig : Symbol(prepareConfig, Decl(destructuringParameterDeclaration10.ts, 0, 0))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 4, 4))
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 1, 22))
+
+    } = {}
+}: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 4, 4))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+} = {}) {
+    json // string[]
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 1, 22))
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : Symbol(prepareConfigWithoutAnnotation, Decl(destructuringParameterDeclaration10.ts, 8, 1))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles)
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
+
+    } = {}
+} = {}) {
+    json
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).symbols
@@ -37,3 +37,25 @@ export function prepareConfigWithoutAnnotation({
 >json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 11, 22))
 }
 
+export const prepareConfigWithContextualSignature: (param:{
+>prepareConfigWithContextualSignature : Symbol(prepareConfigWithContextualSignature, Decl(destructuringParameterDeclaration10.ts, 18, 12))
+>param : Symbol(param, Decl(destructuringParameterDeclaration10.ts, 18, 52))
+
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 18, 59))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+}) => void = ({
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(destructuringParameterDeclaration10.ts, 18, 59))
+
+        json = []
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 21, 22))
+
+    } = {}
+} = {}) => {
+    json // string[]
+>json : Symbol(json, Decl(destructuringParameterDeclaration10.ts, 21, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).types
@@ -1,0 +1,62 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts] ////
+
+=== destructuringParameterDeclaration10.ts ===
+export function prepareConfig({
+>prepareConfig : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>              : ^                             ^^^                                                                            ^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+}: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Partial<Record<"json" | "jsonc" | "json5", string[]>> | undefined
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : ({ additionalFiles: { json } }?: { additionalFiles?: { json?: never[] | undefined; } | undefined; }) => void
+>                               : ^                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : never[]
+>     : ^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json
+>json : never[]
+>     : ^^^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration10(strict=true).types
@@ -60,3 +60,40 @@ export function prepareConfigWithoutAnnotation({
 >     : ^^^^^^^
 }
 
+export const prepareConfigWithContextualSignature: (param:{
+>prepareConfigWithContextualSignature : (param: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                     : ^     ^^                                                                            ^^^^^    
+>param : { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }
+>      : ^^^^^^^^^^^^^^^^^^^^                                                     ^^^
+
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+>additionalFiles : Partial<Record<"json" | "jsonc" | "json5", string[]>> | undefined
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+}) => void = ({
+>({    additionalFiles: {        json = []    } = {}} = {}) => {    json // string[]} : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                                                                     : ^                             ^^^^^^^^^^^^^^^^^^^^^^^                                                     ^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) => {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).symbols
@@ -35,3 +35,21 @@ export function prepareConfigWithoutAnnotation({
 >json : Symbol(json, Decl(index.js, 13, 22))
 }
 
+/** @type {(param: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void} */
+export const prepareConfigWithContextualSignature = ({
+>prepareConfigWithContextualSignature : Symbol(prepareConfigWithContextualSignature, Decl(index.js, 23, 12))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(index.js, 20, 20))
+
+        json = []
+>json : Symbol(json, Decl(index.js, 24, 22))
+
+    } = {}
+} = {})=>  {
+    json // string[]
+>json : Symbol(json, Decl(index.js, 24, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts] ////
+
+=== index.js ===
+/**
+ * @param {Object} [config]
+ * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+ */
+export function prepareConfig({
+>prepareConfig : Symbol(prepareConfig, Decl(index.js, 0, 0))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(index.js, 2, 3))
+
+        json = []
+>json : Symbol(json, Decl(index.js, 5, 22))
+
+    } = {}
+} = {}) {
+    json // string[]
+>json : Symbol(json, Decl(index.js, 5, 22))
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : Symbol(prepareConfigWithoutAnnotation, Decl(index.js, 10, 1))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles)
+
+        json = []
+>json : Symbol(json, Decl(index.js, 13, 22))
+
+    } = {}
+} = {}) {
+    json
+>json : Symbol(json, Decl(index.js, 13, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).types
@@ -1,0 +1,61 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts] ////
+
+=== index.js ===
+/**
+ * @param {Object} [config]
+ * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+ */
+export function prepareConfig({
+>prepareConfig : ({ additionalFiles: { json } }?: {    additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;}) => void
+>              : ^                             ^^^                    ^^^                                                     ^ ^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : ({ additionalFiles: { json } }?: { additionalFiles?: { json?: any[]; }; }) => void
+>                               : ^                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : any[]
+>     : ^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json
+>json : any[]
+>     : ^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=false).types
@@ -59,3 +59,35 @@ export function prepareConfigWithoutAnnotation({
 >     : ^^^^^
 }
 
+/** @type {(param: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void} */
+export const prepareConfigWithContextualSignature = ({
+>prepareConfigWithContextualSignature : (param: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                     : ^     ^^                                                                            ^^^^^    
+>({    additionalFiles: {        json = []    } = {}} = {})=>  {    json // string[]} : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                                                                     : ^                             ^^^^^^^^^^^^^^^^^^^^^^^                                                     ^^^^^^^^    
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {})=>  {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).errors.txt
@@ -1,0 +1,26 @@
+index.js(15,9): error TS7031: Binding element 'json' implicitly has an 'any[]' type.
+
+
+==== index.js (1 errors) ====
+    /**
+     * @param {Object} [config]
+     * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+     */
+    export function prepareConfig({
+        additionalFiles: {
+            json = []
+        } = {}
+    } = {}) {
+        json // string[]
+    }
+    
+    export function prepareConfigWithoutAnnotation({
+        additionalFiles: {
+            json = []
+            ~~~~
+!!! error TS7031: Binding element 'json' implicitly has an 'any[]' type.
+        } = {}
+    } = {}) {
+        json
+    }
+    

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).errors.txt
@@ -24,3 +24,14 @@ index.js(15,9): error TS7031: Binding element 'json' implicitly has an 'any[]' t
         json
     }
     
+    /** @type {(param: {
+      additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+    }) => void} */
+    export const prepareConfigWithContextualSignature = ({
+        additionalFiles: {
+            json = []
+        } = {}
+    } = {})=>  {
+        json // string[]
+    }
+    

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).symbols
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts] ////
+
+=== index.js ===
+/**
+ * @param {Object} [config]
+ * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+ */
+export function prepareConfig({
+>prepareConfig : Symbol(prepareConfig, Decl(index.js, 0, 0))
+
+    additionalFiles: {
+        json = []
+>json : Symbol(json, Decl(index.js, 5, 22))
+
+    } = {}
+} = {}) {
+    json // string[]
+>json : Symbol(json, Decl(index.js, 5, 22))
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : Symbol(prepareConfigWithoutAnnotation, Decl(index.js, 10, 1))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles)
+
+        json = []
+>json : Symbol(json, Decl(index.js, 13, 22))
+
+    } = {}
+} = {}) {
+    json
+>json : Symbol(json, Decl(index.js, 13, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).symbols
@@ -33,3 +33,21 @@ export function prepareConfigWithoutAnnotation({
 >json : Symbol(json, Decl(index.js, 13, 22))
 }
 
+/** @type {(param: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void} */
+export const prepareConfigWithContextualSignature = ({
+>prepareConfigWithContextualSignature : Symbol(prepareConfigWithContextualSignature, Decl(index.js, 23, 12))
+
+    additionalFiles: {
+>additionalFiles : Symbol(additionalFiles, Decl(index.js, 20, 20))
+
+        json = []
+>json : Symbol(json, Decl(index.js, 24, 22))
+
+    } = {}
+} = {})=>  {
+    json // string[]
+>json : Symbol(json, Decl(index.js, 24, 22))
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).types
@@ -1,0 +1,61 @@
+//// [tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts] ////
+
+=== index.js ===
+/**
+ * @param {Object} [config]
+ * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+ */
+export function prepareConfig({
+>prepareConfig : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>> | undefined; } | undefined) => void
+>              : ^                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+
+export function prepareConfigWithoutAnnotation({
+>prepareConfigWithoutAnnotation : ({ additionalFiles: { json } }?: { additionalFiles?: { json?: any[] | undefined; } | undefined; }) => void
+>                               : ^                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : any[]
+>     : ^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {}) {
+>{} : {}
+>   : ^^
+
+    json
+>json : any[]
+>     : ^^^^^
+}
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).types
+++ b/tests/baselines/reference/destructuringParameterDeclaration9(strict=true).types
@@ -59,3 +59,35 @@ export function prepareConfigWithoutAnnotation({
 >     : ^^^^^
 }
 
+/** @type {(param: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void} */
+export const prepareConfigWithContextualSignature = ({
+>prepareConfigWithContextualSignature : (param: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                     : ^     ^^                                                                            ^^^^^    
+>({    additionalFiles: {        json = []    } = {}} = {})=>  {    json // string[]} : ({ additionalFiles: { json } }?: { additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>; }) => void
+>                                                                                     : ^                             ^^^^^^^^^^^^^^^^^^^^^^^                                                     ^^^^^^^^    
+
+    additionalFiles: {
+>additionalFiles : any
+>                : ^^^
+
+        json = []
+>json : string[]
+>     : ^^^^^^^^
+>[] : never[]
+>   : ^^^^^^^
+
+    } = {}
+>{} : {}
+>   : ^^
+
+} = {})=>  {
+>{} : {}
+>   : ^^
+
+    json // string[]
+>json : string[]
+>     : ^^^^^^^^
+}
+

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
@@ -18,3 +18,13 @@ export function prepareConfigWithoutAnnotation({
 } = {}) {
     json
 }
+
+export const prepareConfigWithContextualSignature: (param:{
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void = ({
+    additionalFiles: {
+        json = []
+    } = {}
+} = {}) => {
+    json // string[]
+}

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
@@ -1,0 +1,20 @@
+// @strict: true, false
+// @noEmit: true
+
+export function prepareConfig({
+    additionalFiles: {
+        json = []
+    } = {}
+}: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+} = {}) {
+    json // string[]
+}
+
+export function prepareConfigWithoutAnnotation({
+    additionalFiles: {
+        json = []
+    } = {}
+} = {}) {
+    json
+}

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts
@@ -1,0 +1,28 @@
+// @strict: true, false
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// https://github.com/microsoft/TypeScript/issues/59936
+
+// @filename: index.js
+
+/**
+ * @param {Object} [config]
+ * @param {Partial<Record<'json' | 'jsonc' | 'json5', string[]>>} [config.additionalFiles]
+ */
+export function prepareConfig({
+    additionalFiles: {
+        json = []
+    } = {}
+} = {}) {
+    json // string[]
+}
+
+export function prepareConfigWithoutAnnotation({
+    additionalFiles: {
+        json = []
+    } = {}
+} = {}) {
+    json
+}

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9.ts
@@ -26,3 +26,14 @@ export function prepareConfigWithoutAnnotation({
 } = {}) {
     json
 }
+
+/** @type {(param: {
+  additionalFiles?: Partial<Record<"json" | "jsonc" | "json5", string[]>>;
+}) => void} */
+export const prepareConfigWithContextualSignature = ({
+    additionalFiles: {
+        json = []
+    } = {}
+} = {})=>  {
+    json // string[]
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59936