### PR TITLE
Add compatible overloads that accept ArrayBuffer to BigInt64Array/BigUint64Array

### DIFF
--- a/src/lib/es2020.bigint.d.ts
+++ b/src/lib/es2020.bigint.d.ts
@@ -373,6 +373,7 @@ interface BigInt64ArrayConstructor {
     new (length?: number): BigInt64Array<ArrayBuffer>;
     new (array: ArrayLike<bigint> | Iterable<bigint>): BigInt64Array<ArrayBuffer>;
     new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): BigInt64Array<TArrayBuffer>;
+    new (array: ArrayLike<bigint> | ArrayBuffer): BigInt64Array<ArrayBuffer>;
 
     /** The size in bytes of each element in the array. */
     readonly BYTES_PER_ELEMENT: number;
@@ -649,6 +650,7 @@ interface BigUint64ArrayConstructor {
     new (length?: number): BigUint64Array<ArrayBuffer>;
     new (array: ArrayLike<bigint> | Iterable<bigint>): BigUint64Array<ArrayBuffer>;
     new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): BigUint64Array<TArrayBuffer>;
+    new (array: ArrayLike<bigint> | ArrayBuffer): BigUint64Array<ArrayBuffer>;
 
     /** The size in bytes of each element in the array. */
     readonly BYTES_PER_ELEMENT: number;

--- a/tests/baselines/reference/bigintWithLib.errors.txt
+++ b/tests/baselines/reference/bigintWithLib.errors.txt
@@ -1,39 +1,41 @@
 bigintWithLib.ts(4,1): error TS2350: Only a void function can be called with the 'new' keyword.
-bigintWithLib.ts(19,33): error TS2769: No overload matches this call.
-  Overload 1 of 3, '(length?: number): BigInt64Array<ArrayBuffer>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'number'.
-  Overload 2 of 3, '(array: ArrayLike<bigint> | Iterable<bigint>): BigInt64Array<ArrayBuffer>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'ArrayLike<bigint> | Iterable<bigint>'.
-      Type 'number[]' is not assignable to type 'Iterable<bigint>'.
-        The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-          Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
-            Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
-              Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.
-                Type 'number' is not assignable to type 'bigint'.
-  Overload 3 of 3, '(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigInt64Array<ArrayBufferLike>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'ArrayBufferLike'.
-      Type 'number[]' is missing the following properties from type 'SharedArrayBuffer': byteLength, [Symbol.species], [Symbol.toStringTag]
+bigintWithLib.ts(19,34): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
+bigintWithLib.ts(19,37): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
+bigintWithLib.ts(19,40): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
 bigintWithLib.ts(24,13): error TS2540: Cannot assign to 'length' because it is a read-only property.
-bigintWithLib.ts(31,35): error TS2769: No overload matches this call.
-  Overload 1 of 3, '(length?: number): BigUint64Array<ArrayBuffer>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'number'.
-  Overload 2 of 3, '(array: ArrayLike<bigint> | Iterable<bigint>): BigUint64Array<ArrayBuffer>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'ArrayLike<bigint> | Iterable<bigint>'.
-      Type 'number[]' is not assignable to type 'Iterable<bigint>'.
-        The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-          Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
-            Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
-              Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.
-                Type 'number' is not assignable to type 'bigint'.
-  Overload 3 of 3, '(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigUint64Array<ArrayBufferLike>', gave the following error.
-    Argument of type 'number[]' is not assignable to parameter of type 'ArrayBufferLike'.
-      Type 'number[]' is missing the following properties from type 'SharedArrayBuffer': byteLength, [Symbol.species], [Symbol.toStringTag]
+bigintWithLib.ts(31,36): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
+bigintWithLib.ts(31,39): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
+bigintWithLib.ts(31,42): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'number' is not assignable to type 'bigint'.
+      Type 'number' is not assignable to type 'bigint'.
+        Type 'number' is not assignable to type 'bigint'.
 bigintWithLib.ts(36,13): error TS2540: Cannot assign to 'length' because it is a read-only property.
 bigintWithLib.ts(43,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'bigint'.
 bigintWithLib.ts(46,26): error TS2345: Argument of type 'number' is not assignable to parameter of type 'bigint'.
 
 
-==== bigintWithLib.ts (7 errors) ====
+==== bigintWithLib.ts (11 errors) ====
     // Test BigInt functions
     let bigintVal: bigint = BigInt(123);
     bigintVal = BigInt("456");
@@ -55,21 +57,27 @@ bigintWithLib.ts(46,26): error TS2345: Argument of type 'number' is not assignab
     bigIntArray = new BigInt64Array(10);
     bigIntArray = new BigInt64Array([1n, 2n, 3n]);
     bigIntArray = new BigInt64Array([1, 2, 3]); // should error
-                                    ~~~~~~~~~
+                                     ~
 !!! error TS2769: No overload matches this call.
-!!! error TS2769:   Overload 1 of 3, '(length?: number): BigInt64Array<ArrayBuffer>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'number'.
-!!! error TS2769:   Overload 2 of 3, '(array: ArrayLike<bigint> | Iterable<bigint>): BigInt64Array<ArrayBuffer>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'ArrayLike<bigint> | Iterable<bigint>'.
-!!! error TS2769:       Type 'number[]' is not assignable to type 'Iterable<bigint>'.
-!!! error TS2769:         The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-!!! error TS2769:           Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
-!!! error TS2769:             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
-!!! error TS2769:               Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.
-!!! error TS2769:                 Type 'number' is not assignable to type 'bigint'.
-!!! error TS2769:   Overload 3 of 3, '(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigInt64Array<ArrayBufferLike>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'ArrayBufferLike'.
-!!! error TS2769:       Type 'number[]' is missing the following properties from type 'SharedArrayBuffer': byteLength, [Symbol.species], [Symbol.toStringTag]
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
+                                        ~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
+                                           ~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
     bigIntArray = new BigInt64Array(new ArrayBuffer(80));
     bigIntArray = new BigInt64Array(new ArrayBuffer(80), 8);
     bigIntArray = new BigInt64Array(new ArrayBuffer(80), 8, 3);
@@ -84,21 +92,27 @@ bigintWithLib.ts(46,26): error TS2345: Argument of type 'number' is not assignab
     bigUintArray = new BigUint64Array(10);
     bigUintArray = new BigUint64Array([1n, 2n, 3n]);
     bigUintArray = new BigUint64Array([1, 2, 3]); // should error
-                                      ~~~~~~~~~
+                                       ~
 !!! error TS2769: No overload matches this call.
-!!! error TS2769:   Overload 1 of 3, '(length?: number): BigUint64Array<ArrayBuffer>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'number'.
-!!! error TS2769:   Overload 2 of 3, '(array: ArrayLike<bigint> | Iterable<bigint>): BigUint64Array<ArrayBuffer>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'ArrayLike<bigint> | Iterable<bigint>'.
-!!! error TS2769:       Type 'number[]' is not assignable to type 'Iterable<bigint>'.
-!!! error TS2769:         The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-!!! error TS2769:           Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
-!!! error TS2769:             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
-!!! error TS2769:               Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.
-!!! error TS2769:                 Type 'number' is not assignable to type 'bigint'.
-!!! error TS2769:   Overload 3 of 3, '(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigUint64Array<ArrayBufferLike>', gave the following error.
-!!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'ArrayBufferLike'.
-!!! error TS2769:       Type 'number[]' is missing the following properties from type 'SharedArrayBuffer': byteLength, [Symbol.species], [Symbol.toStringTag]
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
+                                          ~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
+                                             ~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   The last overload gave the following error.
+!!! error TS2769:     Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:       Type 'number' is not assignable to type 'bigint'.
+!!! error TS2769:         Type 'number' is not assignable to type 'bigint'.
+!!! related TS2771 lib.es2020.bigint.d.ts:--:--: The last overload is declared here.
     bigUintArray = new BigUint64Array(new ArrayBuffer(80));
     bigUintArray = new BigUint64Array(new ArrayBuffer(80), 8);
     bigUintArray = new BigUint64Array(new ArrayBuffer(80), 8, 3);

--- a/tests/cases/compiler/typedArrayConstructorOverloads.ts
+++ b/tests/cases/compiler/typedArrayConstructorOverloads.ts
@@ -1,0 +1,13 @@
+// @target: esnext
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/60367
+
+type TypedArrayConstructor =
+    | Float64ArrayConstructor
+    | BigInt64ArrayConstructor
+
+export function makeTypedArray(buffer: ArrayBuffer, ctr: TypedArrayConstructor) {
+  return new ctr(buffer);
+}


### PR DESCRIPTION
This adds a missing overload common to other typed arrays to ensure BigUint64ArrayConstructor and BigInt64ArrayConstructor are consistent.

Fixes #60367
