### PR TITLE
Handle auto-import when `paths` pattern is absolute

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -613,7 +613,7 @@ function getLocalModuleSpecifier(moduleFileName: string, info: Info, compilerOpt
             prefersTsExtension(allowedEndings),
         );
 
-    const fromPaths = pathsOnly || fromPackageJsonImports === undefined ? paths && tryGetModuleNameFromPaths(relativeToBaseUrl, paths, allowedEndings, host, compilerOptions) : undefined;
+    const fromPaths = pathsOnly || fromPackageJsonImports === undefined ? paths && tryGetModuleNameFromPaths(relativeToBaseUrl, paths, allowedEndings, baseDirectory, getCanonicalFileName, host, compilerOptions) : undefined;
     if (pathsOnly) {
         return fromPaths;
     }
@@ -925,10 +925,11 @@ function tryGetModuleNameFromAmbientModule(moduleSymbol: Symbol, checker: TypeCh
     }
 }
 
-function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<readonly string[]>, allowedEndings: ModuleSpecifierEnding[], host: ModuleSpecifierResolutionHost, compilerOptions: CompilerOptions): string | undefined {
+function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<readonly string[]>, allowedEndings: ModuleSpecifierEnding[], baseDirecotry: string, getCanonicalFileName: GetCanonicalFileName, host: ModuleSpecifierResolutionHost, compilerOptions: CompilerOptions): string | undefined {
     for (const key in paths) {
         for (const patternText of paths[key]) {
-            const pattern = normalizePath(patternText);
+            const normalized = normalizePath(patternText);
+            const pattern = getRelativePathIfInSameVolume(normalized, baseDirecotry, getCanonicalFileName) ?? normalized;
             const indexOfStar = pattern.indexOf("*");
             // In module resolution, if `pattern` itself has an extension, a file with that extension is looked up directly,
             // meaning a '.ts' or '.d.ts' extension is allowed to resolve. This is distinct from the case where a '*' substitution
@@ -1290,6 +1291,8 @@ function tryGetModuleNameAsNodeModule({ path, isRedirect }: ModulePath, { getCan
                     subModuleName,
                     versionPaths.paths,
                     allowedEndings,
+                    packageRootPath,
+                    getCanonicalFileName,
                     host,
                     options,
                 );

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -925,11 +925,11 @@ function tryGetModuleNameFromAmbientModule(moduleSymbol: Symbol, checker: TypeCh
     }
 }
 
-function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<readonly string[]>, allowedEndings: ModuleSpecifierEnding[], baseDirecotry: string, getCanonicalFileName: GetCanonicalFileName, host: ModuleSpecifierResolutionHost, compilerOptions: CompilerOptions): string | undefined {
+function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<readonly string[]>, allowedEndings: ModuleSpecifierEnding[], baseDirectory: string, getCanonicalFileName: GetCanonicalFileName, host: ModuleSpecifierResolutionHost, compilerOptions: CompilerOptions): string | undefined {
     for (const key in paths) {
         for (const patternText of paths[key]) {
             const normalized = normalizePath(patternText);
-            const pattern = getRelativePathIfInSameVolume(normalized, baseDirecotry, getCanonicalFileName) ?? normalized;
+            const pattern = getRelativePathIfInSameVolume(normalized, baseDirectory, getCanonicalFileName) ?? normalized;
             const indexOfStar = pattern.indexOf("*");
             // In module resolution, if `pattern` itself has an extension, a file with that extension is looked up directly,
             // meaning a '.ts' or '.d.ts' extension is allowed to resolve. This is distinct from the case where a '*' substitution

--- a/tests/cases/fourslash/autoImportPathsConfigDir.ts
+++ b/tests/cases/fourslash/autoImportPathsConfigDir.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "paths": {
+////             "@root/*": ["${configDir}/src/*"]
+////         }
+////     }
+//// }
+
+// @Filename: src/one.ts
+//// export const one = 1;
+
+// @Filename: src/foo/two.ts
+//// one/**/
+
+verify.importFixModuleSpecifiers("", ["@root/one"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #59734
