### PR TITLE
Allow imports with the same names as global types to be moved by refactoring

### DIFF
--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -885,7 +885,7 @@ export function getUsageInfo(oldFile: SourceFile, toMove: readonly Statement[], 
     const unusedImportsFromOldFile = new Set<Symbol>();
     for (const statement of toMove) {
         forEachReference(statement, checker, enclosingRange, (symbol, isValidTypeOnlyUseSite) => {
-            if (!symbol.declarations || isGlobalType(checker, symbol)) {
+            if (!symbol.declarations) {
                 return;
             }
             if (existingTargetLocals.has(skipAlias(symbol, checker))) {
@@ -900,7 +900,7 @@ export function getUsageInfo(oldFile: SourceFile, toMove: readonly Statement[], 
                         tryCast(decl, (d): d is codefix.ImportOrRequireAliasDeclaration => isImportSpecifier(d) || isImportClause(d) || isNamespaceImport(d) || isImportEqualsDeclaration(d) || isBindingElement(d) || isVariableDeclaration(d)),
                     ]);
                 }
-                else if (isTopLevelDeclaration(decl) && sourceFileOfTopLevelDeclaration(decl) === oldFile && !movedSymbols.has(symbol)) {
+                else if (!isGlobalType(checker, symbol) && isTopLevelDeclaration(decl) && sourceFileOfTopLevelDeclaration(decl) === oldFile && !movedSymbols.has(symbol)) {
                     targetFileImportsFromOldFile.set(symbol, isValidTypeOnlyUseSite);
                 }
             }

--- a/tests/cases/fourslash/moveToNewFile_importNameLikeGlobal1.ts
+++ b/tests/cases/fourslash/moveToNewFile_importNameLikeGlobal1.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @lib: dom
+
+// @Filename: /a.ts
+//// export default class Event {}
+
+// @Filename: /b.ts
+//// import Event from './a.js';
+//// [|export function test(test: Event): void {}|]
+
+verify.noErrors();
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/b.ts": "",
+
+        "/test.ts":
+`import Event from './a';
+
+export function test(test: Event): void { }
+`,
+    },
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60408

cc @iisaduan 