### PR TITLE
add filenames to error messages in verify file content functions in fourslash

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3069,7 +3069,7 @@ export class TestState {
     private verifyFileContent(fileName: string, text: string) {
         const actual = this.getFileContent(fileName);
         if (actual !== text) {
-            throw new Error(`verifyFileContent failed:\n${showTextDiff(text, actual)}`);
+            throw new Error(`verifyFileContent in file '${fileName}' failed:\n${showTextDiff(text, actual)}`);
         }
     }
 
@@ -3404,10 +3404,11 @@ export class TestState {
         return ts.first(ranges);
     }
 
-    private verifyTextMatches(actualText: string, includeWhitespace: boolean, expectedText: string) {
+    private verifyTextMatches(actualText: string, includeWhitespace: boolean, expectedText: string, fileName?: string) {
         const removeWhitespace = (s: string): string => includeWhitespace ? s : this.removeWhitespace(s);
         if (removeWhitespace(actualText) !== removeWhitespace(expectedText)) {
-            this.raiseError(`Actual range text doesn't match expected text.\n${showTextDiff(expectedText, actualText)}`);
+            const addFileName = fileName ? ` in file '${fileName}'` : "";
+            this.raiseError(`Actual range text${addFileName} doesn't match expected text.\n${showTextDiff(expectedText, actualText)}`);
         }
     }
 
@@ -3485,7 +3486,7 @@ export class TestState {
             const newText = ts.textChanges.applyChanges(this.getFileContent(this.activeFile.fileName), change.textChanges);
             const newRange = updateTextRangeForTextChanges(this.getOnlyRange(this.activeFile.fileName), change.textChanges);
             const actualText = newText.slice(newRange.pos, newRange.end);
-            this.verifyTextMatches(actualText, /*includeWhitespace*/ true, newRangeContent);
+            this.verifyTextMatches(actualText, /*includeWhitespace*/ true, newRangeContent, change.fileName);
         }
         else {
             if (newFileContent === undefined) throw ts.Debug.fail();
@@ -3497,7 +3498,7 @@ export class TestState {
                 }
                 const oldText = this.tryGetFileContent(change.fileName);
                 const newContent = change.isNewFile ? ts.first(change.textChanges).newText : ts.textChanges.applyChanges(oldText!, change.textChanges);
-                this.verifyTextMatches(newContent, /*includeWhitespace*/ true, expectedNewContent);
+                this.verifyTextMatches(newContent, /*includeWhitespace*/ true, expectedNewContent, change.fileName);
             }
             for (const newFileName in newFileContent) {
                 ts.Debug.assert(changes.some(c => c.fileName === newFileName), "No change in file", () => newFileName);


### PR DESCRIPTION
This makes it easier to tell what's going wrong in a fourslash test when working with many possible changed files (ex: fixing autoimports for moveToFile).

Example: 
Before: 
![image](https://github.com/user-attachments/assets/7b641120-7db1-4c35-8969-2759ca32b814)

After: 
![image](https://github.com/user-attachments/assets/abe2f2fa-4080-4d80-866a-d4c7d4384759)

