### PR TITLE
Assume that type node annotations resolving to error types can be reused

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6240,6 +6240,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 let annotationType = getTypeFromTypeNodeWithoutContext(existing);
+                if (isErrorType(annotationType)) {
+                    // allow "reusing" type nodes that resolve to error types
+                    // those can't truly be reused but it prevents cascading errors in isolatedDeclarations
+                    // for source with errors there is no guarantee to emit correct code anyway
+                    return true;
+                }
                 if (requiresAddingUndefined && annotationType) {
                     annotationType = getOptionalType(annotationType, !isParameter(node));
                 }

--- a/tests/baselines/reference/circularTypeofWithVarOrFunc.types
+++ b/tests/baselines/reference/circularTypeofWithVarOrFunc.types
@@ -22,16 +22,16 @@ type typeAlias2 = typeof varOfAliasedType2;
 >                  : ^^^
 
 function func(): typeAlias3 { return null; }
->func : () => any
->     : ^^^^^^^^^
+>func : () => typeAlias3
+>     : ^^^^^^          
 
 var varOfAliasedType3 = func();
 >varOfAliasedType3 : any
 >                  : ^^^
 >func() : any
 >       : ^^^
->func : () => any
->     : ^^^^^^^^^
+>func : () => typeAlias3
+>     : ^^^^^^          
 
 type typeAlias3 = typeof varOfAliasedType3;
 >typeAlias3 : any
@@ -54,12 +54,12 @@ interface Input {
 type R = ReturnType<typeof mul>;
 >R : any
 >  : ^^^
->mul : (input: Input) => any
->    : ^     ^^     ^^^^^^^^
+>mul : (input: Input) => R
+>    : ^     ^^     ^^^^^ 
 
 function mul(input: Input): R {
->mul : (input: Input) => any
->    : ^     ^^     ^^^^^^^^
+>mul : (input: Input) => R
+>    : ^     ^^     ^^^^^ 
 >input : Input
 >      : ^^^^^
 
@@ -85,12 +85,12 @@ function mul(input: Input): R {
 type R2 = ReturnType<typeof f>;
 >R2 : any
 >   : ^^^
->f : () => any
->  : ^^^^^^^^^
+>f : () => R2
+>  : ^^^^^^  
 
 function f(): R2 { return 0; }
->f : () => any
->  : ^^^^^^^^^
+>f : () => R2
+>  : ^^^^^^  
 >0 : 0
 >  : ^
 

--- a/tests/baselines/reference/isolatedDeclarationErrorTypes1.errors.txt
+++ b/tests/baselines/reference/isolatedDeclarationErrorTypes1.errors.txt
@@ -1,0 +1,14 @@
+isolatedDeclarationErrorTypes1.ts(3,28): error TS2307: Cannot find module 'foo' or its corresponding type declarations.
+
+
+==== isolatedDeclarationErrorTypes1.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/60192
+    
+    import { Unresolved } from "foo";
+                               ~~~~~
+!!! error TS2307: Cannot find module 'foo' or its corresponding type declarations.
+    
+    export const foo1 = (type?: Unresolved): void => {};
+    export const foo2 = (type?: Unresolved | undefined): void => {};
+    export const foo3 = (type: Unresolved): void => {};
+    

--- a/tests/baselines/reference/isolatedDeclarationErrorTypes1.js
+++ b/tests/baselines/reference/isolatedDeclarationErrorTypes1.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/isolatedDeclarationErrorTypes1.ts] ////
+
+//// [isolatedDeclarationErrorTypes1.ts]
+// https://github.com/microsoft/TypeScript/issues/60192
+
+import { Unresolved } from "foo";
+
+export const foo1 = (type?: Unresolved): void => {};
+export const foo2 = (type?: Unresolved | undefined): void => {};
+export const foo3 = (type: Unresolved): void => {};
+
+
+//// [isolatedDeclarationErrorTypes1.js]
+"use strict";
+// https://github.com/microsoft/TypeScript/issues/60192
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.foo3 = exports.foo2 = exports.foo1 = void 0;
+const foo1 = (type) => { };
+exports.foo1 = foo1;
+const foo2 = (type) => { };
+exports.foo2 = foo2;
+const foo3 = (type) => { };
+exports.foo3 = foo3;
+
+
+//// [isolatedDeclarationErrorTypes1.d.ts]
+import { Unresolved } from "foo";
+export declare const foo1: (type?: Unresolved) => void;
+export declare const foo2: (type?: Unresolved | undefined) => void;
+export declare const foo3: (type: Unresolved) => void;

--- a/tests/baselines/reference/isolatedDeclarationErrorTypes1.symbols
+++ b/tests/baselines/reference/isolatedDeclarationErrorTypes1.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/isolatedDeclarationErrorTypes1.ts] ////
+
+=== isolatedDeclarationErrorTypes1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60192
+
+import { Unresolved } from "foo";
+>Unresolved : Symbol(Unresolved, Decl(isolatedDeclarationErrorTypes1.ts, 2, 8))
+
+export const foo1 = (type?: Unresolved): void => {};
+>foo1 : Symbol(foo1, Decl(isolatedDeclarationErrorTypes1.ts, 4, 12))
+>type : Symbol(type, Decl(isolatedDeclarationErrorTypes1.ts, 4, 21))
+>Unresolved : Symbol(Unresolved, Decl(isolatedDeclarationErrorTypes1.ts, 2, 8))
+
+export const foo2 = (type?: Unresolved | undefined): void => {};
+>foo2 : Symbol(foo2, Decl(isolatedDeclarationErrorTypes1.ts, 5, 12))
+>type : Symbol(type, Decl(isolatedDeclarationErrorTypes1.ts, 5, 21))
+>Unresolved : Symbol(Unresolved, Decl(isolatedDeclarationErrorTypes1.ts, 2, 8))
+
+export const foo3 = (type: Unresolved): void => {};
+>foo3 : Symbol(foo3, Decl(isolatedDeclarationErrorTypes1.ts, 6, 12))
+>type : Symbol(type, Decl(isolatedDeclarationErrorTypes1.ts, 6, 21))
+>Unresolved : Symbol(Unresolved, Decl(isolatedDeclarationErrorTypes1.ts, 2, 8))
+

--- a/tests/baselines/reference/isolatedDeclarationErrorTypes1.types
+++ b/tests/baselines/reference/isolatedDeclarationErrorTypes1.types
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/isolatedDeclarationErrorTypes1.ts] ////
+
+=== isolatedDeclarationErrorTypes1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60192
+
+import { Unresolved } from "foo";
+>Unresolved : any
+>           : ^^^
+
+export const foo1 = (type?: Unresolved): void => {};
+>foo1 : (type?: Unresolved) => void
+>     : ^    ^^^          ^^^^^    
+>(type?: Unresolved): void => {} : (type?: Unresolved) => void
+>                                : ^    ^^^          ^^^^^    
+>type : any
+>     : ^^^
+
+export const foo2 = (type?: Unresolved | undefined): void => {};
+>foo2 : (type?: Unresolved | undefined) => void
+>     : ^    ^^^                      ^^^^^    
+>(type?: Unresolved | undefined): void => {} : (type?: Unresolved | undefined) => void
+>                                            : ^    ^^^                      ^^^^^    
+>type : any
+>     : ^^^
+
+export const foo3 = (type: Unresolved): void => {};
+>foo3 : (type: Unresolved) => void
+>     : ^    ^^          ^^^^^    
+>(type: Unresolved): void => {} : (type: Unresolved) => void
+>                               : ^    ^^          ^^^^^    
+>type : Unresolved
+>     : ^^^^^^^^^^
+

--- a/tests/baselines/reference/isolatedDeclarationsAddUndefined2.types
+++ b/tests/baselines/reference/isolatedDeclarationsAddUndefined2.types
@@ -52,8 +52,8 @@ export function test2(x?: Unresolved | undefined): void {}
 >  : ^^^
 
 export function test3(x?: Unresolved): void {}
->test3 : (x?: any) => void
->      : ^ ^^^^^^^^^^^    
+>test3 : (x?: Unresolved) => void
+>      : ^ ^^^          ^^^^^    
 >x : any
 >  : ^^^
 

--- a/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
+++ b/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
@@ -1,0 +1,13 @@
+// @isolatedDeclarations: true
+// @strict: true
+// @declaration: true
+// @moduleResolution: nodenext
+// @module: nodenext
+
+// https://github.com/microsoft/TypeScript/issues/60192
+
+import { Unresolved } from "foo";
+
+export const foo1 = (type?: Unresolved): void => {};
+export const foo2 = (type?: Unresolved | undefined): void => {};
+export const foo3 = (type: Unresolved): void => {};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60192
similar to https://github.com/microsoft/TypeScript/pull/60129