### PR TITLE
Fix `--showConfig` to show transitively implied options that vary from the default config

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2643,7 +2643,7 @@ export function convertToTSConfig(configParseResult: ParsedCommandLine, configFi
 }
 
 function optionDependsOn(option: string, dependsOn: Set<string>): boolean {
-    const seen = new Map<string, true>();
+    const seen = new Set<string>();
     return optionDependsOnRecursive(option);
 
     function optionDependsOnRecursive(option: string): boolean {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1,4 +1,5 @@
 import {
+    addToSeen,
     AlternateModeDiagnostics,
     append,
     arrayFrom,
@@ -2629,7 +2630,7 @@ export function convertToTSConfig(configParseResult: ParsedCommandLine, configFi
     const providedKeys = new Set(optionMap.keys());
     const impliedCompilerOptions: Record<string, CompilerOptionsValue> = {};
     for (const option in computedOptions) {
-        if (!providedKeys.has(option) && some(computedOptions[option].dependencies, dep => providedKeys.has(dep))) {
+        if (!providedKeys.has(option) && optionDependsOn(option, providedKeys)) {
             const implied = computedOptions[option].computeValue(configParseResult.options);
             const defaultValue = computedOptions[option].computeValue({});
             if (implied !== defaultValue) {
@@ -2639,6 +2640,18 @@ export function convertToTSConfig(configParseResult: ParsedCommandLine, configFi
     }
     assign(config.compilerOptions, optionMapToObject(serializeCompilerOptions(impliedCompilerOptions, pathOptions)));
     return config;
+}
+
+function optionDependsOn(option: string, dependsOn: Set<string>): boolean {
+    const seen = new Map<string, true>();
+    return optionDependsOnRecursive(option);
+
+    function optionDependsOnRecursive(option: string): boolean {
+        if (addToSeen(seen, option)) {
+            return some(computedOptions[option]?.dependencies, dep => dependsOn.has(dep) || optionDependsOnRecursive(dep));
+        }
+        return false;
+    }
 }
 
 /** @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8193,15 +8193,11 @@ export function getLastChild(node: Node): Node | undefined {
  *
  * @internal
  */
-export function addToSeen<K>(seen: Map<K, true>, key: K): boolean;
-/** @internal */
-export function addToSeen<K, T>(seen: Map<K, T>, key: K, value: T): boolean;
-/** @internal */
-export function addToSeen<K, T>(seen: Map<K, T>, key: K, value: T = true as any): boolean {
+export function addToSeen<K>(seen: Set<K>, key: K): boolean {
     if (seen.has(key)) {
         return false;
     }
-    seen.set(key, value);
+    seen.add(key);
     return true;
 }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1297,7 +1297,7 @@ export class ProjectService {
      */
     private readonly filenameToScriptInfoVersion = new Map<Path, number>();
     // Set of all '.js' files ever opened.
-    private readonly allJsFilesForOpenFileTelemetry = new Map<string, true>();
+    private readonly allJsFilesForOpenFileTelemetry = new Set<string>();
 
     /**
      * Map to the real path of the infos

--- a/src/services/codefixes/convertConstToLet.ts
+++ b/src/services/codefixes/convertConstToLet.ts
@@ -36,7 +36,7 @@ registerCodeFix({
     },
     getAllCodeActions: context => {
         const { program } = context;
-        const seen = new Map<number, true>();
+        const seen = new Set<number>();
 
         return createCombinedCodeActions(textChanges.ChangeTracker.with(context, changes => {
             eachDiagnostic(context, errorCodes, diag => {

--- a/src/services/codefixes/convertToTypeOnlyExport.ts
+++ b/src/services/codefixes/convertToTypeOnlyExport.ts
@@ -36,7 +36,7 @@ registerCodeFix({
     },
     fixIds: [fixId],
     getAllCodeActions: function getAllCodeActionsToConvertToTypeOnlyExport(context) {
-        const fixedExportDeclarations = new Map<number, true>();
+        const fixedExportDeclarations = new Set<number>();
         return codeFixAll(context, errorCodes, (changes, diag) => {
             const exportSpecifier = getExportSpecifierForDiagnosticSpan(diag, context.sourceFile);
             if (exportSpecifier && addToSeen(fixedExportDeclarations, getNodeId(exportSpecifier.parent.parent))) {

--- a/src/services/codefixes/fixAddMissingConstraint.ts
+++ b/src/services/codefixes/fixAddMissingConstraint.ts
@@ -63,7 +63,7 @@ registerCodeFix({
     fixIds: [fixId],
     getAllCodeActions: context => {
         const { program, preferences, host } = context;
-        const seen = new Map<number, true>();
+        const seen = new Set<number>();
 
         return createCombinedCodeActions(textChanges.ChangeTracker.with(context, changes => {
             eachDiagnostic(context, errorCodes, diag => {

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -182,7 +182,7 @@ registerCodeFix({
     getAllCodeActions: context => {
         const { program, fixId } = context;
         const checker = program.getTypeChecker();
-        const seen = new Map<string, true>();
+        const seen = new Set<string>();
         const typeDeclToMembers = new Map<ClassLikeDeclaration | InterfaceDeclaration | TypeLiteralNode, TypeLikeDeclarationInfo[]>();
 
         return createCombinedCodeActions(textChanges.ChangeTracker.with(context, changes => {

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -44,7 +44,7 @@ registerCodeFix({
     },
     fixIds: [fixId],
     getAllCodeActions: function getAllCodeActionsToFixAwaitInSyncFunction(context) {
-        const seen = new Map<number, true>();
+        const seen = new Set<number>();
         return codeFixAll(context, errorCodes, (changes, diag) => {
             const nodes = getNodes(diag.file, diag.start);
             if (!nodes || !addToSeen(seen, getNodeId(nodes.insertBefore))) return;

--- a/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
+++ b/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
@@ -44,7 +44,7 @@ registerCodeFix({
     },
     fixIds: [fixId],
     getAllCodeActions: function getAllCodeActionsToFixClassDoesntImplementInheritedAbstractMember(context) {
-        const seenClassDeclarations = new Map<number, true>();
+        const seenClassDeclarations = new Set<number>();
         return codeFixAll(context, errorCodes, (changes, diag) => {
             const classDeclaration = getClass(diag.file, diag.start);
             if (addToSeen(seenClassDeclarations, getNodeId(classDeclaration))) {

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -55,7 +55,7 @@ registerCodeFix({
     },
     fixIds: [fixId],
     getAllCodeActions(context) {
-        const seenClassDeclarations = new Map<number, true>();
+        const seenClassDeclarations = new Set<number>();
         return codeFixAll(context, errorCodes, (changes, diag) => {
             const classDeclaration = getClass(diag.file, diag.start);
             if (addToSeen(seenClassDeclarations, getNodeId(classDeclaration))) {

--- a/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
+++ b/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
@@ -38,7 +38,7 @@ registerCodeFix({
     fixIds: [fixId],
     getAllCodeActions(context) {
         const { sourceFile } = context;
-        const seenClasses = new Map<number, true>(); // Ensure we only do this once per class.
+        const seenClasses = new Set<number>(); // Ensure we only do this once per class.
         return codeFixAll(context, errorCodes, (changes, diag) => {
             const nodes = getNodes(diag.file, diag.start);
             if (!nodes) return;

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -555,7 +555,7 @@ export function getExportInfoMap(importingFile: SourceFile | FutureSourceFile, h
     try {
         forEachExternalModuleToImportFrom(program, host, preferences, /*useAutoImportProvider*/ true, (moduleSymbol, moduleFile, program, isFromPackageJson) => {
             if (++moduleCount % 100 === 0) cancellationToken?.throwIfCancellationRequested();
-            const seenExports = new Map<__String, true>();
+            const seenExports = new Set<__String>();
             const checker = program.getTypeChecker();
             const defaultInfo = getDefaultLikeExportInfo(moduleSymbol, checker);
             // Note: I think we shouldn't actually see resolved module symbols here, but weird merges
@@ -634,7 +634,7 @@ function getNamesForExportedSymbol(defaultExport: Symbol, checker: TypeChecker, 
 export function forEachNameOfDefaultExport<T>(defaultExport: Symbol, checker: TypeChecker, scriptTarget: ScriptTarget | undefined, cb: (name: string, capitalizedName?: string) => T | undefined): T | undefined {
     let chain: Symbol[] | undefined;
     let current: Symbol | undefined = defaultExport;
-    const seen = new Map<Symbol, true>();
+    const seen = new Set<Symbol>();
 
     while (current) {
         // The predecessor to this function also looked for a name on the `localSymbol`

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -251,7 +251,6 @@ import {
     SymbolDisplayPart,
     SymbolDisplayPartKind,
     SymbolFlags,
-    SymbolId,
     symbolName,
     SyntaxKind,
     textPart,
@@ -544,7 +543,7 @@ export function getImplementationsAtPosition(program: Program, cancellationToken
     }
     else if (entries) {
         const queue = createQueue(entries);
-        const seenNodes = new Map<number, true>();
+        const seenNodes = new Set<number>();
         while (!queue.isEmpty()) {
             const entry = queue.dequeue() as NodeEntry;
             if (!addToSeen(seenNodes, getNodeId(entry.node))) {
@@ -2666,7 +2665,7 @@ export namespace Core {
      *                                The value of previousIterationSymbol is undefined when the function is first called.
      */
     function getPropertySymbolsFromBaseTypes<T>(symbol: Symbol, propertyName: string, checker: TypeChecker, cb: (symbol: Symbol) => T | undefined): T | undefined {
-        const seen = new Map<SymbolId, true>();
+        const seen = new Set<Symbol>();
         return recur(symbol);
 
         function recur(symbol: Symbol): T | undefined {
@@ -2674,7 +2673,7 @@ export namespace Core {
             //      interface C extends C {
             //          /*findRef*/propName: string;
             //      }
-            if (!(symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) || !addToSeen(seen, getSymbolId(symbol))) return;
+            if (!(symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) || !addToSeen(seen, symbol)) return;
 
             return firstDefined(symbol.declarations, declaration =>
                 firstDefined(getAllSuperTypeNodes(declaration), typeReference => {

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -247,7 +247,7 @@ function flattenTypeLiteralNodeReference(checker: TypeChecker, selection: TypeNo
     }
     if (isIntersectionTypeNode(selection)) {
         const result: TypeElement[] = [];
-        const seen = new Map<string, true>();
+        const seen = new Set<string>();
         for (const type of selection.types) {
             const flattenedTypeMembers = flattenTypeLiteralNodeReference(checker, type);
             if (!flattenedTypeMembers || !flattenedTypeMembers.every(type => type.name && addToSeen(seen, getNameFromPropertyName(type.name) as string))) {

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -555,7 +555,7 @@ function getAlreadyUsedTypesInStringLiteralUnion(union: UnionTypeNode, current: 
 
 function getStringLiteralCompletionsFromSignature(call: CallLikeExpression, arg: StringLiteralLike, argumentInfo: SignatureHelp.ArgumentInfoForCompletions, checker: TypeChecker): StringLiteralCompletionsFromTypes | undefined {
     let isNewIdentifier = false;
-    const uniques = new Map<string, true>();
+    const uniques = new Set<string>();
     const editingArgument = isJsxOpeningLikeElement(call) ? Debug.checkDefined(findAncestor(arg.parent, isJsxAttribute)) : arg;
     const candidates = checker.getCandidateSignaturesForStringLiteralCompletions(call, editingArgument);
     const types = flatMap(candidates, candidate => {
@@ -600,7 +600,7 @@ function stringLiteralCompletionsForObjectLiteral(checker: TypeChecker, objectLi
     };
 }
 
-function getStringLiteralTypes(type: Type | undefined, uniques = new Map<string, true>()): readonly StringLiteralType[] {
+function getStringLiteralTypes(type: Type | undefined, uniques = new Set<string>()): readonly StringLiteralType[] {
     if (!type) return emptyArray;
     type = skipConstraint(type);
     return type.isUnion() ? flatMap(type.types, t => getStringLiteralTypes(t, uniques)) :

--- a/src/testRunner/unittests/config/showConfig.ts
+++ b/src/testRunner/unittests/config/showConfig.ts
@@ -57,6 +57,8 @@ describe("unittests:: config:: showConfig", () => {
 
     showTSConfigCorrectly("Show TSConfig with advanced options", ["--showConfig", "--declaration", "--declarationDir", "lib", "--skipLibCheck", "--noErrorTruncation"]);
 
+    showTSConfigCorrectly("Show TSConfig with transitively implied options", ["--showConfig", "--module", "nodenext"]);
+
     showTSConfigCorrectly("Show TSConfig with compileOnSave and more", ["-p", "tsconfig.json"], {
         compilerOptions: {
             esModuleInterop: true,

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with transitively implied options/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with transitively implied options/tsconfig.json
@@ -6,6 +6,8 @@
         "moduleDetection": "force",
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
+        "resolvePackageJsonExports": true,
+        "resolvePackageJsonImports": true,
         "useDefineForClassFields": true
     }
 }

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with transitively implied options/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with transitively implied options/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "target": "esnext",
+        "moduleResolution": "nodenext",
+        "moduleDetection": "force",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "useDefineForClassFields": true
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #59442

#56701 made it so `--showConfig` shows implied compiler options if their implied value differs from what you’d get with no config. However, it mistakenly only showed implied options that were affected by an explicitly set option, while failing to show implied options that were affected by other implied options. For example, setting `--module nodenext` implies `--moduleResolution nodenext`, which implies `--resolvePackageJsonExports`. But `--resolvePackageJsonExports` previously didn’t show up with `--module nodenext --showConfig`.
