### PR TITLE
Fix incorrect details in lib.decorators

### DIFF
--- a/src/lib/decorators.d.ts
+++ b/src/lib/decorators.d.ts
@@ -92,9 +92,9 @@ interface ClassMethodDecoratorContext<
     };
 
     /**
-     * Adds a callback to be invoked either before static initializers are run (when
-     * decorating a `static` element), or before instance initializers are run (when
-     * decorating a non-`static` element).
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
      *
      * @example
      * ```ts
@@ -158,9 +158,9 @@ interface ClassGetterDecoratorContext<
     };
 
     /**
-     * Adds a callback to be invoked either before static initializers are run (when
-     * decorating a `static` element), or before instance initializers are run (when
-     * decorating a non-`static` element).
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
      */
     addInitializer(initializer: (this: This) => void): void;
 
@@ -205,9 +205,9 @@ interface ClassSetterDecoratorContext<
     };
 
     /**
-     * Adds a callback to be invoked either before static initializers are run (when
-     * decorating a `static` element), or before instance initializers are run (when
-     * decorating a non-`static` element).
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
      */
     addInitializer(initializer: (this: This) => void): void;
 
@@ -261,9 +261,8 @@ interface ClassAccessorDecoratorContext<
     };
 
     /**
-     * Adds a callback to be invoked either before static initializers are run (when
-     * decorating a `static` element), or before instance initializers are run (when
-     * decorating a non-`static` element).
+     * Adds a callback to be invoked immediately after the auto `accessor` being
+     * decorated is initialized (regardless if the `accessor` is `static` or not).
      */
     addInitializer(initializer: (this: This) => void): void;
 
@@ -358,9 +357,8 @@ interface ClassFieldDecoratorContext<
     };
 
     /**
-     * Adds a callback to be invoked either before static initializers are run (when
-     * decorating a `static` element), or before instance initializers are run (when
-     * decorating a non-`static` element).
+     * Adds a callback to be invoked immediately after the field being decorated
+     * is initialized (regardless if the field is `static` or not).
      */
     addInitializer(initializer: (this: This) => void): void;
 


### PR DESCRIPTION
The described order in which initializers added with `context.addInitializer()` execute was incorrect.

Reference:

https://github.com/tc39/proposal-decorators?tab=readme-ov-file#adding-initialization-logic-with-addinitializer

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #60251