### PR TITLE
feat: allow generics in type parameters [WIP]

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1617,13 +1617,14 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     //
 
     // @api
-    function createTypeParameterDeclaration(modifiers: readonly Modifier[] | undefined, name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration {
+    function createTypeParameterDeclaration(modifiers: readonly Modifier[] | undefined, name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode, typeParameters? :readonly TypeParameterDeclaration[]): TypeParameterDeclaration {
         const node = createBaseDeclaration<TypeParameterDeclaration>(SyntaxKind.TypeParameter);
         node.modifiers = asNodeArray(modifiers);
         node.name = asName(name);
         node.constraint = constraint;
         node.default = defaultType;
         node.transformFlags = TransformFlags.ContainsTypeScript;
+        node.typeParameters = asNodeArray(typeParameters)
 
         node.expression = undefined; // initialized by parser to report grammar errors
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -1631,12 +1632,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     // @api
-    function updateTypeParameterDeclaration(node: TypeParameterDeclaration, modifiers: readonly Modifier[] | undefined, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined): TypeParameterDeclaration {
+    function updateTypeParameterDeclaration(node: TypeParameterDeclaration, modifiers: readonly Modifier[] | undefined, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined): TypeParameterDeclaration {
         return node.modifiers !== modifiers
                 || node.name !== name
                 || node.constraint !== constraint
                 || node.default !== defaultType
-            ? update(createTypeParameterDeclaration(modifiers, name, constraint, defaultType), node)
+                || node.typeParameters !== typeParameters
+            ? update(createTypeParameterDeclaration(modifiers, name, constraint, defaultType, typeParameters), node)
             : node;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1828,6 +1828,7 @@ export interface TypeParameterDeclaration extends NamedDeclaration, JSDocContain
     /** Note: Consider calling `getEffectiveConstraintOfTypeParameter` */
     readonly constraint?: TypeNode;
     readonly default?: TypeNode;
+    readonly typeParameters?: NodeArray<TypeParameterDeclaration>
 
     // For error recovery purposes (see `isGrammarError` in utilities.ts).
     expression?: Expression;

--- a/tests/cases/compiler/typeParameterGeneric.ts
+++ b/tests/cases/compiler/typeParameterGeneric.ts
@@ -1,0 +1,1 @@
+type Monad<TypeParameter<Generic>> = TypeParameter<string>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

# Summary

Allows generics to be in type parameters, similar to type aliases.

```typescript
// no type parameter in type parameter `First`.
export type First<A> = A

// type parameter `Fourth` in type parameter `Third`. 
export type Second<Third<Fourth>> = Third<string>

// type parameter for `Second` is the type alias `First`, which takes an argument.
export type Fifth = Second<First> // string
```
