### PR TITLE
[work in progress] Make enum literal type identical to the union of its values

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21549,7 +21549,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         else if (!((source.flags | target.flags) & (TypeFlags.UnionOrIntersection | TypeFlags.IndexedAccess | TypeFlags.Conditional | TypeFlags.Substitution))) {
             // We have excluded types that may simplify to other forms, so types must have identical flags
-            if (source.flags !== target.flags) return false;
+            if ((source.flags | TypeFlags.EnumLiteral) !== (target.flags | TypeFlags.EnumLiteral)) return false;
             if (source.flags & TypeFlags.Singleton) return true;
         }
         if (source.flags & TypeFlags.Object && target.flags & TypeFlags.Object) {
@@ -22037,7 +22037,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (source === target) return Ternary.True;
 
             if (relation === identityRelation) {
-                if (source.flags !== target.flags) return Ternary.False;
+                if ((source.flags | TypeFlags.EnumLiteral) !== (target.flags | TypeFlags.EnumLiteral)) return Ternary.False;
                 if (source.flags & TypeFlags.Singleton) return Ternary.True;
                 traceUnionsOrIntersectionsTooLarge(source, target);
                 return recursiveTypeRelatedTo(source, target, /*reportErrors*/ false, IntersectionState.None, recursionFlags);

--- a/tests/baselines/reference/identityRelationEnumTypes.js
+++ b/tests/baselines/reference/identityRelationEnumTypes.js
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/identityRelationEnumTypes.ts] ////
+
+//// [identityRelationEnumTypes.ts]
+namespace identityRelationEnumTypes {
+    export type Equals<A, B> = (<T>() => T extends B ? 1 : 0) extends (<T>() => T extends A ? 1 : 0) ? true : false;
+
+    export enum Enum {
+        A = 'a',
+        B = 'b',
+    }
+
+    export type EnumValues = typeof Enum[keyof typeof Enum];
+}
+
+type Result = identityRelationEnumTypes.Equals<
+    identityRelationEnumTypes.Enum,
+    identityRelationEnumTypes.EnumValues
+>;  // true
+
+
+//// [identityRelationEnumTypes.js]
+"use strict";
+var identityRelationEnumTypes;
+(function (identityRelationEnumTypes) {
+    var Enum;
+    (function (Enum) {
+        Enum["A"] = "a";
+        Enum["B"] = "b";
+    })(Enum = identityRelationEnumTypes.Enum || (identityRelationEnumTypes.Enum = {}));
+})(identityRelationEnumTypes || (identityRelationEnumTypes = {}));
+
+
+//// [identityRelationEnumTypes.d.ts]
+declare namespace identityRelationEnumTypes {
+    type Equals<A, B> = (<T>() => T extends B ? 1 : 0) extends (<T>() => T extends A ? 1 : 0) ? true : false;
+    enum Enum {
+        A = "a",
+        B = "b"
+    }
+    type EnumValues = typeof Enum[keyof typeof Enum];
+}
+type Result = identityRelationEnumTypes.Equals<identityRelationEnumTypes.Enum, identityRelationEnumTypes.EnumValues>;

--- a/tests/baselines/reference/identityRelationEnumTypes.symbols
+++ b/tests/baselines/reference/identityRelationEnumTypes.symbols
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/identityRelationEnumTypes.ts] ////
+
+=== identityRelationEnumTypes.ts ===
+namespace identityRelationEnumTypes {
+>identityRelationEnumTypes : Symbol(identityRelationEnumTypes, Decl(identityRelationEnumTypes.ts, 0, 0))
+
+    export type Equals<A, B> = (<T>() => T extends B ? 1 : 0) extends (<T>() => T extends A ? 1 : 0) ? true : false;
+>Equals : Symbol(Equals, Decl(identityRelationEnumTypes.ts, 0, 37))
+>A : Symbol(A, Decl(identityRelationEnumTypes.ts, 1, 23))
+>B : Symbol(B, Decl(identityRelationEnumTypes.ts, 1, 25))
+>T : Symbol(T, Decl(identityRelationEnumTypes.ts, 1, 33))
+>T : Symbol(T, Decl(identityRelationEnumTypes.ts, 1, 33))
+>B : Symbol(B, Decl(identityRelationEnumTypes.ts, 1, 25))
+>T : Symbol(T, Decl(identityRelationEnumTypes.ts, 1, 72))
+>T : Symbol(T, Decl(identityRelationEnumTypes.ts, 1, 72))
+>A : Symbol(A, Decl(identityRelationEnumTypes.ts, 1, 23))
+
+    export enum Enum {
+>Enum : Symbol(Enum, Decl(identityRelationEnumTypes.ts, 1, 116))
+
+        A = 'a',
+>A : Symbol(Enum.A, Decl(identityRelationEnumTypes.ts, 3, 22))
+
+        B = 'b',
+>B : Symbol(Enum.B, Decl(identityRelationEnumTypes.ts, 4, 16))
+    }
+
+    export type EnumValues = typeof Enum[keyof typeof Enum];
+>EnumValues : Symbol(EnumValues, Decl(identityRelationEnumTypes.ts, 6, 5))
+>Enum : Symbol(Enum, Decl(identityRelationEnumTypes.ts, 1, 116))
+>Enum : Symbol(Enum, Decl(identityRelationEnumTypes.ts, 1, 116))
+}
+
+type Result = identityRelationEnumTypes.Equals<
+>Result : Symbol(Result, Decl(identityRelationEnumTypes.ts, 9, 1))
+>identityRelationEnumTypes : Symbol(identityRelationEnumTypes, Decl(identityRelationEnumTypes.ts, 0, 0))
+>Equals : Symbol(identityRelationEnumTypes.Equals, Decl(identityRelationEnumTypes.ts, 0, 37))
+
+    identityRelationEnumTypes.Enum,
+>identityRelationEnumTypes : Symbol(identityRelationEnumTypes, Decl(identityRelationEnumTypes.ts, 0, 0))
+>Enum : Symbol(identityRelationEnumTypes.Enum, Decl(identityRelationEnumTypes.ts, 1, 116))
+
+    identityRelationEnumTypes.EnumValues
+>identityRelationEnumTypes : Symbol(identityRelationEnumTypes, Decl(identityRelationEnumTypes.ts, 0, 0))
+>EnumValues : Symbol(identityRelationEnumTypes.EnumValues, Decl(identityRelationEnumTypes.ts, 6, 5))
+
+>;  // true
+

--- a/tests/baselines/reference/identityRelationEnumTypes.types
+++ b/tests/baselines/reference/identityRelationEnumTypes.types
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/identityRelationEnumTypes.ts] ////
+
+=== identityRelationEnumTypes.ts ===
+namespace identityRelationEnumTypes {
+>identityRelationEnumTypes : typeof identityRelationEnumTypes
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    export type Equals<A, B> = (<T>() => T extends B ? 1 : 0) extends (<T>() => T extends A ? 1 : 0) ? true : false;
+>Equals : Equals<A, B>
+>       : ^^^^^^^^^^^^
+>true : true
+>     : ^^^^
+>false : false
+>      : ^^^^^
+
+    export enum Enum {
+>Enum : Enum
+>     : ^^^^
+
+        A = 'a',
+>A : Enum.A
+>  : ^^^^^^
+>'a' : "a"
+>    : ^^^
+
+        B = 'b',
+>B : Enum.B
+>  : ^^^^^^
+>'b' : "b"
+>    : ^^^
+    }
+
+    export type EnumValues = typeof Enum[keyof typeof Enum];
+>EnumValues : EnumValues
+>           : ^^^^^^^^^^
+>Enum : typeof Enum
+>     : ^^^^^^^^^^^
+>Enum : typeof Enum
+>     : ^^^^^^^^^^^
+}
+
+type Result = identityRelationEnumTypes.Equals<
+>Result : true
+>       : ^^^^
+>identityRelationEnumTypes : any
+>                          : ^^^
+
+    identityRelationEnumTypes.Enum,
+>identityRelationEnumTypes : any
+>                          : ^^^
+
+    identityRelationEnumTypes.EnumValues
+>identityRelationEnumTypes : any
+>                          : ^^^
+
+>;  // true
+

--- a/tests/cases/compiler/identityRelationEnumTypes.ts
+++ b/tests/cases/compiler/identityRelationEnumTypes.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @declaration: true
+
+namespace identityRelationEnumTypes {
+    export type Equals<A, B> = (<T>() => T extends B ? 1 : 0) extends (<T>() => T extends A ? 1 : 0) ? true : false;
+
+    export enum Enum {
+        A = 'a',
+        B = 'b',
+    }
+
+    export type EnumValues = typeof Enum[keyof typeof Enum];
+}
+
+type Result = identityRelationEnumTypes.Equals<
+    identityRelationEnumTypes.Enum,
+    identityRelationEnumTypes.EnumValues
+>;  // true


### PR DESCRIPTION
- Proof of concept. Passes all existing test cases and Airtable codebase ("Identicality" checks are probably quite rare so unsurprising). Creating this in the hopes that we can use the test infra on this repo to run this against the corpus of other open source libraries.
- TODO: Reimplement by normalizing `EnumLiteral` types in `isTypeRelatedTo`/`isRelatedTo` checks instead of current approach.

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**) 
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change


Fixes https://github.com/mmkal/expect-type/issues/33
Fixes https://github.com/microsoft/TypeScript/issues/46112
