### PR TITLE
Enable supply chain security through npm provenance attestation

### DIFF
--- a/.github/workflows/insiders.yaml
+++ b/.github/workflows/insiders.yaml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  packages: write
 
 # Ensure scripts are run with pipefail. See:
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
@@ -60,6 +62,6 @@ jobs:
           npx hereby configure-insiders
           npx hereby LKG
           node ./scripts/addPackageJsonGitHead.mjs package.json
-          npm publish --tag insiders
+          npm publish --provenance --tag insiders
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  packages: write
 
 # Ensure scripts are run with pipefail. See:
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
@@ -60,6 +62,6 @@ jobs:
           npx hereby configure-nightly
           npx hereby LKG
           node ./scripts/addPackageJsonGitHead.mjs package.json
-          npm publish --tag next
+          npm publish --provenance --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
- Configure GitHub Actions workflow for secure publishing
- Enable automatic provenance generation during npm publish
- Add integrity verification through Sigstore transparency logs


Fixes #60497
