### PR TITLE
Fixed a JSDoc-related crash when obtaining type of a type literal type argument

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19362,7 +19362,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!links.resolvedType) {
             // Deferred resolution of members is handled by resolveObjectTypeMembers
             const aliasSymbol = getAliasSymbolForTypeNode(node);
-            if (getMembersOfSymbol(node.symbol).size === 0 && !aliasSymbol) {
+            if (!node.symbol || getMembersOfSymbol(node.symbol).size === 0 && !aliasSymbol) {
                 links.resolvedType = emptyTypeLiteralType;
             }
             else {

--- a/tests/cases/fourslash/completionsJSDocNoCrash3.ts
+++ b/tests/cases/fourslash/completionsJSDocNoCrash3.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+// @filename: index.ts
+//// class MssqlClient {
+////   /**
+////    *
+////    * @param {Object} - args
+////    * @param {String} - args.parentTable
+////    * @returns {Promise<{upStatement/**/, downStatement}>}
+////    */
+////   async relationCreate(args) {}
+//// }
+////
+//// export default MssqlClient;
+
+verify.completions({
+  marker: "",
+  exact: [{
+    name: "readonly",
+    sortText: completion.SortText.GlobalsOrKeywords,
+  }],
+  isNewIdentifierLocation: true,
+});


### PR DESCRIPTION
fixes the crash reported here https://github.com/microsoft/TypeScript/issues/60355#issuecomment-2440205019