### PR TITLE
Allow auto-accessor inference from constructor/static-block

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12005,7 +12005,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 getAnnotatedAccessorType(setter) ||
                 getAnnotatedAccessorType(accessor) ||
                 getter && getter.body && getReturnTypeFromBody(getter) ||
-                accessor && accessor.initializer && getWidenedTypeForVariableLikeDeclaration(accessor, /*reportErrors*/ true);
+                accessor && getWidenedTypeForVariableLikeDeclaration(accessor, /*reportErrors*/ true);
             if (!type) {
                 if (setter && !isPrivateWithinAmbient(setter)) {
                     errorOrSuggestion(noImplicitAny, setter, Diagnostics.Property_0_implicitly_has_type_any_because_its_set_accessor_lacks_a_parameter_type_annotation, symbolToString(symbol));

--- a/tests/baselines/reference/autoAccessorInference.symbols
+++ b/tests/baselines/reference/autoAccessorInference.symbols
@@ -1,0 +1,56 @@
+//// [tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorInference.ts] ////
+
+=== autoAccessorInference.ts ===
+class A {
+>A : Symbol(A, Decl(autoAccessorInference.ts, 0, 0))
+
+    accessor value;
+>value : Symbol(A.value, Decl(autoAccessorInference.ts, 0, 9))
+
+    constructor(n: number) {
+>n : Symbol(n, Decl(autoAccessorInference.ts, 2, 16))
+
+        this.value = n
+>this.value : Symbol(A.value, Decl(autoAccessorInference.ts, 0, 9))
+>this : Symbol(A, Decl(autoAccessorInference.ts, 0, 0))
+>value : Symbol(A.value, Decl(autoAccessorInference.ts, 0, 9))
+>n : Symbol(n, Decl(autoAccessorInference.ts, 2, 16))
+
+        if (n < 0) {
+>n : Symbol(n, Decl(autoAccessorInference.ts, 2, 16))
+
+            this.value = null
+>this.value : Symbol(A.value, Decl(autoAccessorInference.ts, 0, 9))
+>this : Symbol(A, Decl(autoAccessorInference.ts, 0, 0))
+>value : Symbol(A.value, Decl(autoAccessorInference.ts, 0, 9))
+        }
+    }
+}
+
+declare var n: number;
+>n : Symbol(n, Decl(autoAccessorInference.ts, 10, 11))
+
+class B {
+>B : Symbol(B, Decl(autoAccessorInference.ts, 10, 22))
+
+    static accessor value;
+>value : Symbol(B.value, Decl(autoAccessorInference.ts, 11, 9))
+
+    static {
+        this.value = n;
+>this.value : Symbol(B.value, Decl(autoAccessorInference.ts, 11, 9))
+>this : Symbol(B, Decl(autoAccessorInference.ts, 10, 22))
+>value : Symbol(B.value, Decl(autoAccessorInference.ts, 11, 9))
+>n : Symbol(n, Decl(autoAccessorInference.ts, 10, 11))
+
+        if (n < 0) {
+>n : Symbol(n, Decl(autoAccessorInference.ts, 10, 11))
+
+            this.value = null;
+>this.value : Symbol(B.value, Decl(autoAccessorInference.ts, 11, 9))
+>this : Symbol(B, Decl(autoAccessorInference.ts, 10, 22))
+>value : Symbol(B.value, Decl(autoAccessorInference.ts, 11, 9))
+        }
+    }
+}
+

--- a/tests/baselines/reference/autoAccessorInference.types
+++ b/tests/baselines/reference/autoAccessorInference.types
@@ -1,0 +1,94 @@
+//// [tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorInference.ts] ////
+
+=== autoAccessorInference.ts ===
+class A {
+>A : A
+>  : ^
+
+    accessor value;
+>value : number | null
+>      : ^^^^^^^^^^^^^
+
+    constructor(n: number) {
+>n : number
+>  : ^^^^^^
+
+        this.value = n
+>this.value = n : number
+>               : ^^^^^^
+>this.value : number | null
+>           : ^^^^^^^^^^^^^
+>this : this
+>     : ^^^^
+>value : number | null
+>      : ^^^^^^^^^^^^^
+>n : number
+>  : ^^^^^^
+
+        if (n < 0) {
+>n < 0 : boolean
+>      : ^^^^^^^
+>n : number
+>  : ^^^^^^
+>0 : 0
+>  : ^
+
+            this.value = null
+>this.value = null : null
+>                  : ^^^^
+>this.value : number | null
+>           : ^^^^^^^^^^^^^
+>this : this
+>     : ^^^^
+>value : number | null
+>      : ^^^^^^^^^^^^^
+        }
+    }
+}
+
+declare var n: number;
+>n : number
+>  : ^^^^^^
+
+class B {
+>B : B
+>  : ^
+
+    static accessor value;
+>value : number | null
+>      : ^^^^^^^^^^^^^
+
+    static {
+        this.value = n;
+>this.value = n : number
+>               : ^^^^^^
+>this.value : number | null
+>           : ^^^^^^^^^^^^^
+>this : typeof B
+>     : ^^^^^^^^
+>value : number | null
+>      : ^^^^^^^^^^^^^
+>n : number
+>  : ^^^^^^
+
+        if (n < 0) {
+>n < 0 : boolean
+>      : ^^^^^^^
+>n : number
+>  : ^^^^^^
+>0 : 0
+>  : ^
+
+            this.value = null;
+>this.value = null : null
+>                  : ^^^^
+>this.value : number | null
+>           : ^^^^^^^^^^^^^
+>this : typeof B
+>     : ^^^^^^^^
+>value : number | null
+>      : ^^^^^^^^^^^^^
+        }
+    }
+}
+

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorInference.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorInference.ts
@@ -1,0 +1,24 @@
+// @target: esnext
+// @strict: true
+// @noEmit: true
+
+class A {
+    accessor value;
+    constructor(n: number) {
+        this.value = n
+        if (n < 0) {
+            this.value = null
+        }
+    }
+}
+
+declare var n: number;
+class B {
+    static accessor value;
+    static {
+        this.value = n;
+        if (n < 0) {
+            this.value = null;
+        }
+    }
+}


### PR DESCRIPTION
This removes check that prevented type inference for auto-accessors when they were missing in initializer so that auto-accessors may also have their types inferred from the body of the constructor (for instance auto-accessors) or `static {}` block (for static auto-accessors).

Fixes #59728
