### PR TITLE
Try subtype reducing call expression types if type argument arity checks will fail

### DIFF
--- a/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.js
+++ b/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/arrayUnionPassedTypeArgumentFindsFallbackSignature.ts] ////
+
+//// [arrayUnionPassedTypeArgumentFindsFallbackSignature.ts]
+export function groupBy<T>(array: Array<T> | ReadonlyArray<T>) {
+    array.reduce<any>((acc, element) => {
+        throw new Error();
+    }, {});
+}
+
+
+//// [arrayUnionPassedTypeArgumentFindsFallbackSignature.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.groupBy = groupBy;
+function groupBy(array) {
+    array.reduce(function (acc, element) {
+        throw new Error();
+    }, {});
+}

--- a/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.symbols
+++ b/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.symbols
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/arrayUnionPassedTypeArgumentFindsFallbackSignature.ts] ////
+
+=== arrayUnionPassedTypeArgumentFindsFallbackSignature.ts ===
+export function groupBy<T>(array: Array<T> | ReadonlyArray<T>) {
+>groupBy : Symbol(groupBy, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 0))
+>T : Symbol(T, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 24))
+>array : Symbol(array, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 27))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 24))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 24))
+
+    array.reduce<any>((acc, element) => {
+>array.reduce : Symbol(reduce, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>array : Symbol(array, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 0, 27))
+>reduce : Symbol(reduce, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>acc : Symbol(acc, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 1, 23))
+>element : Symbol(element, Decl(arrayUnionPassedTypeArgumentFindsFallbackSignature.ts, 1, 27))
+
+        throw new Error();
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    }, {});
+}
+

--- a/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.types
+++ b/tests/baselines/reference/arrayUnionPassedTypeArgumentFindsFallbackSignature.types
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/arrayUnionPassedTypeArgumentFindsFallbackSignature.ts] ////
+
+=== arrayUnionPassedTypeArgumentFindsFallbackSignature.ts ===
+export function groupBy<T>(array: Array<T> | ReadonlyArray<T>) {
+>groupBy : <T>(array: Array<T> | ReadonlyArray<T>) => void
+>        : ^ ^^     ^^                           ^^^^^^^^^
+>array : T[] | readonly T[]
+>      : ^^^^^^^^^^^^^^^^^^
+
+    array.reduce<any>((acc, element) => {
+>array.reduce<any>((acc, element) => {        throw new Error();    }, {}) : any
+>array.reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; } | { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U; }
+>             : ^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^            ^^^^^^^^^^ ^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^            ^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^            ^^^^^^^^^^
+>array : T[] | readonly T[]
+>      : ^^^^^^^^^^^^^^^^^^
+>reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; } | { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U; }
+>       : ^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^            ^^^^^^^^^^ ^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^            ^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^            ^^^^^^^^^^ ^^          ^^^             ^^^^^            ^^^^^            ^^      ^^     ^^^^^^^^^^^^^^^^^^^^^^            ^^^^^^^^^^
+>(acc, element) => {        throw new Error();    } : (acc: any, element: T) => never
+>                                                   : ^   ^^^^^^^       ^^^^^^^^^^^^^
+>acc : any
+>element : T
+>        : ^
+
+        throw new Error();
+>new Error() : Error
+>            : ^^^^^
+>Error : ErrorConstructor
+>      : ^^^^^^^^^^^^^^^^
+
+    }, {});
+>{} : {}
+>   : ^^
+}
+

--- a/tests/cases/compiler/arrayUnionPassedTypeArgumentFindsFallbackSignature.ts
+++ b/tests/cases/compiler/arrayUnionPassedTypeArgumentFindsFallbackSignature.ts
@@ -1,0 +1,5 @@
+export function groupBy<T>(array: Array<T> | ReadonlyArray<T>) {
+    array.reduce<any>((acc, element) => {
+        throw new Error();
+    }, {});
+}


### PR DESCRIPTION
We basically peek into a cheap part of overload resolution and see if we're destined to report an error on a union's list of signatures, and, if so, try subtype reducing the union and *then* doing the arity checks. If we can find a matching signature in the reduced union, we proceed with that, instead, and avoid the error.

Note that, per the comment in the code, right now I only do this for call expressions, and not other call-like expressions (decorators, tagged templates, jsx tags), because of where this logic needs to sit in the call resolution stack. If we like it, I can make the logic a bit more generic and insert it into all the call resolution codepaths (it's an interesting bit of logic since it needs both expression type information and signature level information - and the core `resolveCall` only operates on the later).

Fixes #60006
