### PR TITLE
Use a literal string for ArrayBuffer's toStringTag

### DIFF
--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -251,7 +251,7 @@ interface String {
 }
 
 interface ArrayBuffer {
-    readonly [Symbol.toStringTag]: string;
+    readonly [Symbol.toStringTag]: "ArrayBuffer";
 }
 
 interface DataView<TArrayBuffer extends ArrayBufferLike> {


### PR DESCRIPTION
Now that all of the typed arrays are generic over `buffer`, we should be able to use a more specific type for `ArrayBuffer`'s `[Symbol.toStringTag]` property.

Fixes #60149
