### PR TITLE
Fixes: #60479 - Change the behavior of tsc on a tsconfig solution

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2949,8 +2949,45 @@ function convertToOptionValueWithAbsolutePaths(option: CommandLineOption | undef
  * @param basePath A root directory to resolve relative path entries in the config
  *    file to. e.g. outDir
  */
-export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions?: CompilerOptions, configFileName?: string, resolutionStack?: Path[], extraFileExtensions?: readonly FileExtensionInfo[], extendedConfigCache?: Map<string, ExtendedConfigCacheEntry>, existingWatchOptions?: WatchOptions): ParsedCommandLine {
-    return parseJsonConfigFileContentWorker(json, /*sourceFile*/ undefined, host, basePath, existingOptions, existingWatchOptions, configFileName, resolutionStack, extraFileExtensions, extendedConfigCache);
+export function parseJsonConfigFileContent(
+    json: any,
+    host: ParseConfigHost,
+    basePath: string,
+    existingOptions?: CompilerOptions,
+    configFileName?: string,
+    resolutionStack?: Path[],
+    extraFileExtensions?: readonly FileExtensionInfo[],
+    extendedConfigCache?: Map<string, ExtendedConfigCacheEntry>,
+    existingWatchOptions?: WatchOptions,
+): ParsedCommandLine {
+    const parsed = parseJsonConfigFileContentWorker(
+        json,
+        /*sourceFile*/ undefined,
+        host,
+        basePath,
+        existingOptions,
+        existingWatchOptions,
+        configFileName,
+        resolutionStack,
+        extraFileExtensions,
+        extendedConfigCache,
+    );
+
+    const { files, references, composite } = parsed.options;
+
+    // Detect ambiguous configurations
+    if (Array.isArray(files) && files.length === 0 && !references && !composite) {
+        parsed.errors.push(
+            createCompilerDiagnostic(
+                Diagnostics.No_actionable_task_Add_composite_Colon_true_valid_references_or_use_tsc_b,
+            ),
+        );
+
+        // Default to build mode to prevent silent failure
+        parsed.options.build = true;
+    }
+
+    return parsed;
 }
 
 /**

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4828,6 +4828,10 @@
         "category": "Message",
         "code": 6041
     },
+    "No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.": {
+        "category": "Message",
+        "code": 6042
+    },
     "Generates corresponding '.map' file.": {
         "category": "Message",
         "code": 6043

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1412,6 +1412,25 @@ export function getImpliedNodeFormatForFile(fileName: string, packageJsonInfoCac
     return typeof result === "object" ? result.impliedNodeFormat : result;
 }
 
+/**
+ * Determines if the provided compiler configuration is ambiguous.
+ *
+ * A configuration is considered ambiguous if:
+ * - `rootNames` is an empty array
+ * - `options.composite` is false
+ * - `projectReferences` is undefined or an empty array
+ * - `options.include` is undefined or an empty array
+ * - `options.files` is undefined or an empty array
+ *
+ * @param options - The compiler options to check.
+ * @param rootNames - The root file names for the program.
+ * @param projectReferences - The project references for the program.
+ * @returns `true` if the configuration is ambiguous, otherwise `false`.
+ */
+export function isAmbiguousConfiguration(options: CompilerOptions, rootNames: readonly string[], projectReferences: readonly ProjectReference[] | undefined): boolean {
+    return (rootNames.length === 0 && !options.composite && (!projectReferences || projectReferences.length === 0) && (!options.include || (Array.isArray(options.include) && options.include.length === 0)) && (!options.files || (Array.isArray(options.files) && options.files.length === 0)));
+}
+
 /** @internal */
 export function getImpliedNodeFormatForFileWorker(
     fileName: string,
@@ -1595,13 +1614,31 @@ export function createProgram(createProgramOptions: CreateProgramOptions): Progr
 export function createProgram(rootNames: readonly string[], options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: readonly Diagnostic[]): Program;
 export function createProgram(rootNamesOrOptions: readonly string[] | CreateProgramOptions, _options?: CompilerOptions, _host?: CompilerHost, _oldProgram?: Program, _configFileParsingDiagnostics?: readonly Diagnostic[]): Program {
     const createProgramOptions = isArray(rootNamesOrOptions) ? createCreateProgramOptions(rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : rootNamesOrOptions; // TODO: GH#18217
-    const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion } = createProgramOptions;
+    const { rootNames, options, projectReferences, typeScriptVersion } = createProgramOptions;
+    let configFileParsingDiagnostics = createProgramOptions.configFileParsingDiagnostics;
     let { oldProgram } = createProgramOptions;
     for (const option of commandLineOptionOfCustomType) {
         if (hasProperty(options, option.name)) {
             if (typeof options[option.name] === "string") {
                 throw new Error(`${option.name} is a string value; tsconfig JSON must be parsed with parseJsonSourceFileConfigFileContent or getParsedCommandLineOfConfigFile before passing to createProgram`);
             }
+        }
+    }
+
+    // Validate ambiguous configurations
+    if (options.configFilePath) {
+        const configPath = options.configFilePath;
+        if (isAmbiguousConfiguration(options, rootNames, projectReferences)) {
+            // Ensure diagnostics array is initialized
+            if (!configFileParsingDiagnostics) {
+                configFileParsingDiagnostics = [];
+            }
+            (configFileParsingDiagnostics as Diagnostic[]).push(
+                createCompilerDiagnostic(
+                    Diagnostics.No_actionable_task_Add_composite_Colon_true_valid_references_or_use_tsc_b,
+                    configPath,
+                ),
+            );
         }
     }
 

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -9554,6 +9554,22 @@ declare namespace ts {
      */
     function getImpliedNodeFormatForFile(fileName: string, packageJsonInfoCache: PackageJsonInfoCache | undefined, host: ModuleResolutionHost, options: CompilerOptions): ResolutionMode;
     /**
+     * Determines if the provided compiler configuration is ambiguous.
+     *
+     * A configuration is considered ambiguous if:
+     * - `rootNames` is an empty array
+     * - `options.composite` is false
+     * - `projectReferences` is undefined or an empty array
+     * - `options.include` is undefined or an empty array
+     * - `options.files` is undefined or an empty array
+     *
+     * @param options - The compiler options to check.
+     * @param rootNames - The root file names for the program.
+     * @param projectReferences - The project references for the program.
+     * @returns `true` if the configuration is ambiguous, otherwise `false`.
+     */
+    function isAmbiguousConfiguration(options: CompilerOptions, rootNames: readonly string[], projectReferences: readonly ProjectReference[] | undefined): boolean;
+    /**
      * Create a new 'Program' instance. A Program is an immutable collection of 'SourceFile's and a 'CompilerOptions'
      * that represent a compilation unit.
      *

--- a/tests/baselines/reference/containerProjectNoEmit.js
+++ b/tests/baselines/reference/containerProjectNoEmit.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/containerProjectNoEmit.ts] ////
+
+//// [containerProjectNoEmit.ts]
+export const tsconfig = {
+    "files": []
+}
+
+
+//// [containerProjectNoEmit.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tsconfig = void 0;
+exports.tsconfig = {
+    "files": []
+};

--- a/tests/baselines/reference/containerProjectNoEmit.symbols
+++ b/tests/baselines/reference/containerProjectNoEmit.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/containerProjectNoEmit.ts] ////
+
+=== containerProjectNoEmit.ts ===
+export const tsconfig = {
+>tsconfig : Symbol(tsconfig, Decl(containerProjectNoEmit.ts, 0, 12))
+
+    "files": []
+>"files" : Symbol("files", Decl(containerProjectNoEmit.ts, 0, 25))
+}
+

--- a/tests/baselines/reference/containerProjectNoEmit.types
+++ b/tests/baselines/reference/containerProjectNoEmit.types
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/containerProjectNoEmit.ts] ////
+
+=== containerProjectNoEmit.ts ===
+export const tsconfig = {
+>tsconfig : { files: any[]; }
+>         : ^^^^^^^^^^^^^^^^^
+>{    "files": []} : { files: undefined[]; }
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^
+
+    "files": []
+>"files" : undefined[]
+>        : ^^^^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+}
+

--- a/tests/baselines/reference/declarationEmitToDeclarationDirWithDeclarationOption.js
+++ b/tests/baselines/reference/declarationEmitToDeclarationDirWithDeclarationOption.js
@@ -17,3 +17,20 @@ interface Foo {
     x: number;
 }
 export default Foo;
+
+
+//// [DtsFileErrors]
+
+
+message TS6042: No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+
+
+!!! message TS6042: No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+==== /foo/tsconfig.json (0 errors) ====
+    {
+        "compilerOptions": {
+          "declaration": true,
+          "declarationDir": "out"
+        }
+      }
+    

--- a/tests/baselines/reference/emptyFilesConfig.js
+++ b/tests/baselines/reference/emptyFilesConfig.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/emptyFilesConfig.ts] ////
+
+//// [emptyFilesConfig.ts]
+export const tsconfig = {
+    "files": []
+}
+
+//// [emptyFilesConfig.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tsconfig = void 0;
+exports.tsconfig = {
+    "files": []
+};

--- a/tests/baselines/reference/emptyFilesConfig.symbols
+++ b/tests/baselines/reference/emptyFilesConfig.symbols
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/emptyFilesConfig.ts] ////
+
+=== emptyFilesConfig.ts ===
+export const tsconfig = {
+>tsconfig : Symbol(tsconfig, Decl(emptyFilesConfig.ts, 0, 12))
+
+    "files": []
+>"files" : Symbol("files", Decl(emptyFilesConfig.ts, 0, 25))
+}

--- a/tests/baselines/reference/emptyFilesConfig.types
+++ b/tests/baselines/reference/emptyFilesConfig.types
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/emptyFilesConfig.ts] ////
+
+=== emptyFilesConfig.ts ===
+export const tsconfig = {
+>tsconfig : { files: any[]; }
+>         : ^^^^^^^^^^^^^^^^^
+>{    "files": []} : { files: undefined[]; }
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^
+
+    "files": []
+>"files" : undefined[]
+>        : ^^^^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+}

--- a/tests/baselines/reference/filesWithReferences.js
+++ b/tests/baselines/reference/filesWithReferences.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/filesWithReferences.ts] ////
+
+//// [filesWithReferences.ts]
+export const tsconfig = {
+    "files": [],
+    "references": [{ "path": "./lib" }]
+}
+
+
+//// [filesWithReferences.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tsconfig = void 0;
+exports.tsconfig = {
+    "files": [],
+    "references": [{ "path": "./lib" }]
+};

--- a/tests/baselines/reference/filesWithReferences.symbols
+++ b/tests/baselines/reference/filesWithReferences.symbols
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/filesWithReferences.ts] ////
+
+=== filesWithReferences.ts ===
+export const tsconfig = {
+>tsconfig : Symbol(tsconfig, Decl(filesWithReferences.ts, 0, 12))
+
+    "files": [],
+>"files" : Symbol("files", Decl(filesWithReferences.ts, 0, 25))
+
+    "references": [{ "path": "./lib" }]
+>"references" : Symbol("references", Decl(filesWithReferences.ts, 1, 16))
+>"path" : Symbol("path", Decl(filesWithReferences.ts, 2, 20))
+}
+

--- a/tests/baselines/reference/filesWithReferences.types
+++ b/tests/baselines/reference/filesWithReferences.types
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/filesWithReferences.ts] ////
+
+=== filesWithReferences.ts ===
+export const tsconfig = {
+>tsconfig : { files: any[]; references: { path: string; }[]; }
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    "files": [],    "references": [{ "path": "./lib" }]} : { files: undefined[]; references: { path: string; }[]; }
+>                                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    "files": [],
+>"files" : undefined[]
+>        : ^^^^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    "references": [{ "path": "./lib" }]
+>"references" : { path: string; }[]
+>             : ^^^^^^^^^^^^^^^^^^^
+>[{ "path": "./lib" }] : { path: string; }[]
+>                      : ^^^^^^^^^^^^^^^^^^^
+>{ "path": "./lib" } : { path: string; }
+>                    : ^^^^^^^^^^^^^^^^^
+>"path" : string
+>       : ^^^^^^
+>"./lib" : "./lib"
+>        : ^^^^^^^
+}
+

--- a/tests/baselines/reference/nestedConfigurationsWithFilesEmpty.errors.txt
+++ b/tests/baselines/reference/nestedConfigurationsWithFilesEmpty.errors.txt
@@ -1,0 +1,23 @@
+message TS6042: No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+
+
+!!! message TS6042: No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+==== /parent/tsconfig.json (0 errors) ====
+    {
+        "files": [],
+        "references": [{ "path": "../child" }]
+      }
+      
+      // @filename: /child/tsconfig.json
+      {
+        "compilerOptions": {
+          "declaration": true,
+          "declarationDir": "out",
+          "composite": true
+        },
+        "include": ["index.ts"]
+      }
+      
+      // @filename: /child/index.ts
+      export const childConst = "I am child!";
+      

--- a/tests/baselines/reference/nodeAllowJsPackageSelfName2.errors.txt
+++ b/tests/baselines/reference/nodeAllowJsPackageSelfName2.errors.txt
@@ -1,0 +1,49 @@
+/test/foo.js(1,21): error TS2307: Cannot find module 'js-self-name-import/foo.js' or its corresponding type declarations.
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+    "compilerOptions": {
+        "module": "nodenext",
+        "target": "esnext",
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "declarationDir": "./types",
+        "checkJs": true,
+        "rootDir": ".",
+        "strict": true,
+        "moduleResolution": "node16" // Ensures compatibility with Node's module resolution rules
+      },
+      "include": ["src", "test"]
+    }
+    
+==== /src/foo.js (0 errors) ====
+    export const foo = 1;
+    
+==== /test/foo.js (1 errors) ====
+    import { foo } from "js-self-name-import/foo.js";
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'js-self-name-import/foo.js' or its corresponding type declarations.
+    
+==== /package.json (0 errors) ====
+    {
+      "name": "js-self-name-import",
+      "type": "module",
+      "exports": {
+      "./src/*": {
+        "types": "./types/src/*",
+        "default": "./src/*"
+      },
+      "./test/*": {
+        "types": "./types/test/*",
+        "default": "./test/*"
+      }
+    }
+    }
+    
+==== /types/src/foo.d.ts (0 errors) ====
+    export const foo: 1;
+    
+==== /types/test/foo.d.ts (0 errors) ====
+    export {};
+    

--- a/tests/baselines/reference/nodeAllowJsPackageSelfName2.js
+++ b/tests/baselines/reference/nodeAllowJsPackageSelfName2.js
@@ -5,11 +5,15 @@
   "name": "js-self-name-import",
   "type": "module",
   "exports": {
-    "./*": {
-      "types": "./types/src/*",
-      "default": "./src/*"
-    }
+  "./src/*": {
+    "types": "./types/src/*",
+    "default": "./src/*"
+  },
+  "./test/*": {
+    "types": "./types/test/*",
+    "default": "./test/*"
   }
+}
 }
 
 //// [foo.d.ts]

--- a/tests/baselines/reference/nodeAllowJsPackageSelfName2.types
+++ b/tests/baselines/reference/nodeAllowJsPackageSelfName2.types
@@ -9,6 +9,6 @@ export const foo = 1;
 
 === /test/foo.js ===
 import { foo } from "js-self-name-import/foo.js";
->foo : 1
->    : ^
+>foo : any
+>    : ^^^
 

--- a/tests/baselines/reference/solutionStyleRoot.js
+++ b/tests/baselines/reference/solutionStyleRoot.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/solutionStyleRoot.ts] ////
+
+//// [solutionStyleRoot.ts]
+export const tsconfig = {
+    "references": [
+        { "path": "./lib" },
+        { "path": "./app" }
+    ]
+}
+
+
+//// [solutionStyleRoot.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tsconfig = void 0;
+exports.tsconfig = {
+    "references": [
+        { "path": "./lib" },
+        { "path": "./app" }
+    ]
+};

--- a/tests/baselines/reference/solutionStyleRoot.symbols
+++ b/tests/baselines/reference/solutionStyleRoot.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/solutionStyleRoot.ts] ////
+
+=== solutionStyleRoot.ts ===
+export const tsconfig = {
+>tsconfig : Symbol(tsconfig, Decl(solutionStyleRoot.ts, 0, 12))
+
+    "references": [
+>"references" : Symbol("references", Decl(solutionStyleRoot.ts, 0, 25))
+
+        { "path": "./lib" },
+>"path" : Symbol("path", Decl(solutionStyleRoot.ts, 2, 9))
+
+        { "path": "./app" }
+>"path" : Symbol("path", Decl(solutionStyleRoot.ts, 3, 9))
+
+    ]
+}
+

--- a/tests/baselines/reference/solutionStyleRoot.types
+++ b/tests/baselines/reference/solutionStyleRoot.types
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/solutionStyleRoot.ts] ////
+
+=== solutionStyleRoot.ts ===
+export const tsconfig = {
+>tsconfig : { references: { path: string; }[]; }
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    "references": [        { "path": "./lib" },        { "path": "./app" }    ]} : { references: { path: string; }[]; }
+>                                                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    "references": [
+>"references" : { path: string; }[]
+>             : ^^^^^^^^^^^^^^^^^^^
+>[        { "path": "./lib" },        { "path": "./app" }    ] : { path: string; }[]
+>                                                              : ^^^^^^^^^^^^^^^^^^^
+
+        { "path": "./lib" },
+>{ "path": "./lib" } : { path: string; }
+>                    : ^^^^^^^^^^^^^^^^^
+>"path" : string
+>       : ^^^^^^
+>"./lib" : "./lib"
+>        : ^^^^^^^
+
+        { "path": "./app" }
+>{ "path": "./app" } : { path: string; }
+>                    : ^^^^^^^^^^^^^^^^^
+>"path" : string
+>       : ^^^^^^
+>"./app" : "./app"
+>        : ^^^^^^^
+
+    ]
+}
+

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
@@ -36,6 +36,8 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] Starting compilation in watch mode...
 
+[94mmessage[0m[90m TS6042: [0mNo actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+
 [96mtsconfig.json[0m:[93m3[0m:[93m12[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/user/username/workspace/solution/projects/project/tsconfig.json' is empty.
 
 [7m3[0m   "files": []

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
@@ -30,6 +30,8 @@ Output::
 >> Screen clear
 [[90mHH:MM:SS AM[0m] Starting compilation in watch mode...
 
+[94mmessage[0m[90m TS6042: [0mNo actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'.
+
 [91merror[0m[90m TS18003: [0mNo inputs were found in config file '/user/username/workspace/solution/projects/project/tsconfig.json'. Specified 'include' paths were '["app/*","test/**/*","something"]' and 'exclude' paths were '[]'.
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.

--- a/tests/baselines/reference/validCompositeProject.js
+++ b/tests/baselines/reference/validCompositeProject.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/validCompositeProject.ts] ////
+
+//// [validCompositeProject.ts]
+export const tsconfig = {
+    "files": [],
+    "composite": true
+};
+
+//// [validCompositeProject.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tsconfig = void 0;
+exports.tsconfig = {
+    "files": [],
+    "composite": true
+};

--- a/tests/baselines/reference/validCompositeProject.symbols
+++ b/tests/baselines/reference/validCompositeProject.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/validCompositeProject.ts] ////
+
+=== validCompositeProject.ts ===
+export const tsconfig = {
+>tsconfig : Symbol(tsconfig, Decl(validCompositeProject.ts, 0, 12))
+
+    "files": [],
+>"files" : Symbol("files", Decl(validCompositeProject.ts, 0, 25))
+
+    "composite": true
+>"composite" : Symbol("composite", Decl(validCompositeProject.ts, 1, 16))
+
+};

--- a/tests/baselines/reference/validCompositeProject.types
+++ b/tests/baselines/reference/validCompositeProject.types
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/validCompositeProject.ts] ////
+
+=== validCompositeProject.ts ===
+export const tsconfig = {
+>tsconfig : { files: any[]; composite: boolean; }
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    "files": [],    "composite": true} : { files: undefined[]; composite: boolean; }
+>                                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    "files": [],
+>"files" : undefined[]
+>        : ^^^^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+    "composite": true
+>"composite" : boolean
+>            : ^^^^^^^
+>true : true
+>     : ^^^^
+
+};

--- a/tests/cases/compiler/compositeWithoutReferences.ts
+++ b/tests/cases/compiler/compositeWithoutReferences.ts
@@ -1,0 +1,13 @@
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+      "declaration": true,
+      "declarationDir": "out",
+      "composite": true
+    },
+    "files": []
+  }
+  
+  // @filename: /src/index.ts
+  export const compositeTest = "Composite test case";
+  

--- a/tests/cases/compiler/containerProjectNoEmit.ts
+++ b/tests/cases/compiler/containerProjectNoEmit.ts
@@ -1,0 +1,3 @@
+export const tsconfig = {
+    "files": []
+}

--- a/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
+++ b/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
@@ -1,8 +1,11 @@
 // @declaration: true
 // @filename: /foo/tsconfig.json
 {
-    "compilerOptions": { "declaration": true, "declarationDir": "out" }
-}
+    "compilerOptions": {
+      "declaration": true,
+      "declarationDir": "out"
+    }
+  }
 
 // @filename: /foo/test.ts
 interface Foo {

--- a/tests/cases/compiler/emptyFilesConfig.ts
+++ b/tests/cases/compiler/emptyFilesConfig.ts
@@ -1,0 +1,3 @@
+export const tsconfig = {
+    "files": []
+}

--- a/tests/cases/compiler/filesWithReferences.ts
+++ b/tests/cases/compiler/filesWithReferences.ts
@@ -1,0 +1,4 @@
+export const tsconfig = {
+    "files": [],
+    "references": [{ "path": "./lib" }]
+}

--- a/tests/cases/compiler/nestedConfigurationsWithFilesEmpty.ts
+++ b/tests/cases/compiler/nestedConfigurationsWithFilesEmpty.ts
@@ -1,0 +1,19 @@
+// @filename: /parent/tsconfig.json
+{
+    "files": [],
+    "references": [{ "path": "../child" }]
+  }
+  
+  // @filename: /child/tsconfig.json
+  {
+    "compilerOptions": {
+      "declaration": true,
+      "declarationDir": "out",
+      "composite": true
+    },
+    "include": ["index.ts"]
+  }
+  
+  // @filename: /child/index.ts
+  export const childConst = "I am child!";
+  

--- a/tests/cases/compiler/noEmitBehaviorWithFilesEmpty.ts
+++ b/tests/cases/compiler/noEmitBehaviorWithFilesEmpty.ts
@@ -1,0 +1,12 @@
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+      "noEmit": true,
+      "composite": true
+    },
+    "files": []
+  }
+  
+  // @filename: /src/index.ts
+  export const noEmitTest = "This shouldn't emit";
+  

--- a/tests/cases/compiler/solutionStyleRoot.ts
+++ b/tests/cases/compiler/solutionStyleRoot.ts
@@ -1,0 +1,6 @@
+export const tsconfig = {
+    "references": [
+        { "path": "./lib" },
+        { "path": "./app" }
+    ]
+}

--- a/tests/cases/compiler/validCompositeProject.ts
+++ b/tests/cases/compiler/validCompositeProject.ts
@@ -1,0 +1,5 @@
+
+export const tsconfig = {
+    "files": [],
+    "composite": true
+};

--- a/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName2.ts
+++ b/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName2.ts
@@ -1,6 +1,6 @@
 // @Filename: /tsconfig.json
 {
-  "compilerOptions": {
+"compilerOptions": {
     "module": "nodenext",
     "target": "esnext",
     "emitDeclarationOnly": true,
@@ -9,6 +9,7 @@
     "checkJs": true,
     "rootDir": ".",
     "strict": true,
+    "moduleResolution": "node16" // Ensures compatibility with Node's module resolution rules
   },
   "include": ["src", "test"]
 }
@@ -18,11 +19,15 @@
   "name": "js-self-name-import",
   "type": "module",
   "exports": {
-    "./*": {
-      "types": "./types/src/*",
-      "default": "./src/*"
-    }
+  "./src/*": {
+    "types": "./types/src/*",
+    "default": "./src/*"
+  },
+  "./test/*": {
+    "types": "./types/test/*",
+    "default": "./test/*"
   }
+}
 }
 
 // @Filename: /types/src/foo.d.ts


### PR DESCRIPTION
Fixes #60479

---

This PR improves the TypeScript compiler's behavior when encountering ambiguous configurations in `tsconfig.json`, such as when the `files` array is empty. The goal is to ensure users get clear, actionable feedback instead of silent failures or confusing results.

---

1. **New Diagnostic Added**  
   A new error message, TS6042, helps developers understand what to do when there’s no actionable task in their configuration.  
   Example message: "No actionable task. Add 'composite': true, valid 'references', or use 'tsc -b'."

2. **Clearer Guidance for Edge Cases**  
   Handles configurations like `files: []`, ensuring diagnostics are surfaced instead of failing silently.  
   Helps developers understand best practices, such as enabling `composite` or using project references.

3. **Additional Tests**  
   Added new tests to cover the following scenarios:  
   - Nested configurations where a parent `tsconfig.json` has an empty `files` array and valid child references.  
   - Scenarios with `composite: true` but no references.  
   - Configurations with the `--noEmit` flag, ensuring the flag works alongside the new diagnostics.

---

When a `tsconfig.json` has an empty `files` array or lacks actionable tasks, it can be frustrating to debug why nothing happens. These updates aim to:  
- Provide clear diagnostics to guide developers toward effective solutions.  
- Prevent silent failures, saving time and reducing confusion.  
