### PR TITLE
fix(60505): Convert to namespace import refactoring should drop file extensions on namespace name

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -4061,7 +4061,7 @@ export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: Scri
 
 /** @internal */
 export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget | undefined, forceCapitalize?: boolean): string {
-    const baseName = getBaseFileName(removeSuffix(moduleSpecifier, "/index"));
+    const baseName = getBaseFileName(removeSuffix(removeFileExtension(moduleSpecifier), "/index"));
     let res = "";
     let lastCharWasValid = true;
     const firstCharCode = baseName.charCodeAt(0);

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace11.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace11.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @checkJs: true
+
+// @filename: /a.js
+/////*a*/import { a } from "./foo.js";/*b*/
+////a;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert import",
+    actionName: "Convert named imports to namespace import",
+    actionDescription: "Convert named imports to namespace import",
+    newContent:
+`import * as foo from "./foo.js";
+foo.a;`,
+});


### PR DESCRIPTION
Fixes #60505