### PR TITLE
Don't use property symbols from contextual types with binding patterns for quick info

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3560,7 +3560,7 @@ function getSymbolAtLocationForQuickInfo(node: Node, checker: TypeChecker): Symb
     const object = getContainingObjectLiteralElement(node);
     if (object) {
         const contextualType = checker.getContextualType(object.parent);
-        const properties = contextualType && getPropertySymbolsFromContextualType(object, checker, contextualType, /*unionSymbolOk*/ false);
+        const properties = contextualType && !contextualType.pattern && getPropertySymbolsFromContextualType(object, checker, contextualType, /*unionSymbolOk*/ false);
         if (properties && properties.length === 1) {
             return first(properties);
         }

--- a/tests/cases/fourslash/quickInfoOnPropertyAssignedToDestructuringName1.ts
+++ b/tests/cases/fourslash/quickInfoOnPropertyAssignedToDestructuringName1.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+// @strict: true
+
+//// const { x } = { x/*1*/: 1 };
+//// const { x: y } = { x/*2*/: 1 };
+////
+//// type Foo = {
+////   /** awesome prop */
+////   x: number;
+//// };
+//// const { x: z }: Foo = { x/*3*/: 1 };
+
+verify.quickInfoAt("1", "(property) x: number");
+verify.quickInfoAt("2", "(property) x: number");
+verify.quickInfoAt("3", "(property) x: number", "awesome prop");


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60170