### PR TITLE
Fix prioritization of `paths` specifiers over node_modules package specifiers

### DIFF
--- a/tests/cases/fourslash/autoImportPathsNodeModules.ts
+++ b/tests/cases/fourslash/autoImportPathsNodeModules.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "amd",
+////         "moduleResolution": "node",
+////         "rootDir": "ts",
+////         "baseUrl": ".",
+////         "paths": {
+////             "*": ["node_modules/@woltlab/wcf/ts/*"]
+////         }
+////     },
+////     "include": [
+////         "ts",
+////         "node_modules/@woltlab/wcf/ts",
+////      ]
+//// }
+
+// @Filename: node_modules/@woltlab/wcf/ts/WoltLabSuite/Core/Component/Dialog.ts
+//// export class Dialog {}
+
+// @Filename: ts/main.ts
+//// Dialog/**/
+
+verify.importFixModuleSpecifiers("", ["WoltLabSuite/Core/Component/Dialog"]);


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #51398 

Review with whitespace changes hidden. Slightly above the diff that GitHub shows is a comment outlining the module specifier priority intended, but it wasn’t working in this case where `paths` points to something inside node_modules.