### PR TITLE
[release-5.6] Remove tsbuildInfo specification error now that we need it for non incremental scenarios as well and there is no way to disable it (#59960)

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4641,10 +4641,6 @@
         "category": "Error",
         "code": 5110
     },
-    "Option 'tsBuildInfoFile' cannot be specified without specifying option 'incremental' or 'composite' or if not running 'tsc -b'.": {
-        "category": "Error",
-        "code": 5111
-    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -499,8 +499,7 @@ export function getTsBuildInfoEmitOutputFilePath(options: CompilerOptions) {
     return buildInfoExtensionLess + Extension.TsBuildInfo;
 }
 
-/** @internal */
-export function canEmitTsBuildInfo(options: CompilerOptions) {
+function canEmitTsBuildInfo(options: CompilerOptions) {
     return isIncrementalCompilation(options) || !!options.tscBuild;
 }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -8,7 +8,6 @@ import {
     AsExpression,
     BuilderProgram,
     CancellationToken,
-    canEmitTsBuildInfo,
     canHaveDecorators,
     canHaveIllegalDecorators,
     chainDiagnosticMessages,
@@ -4302,12 +4301,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         }
 
         const outputFile = options.outFile;
-        if (options.tsBuildInfoFile) {
-            if (!canEmitTsBuildInfo(options)) {
-                createDiagnosticForOptionName(Diagnostics.Option_tsBuildInfoFile_cannot_be_specified_without_specifying_option_incremental_or_composite_or_if_not_running_tsc_b, "tsBuildInfoFile");
-            }
-        }
-        else if (options.incremental && !outputFile && !options.configFilePath) {
+        if (!options.tsBuildInfoFile && options.incremental && !outputFile && !options.configFilePath) {
             programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_incremental_can_only_be_specified_using_tsconfig_emitting_to_single_file_or_when_option_tsBuildInfoFile_is_specified));
         }
 

--- a/tests/baselines/reference/optionsTsBuildInfoFileWithoutIncrementalAndComposite.errors.txt
+++ b/tests/baselines/reference/optionsTsBuildInfoFileWithoutIncrementalAndComposite.errors.txt
@@ -1,7 +1,0 @@
-error TS5111: Option 'tsBuildInfoFile' cannot be specified without specifying option 'incremental' or 'composite' or if not running 'tsc -b'.
-
-
-!!! error TS5111: Option 'tsBuildInfoFile' cannot be specified without specifying option 'incremental' or 'composite' or if not running 'tsc -b'.
-==== optionsTsBuildInfoFileWithoutIncrementalAndComposite.ts (0 errors) ====
-    const x = "Hello World";
-    

--- a/tests/baselines/reference/tsc/composite/when-setting-composite-false-on-command-line-but-has-tsbuild-info-in-config.js
+++ b/tests/baselines/reference/tsc/composite/when-setting-composite-false-on-command-line-but-has-tsbuild-info-in-config.js
@@ -35,15 +35,7 @@ export const x = 10;
 
 Output::
 /lib/tsc --composite false --p src/project
-[96msrc/project/tsconfig.json[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS5111: [0mOption 'tsBuildInfoFile' cannot be specified without specifying option 'incremental' or 'composite' or if not running 'tsc -b'.
-
-[7m6[0m         "tsBuildInfoFile": "tsconfig.json.tsbuildinfo"
-[7m [0m [91m        ~~~~~~~~~~~~~~~~~[0m
-
-
-Found 1 error in src/project/tsconfig.json[90m:6[0m
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+exitCode:: ExitStatus.Success
 
 
 //// [/src/project/src/main.js]


### PR DESCRIPTION
Cherry pick of #59960
