### PR TITLE
Add well-known symbols for ReadonlyMap and ReadonlySet

### DIFF
--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -119,11 +119,19 @@ interface Map<K, V> {
     readonly [Symbol.toStringTag]: string;
 }
 
+interface ReadonlyMap<K, V> {
+    readonly [Symbol.toStringTag]: string;
+}
+
 interface WeakMap<K extends WeakKey, V> {
     readonly [Symbol.toStringTag]: string;
 }
 
 interface Set<T> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface ReadonlySet<T> {
     readonly [Symbol.toStringTag]: string;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #60042

I chose not to use strict string literals of exact well-known tags like `Map` and `Set` for the same reason mentioned in https://github.com/microsoft/TypeScript/issues/19006. Instead, I opted to use `string`. Contra https://github.com/microsoft/TypeScript/pull/59417.

