### PR TITLE
fix(60186): Quick fix "add missing properties" fails with enums from other module

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -681,7 +681,8 @@ function tryGetValueFromType(context: CodeFixContextBase, checker: TypeChecker, 
     }
     if (type.flags & TypeFlags.EnumLike) {
         const enumMember = type.symbol.exports ? firstOrUndefinedIterator(type.symbol.exports.values()) : type.symbol;
-        const name = checker.symbolToExpression(type.symbol.parent ? type.symbol.parent : type.symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ NodeBuilderFlags.UseFullyQualifiedType);
+        const symbol = type.symbol.parent && type.symbol.parent.flags & SymbolFlags.RegularEnum ? type.symbol.parent : type.symbol;
+        const name = checker.symbolToExpression(symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ NodeBuilderFlags.UseFullyQualifiedType);
         return enumMember === undefined || name === undefined ? factory.createNumericLiteral(0) : factory.createPropertyAccessExpression(name, checker.symbolToString(enumMember));
     }
     if (type.flags & TypeFlags.NumberLiteral) {

--- a/tests/cases/fourslash/codeFixAddMissingProperties32.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties32.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: E.ts
+////export enum E {
+////    A,
+////    B,
+////}
+
+// @filename: foo.ts
+////import { E } from "./E"
+////type T = {
+////    e: E,
+////}
+////[|const t: T = { }|]
+
+goTo.file('foo.ts');
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`const t: T = {
+    e: E.A
+}`,
+});


### PR DESCRIPTION
Fixes #60186