### PR TITLE
Fix the type of `growable` on `SharedArrayBuffer`.

### DIFF
--- a/src/lib/es2024.sharedmemory.d.ts
+++ b/src/lib/es2024.sharedmemory.d.ts
@@ -28,7 +28,7 @@ interface SharedArrayBuffer {
      *
      * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable)
      */
-    get growable(): number;
+    get growable(): boolean;
 
     /**
      * If this SharedArrayBuffer is growable, returns the maximum byte length given during construction; returns the byte length if not.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable