### PR TITLE
Implement codefix for adding missing `await` in `return` statements enclosed by try statements

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7255,6 +7255,10 @@
         "category": "Suggestion",
         "code": 80010
     },
+    "This may need `await` keyword. Otherwise the enclosing try statement won't handle this.": {
+        "category": "Suggestion",
+        "code": 80011
+    },
 
     "Add missing 'super()' call": {
         "category": "Message",
@@ -8244,6 +8248,14 @@
     "Add 'resolution-mode' import attribute to all type-only imports that need it": {
         "category": "Message",
         "code": 95197
+    },
+    "Add missing await.": {
+        "category": "Message",
+        "code": 95198
+    },
+    "Add all missing awaits.": {
+        "category": "Message",
+        "code": 95199
     },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {

--- a/src/services/_namespaces/ts.codefix.ts
+++ b/src/services/_namespaces/ts.codefix.ts
@@ -5,6 +5,7 @@ export * from "../codefixes/addConvertToUnknownForNonOverlappingTypes.js";
 export * from "../codefixes/addEmptyExportDeclaration.js";
 export * from "../codefixes/addMissingAsync.js";
 export * from "../codefixes/addMissingAwait.js";
+export * from "../codefixes/addMissingAwaitInReturn.js";
 export * from "../codefixes/addMissingConst.js";
 export * from "../codefixes/addMissingDeclareProperty.js";
 export * from "../codefixes/addMissingInvocationForDecorator.js";

--- a/src/services/codefixes/addMissingAwaitInReturn.ts
+++ b/src/services/codefixes/addMissingAwaitInReturn.ts
@@ -1,0 +1,41 @@
+import {
+    codeFixAll,
+    createCodeFixAction,
+    registerCodeFix,
+} from "../_namespaces/ts.codefix.js";
+import {
+    CodeFixContext,
+    Debug,
+    Diagnostics,
+    factory,
+    getSynthesizedDeepClone,
+    getTokenAtPosition,
+    isReturnStatement,
+    SourceFile,
+    textChanges,
+} from "../_namespaces/ts.js";
+
+const fixId = "addMissingAwaitInReturn";
+const errorCodes = [Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.code];
+
+registerCodeFix({
+    errorCodes,
+    getCodeActions(context: CodeFixContext) {
+        const changes = textChanges.ChangeTracker.with(context, t => makeChange(t, context.sourceFile, context.span.start));
+        return [createCodeFixAction(fixId, changes, Diagnostics.Add_missing_await, fixId, Diagnostics.Add_all_missing_awaits)];
+    },
+    fixIds: [fixId],
+    getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => makeChange(changes, diag.file, diag.start)),
+});
+
+function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number) {
+    const token = getTokenAtPosition(sourceFile, pos);
+    Debug.assertNode(token.parent, isReturnStatement);
+    Debug.assertIsDefined(token.parent.expression);
+    const expression = token.parent.expression;
+    changeTracker.replaceNode(
+        sourceFile,
+        expression,
+        factory.createAwaitExpression(getSynthesizedDeepClone(expression, /*includeTrivia*/ true)),
+    );
+}

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn1.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn1.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   return inner();
+//// }
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn10.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn10.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   return 42;
+//// }
+////
+//// const outer = async () => inner();
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn11.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn11.ts
@@ -1,0 +1,61 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   return 42;
+//// }
+////
+//// async function outer(v: number) {
+////   try {
+////     if (v > 30) {
+////       [|return|] inner();
+////     }
+////     if (v > 20) {
+////       return await inner();
+////     }
+////     if (v > 10) {
+////       [|return|] inner();
+////     }
+////     [|return|] inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}, {
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[1],
+}, {
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[2],
+}]);
+verify.codeFixAll({
+    fixId: "addMissingAwaitInReturn",
+    fixAllDescription: ts.Diagnostics.Add_all_missing_awaits.message,
+    newFileContent:
+`async function inner() {
+  return 42;
+}
+
+async function outer(v: number) {
+  try {
+    if (v > 30) {
+      return await inner();
+    }
+    if (v > 20) {
+      return await inner();
+    }
+    if (v > 10) {
+      return await inner();
+    }
+    return await inner();
+  } catch (e) {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn12.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn12.ts
@@ -1,0 +1,41 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     [|return|] Math.random() > 0.5 ? inner() : 5;
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}]);
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_await.message,
+    index: 0,
+    newFileContent:
+`async function inner() {
+  if (Math.random() > 0.5) {
+    throw new Error("Ooops");
+  }
+  return 42;
+}
+
+async function outer() {
+  try {
+    return await (Math.random() > 0.5 ? inner() : 5);
+  } catch (e) {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn2.ts
@@ -1,0 +1,41 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     [|return|] inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}]);
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_await.message,
+    index: 0,
+    newFileContent:
+`async function inner() {
+  if (Math.random() > 0.5) {
+    throw new Error("Ooops");
+  }
+  return 42;
+}
+
+async function outer() {
+  try {
+    return await inner();
+  } catch (e) {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn3.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn3.ts
@@ -1,0 +1,41 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     [|return|] inner();
+////   } catch {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}]);
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_await.message,
+    index: 0,
+    newFileContent:
+`async function inner() {
+  if (Math.random() > 0.5) {
+    throw new Error("Ooops");
+  }
+  return 42;
+}
+
+async function outer() {
+  try {
+    return await inner();
+  } catch {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn4.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn4.ts
@@ -1,0 +1,41 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     [|return|] inner();
+////   } finally {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}]);
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_await.message,
+    index: 0,
+    newFileContent:
+`async function inner() {
+  if (Math.random() > 0.5) {
+    throw new Error("Ooops");
+  }
+  return 42;
+}
+
+async function outer() {
+  try {
+    return await inner();
+  } finally {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn5.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn5.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     return await inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn6.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn6.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// function inner() {
+////   if (Math.random() > 0.5) {
+////     throw new Error("Ooops");
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     return inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn7.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn7.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// async function fn() {
+////   try {
+////     return 42;
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn8.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn8.ts
@@ -1,0 +1,47 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// function inner(v: number) {
+////   if (Math.random() > 0.5) {
+////     return Promise.reject(new Error("Ooops"));
+////   }
+////   if (v > 10) {
+////     return Promise.resolve(100);
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     [|return|] inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([{
+    message: ts.Diagnostics.This_may_need_await_keyword_Otherwise_the_enclosing_try_statement_won_t_handle_this.message,
+    code: 80011,
+    range: test.ranges()[0],
+}]);
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_await.message,
+    index: 0,
+    newFileContent:
+`function inner(v: number) {
+  if (Math.random() > 0.5) {
+    return Promise.reject(new Error("Ooops"));
+  }
+  if (v > 10) {
+    return Promise.resolve(100);
+  }
+  return 42;
+}
+
+async function outer() {
+  try {
+    return await inner();
+  } catch (e) {}
+}`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingAwaitInReturn9.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAwaitInReturn9.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// function inner(v: number) {
+////   if (Math.random() > 0.5) {
+////     return Promise.reject(new Error("Ooops"));
+////   }
+////   if (v > 10) {
+////     return Promise.resolve(100);
+////   }
+////   return 42;
+//// }
+////
+//// async function outer() {
+////   try {
+////     return await inner();
+////   } catch (e) {}
+//// }
+
+verify.getSuggestionDiagnostics([]);
+verify.not.codeFixAvailable(ts.Diagnostics.Add_missing_await.message);


### PR DESCRIPTION
Given that async functions flatten returned promises it's a fairly easy mistake to make to assume that `try/catch/finally` enclosing a **return**ed promise can handle that as if `return await p` would be written:
```ts
declare function mayThrow(): Promise<number>

async function caller(): Promise<number> {
  try {
    return mayThrow()
  } catch (err) {
    // oops, this *won't* be executed
  }
}
```

For that reason, I think, it would be great if TS could suggest adding that "missing" `await`