### PR TITLE
Fixed crash in auto import suggestions for `default` of exported UMD objects

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -169,6 +169,7 @@ import {
     isExternalModule,
     isExternalModuleImportEqualsDeclaration,
     isExternalModuleReference,
+    isExternalModuleSymbol,
     isFileLevelUniqueName,
     isForInStatement,
     isForOfStatement,
@@ -4027,7 +4028,13 @@ export function getDefaultLikeExportNameFromDeclaration(symbol: Symbol): string 
             return tryCast(d.propertyName, isIdentifier)?.text;
         }
         // GH#52694
-        return tryCast(getNameOfDeclaration(d), isIdentifier)?.text;
+        const name = tryCast(getNameOfDeclaration(d), isIdentifier)?.text;
+        if (name) {
+            return name;
+        }
+        if (symbol.parent && !isExternalModuleSymbol(symbol.parent)) {
+            return symbol.parent.getName();
+        }
     });
 }
 

--- a/tests/cases/fourslash/completionsImportDefaultExportCrash1.ts
+++ b/tests/cases/fourslash/completionsImportDefaultExportCrash1.ts
@@ -1,0 +1,42 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+// @allowJs: true
+
+// @Filename: /node_modules/dom7/index.d.ts
+//// export interface Dom7Array {
+////   length: number;
+////   prop(propName: string): any;
+//// }
+////
+//// export interface Dom7 {
+////   (): Dom7Array;
+////   fn: any;
+//// }
+////
+//// declare const Dom7: Dom7;
+////
+//// export {
+////   Dom7 as $,
+//// };
+
+// @Filename: /dom7.js
+//// import * as methods from 'dom7';
+//// Object.keys(methods).forEach((methodName) => {
+////   if (methodName === '$') return;
+////   methods.$.fn[methodName] = methods[methodName];
+//// });
+////
+//// export default methods.$;
+
+// @Filename: /swipe-back.js
+//// import $ from './dom7.js';
+//// /*1*/
+
+verify.completions({
+  marker: "1",
+  includes: [{ name: "$" }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  }
+});

--- a/tests/cases/fourslash/completionsImportDefaultExportCrash2.ts
+++ b/tests/cases/fourslash/completionsImportDefaultExportCrash2.ts
@@ -30,13 +30,22 @@
 //// export default methods.$;
 
 // @Filename: /swipe-back.js
-//// import $ from './dom7.js';
 //// /*1*/
 
 verify.completions({
   marker: "1",
-  // some kind of a check should be added here
+  includes: [{
+    name: "$",
+    hasAction: true,
+    source: 'dom7',
+    sortText: completion.SortText.AutoImportSuggestions,
+  }, {
+    name: "Dom7",
+    hasAction: true,
+    source: './dom7',
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
   preferences: {
-      includeCompletionsForModuleExports: true,
+    includeCompletionsForModuleExports: true,
   }
 });

--- a/tests/cases/fourslash/completionsImport_umdDefaultNoCrash1.ts
+++ b/tests/cases/fourslash/completionsImport_umdDefaultNoCrash1.ts
@@ -1,0 +1,49 @@
+/// <reference path="fourslash.ts" />
+
+// @moduleResolution: node
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /node_modules/dottie/package.json
+//// {
+////   "name": "dottie",
+////   "main": "dottie.js"
+//// }
+
+// @Filename: /node_modules/dottie/dottie.js
+//// (function (undefined) {
+////   var root = this;
+////
+////   var Dottie = function () {};
+////
+////   Dottie["default"] = function (object, path, value) {};
+////
+////   if (typeof module !== "undefined" && module.exports) {
+////     exports = module.exports = Dottie;
+////   } else {
+////     root["Dottie"] = Dottie;
+////     root["Dot"] = Dottie;
+////
+////     if (typeof define === "function") {
+////       define([], function () {
+////         return Dottie;
+////       });
+////     }
+////   }
+//// })();
+
+// @Filename: /src/index.js
+//// /**/
+
+verify.completions({
+  marker: "",
+  includes: [
+    {
+      name: "Dottie",
+      hasAction: true,
+      source: "/node_modules/dottie/dottie",
+      sortText: completion.SortText.AutoImportSuggestions,
+    },
+  ],
+  preferences: { includeCompletionsForModuleExports: true },
+});

--- a/tests/cases/fourslash/completionsImport_umdDefaultNoCrash2.ts
+++ b/tests/cases/fourslash/completionsImport_umdDefaultNoCrash2.ts
@@ -1,0 +1,43 @@
+/// <reference path="fourslash.ts" />
+
+// @moduleResolution: node
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /node_modules/dottie/package.json
+//// {
+////   "name": "dottie",
+////   "main": "dottie.js"
+//// }
+
+// @Filename: /node_modules/dottie/dottie.js
+//// (function (undefined) {
+////   var root = this;
+////
+////   var Dottie = function () {};
+////
+////   Dottie["default"] = function (object, path, value) {};
+////
+////   if (typeof module !== "undefined" && module.exports) {
+////     exports = module.exports = Dottie;
+////   } else {
+////     root["Dottie"] = Dottie;
+////     root["Dot"] = Dottie;
+////
+////     if (typeof define === "function") {
+////       define([], function () {
+////         return Dottie;
+////       });
+////     }
+////   }
+//// })();
+
+// @Filename: /src/index.js
+//// import Dottie from 'dottie';
+//// /**/
+
+verify.completions({
+  marker: "",
+  includes: [{ name: "Dottie" }],
+  preferences: { includeCompletionsForModuleExports: true },
+});


### PR DESCRIPTION
Fixes the crash reported here: https://github.com/microsoft/TypeScript/issues/60294#issuecomment-2425274891

https://github.com/microsoft/TypeScript/pull/58460 regressed this by unwrapping `default` from the `module.exports` here: https://github.com/microsoft/TypeScript/pull/58460/files#diff-e103edcf604d8cf6f9e4e9bc7bd6bab002b5eaa96719fee4909d4b69e4f46623R553-R554 (cc @andrewbranch). That ultimately led to a crash because a different symbol was returned and processed. Using `module.exports.default` is correct though, it's just that the latter code didn't handle this case alright