### PR TITLE
Fix #60479 - Change the behavior of tsc on a tsconfig solution

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -3048,6 +3048,11 @@ function parseJsonConfigFileContentWorker(
     function getConfigFileSpecs(): ConfigFileSpecs {
         const referencesOfRaw = getPropFromRaw<ProjectReference>("references", element => typeof element === "object", "object");
         const filesSpecs = toPropValue(getSpecsFromRaw("files"));
+        if (options.noEmit && filesSpecs && filesSpecs.length === 0 && isArray(referencesOfRaw) && referencesOfRaw.length > 0) {
+            errors.push(
+                createCompilerDiagnostic(Diagnostics.Detected_empty_files_with_references_use_tsc_b)
+            );
+        }
         if (filesSpecs) {
             const hasZeroOrNoReferences = referencesOfRaw === "no-prop" || isArray(referencesOfRaw) && referencesOfRaw.length === 0;
             const hasExtends = hasProperty(raw, "extends");

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -8246,6 +8246,11 @@
         "code": 95197
     },
 
+    "Detected_empty_files_with_references_use_tsc_b": {
+        "category": "Message",
+        "code": 95200
+    },
+
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",
         "code": 18004


### PR DESCRIPTION
**Fix #60479** Diagnostic warning for `tsc --noEmit` when using solution-style `tsconfig.json`

#### Summary

This PR adds a diagnostic warning when `tsc` is run with `--noEmit` in a solution-style setup where `tsconfig.json` has:
- `noEmit` set to `true`
- An empty `files` array
- Project `references` defined

#### Context

The motivation for this change is to help users avoid a common point of confusion. With this configuration, many users expect `tsc` to handle project references, but `--noEmit` prevents any output, and until now, `tsc` hasn’t shown any guidance. The new warning suggests using `tsc -b`, which is the recommended command for managing builds with project references.

#### Changes Made

1. **New Diagnostic Message:** Adds a warning when `noEmit` is set to true with `files: []` and `references` defined, suggesting the use of `tsc -b`.
   - Message: `"Detected an empty 'files' array with project 'references'. Consider using 'tsc -b' for correct handling of project references."`

2. **Files Updated:**
   - `commandLineParser.ts`: Adds logic to check for the misconfiguration and issue the new diagnostic.
   - `diagnosticMessages.json`: Adds the new diagnostic message.

#### Example

For a setup like this:

```json
{
    "compilerOptions": {
        "noEmit": true
    },
    "files": [],
    "references": [
        { "path": "./lib" }
    ]
}
```

Running `tsc --noEmit` will now output the following warning:
```
Detected an empty 'files' array with project 'references'. Consider using 'tsc -b' for correct handling of project references.
```

