### PR TITLE
Use contextual type of the left operand for the right one in assignments to auto-typed class fields

### DIFF
--- a/tests/baselines/reference/classAccessorInitializationInferenceWithElementAccess1.types
+++ b/tests/baselines/reference/classAccessorInitializationInferenceWithElementAccess1.types
@@ -28,8 +28,7 @@ export class Cls {
         this['x'] = [seed];
 >this['x'] = [seed] : number[]
 >                   : ^^^^^^^^
->this['x'] : number[]
->          : ^^^^^^^^
+>this['x'] : any
 >this : this
 >     : ^^^^
 >'x' : "x"
@@ -42,8 +41,7 @@ export class Cls {
         this['y'] = { seed };
 >this['y'] = { seed } : { seed: number; }
 >                     : ^^^^^^^^^^^^^^^^^
->this['y'] : { seed: number; }
->          : ^^^^^^^^^^^^^^^^^
+>this['y'] : any
 >this : this
 >     : ^^^^
 >'y' : "y"
@@ -56,8 +54,7 @@ export class Cls {
         this['z'] = `${seed}`;
 >this['z'] = `${seed}` : string
 >                      : ^^^^^^
->this['z'] : string
->          : ^^^^^^
+>this['z'] : any
 >this : this
 >     : ^^^^
 >'z' : "z"
@@ -70,8 +67,7 @@ export class Cls {
         this[0] = [seed];
 >this[0] = [seed] : number[]
 >                 : ^^^^^^^^
->this[0] : number[]
->        : ^^^^^^^^
+>this[0] : any
 >this : this
 >     : ^^^^
 >0 : 0

--- a/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.errors.txt
+++ b/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.errors.txt
@@ -1,0 +1,43 @@
+classAttributeInferenceContextualTypingOutsideOfConstructor1.ts(16,20): error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+classAttributeInferenceContextualTypingOutsideOfConstructor1.ts(29,20): error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+
+
+==== classAttributeInferenceContextualTypingOutsideOfConstructor1.ts (2 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/60394
+    
+    type State = { type: "running"; speed: number } | { type: "stopped" };
+    
+    declare const initialState: State;
+    
+    class Actor1 {
+      private state;
+    
+      constructor() {
+        this.state = initialState;
+      }
+    
+      run(speed: number) {
+        this.state = { type: "running", speed };
+        this.state = { type: "runnnning", speed }; // error
+                       ~~~~
+!!! error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+!!! related TS6500 classAttributeInferenceContextualTypingOutsideOfConstructor1.ts:3:16: The expected type comes from property 'type' which is declared here on type 'State'
+      }
+    }
+    
+    class Actor2 {
+      accessor state;
+    
+      constructor() {
+        this.state = initialState;
+      }
+    
+      run(speed: number) {
+        this.state = { type: "running", speed };
+        this.state = { type: "runnnning", speed }; // error
+                       ~~~~
+!!! error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+!!! related TS6500 classAttributeInferenceContextualTypingOutsideOfConstructor1.ts:3:16: The expected type comes from property 'type' which is declared here on type 'State'
+      }
+    }
+    

--- a/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.symbols
+++ b/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.symbols
@@ -1,0 +1,83 @@
+//// [tests/cases/compiler/classAttributeInferenceContextualTypingOutsideOfConstructor1.ts] ////
+
+=== classAttributeInferenceContextualTypingOutsideOfConstructor1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60394
+
+type State = { type: "running"; speed: number } | { type: "stopped" };
+>State : Symbol(State, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 0, 0))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 2, 14))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 2, 31))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 2, 51))
+
+declare const initialState: State;
+>initialState : Symbol(initialState, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 13))
+>State : Symbol(State, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 0, 0))
+
+class Actor1 {
+>Actor1 : Symbol(Actor1, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 34))
+
+  private state;
+>state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+
+  constructor() {
+    this.state = initialState;
+>this.state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>this : Symbol(Actor1, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 34))
+>state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>initialState : Symbol(initialState, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 13))
+  }
+
+  run(speed: number) {
+>run : Symbol(Actor1.run, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 11, 3))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 13, 6))
+
+    this.state = { type: "running", speed };
+>this.state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>this : Symbol(Actor1, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 34))
+>state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 14, 18))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 14, 35))
+
+    this.state = { type: "runnnning", speed }; // error
+>this.state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>this : Symbol(Actor1, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 34))
+>state : Symbol(Actor1.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 6, 14))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 15, 18))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 15, 37))
+  }
+}
+
+class Actor2 {
+>Actor2 : Symbol(Actor2, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 17, 1))
+
+  accessor state;
+>state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+
+  constructor() {
+    this.state = initialState;
+>this.state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>this : Symbol(Actor2, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 17, 1))
+>state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>initialState : Symbol(initialState, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 4, 13))
+  }
+
+  run(speed: number) {
+>run : Symbol(Actor2.run, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 24, 3))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 26, 6))
+
+    this.state = { type: "running", speed };
+>this.state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>this : Symbol(Actor2, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 17, 1))
+>state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 27, 18))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 27, 35))
+
+    this.state = { type: "runnnning", speed }; // error
+>this.state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>this : Symbol(Actor2, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 17, 1))
+>state : Symbol(Actor2.state, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 19, 14))
+>type : Symbol(type, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 28, 18))
+>speed : Symbol(speed, Decl(classAttributeInferenceContextualTypingOutsideOfConstructor1.ts, 28, 37))
+  }
+}
+

--- a/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.types
+++ b/tests/baselines/reference/classAttributeInferenceContextualTypingOutsideOfConstructor1.types
@@ -1,0 +1,151 @@
+//// [tests/cases/compiler/classAttributeInferenceContextualTypingOutsideOfConstructor1.ts] ////
+
+=== classAttributeInferenceContextualTypingOutsideOfConstructor1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60394
+
+type State = { type: "running"; speed: number } | { type: "stopped" };
+>State : State
+>      : ^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+>type : "stopped"
+>     : ^^^^^^^^^
+
+declare const initialState: State;
+>initialState : State
+>             : ^^^^^
+
+class Actor1 {
+>Actor1 : Actor1
+>       : ^^^^^^
+
+  private state;
+>state : State
+>      : ^^^^^
+
+  constructor() {
+    this.state = initialState;
+>this.state = initialState : State
+>                          : ^^^^^
+>this.state : any
+>           : ^^^
+>this : this
+>     : ^^^^
+>state : any
+>      : ^^^
+>initialState : State
+>             : ^^^^^
+  }
+
+  run(speed: number) {
+>run : (speed: number) => void
+>    : ^     ^^      ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.state = { type: "running", speed };
+>this.state = { type: "running", speed } : { type: "running"; speed: number; }
+>                                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.state : State
+>           : ^^^^^
+>this : this
+>     : ^^^^
+>state : State
+>      : ^^^^^
+>{ type: "running", speed } : { type: "running"; speed: number; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>"running" : "running"
+>          : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.state = { type: "runnnning", speed }; // error
+>this.state = { type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.state : State
+>           : ^^^^^
+>this : this
+>     : ^^^^
+>state : State
+>      : ^^^^^
+>{ type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "runnnning"
+>     : ^^^^^^^^^^^
+>"runnnning" : "runnnning"
+>            : ^^^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+  }
+}
+
+class Actor2 {
+>Actor2 : Actor2
+>       : ^^^^^^
+
+  accessor state;
+>state : State
+>      : ^^^^^
+
+  constructor() {
+    this.state = initialState;
+>this.state = initialState : State
+>                          : ^^^^^
+>this.state : any
+>           : ^^^
+>this : this
+>     : ^^^^
+>state : any
+>      : ^^^
+>initialState : State
+>             : ^^^^^
+  }
+
+  run(speed: number) {
+>run : (speed: number) => void
+>    : ^     ^^      ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.state = { type: "running", speed };
+>this.state = { type: "running", speed } : { type: "running"; speed: number; }
+>                                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.state : State
+>           : ^^^^^
+>this : this
+>     : ^^^^
+>state : State
+>      : ^^^^^
+>{ type: "running", speed } : { type: "running"; speed: number; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>"running" : "running"
+>          : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.state = { type: "runnnning", speed }; // error
+>this.state = { type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.state : State
+>           : ^^^^^
+>this : this
+>     : ^^^^
+>state : State
+>      : ^^^^^
+>{ type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "runnnning"
+>     : ^^^^^^^^^^^
+>"runnnning" : "runnnning"
+>            : ^^^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+  }
+}
+

--- a/tests/baselines/reference/classAttributeInferenceTemplate.js
+++ b/tests/baselines/reference/classAttributeInferenceTemplate.js
@@ -8,10 +8,10 @@ class MyClass {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }
 
@@ -22,10 +22,10 @@ class MyClass2 {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }
 
@@ -37,9 +37,9 @@ class MyClass {
     property2;
     constructor() {
         const variable = 'something';
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
+        const localProperty = `foo-${variable}`;
     }
 }
 class MyClass2 {
@@ -47,8 +47,8 @@ class MyClass2 {
     accessor property2;
     constructor() {
         const variable = 'something';
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
+        const localProperty = `foo-${variable}`;
     }
 }

--- a/tests/baselines/reference/classAttributeInferenceTemplate.symbols
+++ b/tests/baselines/reference/classAttributeInferenceTemplate.symbols
@@ -14,18 +14,18 @@ class MyClass {
         const variable = 'something'
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 5, 13))
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property : Symbol(MyClass.property, Decl(classAttributeInferenceTemplate.ts, 0, 15))
 >this : Symbol(MyClass, Decl(classAttributeInferenceTemplate.ts, 0, 0))
 >property : Symbol(MyClass.property, Decl(classAttributeInferenceTemplate.ts, 0, 15))
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 : Symbol(MyClass.property2, Decl(classAttributeInferenceTemplate.ts, 1, 13))
 >this : Symbol(MyClass, Decl(classAttributeInferenceTemplate.ts, 0, 0))
 >property2 : Symbol(MyClass.property2, Decl(classAttributeInferenceTemplate.ts, 1, 13))
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 5, 13))
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : Symbol(localProperty, Decl(classAttributeInferenceTemplate.ts, 10, 13))
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 5, 13))
     }
@@ -44,18 +44,18 @@ class MyClass2 {
         const variable = 'something'
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 19, 13))
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property : Symbol(MyClass2.property, Decl(classAttributeInferenceTemplate.ts, 14, 16))
 >this : Symbol(MyClass2, Decl(classAttributeInferenceTemplate.ts, 12, 1))
 >property : Symbol(MyClass2.property, Decl(classAttributeInferenceTemplate.ts, 14, 16))
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 : Symbol(MyClass2.property2, Decl(classAttributeInferenceTemplate.ts, 15, 22))
 >this : Symbol(MyClass2, Decl(classAttributeInferenceTemplate.ts, 12, 1))
 >property2 : Symbol(MyClass2.property2, Decl(classAttributeInferenceTemplate.ts, 15, 22))
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 19, 13))
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : Symbol(localProperty, Decl(classAttributeInferenceTemplate.ts, 24, 13))
 >variable : Symbol(variable, Decl(classAttributeInferenceTemplate.ts, 19, 13))
     }

--- a/tests/baselines/reference/classAttributeInferenceTemplate.types
+++ b/tests/baselines/reference/classAttributeInferenceTemplate.types
@@ -20,33 +20,31 @@ class MyClass {
 >'something' : "something"
 >            : ^^^^^^^^^^^
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property = `foo` : "foo"
 >                      : ^^^^^
->this.property : string
->              : ^^^^^^
+>this.property : any
 >this : this
 >     : ^^^^
->property : string
->         : ^^^^^^
+>property : any
+>         : ^^^
 >`foo` : "foo"
 >      : ^^^^^
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 = `foo-${variable}` : "foo-something"
 >                                   : ^^^^^^^^^^^^^^^
->this.property2 : string
->               : ^^^^^^
+>this.property2 : any
 >this : this
 >     : ^^^^
->property2 : string
->          : ^^^^^^
+>property2 : any
+>          : ^^^
 >`foo-${variable}` : "foo-something"
 >                  : ^^^^^^^^^^^^^^^
 >variable : "something"
 >         : ^^^^^^^^^^^
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : "foo-something"
 >              : ^^^^^^^^^^^^^^^
 >`foo-${variable}` : "foo-something"
@@ -75,33 +73,31 @@ class MyClass2 {
 >'something' : "something"
 >            : ^^^^^^^^^^^
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property = `foo` : "foo"
 >                      : ^^^^^
->this.property : string
->              : ^^^^^^
+>this.property : any
 >this : this
 >     : ^^^^
->property : string
->         : ^^^^^^
+>property : any
+>         : ^^^
 >`foo` : "foo"
 >      : ^^^^^
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 = `foo-${variable}` : "foo-something"
 >                                   : ^^^^^^^^^^^^^^^
->this.property2 : string
->               : ^^^^^^
+>this.property2 : any
 >this : this
 >     : ^^^^
->property2 : string
->          : ^^^^^^
+>property2 : any
+>          : ^^^
 >`foo-${variable}` : "foo-something"
 >                  : ^^^^^^^^^^^^^^^
 >variable : "something"
 >         : ^^^^^^^^^^^
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : "foo-something"
 >              : ^^^^^^^^^^^^^^^
 >`foo-${variable}` : "foo-something"

--- a/tests/baselines/reference/classAttributeInferenceTemplateJS.symbols
+++ b/tests/baselines/reference/classAttributeInferenceTemplateJS.symbols
@@ -14,18 +14,18 @@ class MyClass {
         const variable = 'something'
 >variable : Symbol(variable, Decl(index.js, 5, 13))
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property : Symbol(MyClass.property, Decl(index.js, 0, 15))
 >this : Symbol(MyClass, Decl(index.js, 0, 0))
 >property : Symbol(MyClass.property, Decl(index.js, 0, 15))
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 : Symbol(MyClass.property2, Decl(index.js, 1, 13))
 >this : Symbol(MyClass, Decl(index.js, 0, 0))
 >property2 : Symbol(MyClass.property2, Decl(index.js, 1, 13))
 >variable : Symbol(variable, Decl(index.js, 5, 13))
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : Symbol(localProperty, Decl(index.js, 10, 13))
 >variable : Symbol(variable, Decl(index.js, 5, 13))
     }
@@ -44,18 +44,18 @@ class MyClass2 {
         const variable = 'something'
 >variable : Symbol(variable, Decl(index.js, 19, 13))
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property : Symbol(MyClass2.property, Decl(index.js, 14, 16))
 >this : Symbol(MyClass2, Decl(index.js, 12, 1))
 >property : Symbol(MyClass2.property, Decl(index.js, 14, 16))
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 : Symbol(MyClass2.property2, Decl(index.js, 15, 22))
 >this : Symbol(MyClass2, Decl(index.js, 12, 1))
 >property2 : Symbol(MyClass2.property2, Decl(index.js, 15, 22))
 >variable : Symbol(variable, Decl(index.js, 19, 13))
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : Symbol(localProperty, Decl(index.js, 24, 13))
 >variable : Symbol(variable, Decl(index.js, 19, 13))
     }

--- a/tests/baselines/reference/classAttributeInferenceTemplateJS.types
+++ b/tests/baselines/reference/classAttributeInferenceTemplateJS.types
@@ -20,33 +20,31 @@ class MyClass {
 >'something' : "something"
 >            : ^^^^^^^^^^^
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property = `foo` : "foo"
 >                      : ^^^^^
->this.property : string
->              : ^^^^^^
+>this.property : any
 >this : this
 >     : ^^^^
->property : string
->         : ^^^^^^
+>property : any
+>         : ^^^
 >`foo` : "foo"
 >      : ^^^^^
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 = `foo-${variable}` : "foo-something"
 >                                   : ^^^^^^^^^^^^^^^
->this.property2 : string
->               : ^^^^^^
+>this.property2 : any
 >this : this
 >     : ^^^^
->property2 : string
->          : ^^^^^^
+>property2 : any
+>          : ^^^
 >`foo-${variable}` : "foo-something"
 >                  : ^^^^^^^^^^^^^^^
 >variable : "something"
 >         : ^^^^^^^^^^^
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : "foo-something"
 >              : ^^^^^^^^^^^^^^^
 >`foo-${variable}` : "foo-something"
@@ -75,33 +73,31 @@ class MyClass2 {
 >'something' : "something"
 >            : ^^^^^^^^^^^
 
-        this.property = `foo`; // Correctly inferred as `string`
+        this.property = `foo`;
 >this.property = `foo` : "foo"
 >                      : ^^^^^
->this.property : string
->              : ^^^^^^
+>this.property : any
 >this : this
 >     : ^^^^
->property : string
->         : ^^^^^^
+>property : any
+>         : ^^^
 >`foo` : "foo"
 >      : ^^^^^
 
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property2 = `foo-${variable}`;
 >this.property2 = `foo-${variable}` : "foo-something"
 >                                   : ^^^^^^^^^^^^^^^
->this.property2 : string
->               : ^^^^^^
+>this.property2 : any
 >this : this
 >     : ^^^^
->property2 : string
->          : ^^^^^^
+>property2 : any
+>          : ^^^
 >`foo-${variable}` : "foo-something"
 >                  : ^^^^^^^^^^^^^^^
 >variable : "something"
 >         : ^^^^^^^^^^^
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
 >localProperty : "foo-something"
 >              : ^^^^^^^^^^^^^^^
 >`foo-${variable}` : "foo-something"

--- a/tests/baselines/reference/classAttributeInferenceUncheckedJs1.symbols
+++ b/tests/baselines/reference/classAttributeInferenceUncheckedJs1.symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/classAttributeInferenceUncheckedJs1.ts] ////
+
+=== classAttributeInferenceUncheckedJs1.js ===
+class C1 {
+>C1 : Symbol(C1, Decl(classAttributeInferenceUncheckedJs1.js, 0, 0))
+
+    bar;
+>bar : Symbol(C1.bar, Decl(classAttributeInferenceUncheckedJs1.js, 0, 10))
+
+    constructor () {
+        this.foo;
+>this : Symbol(C1, Decl(classAttributeInferenceUncheckedJs1.js, 0, 0))
+
+        this.bar;
+>this.bar : Symbol(C1.bar, Decl(classAttributeInferenceUncheckedJs1.js, 0, 10))
+>this : Symbol(C1, Decl(classAttributeInferenceUncheckedJs1.js, 0, 0))
+>bar : Symbol(C1.bar, Decl(classAttributeInferenceUncheckedJs1.js, 0, 10))
+    }
+}
+
+class C2 {
+>C2 : Symbol(C2, Decl(classAttributeInferenceUncheckedJs1.js, 6, 1))
+
+    #bar;
+>#bar : Symbol(C2.#bar, Decl(classAttributeInferenceUncheckedJs1.js, 8, 10))
+
+    constructor () {
+        this.#foo;
+>this : Symbol(C2, Decl(classAttributeInferenceUncheckedJs1.js, 6, 1))
+
+        this.#bar;
+>this.#bar : Symbol(C2.#bar, Decl(classAttributeInferenceUncheckedJs1.js, 8, 10))
+>this : Symbol(C2, Decl(classAttributeInferenceUncheckedJs1.js, 6, 1))
+    }
+}
+

--- a/tests/baselines/reference/classAttributeInferenceUncheckedJs1.types
+++ b/tests/baselines/reference/classAttributeInferenceUncheckedJs1.types
@@ -1,0 +1,49 @@
+//// [tests/cases/compiler/classAttributeInferenceUncheckedJs1.ts] ////
+
+=== classAttributeInferenceUncheckedJs1.js ===
+class C1 {
+>C1 : C1
+>   : ^^
+
+    bar;
+>bar : any
+
+    constructor () {
+        this.foo;
+>this.foo : error
+>this : this
+>     : ^^^^
+>foo : any
+>    : ^^^
+
+        this.bar;
+>this.bar : undefined
+>         : ^^^^^^^^^
+>this : this
+>     : ^^^^
+>bar : undefined
+>    : ^^^^^^^^^
+    }
+}
+
+class C2 {
+>C2 : C2
+>   : ^^
+
+    #bar;
+>#bar : any
+
+    constructor () {
+        this.#foo;
+>this.#foo : error
+>this : this
+>     : ^^^^
+
+        this.#bar;
+>this.#bar : undefined
+>          : ^^^^^^^^^
+>this : this
+>     : ^^^^
+    }
+}
+

--- a/tests/baselines/reference/classPropInitializationInferenceWithElementAccess.types
+++ b/tests/baselines/reference/classPropInitializationInferenceWithElementAccess.types
@@ -29,8 +29,7 @@ export class Cls {
         this['x'] = [seed];
 >this['x'] = [seed] : number[]
 >                   : ^^^^^^^^
->this['x'] : number[]
->          : ^^^^^^^^
+>this['x'] : any
 >this : this
 >     : ^^^^
 >'x' : "x"
@@ -43,8 +42,7 @@ export class Cls {
         this['y'] = { seed };
 >this['y'] = { seed } : { seed: number; }
 >                     : ^^^^^^^^^^^^^^^^^
->this['y'] : { seed: number; }
->          : ^^^^^^^^^^^^^^^^^
+>this['y'] : any
 >this : this
 >     : ^^^^
 >'y' : "y"
@@ -57,8 +55,7 @@ export class Cls {
         this['z'] = `${seed}`;
 >this['z'] = `${seed}` : string
 >                      : ^^^^^^
->this['z'] : string
->          : ^^^^^^
+>this['z'] : any
 >this : this
 >     : ^^^^
 >'z' : "z"
@@ -71,8 +68,7 @@ export class Cls {
         this[0] = [seed];
 >this[0] = [seed] : number[]
 >                 : ^^^^^^^^
->this[0] : number[]
->        : ^^^^^^^^
+>this[0] : any
 >this : this
 >     : ^^^^
 >0 : 0

--- a/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.errors.txt
+++ b/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.errors.txt
@@ -1,0 +1,41 @@
+classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts(14,27): error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts(27,27): error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+
+
+==== classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts (2 errors) ====
+    type State = { type: "running"; speed: number } | { type: "stopped" };
+    
+    declare const initialState: State;
+    
+    class Actor1 {
+      static initialState;
+    
+      static {
+        this.initialState = initialState;
+      }
+    
+      static setAsInitiallyRunning(speed: number) {
+        this.initialState = { type: "running", speed };
+        this.initialState = { type: "runnnning", speed }; // error
+                              ~~~~
+!!! error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+!!! related TS6500 classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts:1:16: The expected type comes from property 'type' which is declared here on type 'State'
+      }
+    }
+    
+    class Actor2 {
+      static accessor initialState;
+    
+      static {
+        this.initialState = initialState;
+      }
+    
+      static setAsInitiallyRunning(speed: number) {
+        this.initialState = { type: "running", speed };
+        this.initialState = { type: "runnnning", speed }; // error
+                              ~~~~
+!!! error TS2820: Type '"runnnning"' is not assignable to type '"running" | "stopped"'. Did you mean '"running"'?
+!!! related TS6500 classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts:1:16: The expected type comes from property 'type' which is declared here on type 'State'
+      }
+    }
+    

--- a/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.symbols
+++ b/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.symbols
@@ -1,0 +1,81 @@
+//// [tests/cases/conformance/classes/classStaticBlock/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts] ////
+
+=== classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts ===
+type State = { type: "running"; speed: number } | { type: "stopped" };
+>State : Symbol(State, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 0, 0))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 0, 14))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 0, 31))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 0, 51))
+
+declare const initialState: State;
+>initialState : Symbol(initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 13))
+>State : Symbol(State, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 0, 0))
+
+class Actor1 {
+>Actor1 : Symbol(Actor1, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 34))
+
+  static initialState;
+>initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+
+  static {
+    this.initialState = initialState;
+>this.initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>this : Symbol(Actor1, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 34))
+>initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>initialState : Symbol(initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 13))
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+>setAsInitiallyRunning : Symbol(Actor1.setAsInitiallyRunning, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 9, 3))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 11, 31))
+
+    this.initialState = { type: "running", speed };
+>this.initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>this : Symbol(Actor1, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 34))
+>initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 12, 25))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 12, 42))
+
+    this.initialState = { type: "runnnning", speed }; // error
+>this.initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>this : Symbol(Actor1, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 34))
+>initialState : Symbol(Actor1.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 4, 14))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 13, 25))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 13, 44))
+  }
+}
+
+class Actor2 {
+>Actor2 : Symbol(Actor2, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 15, 1))
+
+  static accessor initialState;
+>initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+
+  static {
+    this.initialState = initialState;
+>this.initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>this : Symbol(Actor2, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 15, 1))
+>initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>initialState : Symbol(initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 2, 13))
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+>setAsInitiallyRunning : Symbol(Actor2.setAsInitiallyRunning, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 22, 3))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 24, 31))
+
+    this.initialState = { type: "running", speed };
+>this.initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>this : Symbol(Actor2, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 15, 1))
+>initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 25, 25))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 25, 42))
+
+    this.initialState = { type: "runnnning", speed }; // error
+>this.initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>this : Symbol(Actor2, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 15, 1))
+>initialState : Symbol(Actor2.initialState, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 17, 14))
+>type : Symbol(type, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 26, 25))
+>speed : Symbol(speed, Decl(classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts, 26, 44))
+  }
+}
+

--- a/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.types
+++ b/tests/baselines/reference/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.types
@@ -1,0 +1,149 @@
+//// [tests/cases/conformance/classes/classStaticBlock/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts] ////
+
+=== classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts ===
+type State = { type: "running"; speed: number } | { type: "stopped" };
+>State : State
+>      : ^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+>type : "stopped"
+>     : ^^^^^^^^^
+
+declare const initialState: State;
+>initialState : State
+>             : ^^^^^
+
+class Actor1 {
+>Actor1 : Actor1
+>       : ^^^^^^
+
+  static initialState;
+>initialState : State
+>             : ^^^^^
+
+  static {
+    this.initialState = initialState;
+>this.initialState = initialState : State
+>                                 : ^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor1
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>initialState : State
+>             : ^^^^^
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+>setAsInitiallyRunning : (speed: number) => void
+>                      : ^     ^^      ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.initialState = { type: "running", speed };
+>this.initialState = { type: "running", speed } : { type: "running"; speed: number; }
+>                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor1
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>{ type: "running", speed } : { type: "running"; speed: number; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>"running" : "running"
+>          : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.initialState = { type: "runnnning", speed }; // error
+>this.initialState = { type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor1
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>{ type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "runnnning"
+>     : ^^^^^^^^^^^
+>"runnnning" : "runnnning"
+>            : ^^^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+  }
+}
+
+class Actor2 {
+>Actor2 : Actor2
+>       : ^^^^^^
+
+  static accessor initialState;
+>initialState : State
+>             : ^^^^^
+
+  static {
+    this.initialState = initialState;
+>this.initialState = initialState : State
+>                                 : ^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor2
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>initialState : State
+>             : ^^^^^
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+>setAsInitiallyRunning : (speed: number) => void
+>                      : ^     ^^      ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.initialState = { type: "running", speed };
+>this.initialState = { type: "running", speed } : { type: "running"; speed: number; }
+>                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor2
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>{ type: "running", speed } : { type: "running"; speed: number; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "running"
+>     : ^^^^^^^^^
+>"running" : "running"
+>          : ^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+
+    this.initialState = { type: "runnnning", speed }; // error
+>this.initialState = { type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.initialState : State
+>                  : ^^^^^
+>this : typeof Actor2
+>     : ^^^^^^^^^^^^^
+>initialState : State
+>             : ^^^^^
+>{ type: "runnnning", speed } : { type: "runnnning"; speed: number; }
+>                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : "runnnning"
+>     : ^^^^^^^^^^^
+>"runnnning" : "runnnning"
+>            : ^^^^^^^^^^^
+>speed : number
+>      : ^^^^^^
+  }
+}
+

--- a/tests/baselines/reference/controlFlowAutoAccessor1.types
+++ b/tests/baselines/reference/controlFlowAutoAccessor1.types
@@ -16,12 +16,12 @@ class Example {
     this.test = test;
 >this.test = test : number
 >                 : ^^^^^^
->this.test : number
->          : ^^^^^^
+>this.test : any
+>          : ^^^
 >this : this
 >     : ^^^^
->test : number
->     : ^^^^^^
+>test : any
+>     : ^^^
 >test : number
 >     : ^^^^^^
   }
@@ -55,12 +55,12 @@ class Example2 {
     this.test = test;
 >this.test = test : number | undefined
 >                 : ^^^^^^^^^^^^^^^^^^
->this.test : number | undefined
->          : ^^^^^^^^^^^^^^^^^^
+>this.test : any
+>          : ^^^
 >this : this
 >     : ^^^^
->test : number | undefined
->     : ^^^^^^^^^^^^^^^^^^
+>test : any
+>     : ^^^
 >test : number | undefined
 >     : ^^^^^^^^^^^^^^^^^^
   }
@@ -108,12 +108,12 @@ class Example3 {
     this.value = n;
 >this.value = n : number
 >               : ^^^^^^
->this.value : number | null
->           : ^^^^^^^^^^^^^
+>this.value : any
+>           : ^^^
 >this : this
 >     : ^^^^
->value : number | null
->      : ^^^^^^^^^^^^^
+>value : any
+>      : ^^^
 >n : number
 >  : ^^^^^^
 
@@ -128,12 +128,12 @@ class Example3 {
       this.value = null;
 >this.value = null : null
 >                  : ^^^^
->this.value : number | null
->           : ^^^^^^^^^^^^^
+>this.value : any
+>           : ^^^
 >this : this
 >     : ^^^^
->value : number | null
->      : ^^^^^^^^^^^^^
+>value : any
+>      : ^^^
     }
   }
 }

--- a/tests/baselines/reference/controlFlowPrivateClassField.types
+++ b/tests/baselines/reference/controlFlowPrivateClassField.types
@@ -16,8 +16,7 @@ class Example {
         this.#test = test;
 >this.#test = test : number
 >                  : ^^^^^^
->this.#test : number
->           : ^^^^^^
+>this.#test : any
 >this : this
 >     : ^^^^
 >test : number
@@ -51,8 +50,7 @@ class Example2 {
         this.#test = test;
 >this.#test = test : number | undefined
 >                  : ^^^^^^^^^^^^^^^^^^
->this.#test : number | undefined
->           : ^^^^^^^^^^^^^^^^^^
+>this.#test : any
 >this : this
 >     : ^^^^
 >test : number | undefined

--- a/tests/baselines/reference/genericSetterInClassTypeJsDoc.types
+++ b/tests/baselines/reference/genericSetterInClassTypeJsDoc.types
@@ -20,8 +20,7 @@
         this.#value = initialValue;
 >this.#value = initialValue : T
 >                           : ^
->this.#value : T
->            : ^
+>this.#value : any
 >this : this
 >     : ^^^^
 >initialValue : T

--- a/tests/baselines/reference/privateNameUncheckedJsOptionalChain.types
+++ b/tests/baselines/reference/privateNameUncheckedJsOptionalChain.types
@@ -17,8 +17,8 @@ class C {
 >     : ^^^^
 
         this?.#bar;
->this?.#bar : any
->           : ^^^
+>this?.#bar : undefined
+>           : ^^^^^^^^^
 >this : this
 >     : ^^^^
     }

--- a/tests/cases/compiler/classAttributeInferenceContextualTypingOutsideOfConstructor1.ts
+++ b/tests/cases/compiler/classAttributeInferenceContextualTypingOutsideOfConstructor1.ts
@@ -1,0 +1,35 @@
+// @strict: true
+// @noEmit: true
+// @target: esnext
+
+// https://github.com/microsoft/TypeScript/issues/60394
+
+type State = { type: "running"; speed: number } | { type: "stopped" };
+
+declare const initialState: State;
+
+class Actor1 {
+  private state;
+
+  constructor() {
+    this.state = initialState;
+  }
+
+  run(speed: number) {
+    this.state = { type: "running", speed };
+    this.state = { type: "runnnning", speed }; // error
+  }
+}
+
+class Actor2 {
+  accessor state;
+
+  constructor() {
+    this.state = initialState;
+  }
+
+  run(speed: number) {
+    this.state = { type: "running", speed };
+    this.state = { type: "runnnning", speed }; // error
+  }
+}

--- a/tests/cases/compiler/classAttributeInferenceTemplate.ts
+++ b/tests/cases/compiler/classAttributeInferenceTemplate.ts
@@ -7,10 +7,10 @@ class MyClass {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }
 
@@ -21,9 +21,9 @@ class MyClass2 {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }

--- a/tests/cases/compiler/classAttributeInferenceTemplateJS.ts
+++ b/tests/cases/compiler/classAttributeInferenceTemplateJS.ts
@@ -10,10 +10,10 @@ class MyClass {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }
 
@@ -24,9 +24,9 @@ class MyClass2 {
     constructor() {
         const variable = 'something'
 
-        this.property = `foo`; // Correctly inferred as `string`
-        this.property2 = `foo-${variable}`; // Causes an error
+        this.property = `foo`;
+        this.property2 = `foo-${variable}`;
 
-        const localProperty = `foo-${variable}`; // Correctly inferred as `string`
+        const localProperty = `foo-${variable}`;
     }
 }

--- a/tests/cases/compiler/classAttributeInferenceUncheckedJs1.ts
+++ b/tests/cases/compiler/classAttributeInferenceUncheckedJs1.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @checkJs: false
+// @noEmit: true
+// @Filename: classAttributeInferenceUncheckedJs1.js
+// @target: es2015
+
+class C1 {
+    bar;
+    constructor () {
+        this.foo;
+        this.bar;
+    }
+}
+
+class C2 {
+    #bar;
+    constructor () {
+        this.#foo;
+        this.#bar;
+    }
+}

--- a/tests/cases/conformance/classes/classStaticBlock/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts
+++ b/tests/cases/conformance/classes/classStaticBlock/classStaticFieldInferenceContextualTypingOutsideOfStaticBlock1.ts
@@ -1,0 +1,33 @@
+// @strict: true
+// @noEmit: true
+// @target: esnext
+
+type State = { type: "running"; speed: number } | { type: "stopped" };
+
+declare const initialState: State;
+
+class Actor1 {
+  static initialState;
+
+  static {
+    this.initialState = initialState;
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+    this.initialState = { type: "running", speed };
+    this.initialState = { type: "runnnning", speed }; // error
+  }
+}
+
+class Actor2 {
+  static accessor initialState;
+
+  static {
+    this.initialState = initialState;
+  }
+
+  static setAsInitiallyRunning(speed: number) {
+    this.initialState = { type: "running", speed };
+    this.initialState = { type: "runnnning", speed }; // error
+  }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60394