### PR TITLE
Fix a crash in an anonymous buffer that copilot is writing to.

### DIFF
--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -632,6 +632,7 @@ export class LineNode implements LineCollection {
 
     walk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker): void {
         // assume (rangeStart < this.totalChars) && (rangeLength <= this.totalChars)
+        if (this.children.length === 0) return;
         let childIndex = 0;
         let childCharCount = this.children[childIndex].charCount();
         // find sub-tree containing start


### PR DESCRIPTION
Fix #60118

LineNode.walk reads the first element out of LineNode.children without checking that there are any elements to read. Of course, it's supposed to be called only on nodes that have children.

Why no tests?
-------------

- This failure is flaky -- I never managed to reproduce it.
- scriptVersionCache is barely maintained. The last two fixes in this particular code are 3.5 and 6.5 years ago.
- #21924 has no tests to fix an assert
- #44746 has an exasperated comment about the difficulty of learning invariants and an apology for an only-possibly-relevant test.
- So, I didn't think the effort of a complete fix was worthwhile in a case where a small, local fix will stop the crashes.

