### PR TITLE
Always use `nonFixingMapper` in `instantiateSignatureInContextOf`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35092,8 +35092,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // We clone the inferenceContext to avoid fixing. For example, when the source signature is <T>(x: T) => T[] and
         // the contextual signature is (...args: A) => B, we want to infer the element type of A's constraint (say 'any')
         // for T but leave it possible to later infer '[any]' back to A.
-        const restType = getEffectiveRestType(contextualSignature);
-        const mapper = inferenceContext && (restType && restType.flags & TypeFlags.TypeParameter ? inferenceContext.nonFixingMapper : inferenceContext.mapper);
+        const mapper = inferenceContext?.nonFixingMapper;
         const sourceSignature = mapper ? instantiateSignature(contextualSignature, mapper) : contextualSignature;
         applyToParameterTypes(sourceSignature, signature, (source, target) => {
             // Type parameters from outer context referenced by source type are fixed by instantiation of the source type

--- a/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
+++ b/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
@@ -3,16 +3,18 @@ contextualSignatureInstantiation.ts(19,13): error TS2345: Argument of type '<T>(
   Types of parameters 'y' and 'y' are incompatible.
     Type 'string' is not assignable to type 'number'.
 contextualSignatureInstantiation.ts(20,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'unknown'.
-contextualSignatureInstantiation.ts(20,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+contextualSignatureInstantiation.ts(20,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: "one") => number'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'string' is not assignable to type 'number'.
 contextualSignatureInstantiation.ts(21,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'unknown'.
-contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: number) => string'.
+contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: 1) => string'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'number' is not assignable to type 'string'.
+contextualSignatureInstantiation.ts(27,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'number'.
+contextualSignatureInstantiation.ts(28,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'number'.
 
 
-==== contextualSignatureInstantiation.ts (6 errors) ====
+==== contextualSignatureInstantiation.ts (8 errors) ====
     // TypeScript Spec, section 4.12.2:
     // If e is an expression of a function type that contains exactly one generic call signature and no other members,
     // and T is a function type with exactly one non - generic call signature and no other members, then any inferences
@@ -44,7 +46,7 @@ contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '<T>(
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'unknown'.
 !!! related TS6203 contextualSignatureInstantiation.ts:18:5: 'b' was also declared here.
                           ~
-!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: "one") => number'.
 !!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
 !!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var b = bar("one", 1, g);  // Error, number and string are disjoint types
@@ -52,10 +54,22 @@ contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '<T>(
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'unknown'.
 !!! related TS6203 contextualSignatureInstantiation.ts:18:5: 'b' was also declared here.
                           ~
-!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: number) => string'.
+!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: 1) => string'.
 !!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type 'string'.
     var b = baz(b, b, g);      // Should be number | string
+    
+    var one: 1 = 1
+    var num: number = 10;
+    
+    var b = bar(one, num, g);  // ok
+        ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'number'.
+!!! related TS6203 contextualSignatureInstantiation.ts:18:5: 'b' was also declared here.
+    var b = bar(num, one, g);  // ok
+        ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'b' must be of type 'string | number', but here has type 'number'.
+!!! related TS6203 contextualSignatureInstantiation.ts:18:5: 'b' was also declared here.
     
     var d: number[] | string[];
     var d = foo(h);            // Should be number[] | string[]

--- a/tests/baselines/reference/contextualSignatureInstantiation.js
+++ b/tests/baselines/reference/contextualSignatureInstantiation.js
@@ -24,6 +24,12 @@ var b = bar(1, "one", g);  // Error, number and string are disjoint types
 var b = bar("one", 1, g);  // Error, number and string are disjoint types
 var b = baz(b, b, g);      // Should be number | string
 
+var one: 1 = 1
+var num: number = 10;
+
+var b = bar(one, num, g);  // ok
+var b = bar(num, one, g);  // ok
+
 var d: number[] | string[];
 var d = foo(h);            // Should be number[] | string[]
 var d = bar(1, "one", h);  // Should be number[] | string[]
@@ -45,6 +51,10 @@ var b = foo(g); // Error, number and string are disjoint types
 var b = bar(1, "one", g); // Error, number and string are disjoint types
 var b = bar("one", 1, g); // Error, number and string are disjoint types
 var b = baz(b, b, g); // Should be number | string
+var one = 1;
+var num = 10;
+var b = bar(one, num, g); // ok
+var b = bar(num, one, g); // ok
 var d;
 var d = foo(h); // Should be number[] | string[]
 var d = bar(1, "one", h); // Should be number[] | string[]

--- a/tests/baselines/reference/contextualSignatureInstantiation.symbols
+++ b/tests/baselines/reference/contextualSignatureInstantiation.symbols
@@ -83,52 +83,72 @@ var a = baz(1, 1, g);      // Should be number
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
 var b: number | string;
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
 
 var b = foo(g);            // Error, number and string are disjoint types
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
 >foo : Symbol(foo, Decl(contextualSignatureInstantiation.ts, 0, 0))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
 var b = bar(1, "one", g);  // Error, number and string are disjoint types
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
 var b = bar("one", 1, g);  // Error, number and string are disjoint types
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
 var b = baz(b, b, g);      // Should be number | string
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
 >baz : Symbol(baz, Decl(contextualSignatureInstantiation.ts, 7, 68))
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
->b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
+>g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
+
+var one: 1 = 1
+>one : Symbol(one, Decl(contextualSignatureInstantiation.ts, 23, 3))
+
+var num: number = 10;
+>num : Symbol(num, Decl(contextualSignatureInstantiation.ts, 24, 3))
+
+var b = bar(one, num, g);  // ok
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
+>bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
+>one : Symbol(one, Decl(contextualSignatureInstantiation.ts, 23, 3))
+>num : Symbol(num, Decl(contextualSignatureInstantiation.ts, 24, 3))
+>g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
+
+var b = bar(num, one, g);  // ok
+>b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3) ... and 2 more)
+>bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
+>num : Symbol(num, Decl(contextualSignatureInstantiation.ts, 24, 3))
+>one : Symbol(one, Decl(contextualSignatureInstantiation.ts, 23, 3))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
 var d: number[] | string[];
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 
 var d = foo(h);            // Should be number[] | string[]
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 >foo : Symbol(foo, Decl(contextualSignatureInstantiation.ts, 0, 0))
 >h : Symbol(h, Decl(contextualSignatureInstantiation.ts, 10, 37))
 
 var d = bar(1, "one", h);  // Should be number[] | string[]
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >h : Symbol(h, Decl(contextualSignatureInstantiation.ts, 10, 37))
 
 var d = bar("one", 1, h);  // Should be number[] | string[]
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >h : Symbol(h, Decl(contextualSignatureInstantiation.ts, 10, 37))
 
 var d = baz(d, d, g);      // Should be number[] | string[]
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 >baz : Symbol(baz, Decl(contextualSignatureInstantiation.ts, 7, 68))
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
->d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 23, 3), Decl(contextualSignatureInstantiation.ts, 24, 3), Decl(contextualSignatureInstantiation.ts, 25, 3), Decl(contextualSignatureInstantiation.ts, 26, 3), Decl(contextualSignatureInstantiation.ts, 27, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
+>d : Symbol(d, Decl(contextualSignatureInstantiation.ts, 29, 3), Decl(contextualSignatureInstantiation.ts, 30, 3), Decl(contextualSignatureInstantiation.ts, 31, 3), Decl(contextualSignatureInstantiation.ts, 32, 3), Decl(contextualSignatureInstantiation.ts, 33, 3))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 

--- a/tests/baselines/reference/contextualSignatureInstantiation.types
+++ b/tests/baselines/reference/contextualSignatureInstantiation.types
@@ -149,6 +149,46 @@ var b = baz(b, b, g);      // Should be number | string
 >g : <T>(x: T, y: T) => T
 >  : ^ ^^ ^^ ^^ ^^ ^^^^^ 
 
+var one: 1 = 1
+>one : 1
+>    : ^
+>1 : 1
+>  : ^
+
+var num: number = 10;
+>num : number
+>    : ^^^^^^
+>10 : 10
+>   : ^^
+
+var b = bar(one, num, g);  // ok
+>b : string | number
+>  : ^^^^^^^^^^^^^^^
+>bar(one, num, g) : number
+>                 : ^^^^^^
+>bar : <T, U, V>(x: T, y: U, cb: (x: T, y: U) => V) => V
+>    : ^ ^^ ^^ ^^ ^^ ^^ ^^ ^^  ^^                 ^^^^^ 
+>one : 1
+>    : ^
+>num : number
+>    : ^^^^^^
+>g : <T>(x: T, y: T) => T
+>  : ^ ^^ ^^ ^^ ^^ ^^^^^ 
+
+var b = bar(num, one, g);  // ok
+>b : string | number
+>  : ^^^^^^^^^^^^^^^
+>bar(num, one, g) : number
+>                 : ^^^^^^
+>bar : <T, U, V>(x: T, y: U, cb: (x: T, y: U) => V) => V
+>    : ^ ^^ ^^ ^^ ^^ ^^ ^^ ^^  ^^                 ^^^^^ 
+>num : number
+>    : ^^^^^^
+>one : 1
+>    : ^
+>g : <T>(x: T, y: T) => T
+>  : ^ ^^ ^^ ^^ ^^ ^^^^^ 
+
 var d: number[] | string[];
 >d : number[] | string[]
 >  : ^^^^^^^^^^^^^^^^^^^

--- a/tests/baselines/reference/contextualSignatureInstantiation5.symbols
+++ b/tests/baselines/reference/contextualSignatureInstantiation5.symbols
@@ -1,0 +1,87 @@
+//// [tests/cases/compiler/contextualSignatureInstantiation5.ts] ////
+
+=== contextualSignatureInstantiation5.ts ===
+// https://github.com/microsoft/TypeScript/issues/60552
+
+declare function fooooooo<
+>fooooooo : Symbol(fooooooo, Decl(contextualSignatureInstantiation5.ts, 0, 0))
+
+  T,
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 2, 26))
+
+  Result extends ArrayLike<unknown>,
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 3, 4))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+
+  Extra extends readonly unknown[],
+>Extra : Symbol(Extra, Decl(contextualSignatureInstantiation5.ts, 4, 36))
+
+>(
+  input: T,
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 6, 2))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 2, 26))
+
+  callback: (input: T, prev: Result, ...extra: Extra) => Result,
+>callback : Symbol(callback, Decl(contextualSignatureInstantiation5.ts, 7, 11))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 8, 13))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 2, 26))
+>prev : Symbol(prev, Decl(contextualSignatureInstantiation5.ts, 8, 22))
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 3, 4))
+>extra : Symbol(extra, Decl(contextualSignatureInstantiation5.ts, 8, 36))
+>Extra : Symbol(Extra, Decl(contextualSignatureInstantiation5.ts, 4, 36))
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 3, 4))
+
+  extra: Extra,
+>extra : Symbol(extra, Decl(contextualSignatureInstantiation5.ts, 8, 64))
+>Extra : Symbol(Extra, Decl(contextualSignatureInstantiation5.ts, 4, 36))
+
+): Result;
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 3, 4))
+
+declare function baaaaaar<T, Result extends ArrayLike<unknown>>(
+>baaaaaar : Symbol(baaaaaar, Decl(contextualSignatureInstantiation5.ts, 10, 10))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 12, 26))
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 12, 28))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+
+  input: T,
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 12, 64))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 12, 26))
+
+  callback: (input: T, prev: Result) => Result,
+>callback : Symbol(callback, Decl(contextualSignatureInstantiation5.ts, 13, 11))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 14, 13))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 12, 26))
+>prev : Symbol(prev, Decl(contextualSignatureInstantiation5.ts, 14, 22))
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 12, 28))
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 12, 28))
+
+): Result;
+>Result : Symbol(Result, Decl(contextualSignatureInstantiation5.ts, 12, 28))
+
+declare function callback<T>(input: T, prev: string[]): string[];
+>callback : Symbol(callback, Decl(contextualSignatureInstantiation5.ts, 15, 10))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 17, 26))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 17, 29))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 17, 26))
+>prev : Symbol(prev, Decl(contextualSignatureInstantiation5.ts, 17, 38))
+
+export function example<T>(input: T) {
+>example : Symbol(example, Decl(contextualSignatureInstantiation5.ts, 17, 65))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 19, 24))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 19, 27))
+>T : Symbol(T, Decl(contextualSignatureInstantiation5.ts, 19, 24))
+
+  const result1 = fooooooo(input, callback, []); // ok
+>result1 : Symbol(result1, Decl(contextualSignatureInstantiation5.ts, 20, 7))
+>fooooooo : Symbol(fooooooo, Decl(contextualSignatureInstantiation5.ts, 0, 0))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 19, 27))
+>callback : Symbol(callback, Decl(contextualSignatureInstantiation5.ts, 15, 10))
+
+  const result2 = baaaaaar(input, callback); // ok
+>result2 : Symbol(result2, Decl(contextualSignatureInstantiation5.ts, 21, 7))
+>baaaaaar : Symbol(baaaaaar, Decl(contextualSignatureInstantiation5.ts, 10, 10))
+>input : Symbol(input, Decl(contextualSignatureInstantiation5.ts, 19, 27))
+>callback : Symbol(callback, Decl(contextualSignatureInstantiation5.ts, 15, 10))
+}
+

--- a/tests/baselines/reference/contextualSignatureInstantiation5.types
+++ b/tests/baselines/reference/contextualSignatureInstantiation5.types
@@ -1,0 +1,92 @@
+//// [tests/cases/compiler/contextualSignatureInstantiation5.ts] ////
+
+=== contextualSignatureInstantiation5.ts ===
+// https://github.com/microsoft/TypeScript/issues/60552
+
+declare function fooooooo<
+>fooooooo : <T, Result extends ArrayLike<unknown>, Extra extends readonly unknown[]>(input: T, callback: (input: T, prev: Result, ...extra: Extra) => Result, extra: Extra) => Result
+>         : ^ ^^      ^^^^^^^^^                  ^^     ^^^^^^^^^                  ^^     ^^ ^^        ^^                                                   ^^     ^^     ^^^^^      
+
+  T,
+  Result extends ArrayLike<unknown>,
+  Extra extends readonly unknown[],
+>(
+  input: T,
+>input : T
+>      : ^
+
+  callback: (input: T, prev: Result, ...extra: Extra) => Result,
+>callback : (input: T, prev: Result, ...extra: Extra) => Result
+>         : ^     ^^ ^^    ^^      ^^^^^     ^^     ^^^^^      
+>input : T
+>      : ^
+>prev : Result
+>     : ^^^^^^
+>extra : Extra
+>      : ^^^^^
+
+  extra: Extra,
+>extra : Extra
+>      : ^^^^^
+
+): Result;
+
+declare function baaaaaar<T, Result extends ArrayLike<unknown>>(
+>baaaaaar : <T, Result extends ArrayLike<unknown>>(input: T, callback: (input: T, prev: Result) => Result) => Result
+>         : ^ ^^      ^^^^^^^^^                  ^^     ^^ ^^        ^^                                  ^^^^^      
+
+  input: T,
+>input : T
+>      : ^
+
+  callback: (input: T, prev: Result) => Result,
+>callback : (input: T, prev: Result) => Result
+>         : ^     ^^ ^^    ^^      ^^^^^      
+>input : T
+>      : ^
+>prev : Result
+>     : ^^^^^^
+
+): Result;
+
+declare function callback<T>(input: T, prev: string[]): string[];
+>callback : <T>(input: T, prev: string[]) => string[]
+>         : ^ ^^     ^^ ^^    ^^        ^^^^^        
+>input : T
+>      : ^
+>prev : string[]
+>     : ^^^^^^^^
+
+export function example<T>(input: T) {
+>example : <T>(input: T) => void
+>        : ^ ^^     ^^ ^^^^^^^^^
+>input : T
+>      : ^
+
+  const result1 = fooooooo(input, callback, []); // ok
+>result1 : string[]
+>        : ^^^^^^^^
+>fooooooo(input, callback, []) : string[]
+>                              : ^^^^^^^^
+>fooooooo : <T_1, Result extends ArrayLike<unknown>, Extra extends readonly unknown[]>(input: T_1, callback: (input: T_1, prev: Result, ...extra: Extra) => Result, extra: Extra) => Result
+>         : ^^^^^^      ^^^^^^^^^                  ^^     ^^^^^^^^^                  ^^     ^^   ^^        ^^                                                     ^^     ^^     ^^^^^      
+>input : T
+>      : ^
+>callback : <T_1>(input: T_1, prev: string[]) => string[]
+>         : ^^^^^^     ^^   ^^    ^^        ^^^^^        
+>[] : []
+>   : ^^
+
+  const result2 = baaaaaar(input, callback); // ok
+>result2 : string[]
+>        : ^^^^^^^^
+>baaaaaar(input, callback) : string[]
+>                          : ^^^^^^^^
+>baaaaaar : <T_1, Result extends ArrayLike<unknown>>(input: T_1, callback: (input: T_1, prev: Result) => Result) => Result
+>         : ^^^^^^      ^^^^^^^^^                  ^^     ^^   ^^        ^^                                    ^^^^^      
+>input : T
+>      : ^
+>callback : <T_1>(input: T_1, prev: string[]) => string[]
+>         : ^^^^^^     ^^   ^^    ^^        ^^^^^        
+}
+

--- a/tests/baselines/reference/nonInferrableTypePropagation2.types
+++ b/tests/baselines/reference/nonInferrableTypePropagation2.types
@@ -92,8 +92,8 @@ const x = pipe(es, filter(exists((n) => n > 0)))
 >     : ^ ^^ ^^ ^^ ^^  ^^           ^^^^^ 
 >es : Either<string, number>[]
 >   : ^^^^^^^^^^^^^^^^^^^^^^^^
->filter(exists((n) => n > 0)) : (as: readonly Either<string, number>[]) => readonly Either<string, number>[]
->                             : ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>filter(exists((n) => n > 0)) : <B extends Either<unknown, number>>(bs: readonly B[]) => readonly B[]
+>                             : ^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >filter : { <A, B extends A>(refinement: Refinement<A, B>): (as: ReadonlyArray<A>) => ReadonlyArray<B>; <A>(predicate: Predicate<A>): <B extends A>(bs: ReadonlyArray<B>) => ReadonlyArray<B>; <A>(predicate: Predicate<A>): (as: ReadonlyArray<A>) => ReadonlyArray<A>; }
 >       : ^^^ ^^ ^^^^^^^^^ ^^          ^^                ^^^                                          ^^^ ^^         ^^            ^^^                                                       ^^^ ^^         ^^            ^^^                                          ^^^
 >exists((n) => n > 0) : <E>(ma: Either<E, number>) => boolean

--- a/tests/cases/compiler/contextualSignatureInstantiation5.ts
+++ b/tests/cases/compiler/contextualSignatureInstantiation5.ts
@@ -1,0 +1,26 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/60552
+
+declare function fooooooo<
+  T,
+  Result extends ArrayLike<unknown>,
+  Extra extends readonly unknown[],
+>(
+  input: T,
+  callback: (input: T, prev: Result, ...extra: Extra) => Result,
+  extra: Extra,
+): Result;
+
+declare function baaaaaar<T, Result extends ArrayLike<unknown>>(
+  input: T,
+  callback: (input: T, prev: Result) => Result,
+): Result;
+
+declare function callback<T>(input: T, prev: string[]): string[];
+
+export function example<T>(input: T) {
+  const result1 = fooooooo(input, callback, []); // ok
+  const result2 = baaaaaar(input, callback); // ok
+}

--- a/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
@@ -21,6 +21,12 @@ var b = bar(1, "one", g);  // Error, number and string are disjoint types
 var b = bar("one", 1, g);  // Error, number and string are disjoint types
 var b = baz(b, b, g);      // Should be number | string
 
+var one: 1 = 1
+var num: number = 10;
+
+var b = bar(one, num, g);  // ok
+var b = bar(num, one, g);  // ok
+
 var d: number[] | string[];
 var d = foo(h);            // Should be number[] | string[]
 var d = bar(1, "one", h);  // Should be number[] | string[]


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60552

I'm not exactly sure if this is right but the presented issue shows how the current logic can lead to surprising results. The existing test cases are fairly OK with this change, it would be great to run the extended test suite to learn what kind of unwanted effects this change might have (cc @jakebailey )