### PR TITLE
Simplify object types when distributing index over them

### DIFF
--- a/tests/baselines/reference/indexedAccessConstraints2.symbols
+++ b/tests/baselines/reference/indexedAccessConstraints2.symbols
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/indexedAccessConstraints2.ts] ////
+
+=== indexedAccessConstraints2.ts ===
+// https://github.com/microsoft/TypeScript/issues/59946
+
+type Test<T extends string> = { [K in T]: { key: K } }[T] & { target: string };
+>Test : Symbol(Test, Decl(indexedAccessConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 2, 10))
+>K : Symbol(K, Decl(indexedAccessConstraints2.ts, 2, 33))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 2, 10))
+>key : Symbol(key, Decl(indexedAccessConstraints2.ts, 2, 43))
+>K : Symbol(K, Decl(indexedAccessConstraints2.ts, 2, 33))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 2, 10))
+>target : Symbol(target, Decl(indexedAccessConstraints2.ts, 2, 61))
+
+const foo = <T extends string>(arg: Test<T>) => {
+>foo : Symbol(foo, Decl(indexedAccessConstraints2.ts, 4, 5))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 4, 13))
+>arg : Symbol(arg, Decl(indexedAccessConstraints2.ts, 4, 31))
+>Test : Symbol(Test, Decl(indexedAccessConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 4, 13))
+
+  const value: Test<T> = arg; // ok
+>value : Symbol(value, Decl(indexedAccessConstraints2.ts, 5, 7))
+>Test : Symbol(Test, Decl(indexedAccessConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 4, 13))
+>arg : Symbol(arg, Decl(indexedAccessConstraints2.ts, 4, 31))
+
+  const value2: Test<T>["key"] = arg["key"]; // ok
+>value2 : Symbol(value2, Decl(indexedAccessConstraints2.ts, 6, 7))
+>Test : Symbol(Test, Decl(indexedAccessConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 4, 13))
+>arg : Symbol(arg, Decl(indexedAccessConstraints2.ts, 4, 31))
+>"key" : Symbol(key, Decl(indexedAccessConstraints2.ts, 2, 43))
+
+  const value3: Test<T>["target"] = arg["target"]; // ok
+>value3 : Symbol(value3, Decl(indexedAccessConstraints2.ts, 7, 7))
+>Test : Symbol(Test, Decl(indexedAccessConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessConstraints2.ts, 4, 13))
+>arg : Symbol(arg, Decl(indexedAccessConstraints2.ts, 4, 31))
+>"target" : Symbol(target, Decl(indexedAccessConstraints2.ts, 2, 61))
+
+};
+

--- a/tests/baselines/reference/indexedAccessConstraints2.types
+++ b/tests/baselines/reference/indexedAccessConstraints2.types
@@ -1,0 +1,49 @@
+//// [tests/cases/compiler/indexedAccessConstraints2.ts] ////
+
+=== indexedAccessConstraints2.ts ===
+// https://github.com/microsoft/TypeScript/issues/59946
+
+type Test<T extends string> = { [K in T]: { key: K } }[T] & { target: string };
+>Test : Test<T>
+>     : ^^^^^^^
+>key : K
+>    : ^
+>target : string
+>       : ^^^^^^
+
+const foo = <T extends string>(arg: Test<T>) => {
+>foo : <T extends string>(arg: Test<T>) => void
+>    : ^ ^^^^^^^^^      ^^   ^^       ^^^^^^^^^
+><T extends string>(arg: Test<T>) => {  const value: Test<T> = arg; // ok  const value2: Test<T>["key"] = arg["key"]; // ok  const value3: Test<T>["target"] = arg["target"]; // ok} : <T extends string>(arg: Test<T>) => void
+>                                                                                                                                                                                    : ^ ^^^^^^^^^      ^^   ^^       ^^^^^^^^^
+>arg : Test<T>
+>    : ^^^^^^^
+
+  const value: Test<T> = arg; // ok
+>value : Test<T>
+>      : ^^^^^^^
+>arg : Test<T>
+>    : ^^^^^^^
+
+  const value2: Test<T>["key"] = arg["key"]; // ok
+>value2 : Test<T>["key"]
+>       : ^^^^^^^^^^^^^^
+>arg["key"] : T
+>           : ^
+>arg : Test<T>
+>    : ^^^^^^^
+>"key" : "key"
+>      : ^^^^^
+
+  const value3: Test<T>["target"] = arg["target"]; // ok
+>value3 : Test<T>["target"]
+>       : ^^^^^^^^^^^^^^^^^
+>arg["target"] : string
+>              : ^^^^^^
+>arg : Test<T>
+>    : ^^^^^^^
+>"target" : "target"
+>         : ^^^^^^^^
+
+};
+

--- a/tests/cases/compiler/indexedAccessConstraints2.ts
+++ b/tests/cases/compiler/indexedAccessConstraints2.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/59946
+
+type Test<T extends string> = { [K in T]: { key: K } }[T] & { target: string };
+
+const foo = <T extends string>(arg: Test<T>) => {
+  const value: Test<T> = arg; // ok
+  const value2: Test<T>["key"] = arg["key"]; // ok
+  const value3: Test<T>["target"] = arg["target"]; // ok
+};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/59946