### PR TITLE
Fix union of callable signatures with any parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13698,6 +13698,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (shorter === right) {
                 shorterParamType = instantiateType(shorterParamType, mapper);
             }
+            if (tryGetTypeAtPosition(shorter, i)) {
+                // Remove one any type from union params, if both params exists
+                if (longestParamType.flags & TypeFlags.Any) {
+                    longestParamType = unknownType;
+                }
+                else if (shorterParamType.flags & TypeFlags.Any) {
+                    shorterParamType = unknownType;
+                }
+            }
             const unionParamType = getIntersectionType([longestParamType, shorterParamType]);
             const isRestParam = eitherHasEffectiveRest && !needsExtraRestElement && i === (longestCount - 1);
             const isOptional = i >= getMinArgumentCount(longest) && i >= getMinArgumentCount(shorter);

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -35,9 +35,16 @@ unionTypeCallSignatures.ts(63,12): error TS2554: Expected 2 arguments, but got 0
 unionTypeCallSignatures.ts(69,45): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
 unionTypeCallSignatures.ts(70,12): error TS2555: Expected at least 1 arguments, but got 0.
 unionTypeCallSignatures.ts(73,12): error TS2554: Expected 2 arguments, but got 1.
+unionTypeCallSignatures.ts(78,24): error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'.
+unionTypeCallSignatures.ts(82,24): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+unionTypeCallSignatures.ts(83,33): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+unionTypeCallSignatures.ts(84,24): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+unionTypeCallSignatures.ts(89,24): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+unionTypeCallSignatures.ts(90,33): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+unionTypeCallSignatures.ts(94,24): error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'.
 
 
-==== unionTypeCallSignatures.ts (28 errors) ====
+==== unionTypeCallSignatures.ts (35 errors) ====
     var numOrDate: number | Date;
     var strOrBoolean: string | boolean;
     var strOrNum: string | number;
@@ -191,4 +198,38 @@ unionTypeCallSignatures.ts(73,12): error TS2554: Expected 2 arguments, but got 1
 !!! error TS2554: Expected 2 arguments, but got 1.
 !!! related TS6210 unionTypeCallSignatures.ts:72:76: An argument for 'b' was not provided.
     strOrNum = unionWithRestParameter4("hello", "world");
+    
+    var unionWithAnyParameter1: { (a: string): void; } | { (a: any): void; };
+    unionWithAnyParameter1('hello');
+    unionWithAnyParameter1({}); // wrong argument type
+                           ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'.
+    
+    var unionWithAnyParameter2: { (a: string, b: any): void; } | { (a: any, b: number): void; };
+    unionWithAnyParameter2('hello', 10);
+    unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+                           ~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+    unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+                                    ~~~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+    unionWithAnyParameter2(10, 10); // error wrong argument type
+                           ~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+    
+    var unionWithAnyParameter3: { (a: string | number, b: any): void; } | { (...a: string[]): void; };
+    unionWithAnyParameter3('hello', 'hello');
+    unionWithAnyParameter3('hello', 'hello', 'hello');
+    unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+                           ~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+    unionWithAnyParameter3('hello', 10); // error wrong argument type
+                                    ~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+    
+    var unionWithAnyParameter4: { (a: string, b: any): void; } | { (a: any): void; };
+    unionWithAnyParameter4('hello', {}); 
+    unionWithAnyParameter4({}, {}); // error wrong argument type 
+                           ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'.
     

--- a/tests/baselines/reference/unionTypeCallSignatures.js
+++ b/tests/baselines/reference/unionTypeCallSignatures.js
@@ -76,6 +76,26 @@ var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: st
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
 
+var unionWithAnyParameter1: { (a: string): void; } | { (a: any): void; };
+unionWithAnyParameter1('hello');
+unionWithAnyParameter1({}); // wrong argument type
+
+var unionWithAnyParameter2: { (a: string, b: any): void; } | { (a: any, b: number): void; };
+unionWithAnyParameter2('hello', 10);
+unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+unionWithAnyParameter2(10, 10); // error wrong argument type
+
+var unionWithAnyParameter3: { (a: string | number, b: any): void; } | { (...a: string[]): void; };
+unionWithAnyParameter3('hello', 'hello');
+unionWithAnyParameter3('hello', 'hello', 'hello');
+unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+unionWithAnyParameter3('hello', 10); // error wrong argument type
+
+var unionWithAnyParameter4: { (a: string, b: any): void; } | { (a: any): void; };
+unionWithAnyParameter4('hello', {}); 
+unionWithAnyParameter4({}, {}); // error wrong argument type 
+
 
 //// [unionTypeCallSignatures.js]
 var numOrDate;
@@ -140,3 +160,19 @@ strOrNum = unionWithRestParameter3(); // error no call signature
 var unionWithRestParameter4;
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
+var unionWithAnyParameter1;
+unionWithAnyParameter1('hello');
+unionWithAnyParameter1({}); // wrong argument type
+var unionWithAnyParameter2;
+unionWithAnyParameter2('hello', 10);
+unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+unionWithAnyParameter2(10, 10); // error wrong argument type
+var unionWithAnyParameter3;
+unionWithAnyParameter3('hello', 'hello');
+unionWithAnyParameter3('hello', 'hello', 'hello');
+unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+unionWithAnyParameter3('hello', 10); // error wrong argument type
+var unionWithAnyParameter4;
+unionWithAnyParameter4('hello', {});
+unionWithAnyParameter4({}, {}); // error wrong argument type 

--- a/tests/baselines/reference/unionTypeCallSignatures.symbols
+++ b/tests/baselines/reference/unionTypeCallSignatures.symbols
@@ -260,3 +260,63 @@ strOrNum = unionWithRestParameter4("hello", "world");
 >strOrNum : Symbol(strOrNum, Decl(unionTypeCallSignatures.ts, 2, 3))
 >unionWithRestParameter4 : Symbol(unionWithRestParameter4, Decl(unionTypeCallSignatures.ts, 71, 3))
 
+var unionWithAnyParameter1: { (a: string): void; } | { (a: any): void; };
+>unionWithAnyParameter1 : Symbol(unionWithAnyParameter1, Decl(unionTypeCallSignatures.ts, 75, 3))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 75, 31))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 75, 56))
+
+unionWithAnyParameter1('hello');
+>unionWithAnyParameter1 : Symbol(unionWithAnyParameter1, Decl(unionTypeCallSignatures.ts, 75, 3))
+
+unionWithAnyParameter1({}); // wrong argument type
+>unionWithAnyParameter1 : Symbol(unionWithAnyParameter1, Decl(unionTypeCallSignatures.ts, 75, 3))
+
+var unionWithAnyParameter2: { (a: string, b: any): void; } | { (a: any, b: number): void; };
+>unionWithAnyParameter2 : Symbol(unionWithAnyParameter2, Decl(unionTypeCallSignatures.ts, 79, 3))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 79, 31))
+>b : Symbol(b, Decl(unionTypeCallSignatures.ts, 79, 41))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 79, 64))
+>b : Symbol(b, Decl(unionTypeCallSignatures.ts, 79, 71))
+
+unionWithAnyParameter2('hello', 10);
+>unionWithAnyParameter2 : Symbol(unionWithAnyParameter2, Decl(unionTypeCallSignatures.ts, 79, 3))
+
+unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+>unionWithAnyParameter2 : Symbol(unionWithAnyParameter2, Decl(unionTypeCallSignatures.ts, 79, 3))
+
+unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+>unionWithAnyParameter2 : Symbol(unionWithAnyParameter2, Decl(unionTypeCallSignatures.ts, 79, 3))
+
+unionWithAnyParameter2(10, 10); // error wrong argument type
+>unionWithAnyParameter2 : Symbol(unionWithAnyParameter2, Decl(unionTypeCallSignatures.ts, 79, 3))
+
+var unionWithAnyParameter3: { (a: string | number, b: any): void; } | { (...a: string[]): void; };
+>unionWithAnyParameter3 : Symbol(unionWithAnyParameter3, Decl(unionTypeCallSignatures.ts, 85, 3))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 85, 31))
+>b : Symbol(b, Decl(unionTypeCallSignatures.ts, 85, 50))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 85, 73))
+
+unionWithAnyParameter3('hello', 'hello');
+>unionWithAnyParameter3 : Symbol(unionWithAnyParameter3, Decl(unionTypeCallSignatures.ts, 85, 3))
+
+unionWithAnyParameter3('hello', 'hello', 'hello');
+>unionWithAnyParameter3 : Symbol(unionWithAnyParameter3, Decl(unionTypeCallSignatures.ts, 85, 3))
+
+unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+>unionWithAnyParameter3 : Symbol(unionWithAnyParameter3, Decl(unionTypeCallSignatures.ts, 85, 3))
+
+unionWithAnyParameter3('hello', 10); // error wrong argument type
+>unionWithAnyParameter3 : Symbol(unionWithAnyParameter3, Decl(unionTypeCallSignatures.ts, 85, 3))
+
+var unionWithAnyParameter4: { (a: string, b: any): void; } | { (a: any): void; };
+>unionWithAnyParameter4 : Symbol(unionWithAnyParameter4, Decl(unionTypeCallSignatures.ts, 91, 3))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 91, 31))
+>b : Symbol(b, Decl(unionTypeCallSignatures.ts, 91, 41))
+>a : Symbol(a, Decl(unionTypeCallSignatures.ts, 91, 64))
+
+unionWithAnyParameter4('hello', {}); 
+>unionWithAnyParameter4 : Symbol(unionWithAnyParameter4, Decl(unionTypeCallSignatures.ts, 91, 3))
+
+unionWithAnyParameter4({}, {}); // error wrong argument type 
+>unionWithAnyParameter4 : Symbol(unionWithAnyParameter4, Decl(unionTypeCallSignatures.ts, 91, 3))
+

--- a/tests/baselines/reference/unionTypeCallSignatures.types
+++ b/tests/baselines/reference/unionTypeCallSignatures.types
@@ -653,3 +653,161 @@ strOrNum = unionWithRestParameter4("hello", "world");
 >"world" : "world"
 >        : ^^^^^^^
 
+var unionWithAnyParameter1: { (a: string): void; } | { (a: any): void; };
+>unionWithAnyParameter1 : ((a: string) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>a : string
+>  : ^^^^^^
+>a : any
+>  : ^^^
+
+unionWithAnyParameter1('hello');
+>unionWithAnyParameter1('hello') : void
+>                                : ^^^^
+>unionWithAnyParameter1 : ((a: string) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter1({}); // wrong argument type
+>unionWithAnyParameter1({}) : void
+>                           : ^^^^
+>unionWithAnyParameter1 : ((a: string) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>{} : {}
+>   : ^^
+
+var unionWithAnyParameter2: { (a: string, b: any): void; } | { (a: any, b: number): void; };
+>unionWithAnyParameter2 : ((a: string, b: any) => void) | ((a: any, b: number) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^ ^^      ^^^^^    ^
+>a : string
+>  : ^^^^^^
+>b : any
+>  : ^^^
+>a : any
+>  : ^^^
+>b : number
+>  : ^^^^^^
+
+unionWithAnyParameter2('hello', 10);
+>unionWithAnyParameter2('hello', 10) : void
+>                                    : ^^^^
+>unionWithAnyParameter2 : ((a: string, b: any) => void) | ((a: any, b: number) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^ ^^      ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>10 : 10
+>   : ^^
+
+unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+>unionWithAnyParameter2(10, 'hello') : void
+>                                    : ^^^^
+>unionWithAnyParameter2 : ((a: string, b: any) => void) | ((a: any, b: number) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^ ^^      ^^^^^    ^
+>10 : 10
+>   : ^^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+>unionWithAnyParameter2('hello', 'hello') : void
+>                                         : ^^^^
+>unionWithAnyParameter2 : ((a: string, b: any) => void) | ((a: any, b: number) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^ ^^      ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter2(10, 10); // error wrong argument type
+>unionWithAnyParameter2(10, 10) : void
+>                               : ^^^^
+>unionWithAnyParameter2 : ((a: string, b: any) => void) | ((a: any, b: number) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^ ^^      ^^^^^    ^
+>10 : 10
+>   : ^^
+>10 : 10
+>   : ^^
+
+var unionWithAnyParameter3: { (a: string | number, b: any): void; } | { (...a: string[]): void; };
+>unionWithAnyParameter3 : ((a: string | number, b: any) => void) | ((...a: string[]) => void)
+>                       : ^^ ^^               ^^ ^^   ^^^^^    ^^^^^^^^^ ^^        ^^^^^    ^
+>a : string | number
+>  : ^^^^^^^^^^^^^^^
+>b : any
+>  : ^^^
+>a : string[]
+>  : ^^^^^^^^
+
+unionWithAnyParameter3('hello', 'hello');
+>unionWithAnyParameter3('hello', 'hello') : void
+>                                         : ^^^^
+>unionWithAnyParameter3 : ((a: string | number, b: any) => void) | ((...a: string[]) => void)
+>                       : ^^ ^^               ^^ ^^   ^^^^^    ^^^^^^^^^ ^^        ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter3('hello', 'hello', 'hello');
+>unionWithAnyParameter3('hello', 'hello', 'hello') : void
+>                                                  : ^^^^
+>unionWithAnyParameter3 : ((a: string | number, b: any) => void) | ((...a: string[]) => void)
+>                       : ^^ ^^               ^^ ^^   ^^^^^    ^^^^^^^^^ ^^        ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>'hello' : "hello"
+>        : ^^^^^^^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+>unionWithAnyParameter3(10, 'hello') : void
+>                                    : ^^^^
+>unionWithAnyParameter3 : ((a: string | number, b: any) => void) | ((...a: string[]) => void)
+>                       : ^^ ^^               ^^ ^^   ^^^^^    ^^^^^^^^^ ^^        ^^^^^    ^
+>10 : 10
+>   : ^^
+>'hello' : "hello"
+>        : ^^^^^^^
+
+unionWithAnyParameter3('hello', 10); // error wrong argument type
+>unionWithAnyParameter3('hello', 10) : void
+>                                    : ^^^^
+>unionWithAnyParameter3 : ((a: string | number, b: any) => void) | ((...a: string[]) => void)
+>                       : ^^ ^^               ^^ ^^   ^^^^^    ^^^^^^^^^ ^^        ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>10 : 10
+>   : ^^
+
+var unionWithAnyParameter4: { (a: string, b: any): void; } | { (a: any): void; };
+>unionWithAnyParameter4 : ((a: string, b: any) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>a : string
+>  : ^^^^^^
+>b : any
+>  : ^^^
+>a : any
+>  : ^^^
+
+unionWithAnyParameter4('hello', {}); 
+>unionWithAnyParameter4('hello', {}) : void
+>                                    : ^^^^
+>unionWithAnyParameter4 : ((a: string, b: any) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>'hello' : "hello"
+>        : ^^^^^^^
+>{} : {}
+>   : ^^
+
+unionWithAnyParameter4({}, {}); // error wrong argument type 
+>unionWithAnyParameter4({}, {}) : void
+>                               : ^^^^
+>unionWithAnyParameter4 : ((a: string, b: any) => void) | ((a: any) => void)
+>                       : ^^ ^^      ^^ ^^   ^^^^^    ^^^^^^ ^^   ^^^^^    ^
+>{} : {}
+>   : ^^
+>{} : {}
+>   : ^^
+

--- a/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
+++ b/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
@@ -72,3 +72,23 @@ strOrNum = unionWithRestParameter3(); // error no call signature
 var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
+
+var unionWithAnyParameter1: { (a: string): void; } | { (a: any): void; };
+unionWithAnyParameter1('hello');
+unionWithAnyParameter1({}); // wrong argument type
+
+var unionWithAnyParameter2: { (a: string, b: any): void; } | { (a: any, b: number): void; };
+unionWithAnyParameter2('hello', 10);
+unionWithAnyParameter2(10, 'hello'); // error wrong arguments types
+unionWithAnyParameter2('hello', 'hello'); // error wrong argument type
+unionWithAnyParameter2(10, 10); // error wrong argument type
+
+var unionWithAnyParameter3: { (a: string | number, b: any): void; } | { (...a: string[]): void; };
+unionWithAnyParameter3('hello', 'hello');
+unionWithAnyParameter3('hello', 'hello', 'hello');
+unionWithAnyParameter3(10, 'hello'); // error wrong argument type
+unionWithAnyParameter3('hello', 10); // error wrong argument type
+
+var unionWithAnyParameter4: { (a: string, b: any): void; } | { (a: any): void; };
+unionWithAnyParameter4('hello', {}); 
+unionWithAnyParameter4({}, {}); // error wrong argument type 

--- a/tests/cases/fourslash/calledUnionsOfDissimilarTyeshaveGoodDisplay.ts
+++ b/tests/cases/fourslash/calledUnionsOfDissimilarTyeshaveGoodDisplay.ts
@@ -41,7 +41,34 @@
 ////    ;
 ////
 ////callableThing5(/*5*/1)
-////
+//// 
+//// declare const callableThing6:
+////     | ((a: string) => void)
+////     | ((a: string, b: number) => void)
+////     ;
+//// 
+//// callableThing6(/*6*/);
+//// 
+//// declare const callableThing7:
+////     | ((a: string) => void)
+////     | ((a: any) => void)
+////     ;
+//// 
+//// callableThing7(/*7*/);
+//// 
+//// declare const callableThing8:
+////     | ((a: string, b: any) => void)
+////     | ((a: any, b: number) => void)
+////     ;
+//// 
+//// callableThing8(/*8*/);
+//// 
+//// declare const callableThing9:
+////     | ((a: string, b: any) => void)
+////     | ((a: any) => void)
+////     ;
+//// 
+//// callableThing9(/*9*/);
 
 verify.signatureHelp({
     marker: "1",
@@ -62,4 +89,20 @@ verify.signatureHelp({
 {
     marker: "5",
     text: "callableThing5(a1: number): void"
+},
+{
+    marker: "6",
+    text: "callableThing6(a: string, b: number): void"
+},
+{
+    marker: "7",
+    text: "callableThing7(a: string): void"
+},
+{
+    marker: "8",
+    text: "callableThing8(a: string, b: number): void"
+},
+{
+    marker: "9",
+    text: "callableThing9(a: string, b: any): void"
 });


### PR DESCRIPTION
Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Fixes #46713
See: https://github.com/microsoft/TypeScript/issues/46713#issuecomment-2459556768

Description:
`any` type is ignored when intersecting two parameters in union of callables