### PR TITLE
Fixed crash when getting a definition for a class member with a computed name and an `override` modifier

### DIFF
--- a/tests/baselines/reference/goToDefinitionOverriddenMember17.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember17.baseline.jsonc
@@ -1,0 +1,23 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember17.ts ===
+// const entityKind = Symbol.for("drizzle:entityKind");
+// 
+// abstract class MySqlColumn {
+//   <|static readonly [|[entityKind]|]: string = "MySqlColumn";|>
+// }
+// 
+// export class MySqlVarBinary extends MySqlColumn {
+//   static /*GOTO DEF*/override readonly [entityKind]: string = "MySqlVarBinary";
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "[entityKind]",
+    "containerName": "MySqlColumn",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember18.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember18.baseline.jsonc
@@ -1,0 +1,23 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember18.ts ===
+// const entityKind = Symbol.for("drizzle:entityKind");
+// 
+// abstract class MySqlColumn {
+//   <|readonly [|[entityKind]|]: string = "MySqlColumn";|>
+// }
+// 
+// export class MySqlVarBinary extends MySqlColumn {
+//   /*GOTO DEF*/override readonly [entityKind]: string = "MySqlVarBinary";
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "[entityKind]",
+    "containerName": "MySqlColumn",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember19.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember19.baseline.jsonc
@@ -1,0 +1,23 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember19.ts ===
+// const prop = "foo" as const;
+// 
+// abstract class A {
+//   <|static readonly [|[prop]|] = "A";|>
+// }
+// 
+// export class B extends A {
+//   static /*GOTO DEF*/override readonly [prop] = "B";
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "[prop]",
+    "containerName": "A",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember20.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember20.baseline.jsonc
@@ -1,0 +1,23 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember20.ts ===
+// const prop = "foo" as const;
+// 
+// abstract class A {
+//   <|readonly [|[prop]|] = "A";|>
+// }
+// 
+// export class B extends A {
+//   /*GOTO DEF*/override readonly [prop] = "B";
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "[prop]",
+    "containerName": "A",
+    "isLocal": true,
+    "isAmbient": false,
+    "unverified": false
+   }
+  ]

--- a/tests/baselines/reference/goToDefinitionOverriddenMember21.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember21.baseline.jsonc
@@ -1,0 +1,9 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember21.ts ===
+// const prop = "foo" as const;
+// 
+// abstract class A {}
+// 
+// export class B extends A {
+//   static /*GOTO DEF*/override readonly [prop] = "B";
+// }

--- a/tests/baselines/reference/goToDefinitionOverriddenMember22.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember22.baseline.jsonc
@@ -1,0 +1,9 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember22.ts ===
+// const prop = "foo" as const;
+// 
+// abstract class A {}
+// 
+// export class B extends A {
+//   /*GOTO DEF*/override readonly [prop] = "B";
+// }

--- a/tests/baselines/reference/goToDefinitionOverriddenMember23.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember23.baseline.jsonc
@@ -1,0 +1,8 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember23.ts ===
+// --- (line: 4) skipped ---
+// }
+// 
+// export class B extends A {
+//   static /*GOTO DEF*/override [prop]() {}
+// }

--- a/tests/baselines/reference/goToDefinitionOverriddenMember24.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember24.baseline.jsonc
@@ -1,0 +1,8 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember24.ts ===
+// --- (line: 4) skipped ---
+// }
+// 
+// export class B extends A {
+//   /*GOTO DEF*/override [prop]() {}
+// }

--- a/tests/baselines/reference/goToDefinitionOverriddenMember25.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember25.baseline.jsonc
@@ -1,0 +1,9 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember25.ts ===
+// const prop: symbol = Symbol();
+// 
+// abstract class A {}
+// 
+// export class B extends A {
+//   static /*GOTO DEF*/override [prop]() {}
+// }

--- a/tests/baselines/reference/goToDefinitionOverriddenMember26.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinitionOverriddenMember26.baseline.jsonc
@@ -1,0 +1,9 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinitionOverriddenMember26.ts ===
+// const prop: symbol = Symbol();
+// 
+// abstract class A {}
+// 
+// export class B extends A {
+//   /*GOTO DEF*/override [prop]() {}
+// }

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember17.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember17.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const entityKind = Symbol.for("drizzle:entityKind");
+////
+//// abstract class MySqlColumn {
+////   static readonly /*2*/[entityKind]: string = "MySqlColumn";
+//// }
+////
+//// export class MySqlVarBinary extends MySqlColumn {
+////   static [|/*1*/override|] readonly [entityKind]: string = "MySqlVarBinary";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember18.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember18.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const entityKind = Symbol.for("drizzle:entityKind");
+////
+//// abstract class MySqlColumn {
+////   readonly /*2*/[entityKind]: string = "MySqlColumn";
+//// }
+////
+//// export class MySqlVarBinary extends MySqlColumn {
+////   [|/*1*/override|] readonly [entityKind]: string = "MySqlVarBinary";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember19.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember19.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop = "foo" as const;
+////
+//// abstract class A {
+////   static readonly /*2*/[prop] = "A";
+//// }
+////
+//// export class B extends A {
+////   static [|/*1*/override|] readonly [prop] = "B";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember20.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember20.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop = "foo" as const;
+////
+//// abstract class A {
+////   readonly /*2*/[prop] = "A";
+//// }
+////
+//// export class B extends A {
+////   [|/*1*/override|] readonly [prop] = "B";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember21.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember21.ts
@@ -1,0 +1,15 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop = "foo" as const;
+////
+//// abstract class A {}
+////
+//// export class B extends A {
+////   static [|/*1*/override|] readonly [prop] = "B";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember22.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember22.ts
@@ -1,0 +1,15 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop = "foo" as const;
+////
+//// abstract class A {}
+////
+//// export class B extends A {
+////   [|/*1*/override|] readonly [prop] = "B";
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember23.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember23.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop: symbol = Symbol();
+////
+//// abstract class A {
+////   static [prop]() {}
+//// }
+////
+//// export class B extends A {
+////   static [|/*1*/override|] [prop]() {}
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember24.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember24.ts
@@ -1,0 +1,17 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop: symbol = Symbol();
+////
+//// abstract class A {
+////   [prop]() {}
+//// }
+////
+//// export class B extends A {
+////   [|/*1*/override|] [prop]() {}
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember25.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember25.ts
@@ -1,0 +1,15 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop: symbol = Symbol();
+////
+//// abstract class A {}
+////
+//// export class B extends A {
+////   static [|/*1*/override|] [prop]() {}
+//// }
+
+verify.baselineGoToDefinition("1");

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember26.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember26.ts
@@ -1,0 +1,15 @@
+/// <reference path="./fourslash.ts"/>
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// const prop: symbol = Symbol();
+////
+//// abstract class A {}
+////
+//// export class B extends A {
+////   [|/*1*/override|] [prop]() {}
+//// }
+
+verify.baselineGoToDefinition("1");


### PR DESCRIPTION
fixes crash reported here: https://github.com/microsoft/TypeScript/issues/60580#issuecomment-2496317290