### PR TITLE
Specialized error message for setting `lib` or `target` to a future ES version

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -678,13 +678,13 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
             name: "lib",
             type: libMap,
             defaultValueDescription: undefined,
+            mayBeESVersion: true,
         },
         affectsProgramStructure: true,
         showInSimplifiedHelpView: true,
         category: Diagnostics.Language_and_Environment,
         description: Diagnostics.Specify_a_set_of_bundled_library_declaration_files_that_describe_the_target_runtime_environment,
         transpileOptionValue: undefined,
-        mayBeESVersion: true,
     },
     {
         name: "allowJs",
@@ -1810,14 +1810,32 @@ export const defaultInitCompilerOptions: CompilerOptions = {
 };
 
 /** @internal */
-export function createCompilerDiagnosticForInvalidCustomType(opt: CommandLineOptionOfCustomType): Diagnostic {
-    return createDiagnosticForInvalidCustomType(opt, createCompilerDiagnostic);
+export function createCompilerDiagnosticForInvalidCustomType(opt: CommandLineOptionOfCustomType, value: unknown): Diagnostic {
+    return createDiagnosticForInvalidCustomType(opt, value, createCompilerDiagnostic);
 }
 
-function createDiagnosticForInvalidCustomType(opt: CommandLineOptionOfCustomType, createDiagnostic: (message: DiagnosticMessage, ...args: DiagnosticArguments) => Diagnostic): Diagnostic {
+function createDiagnosticForInvalidCustomType(opt: CommandLineOptionOfCustomType, value: unknown, createDiagnostic: (message: DiagnosticMessage, ...args: DiagnosticArguments) => Diagnostic): Diagnostic {
+    if (opt.mayBeESVersion && typeof value === 'string') {
+        // If the value looks like an ECMAScript version but not is a valid one,
+        // remind the user that this TypeScript version may be outdated and
+        // does not support that ECMAScript version.
+        const esVersion = extractECMAScriptVersion(value);
+        if (esVersion !== undefined && esVersion >= 2015) {
+            return createDiagnostic(Diagnostics.Argument_0_for_1_option_is_a_year_not_yet_supported_by_this_version_of_TypeScript, value, opt.name);
+        }
+    }
+
     const namesOfType = arrayFrom(opt.type.keys());
     const stringNames = (opt.deprecatedKeys ? namesOfType.filter(k => !opt.deprecatedKeys!.has(k)) : namesOfType).map(key => `'${key}'`).join(", ");
     return createDiagnostic(Diagnostics.Argument_for_0_option_must_be_Colon_1, `--${opt.name}`, stringNames);
+}
+
+function extractECMAScriptVersion(value: string): number | undefined {
+    const match = /^es(\d+)$/i.exec(value);
+    if (!match) {
+        return undefined;
+    }
+    return Number(match[1]);
 }
 
 /** @internal */
@@ -3798,7 +3816,7 @@ function convertJsonOptionOfCustomType(
         return validateJsonOptionValue(opt, val, errors, valueExpression, sourceFile);
     }
     else {
-        errors.push(createDiagnosticForInvalidCustomType(opt, (message, ...args) => createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, valueExpression, message, ...args)));
+        errors.push(createDiagnosticForInvalidCustomType(opt, value, (message, ...args) => createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, valueExpression, message, ...args)));
     }
 }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -580,6 +580,7 @@ export const targetOptionDeclaration: CommandLineOptionOfCustomType = {
     category: Diagnostics.Language_and_Environment,
     description: Diagnostics.Set_the_JavaScript_language_version_for_emitted_JavaScript_and_include_compatible_library_declarations,
     defaultValueDescription: ScriptTarget.ES5,
+    mayBeESVersion: true,
 };
 
 /** @internal */
@@ -683,6 +684,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         category: Diagnostics.Language_and_Environment,
         description: Diagnostics.Specify_a_set_of_bundled_library_declaration_files_that_describe_the_target_runtime_environment,
         transpileOptionValue: undefined,
+        mayBeESVersion: true,
     },
     {
         name: "allowJs",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5683,6 +5683,10 @@
         "category": "Message",
         "code": 6283
     },
+    "Argument '{0}' for '{1}' option is a year not yet supported by this version of TypeScript.": {
+        "category": "Error",
+        "code": 6284
+    },
 
     "Enable project compilation": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7689,6 +7689,7 @@ export interface CommandLineOptionBase {
     extraValidation?: (value: CompilerOptionsValue) => [DiagnosticMessage, ...string[]] | undefined; // Additional validation to be performed for the value to be valid
     disallowNullOrUndefined?: true;                         // If set option does not allow setting null
     allowConfigDirTemplateSubstitution?: true;              // If set option allows substitution of `${configDir}` in the value
+    mayBeESVersion?: true;                                  // true if the option accepts supported ECMAScript version numbers
 }
 
 /** @internal */

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -256,7 +256,7 @@ export function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diag
         else {
             if (!forEachEntry(opt.type, v => v === value)) {
                 // Supplied value isn't a valid enum value.
-                diagnostics.push(createCompilerDiagnosticForInvalidCustomType(opt));
+                diagnostics.push(createCompilerDiagnosticForInvalidCustomType(opt, value));
             }
         }
     }

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -33,6 +33,8 @@ describe("unittests:: config:: commandLineParsing:: parseCommandLine", () => {
     assertParseResult("Parse multiple options of library flags", ["--lib", "es5,es2015.symbol.wellknown", "0.ts"]);
     // --lib es5,invalidOption 0.ts
     assertParseResult("Parse invalid option of library flags", ["--lib", "es5,invalidOption", "0.ts"]);
+    // --lib es2099 --target es2098 0.ts
+    assertParseResult("Parse future ECMAScript version specified for lib and target", ["--lib", "es2099", "--target", "es2098", "0.ts"]);
     // 0.ts --jsx
     assertParseResult("Parse empty options of --jsx", ["0.ts", "--jsx"]);
     // 0.ts --

--- a/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse future ECMAScript version specified for lib and target.js
+++ b/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse future ECMAScript version specified for lib and target.js
@@ -1,0 +1,12 @@
+--lib es2099 --target es2098 0.ts
+CompilerOptions::
+{
+  "lib": []
+}
+WatchOptions::
+
+FileNames::
+0.ts
+Errors::
+error TS6284: Argument 'es2099' for 'lib' option is a year not yet supported by this version of TypeScript.
+error TS6284: Argument 'es2098' for 'target' option is a year not yet supported by this version of TypeScript.


### PR DESCRIPTION
Fixes #60050 

This PR improves the diagnostic message for unsupported `lib` or `target` value by emitting a specifialized message when the specified value looks like a future ES version.

I altered the originally suggested message a bit because mentioning the TypeScript version in the error message felt a skosh unusual to me, instead using the phrase `this version of TypeScript`. Of course I'm open to any change suggested by reviewers.

## Example

**tsconfig.json**

```json
{
  "compilerOptions": {
    "target": "es2099",
    "lib": ["es2098", "dom"],
  },
  "include": ["src"]
}
```

### 🏠 Current Behavior

```
tsconfig.json:3:15 - error TS6046: Argument for '--target' option must be: 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'es2023', 'esnext'.

3     "target": "es2099",
                ~~~~~~~~

tsconfig.json:4:13 - error TS6046: Argument for '--lib' option must be: 'es5', 'es6', 'es2015', 'es7', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'es2023', 'esnext', 'dom', 'dom.iterable', 'dom.asynciterable', 'webworker', 'webworker.importscripts', 'webworker.iterable', 'webworker.asynciterable', 'scripthost', 'es2015.core', 'es2015.collection', 'es2015.generator', 'es2015.iterable', 'es2015.promise', 'es2015.proxy', 'es2015.reflect', 'es2015.symbol', 'es2015.symbol.wellknown', 'es2016.array.include', 'es2016.intl', 'es2017.date', 'es2017.object', 'es2017.sharedmemory', 'es2017.string', 'es2017.intl', 'es2017.typedarrays', 'es2018.asyncgenerator', 'es2018.asynciterable', 'es2018.intl', 'es2018.promise', 'es2018.regexp', 'es2019.array', 'es2019.object', 'es2019.string', 'es2019.symbol', 'es2019.intl', 'es2020.bigint', 'es2020.date', 'es2020.promise', 'es2020.sharedmemory', 'es2020.string', 'es2020.symbol.wellknown', 'es2020.intl', 'es2020.number', 'es2021.promise', 'es2021.string', 'es2021.weakref', 'es2021.intl', 'es2022.array', 'es2022.error', 'es2022.intl', 'es2022.object', 'es2022.sharedmemory', 'es2022.string', 'es2022.regexp', 'es2023.array', 'es2023.collection', 'es2023.intl', 'esnext.array', 'esnext.collection', 'esnext.symbol', 'esnext.asynciterable', 'esnext.intl', 'esnext.disposable', 'esnext.bigint', 'esnext.string', 'esnext.promise', 'esnext.weakref', 'esnext.decorators', 'esnext.object', 'esnext.regexp', 'esnext.iterator', 'decorators', 'decorators.legacy'.

4     "lib": ["es2098", "dom"],
              ~~~~~~~~
```

### 🌟 New Behavior

```
tsconfig.json:3:15 - error TS6284: Argument 'es2099' for 'target' option is a year not yet supported by this version of TypeScript.

3     "target": "es2099",
                ~~~~~~~~

tsconfig.json:4:13 - error TS6284: Argument 'es2098' for 'lib' option is a year not yet supported by this version of TypeScript.

4     "lib": ["es2098", "dom"],
              ~~~~~~~~
```