### PR TITLE
Let isolated declarations fixer add toplevel imports more

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -606,12 +606,10 @@ export function typeToAutoImportableTypeNode(checker: TypeChecker, importAdder: 
 
 /** @internal */
 export function typeNodeToAutoImportableTypeNode(typeNode: TypeNode, importAdder: ImportAdder, scriptTarget: ScriptTarget): TypeNode | undefined {
-    if (typeNode && isImportTypeNode(typeNode)) {
-        const importableReference = tryGetAutoImportableReferenceFromTypeNode(typeNode, scriptTarget);
-        if (importableReference) {
-            importSymbols(importAdder, importableReference.symbols);
-            typeNode = importableReference.typeNode;
-        }
+    const importableReference = tryGetAutoImportableReferenceFromTypeNode(typeNode, scriptTarget);
+    if (importableReference) {
+        importSymbols(importAdder, importableReference.symbols);
+        typeNode = importableReference.typeNode;
     }
 
     // Ensure nodes are fresh so they can have different positions when going through formatting.

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports56-toplevel-import.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports56-toplevel-import.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+
+// @Filename: /person-code.ts
+////export interface Person { x: string; }
+////export function getPerson() : Person {
+////  return null!
+////}
+
+// @Filename: /code.ts
+////import { getPerson } from "./person-code";
+////export function wrapPerson() {
+////  return { person: getPerson() }
+////};
+
+goTo.file("/code.ts");
+
+verify.codeFix({
+    description: "Add return type '{ person: Person; }'",
+    index: 0,
+    newFileContent:
+`import { getPerson, Person } from "./person-code";
+export function wrapPerson(): {
+    person: Person;
+} {
+  return { person: getPerson() }
+};`
+});


### PR DESCRIPTION
The fixer has a tendency to create inline imports, whereas toplevel imports are almost always more readable. And the code already exists, it's just a matter of using it.

I assume there may be value in applying this in some other places, but this is the one that's bugging me!

Fixes #60266.