### PR TITLE
Unexport NodeTypingsInstaller in typingsInstaller.js

### DIFF
--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -81,7 +81,7 @@ interface ExecSyncOptions {
     encoding: "utf-8";
 }
 
-export class NodeTypingsInstaller extends ts.server.typingsInstaller.TypingsInstaller {
+class NodeTypingsInstaller extends ts.server.typingsInstaller.TypingsInstaller {
     private readonly npmPath: string;
     readonly typesRegistry: Map<string, MapLike<string>>;
 


### PR DESCRIPTION
This export is never used because `typingsInstaller.js` is an executable script, not a library.

Extremely minimal package size savings, but less confusing IMO.

```diff js
diff --git a/./built/local-old/typingsInstaller.js b/./built/local/typingsInstaller.js
index 64d72785f2..07c59c3844 100644
--- a/./built/local-old/typingsInstaller.js
+++ b/./built/local/typingsInstaller.js
@@ -21,10 +21,6 @@ var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __export = (target, all) => {
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
 var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === "object" || typeof from === "function") {
     for (let key of __getOwnPropNames(from))
@@ -42,14 +38,8 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
-var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // src/typingsInstaller/nodeTypingsInstaller.ts
-var nodeTypingsInstaller_exports = {};
-__export(nodeTypingsInstaller_exports, {
-  NodeTypingsInstaller: () => NodeTypingsInstaller
-});
-module.exports = __toCommonJS(nodeTypingsInstaller_exports);
 var import_child_process = require("child_process");
 var fs = __toESM(require("fs"));
 var path = __toESM(require("path"));
@@ -229,8 +219,4 @@ process.on("message", (req) => {
 function indent(newline, str) {
   return str && str.length ? `${newline}    ` + str.replace(/\r?\n/, `${newline}    `) : "";
 }
-// Annotate the CommonJS export names for ESM import in node:
-0 && (module.exports = {
-  NodeTypingsInstaller
-});
 //# sourceMappingURL=typingsInstaller.js.map
```