### PR TITLE
allow calling `goToDef` on modifiers of named declarations

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -66,6 +66,7 @@ import {
     isJumpStatementTarget,
     isModifier,
     isModuleSpecifierLike,
+    isNamedDeclaration,
     isNameOfFunctionDeclaration,
     isNewExpressionTarget,
     isObjectBindingPattern,
@@ -156,7 +157,7 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
             break;
     }
 
-    // for keywords related to function or method declarations
+    // for keywords related to function or method definitions
     let findFunctionDecl: ((n: Node) => boolean | "quit") | undefined;
     let checkFunctionDeclaration: ((decl: FunctionLikeDeclaration) => boolean) | undefined;
     switch (node.kind) {
@@ -167,15 +168,12 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
                     : isFunctionLikeDeclaration(n);
             };
             break;
-        case SyntaxKind.AsyncKeyword:
         case SyntaxKind.AwaitKeyword:
-            findFunctionDecl = isFunctionLikeDeclaration;
             checkFunctionDeclaration = (functionDeclaration: FunctionLikeDeclaration) => some(functionDeclaration.modifiers, node => node.kind === SyntaxKind.AsyncKeyword);
+            findFunctionDecl = isFunctionLikeDeclaration;
             break;
         case SyntaxKind.YieldKeyword:
             checkFunctionDeclaration = functionDeclaration => !!functionDeclaration.asteriskToken;
-            // falls through
-        case SyntaxKind.ExportKeyword:
             findFunctionDecl = isFunctionLikeDeclaration;
             break;
     }
@@ -231,7 +229,7 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
         }
     }
 
-    if (isModifier(node) && isClassElement(parent)) {
+    if (isModifier(node) && (isClassElement(parent) || isNamedDeclaration(parent))) {
         symbol = parent.symbol;
     }
 

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -159,28 +159,13 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
 
     // for keywords related to function or method definitions
     let findFunctionDecl: ((n: Node) => boolean | "quit") | undefined;
-    let checkFunctionDeclaration: ((decl: FunctionLikeDeclaration) => boolean) | undefined;
     switch (node.kind) {
         case SyntaxKind.ReturnKeyword:
-            findFunctionDecl = n => {
-                return isClassStaticBlockDeclaration(n)
-                    ? "quit"
-                    : isFunctionLikeDeclaration(n);
-            };
-            break;
         case SyntaxKind.AwaitKeyword:
-            checkFunctionDeclaration = (functionDeclaration: FunctionLikeDeclaration) => some(functionDeclaration.modifiers, node => node.kind === SyntaxKind.AsyncKeyword);
-            findFunctionDecl = isFunctionLikeDeclaration;
-            break;
         case SyntaxKind.YieldKeyword:
-            checkFunctionDeclaration = functionDeclaration => !!functionDeclaration.asteriskToken;
             findFunctionDecl = isFunctionLikeDeclaration;
-            break;
-    }
-    if (findFunctionDecl) {
-        const functionDeclaration = findAncestor(node, findFunctionDecl) as FunctionLikeDeclaration | undefined;
-        const isCorrectDeclaration = functionDeclaration && (!checkFunctionDeclaration || checkFunctionDeclaration(functionDeclaration));
-        return isCorrectDeclaration ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
+            const functionDeclaration = findAncestor(node, findFunctionDecl) as FunctionLikeDeclaration | undefined;
+            return functionDeclaration ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
     }
 
     if (isStaticModifier(node) && isClassStaticBlockDeclaration(node.parent)) {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -473,7 +473,11 @@ export function getTypeDefinitionAtPosition(typeChecker: TypeChecker, sourceFile
     if (isImportMeta(node.parent) && node.parent.name === node) {
         return definitionFromType(typeChecker.getTypeAtLocation(node.parent), typeChecker, node.parent, /*failedAliasResolution*/ false);
     }
-    const { symbol, failedAliasResolution } = getSymbol(node, typeChecker, /*stopAtAlias*/ false);
+    let { symbol, failedAliasResolution } = getSymbol(node, typeChecker, /*stopAtAlias*/ false);
+    if (isModifier(node) && (isClassElement(node.parent) || isNamedDeclaration(node.parent))) {
+        symbol = node.parent.symbol;
+        failedAliasResolution = false;
+    }
     if (!symbol) return undefined;
 
     const typeAtLocation = typeChecker.getTypeOfSymbolAtLocation(symbol, node);

--- a/tests/baselines/reference/goToDefinitionAwait1.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionAwait1.baseline.jsonc
@@ -26,6 +26,18 @@
 // async function foo() {
 //     await Promise.resolve(0);
 // }
-// function notAsync() {
+// <|function [|notAsync|]() {
 //     /*GOTO DEF*/await Promise.resolve(0);
-// }
+// }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "notAsync",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionAwait3.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionAwait3.baseline.jsonc
@@ -1,12 +1,26 @@
 // === goToDefinition ===
 // === /tests/cases/fourslash/goToDefinitionAwait3.ts ===
 // class C {
-//     notAsync() {
+//     <|[|notAsync|]() {
 //       /*GOTO DEF*/await Promise.resolve(0);
-//     }
+//     }|>
 // 
 //     async foo() {
-// --- (line: 7) skipped ---
+//       await Promise.resolve(0);
+//     }
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "notAsync",
+    "containerName": "C",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]
 
 
 

--- a/tests/baselines/reference/goToDefinitionMember.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionMember.baseline.jsonc
@@ -1,12 +1,8 @@
 // === goToDefinition ===
 // === /a.ts ===
 // class A {
-// 
 //     <|private [|{| textSpan: true |}z|]/*GOTO DEF*/: string;|>
-// 
-//     readonly x: string;
-// 
-// --- (line: 7) skipped ---
+// }
 
   // === Details ===
   [

--- a/tests/baselines/reference/goToDefinitionMember.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionMember.baseline.jsonc
@@ -1,0 +1,22 @@
+// === goToDefinition ===
+// === /a.ts ===
+// class A {
+// 
+//     <|private [|{| textSpan: true |}z|]/*GOTO DEF*/: string;|>
+// 
+//     readonly x: string;
+// 
+// --- (line: 7) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "z",
+    "containerName": "A",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
@@ -32,39 +32,7 @@
 
 // === goToDefinition ===
 // === /a.ts ===
-// <|expo/*GOTO DEF*/rt class [|A|] {
-// 
-//     private z: string;
-// 
-//     readonly x: string;
-// 
-//     async a() {  }
-// 
-//     override b() {}
-// 
-//     public async c() { }
-// }|>
-// 
-// export function foo() { }
-
-  // === Details ===
-  [
-   {
-    "kind": "class",
-    "name": "A",
-    "containerName": "\"/a\"",
-    "isLocal": false,
-    "isAmbient": false,
-    "unverified": false,
-    "failedAliasResolution": false
-   }
-  ]
-
-
-
-// === goToDefinition ===
-// === /a.ts ===
-// <|export/*GOTO DEF*/ class [|A|] {
+// <|export class [|{| textSpan: true |}A|]/*GOTO DEF*/ {
 // 
 //     private z: string;
 // 
@@ -123,9 +91,61 @@
 // === /a.ts ===
 // export class A {
 // 
+//     <|private [|{| textSpan: true |}z|]/*GOTO DEF*/: string;|>
+// 
+//     readonly x: string;
+// 
+// --- (line: 7) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "z",
+    "containerName": "A",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// export class A {
+// 
 //     private z: string;
 // 
 //     /*GOTO DEF*/<|readonly [|x|]: string;|>
+// 
+//     async a() {  }
+// 
+// --- (line: 9) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "x",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// export class A {
+// 
+//     private z: string;
+// 
+//     <|readonly [|{| textSpan: true |}x|]/*GOTO DEF*/: string;|>
 // 
 //     async a() {  }
 // 
@@ -175,6 +195,31 @@
 
 // === goToDefinition ===
 // === /a.ts ===
+// --- (line: 3) skipped ---
+// 
+//     readonly x: string;
+// 
+//     <|async [|{| textSpan: true |}a|]/*GOTO DEF*/() {  }|>
+// 
+//     override b() {}
+// 
+// --- (line: 11) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "a",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
 // --- (line: 5) skipped ---
 // 
 //     async a() {  }
@@ -196,6 +241,32 @@
     "isAmbient": false,
     "unverified": false,
     "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 5) skipped ---
+// 
+//     async a() {  }
+// 
+//     <|override [|{| textSpan: true |}b|]/*GOTO DEF*/() {}|>
+// 
+//     public async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "b",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false
    }
   ]
 
@@ -274,5 +345,73 @@
     "isAmbient": false,
     "unverified": false,
     "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     override b() {}
+// 
+//     <|public async [|{| textSpan: true |}c|]/*GOTO DEF*/() { }|>
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "c",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 10) skipped ---
+//     public async c() { }
+// }
+// 
+// <|exp/*GOTO DEF*/ort function [|foo|]() { }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "foo",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 10) skipped ---
+//     public async c() { }
+// }
+// 
+// <|export function [|{| textSpan: true |}foo|]/*GOTO DEF*/() { }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "foo",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false
    }
   ]

--- a/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
@@ -1,30 +1,96 @@
 // === goToDefinition ===
 // === /a.ts ===
-// /*GOTO DEF*/export class A {
+// /*GOTO DEF*/<|export class [|A|] {
 // 
 //     private z: string;
 // 
-// --- (line: 5) skipped ---
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
 
 
 
 // === goToDefinition ===
 // === /a.ts ===
-// expo/*GOTO DEF*/rt class A {
+// <|expo/*GOTO DEF*/rt class [|A|] {
 // 
 //     private z: string;
 // 
-// --- (line: 5) skipped ---
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
 
 
 
 // === goToDefinition ===
 // === /a.ts ===
-// export/*GOTO DEF*/ class A {
+// <|export/*GOTO DEF*/ class [|A|] {
 // 
 //     private z: string;
 // 
-// --- (line: 5) skipped ---
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
 
 
 
@@ -100,7 +166,8 @@
     "containerName": "A",
     "isLocal": false,
     "isAmbient": false,
-    "unverified": false
+    "unverified": false,
+    "failedAliasResolution": false
    }
   ]
 
@@ -205,6 +272,7 @@
     "containerName": "A",
     "isLocal": false,
     "isAmbient": false,
-    "unverified": false
+    "unverified": false,
+    "failedAliasResolution": false
    }
   ]

--- a/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionModifiers.baseline.jsonc
@@ -1,0 +1,210 @@
+// === goToDefinition ===
+// === /a.ts ===
+// /*GOTO DEF*/export class A {
+// 
+//     private z: string;
+// 
+// --- (line: 5) skipped ---
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// expo/*GOTO DEF*/rt class A {
+// 
+//     private z: string;
+// 
+// --- (line: 5) skipped ---
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// export/*GOTO DEF*/ class A {
+// 
+//     private z: string;
+// 
+// --- (line: 5) skipped ---
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// export class A {
+// 
+//     /*GOTO DEF*/<|private [|z|]: string;|>
+// 
+//     readonly x: string;
+// 
+// --- (line: 7) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "z",
+    "containerName": "A",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// export class A {
+// 
+//     private z: string;
+// 
+//     /*GOTO DEF*/<|readonly [|x|]: string;|>
+// 
+//     async a() {  }
+// 
+// --- (line: 9) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "x",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 3) skipped ---
+// 
+//     readonly x: string;
+// 
+//     /*GOTO DEF*/<|async [|a|]() {  }|>
+// 
+//     override b() {}
+// 
+// --- (line: 11) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "a",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 5) skipped ---
+// 
+//     async a() {  }
+// 
+//     /*GOTO DEF*/<|override [|b|]() {}|>
+// 
+//     public async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "b",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     override b() {}
+// 
+//     /*GOTO DEF*/<|public async [|c|]() { }|>
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "c",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     override b() {}
+// 
+//     <|public/*GOTO DEF*/ async [|c|]() { }|>
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "c",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     override b() {}
+// 
+//     <|public as/*GOTO DEF*/ync [|c|]() { }|>
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "c",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember6.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember6.baseline.jsonc
@@ -4,5 +4,18 @@
 //     m() {}
 // }
 // class Bar extends Foo {
-//     /*GOTO DEF*/override m1() {}
+//     /*GOTO DEF*/<|override [|m1|]() {}|>
 // }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "m1",
+    "containerName": "Bar",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember7.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember7.baseline.jsonc
@@ -1,5 +1,18 @@
 // === goToDefinition ===
 // === /tests/cases/fourslash/goToDefinitionOverriddenMember7.ts ===
 // class Foo {
-//     /*GOTO DEF*/override m() {}
+//     /*GOTO DEF*/<|override [|m|]() {}|>
 // }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "m",
+    "containerName": "Foo",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionReturn5.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionReturn5.baseline.jsonc
@@ -1,7 +1,19 @@
 // === goToDefinition ===
 // === /tests/cases/fourslash/goToDefinitionReturn5.ts ===
-// function foo() {
+// <|function [|foo|]() {
 //     class Foo {
 //         static { /*GOTO DEF*/return; }
 //     }
-// }
+// }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "foo",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionYield3.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionYield3.baseline.jsonc
@@ -1,12 +1,26 @@
 // === goToDefinition ===
 // === /tests/cases/fourslash/goToDefinitionYield3.ts ===
 // class C {
-//     notAGenerator() {
+//     <|[|notAGenerator|]() {
 //       /*GOTO DEF*/yield 0;
-//     }
+//     }|>
 // 
 //     foo*() {
-// --- (line: 7) skipped ---
+//       yield 0;
+//     }
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "notAGenerator",
+    "containerName": "C",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]
 
 
 

--- a/tests/baselines/reference/goToDefinitionYield4.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionYield4.baseline.jsonc
@@ -1,5 +1,17 @@
 // === goToDefinition ===
 // === /tests/cases/fourslash/goToDefinitionYield4.ts ===
 // function* gen() {
-//     class C { [/*GOTO DEF*/yield 10]() {} }
+//     class C { <|[|[/*GOTO DEF*/yield 10]|]() {}|> }
 // }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "[yield 10]",
+    "containerName": "C",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToTypeDefinitionModifiers.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinitionModifiers.baseline.jsonc
@@ -1,0 +1,597 @@
+// === goToType ===
+// === /a.ts ===
+// /*GOTO TYPE*/<|export class [|A|] {
+// 
+//     private z: string;
+// 
+//     private y: A;
+// 
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// <|export class [|A|]/*GOTO TYPE*/ {
+// 
+//     private z: string;
+// 
+//     private y: A;
+// 
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// export class A {
+// 
+//     /*GOTO TYPE*/private z: string;
+// 
+//     private y: A;
+// 
+// --- (line: 7) skipped ---
+
+
+
+// === goToType ===
+// === /a.ts ===
+// export class A {
+// 
+//     private z/*GOTO TYPE*/: string;
+// 
+//     private y: A;
+// 
+// --- (line: 7) skipped ---
+
+
+
+// === goToType ===
+// === /a.ts ===
+// <|export class [|A|] {
+// 
+//     private z: string;
+// 
+//     /*GOTO TYPE*/private y: A;
+// 
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// <|export class [|A|] {
+// 
+//     private z: string;
+// 
+//     private y/*GOTO TYPE*/: A;
+// 
+//     readonly x: string;
+// 
+//     async a() {  }
+// 
+//     override b() {}
+// 
+//     public async c() { }
+// }|>
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "A",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 3) skipped ---
+// 
+//     private y: A;
+// 
+//     /*GOTO TYPE*/readonly x: string;
+// 
+//     async a() {  }
+// 
+// --- (line: 11) skipped ---
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 3) skipped ---
+// 
+//     private y: A;
+// 
+//     readonly x/*GOTO TYPE*/: string;
+// 
+//     async a() {  }
+// 
+// --- (line: 11) skipped ---
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 5) skipped ---
+// 
+//     readonly x: string;
+// 
+//     /*GOTO TYPE*/async a() {  }
+// 
+//     override b() {}
+// 
+// --- (line: 13) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 5) skipped ---
+// 
+//     readonly x: string;
+// 
+//     async a/*GOTO TYPE*/() {  }
+// 
+//     override b() {}
+// 
+// --- (line: 13) skipped ---
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     async a() {  }
+// 
+//     /*GOTO TYPE*/<|override [|b|]() {}|>
+// 
+//     public async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "b",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 7) skipped ---
+// 
+//     async a() {  }
+// 
+//     <|override [|b|]/*GOTO TYPE*/() {}|>
+// 
+//     public async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "method",
+    "name": "b",
+    "containerName": "A",
+    "isLocal": false,
+    "isAmbient": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 9) skipped ---
+// 
+//     override b() {}
+// 
+//     /*GOTO TYPE*/public async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 9) skipped ---
+// 
+//     override b() {}
+// 
+//     public/*GOTO TYPE*/ async c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 9) skipped ---
+// 
+//     override b() {}
+// 
+//     public as/*GOTO TYPE*/ync c() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === lib.d.ts ===
+// --- (line: --) skipped ---
+// /**
+//  * Represents the completion of an asynchronous operation
+//  */
+// <|interface [|Promise|]<T> {
+//     /**
+//      * Attaches callbacks for the resolution and/or rejection of the Promise.
+//      * @param onfulfilled The callback to execute when the Promise is resolved.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of which ever callback is executed.
+//      */
+//     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+// 
+//     /**
+//      * Attaches a callback for only the rejection of the Promise.
+//      * @param onrejected The callback to execute when the Promise is rejected.
+//      * @returns A Promise for the completion of the callback.
+//      */
+//     catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+// }|>
+// 
+// /**
+//  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+// --- (line: --) skipped ---
+
+// === /a.ts ===
+// --- (line: 9) skipped ---
+// 
+//     override b() {}
+// 
+//     public async c/*GOTO TYPE*/() { }
+// }
+// 
+// export function foo() { }
+
+  // === Details ===
+  [
+   {
+    "kind": "interface",
+    "name": "Promise",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": true,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 12) skipped ---
+//     public async c() { }
+// }
+// 
+// <|exp/*GOTO TYPE*/ort function [|foo|]() { }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "foo",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.ts ===
+// --- (line: 12) skipped ---
+//     public async c() { }
+// }
+// 
+// <|export function [|foo|]/*GOTO TYPE*/() { }|>
+
+  // === Details ===
+  [
+   {
+    "kind": "function",
+    "name": "foo",
+    "containerName": "\"/a\"",
+    "isLocal": false,
+    "isAmbient": false
+   }
+  ]

--- a/tests/cases/fourslash/goToDefinitionMember.ts
+++ b/tests/cases/fourslash/goToDefinitionMember.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /a.ts
+//// class A {
+////     private z/*z*/: string;
+//// }
+
+verify.baselineGoToDefinition(
+    "z"
+);

--- a/tests/cases/fourslash/goToDefinitionModifiers.ts
+++ b/tests/cases/fourslash/goToDefinitionModifiers.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /a.ts
+//// /*export1*/expo/*export2*/rt/*export3*/ class A {
+//// 
+////     /*private*/private z: string;
+//// 
+////     /*readonly*/readonly x: string;
+//// 
+////     /*async*/async a() {  }
+//// 
+////     /*override*/override b() {}
+//// 
+////     /*public1*/public/*public2*/ as/*multipleModifiers*/ync c() { }
+//// }
+////
+//// exp/**/ort function foo() { }
+
+verify.baselineGoToDefinition(
+    "export1",
+    "export2",
+    "export3",
+    "private",
+    "readonly",
+    "async",
+    "override",
+    "public1",
+    "public2",
+    "multipleModifiers"
+);

--- a/tests/cases/fourslash/goToTypeDefinitionModifiers.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionModifiers.ts
@@ -5,6 +5,8 @@
 //// 
 ////     /*private*/private z/*z*/: string;
 ////
+////     /*private2*/private y/*y*/: A;
+//// 
 ////     /*readonly*/readonly x/*x*/: string;
 //// 
 ////     /*async*/async a/*a*/() {  }
@@ -16,11 +18,13 @@
 ////
 //// exp/*exportFunction*/ort function foo/*foo*/() { }
 
-verify.baselineGoToDefinition(
+verify.baselineGoToType(
     "export",
     "A",
     "private",
     "z",
+    "private2",
+    "y",
     "readonly",
     "x",
     "async",


### PR DESCRIPTION
Fixes #60308.

There are some symbols where goToDef/goToType previously did not return a definition. For those cases, I have not changed the behavior, this PR just makes it so that calling `goTo(Type)Definition` on a modifier will do the same behavior as if the call was triggered on the name.

The first commit refactors some existing `goToDefinition` keyword cases. It may be easier to review by looking at the first commit, and then the rest of the commits without the first one.