### PR TITLE
fix(59825): getNavigationTree crash on invalid class merge and function merge with expando members

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -760,6 +760,7 @@ function isSynthesized(node: Node) {
 // We want to merge own children like `I` in in `module A { interface I {} } module A { interface I {} }`
 // We don't want to merge unrelated children like `m` in `const o = { a: { m() {} }, b: { m() {} } };`
 function isOwnChild(n: Node, parent: NavigationBarNode): boolean {
+    if (n.parent === undefined) return false;
     const par = isModuleBlock(n.parent) ? n.parent.parent : n.parent;
     return par === parent.node || contains(parent.additionalNodes, par);
 }

--- a/tests/cases/fourslash/navigationBarItemsClass6.ts
+++ b/tests/cases/fourslash/navigationBarItemsClass6.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts"/>
+
+////function Z() { }
+////
+////Z.foo = 42
+////
+////class Z { }
+
+verify.navigationTree({
+  text: "<global>",
+  kind: "script",
+  childItems: [
+    {
+      text: "Z",
+      kind: "class",
+      childItems: [
+        {
+          text: "constructor",
+          kind: "constructor"
+        },
+        {
+          text: "foo"
+        }
+      ]
+    },
+    {
+      text: "Z",
+      kind: "class"
+    }
+  ]
+});


### PR DESCRIPTION
Fixes #59825 