### PR TITLE
Created a reusable implementation for the intrinsic capitalize and uncapitalize by removing duplication.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18430,11 +18430,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case IntrinsicTypeKind.Lowercase:
                 return str.toLowerCase();
             case IntrinsicTypeKind.Capitalize:
-                return str.charAt(0).toUpperCase() + str.slice(1);
+                return toCapitalized(str);
             case IntrinsicTypeKind.Uncapitalize:
-                return str.charAt(0).toLowerCase() + str.slice(1);
+                return toUncapitalized(str);
         }
         return str;
+    }
+
+    function toCapitalized(str: string) {
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    function toUncapitalized(str: string) {
+        return str.charAt(0).toLowerCase() + str.slice(1);
     }
 
     function applyTemplateStringMapping(symbol: Symbol, texts: readonly string[], types: readonly Type[]): [texts: readonly string[], types: readonly Type[]] {
@@ -18444,11 +18452,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case IntrinsicTypeKind.Lowercase:
                 return [texts.map(t => t.toLowerCase()), types.map(t => getStringMappingType(symbol, t))];
             case IntrinsicTypeKind.Capitalize:
-                return [texts[0] === "" ? texts : [texts[0].charAt(0).toUpperCase() + texts[0].slice(1), ...texts.slice(1)], texts[0] === "" ? [getStringMappingType(symbol, types[0]), ...types.slice(1)] : types];
+                return handleCapitalization(symbol, texts, types, toCapitalized);
             case IntrinsicTypeKind.Uncapitalize:
-                return [texts[0] === "" ? texts : [texts[0].charAt(0).toLowerCase() + texts[0].slice(1), ...texts.slice(1)], texts[0] === "" ? [getStringMappingType(symbol, types[0]), ...types.slice(1)] : types];
+                return handleCapitalization(symbol, texts, types, toUncapitalized);
         }
         return [texts, types];
+    }
+
+    function handleCapitalization(symbol: Symbol, texts: readonly string[], types: readonly Type[], updateFn: (input: string) => string): [texts: readonly string[], types: readonly Type[]] {
+        return [texts[0] === "" ? texts : [updateFn(texts[0]), ...texts.slice(1)], texts[0] === "" ? [getStringMappingType(symbol, types[0]), ...types.slice(1)] : types];
     }
 
     function getStringMappingTypeForGenericType(symbol: Symbol, type: Type): Type {
@@ -34430,7 +34442,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (symbols === globals) {
             const primitives = mapDefined(
                 ["string", "number", "boolean", "object", "bigint", "symbol"],
-                s => symbols.has((s.charAt(0).toUpperCase() + s.slice(1)) as __String)
+                s => symbols.has((toCapitalized(s)) as __String)
                     ? createSymbol(SymbolFlags.TypeAlias, s as __String) as Symbol
                     : undefined,
             );


### PR DESCRIPTION
**This PR does not have an issue in the backlog but I still give it a shot as I think it helps the code by removing duplication.**

Feel free to reject this pull-request if you don't like the change. For me it's now better understandable, what the code for the capitalization and uncapitalization does as it's capsuled in two functions.

