### PR TITLE
Improve `isTypeParameterAtTopLevel` to handle substitution types and template literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25741,12 +25741,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTypeParameterAtTopLevel(type: Type, tp: TypeParameter, depth = 0): boolean {
+        if (type.flags & TypeFlags.Substitution) {
+            type = getActualTypeVariable(type);
+        }
         return !!(type === tp ||
             type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, t => isTypeParameterAtTopLevel(t, tp, depth)) ||
-            depth < 3 && type.flags & TypeFlags.Conditional && (
+            depth < 3 && (type.flags & TypeFlags.Conditional && (
                     isTypeParameterAtTopLevel(getTrueTypeFromConditionalType(type as ConditionalType), tp, depth + 1) ||
                     isTypeParameterAtTopLevel(getFalseTypeFromConditionalType(type as ConditionalType), tp, depth + 1)
-                ));
+                ) || type.flags & TypeFlags.TemplateLiteral && some((type as TemplateLiteralType).types, t => isTypeParameterAtTopLevel(t, tp, depth))));
     }
 
     function isTypeParameterAtTopLevelInReturnType(signature: Signature, typeParameter: TypeParameter) {

--- a/tests/baselines/reference/returnTypeTopLevelInferenceLiteralDontWiden1.symbols
+++ b/tests/baselines/reference/returnTypeTopLevelInferenceLiteralDontWiden1.symbols
@@ -1,0 +1,128 @@
+//// [tests/cases/compiler/returnTypeTopLevelInferenceLiteralDontWiden1.ts] ////
+
+=== returnTypeTopLevelInferenceLiteralDontWiden1.ts ===
+declare function A<T>(value: T): T extends string ? T : never;
+>A : Symbol(A, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 0))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 19))
+
+const ATest = A("foo");
+>ATest : Symbol(ATest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 2, 5))
+>A : Symbol(A, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 0, 0))
+
+declare function B<T>(value: T): `test_${T & string}`;
+>B : Symbol(B, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 2, 23))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 4, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 4, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 4, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 4, 19))
+
+const BTest = B("foo");
+>BTest : Symbol(BTest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 6, 5))
+>B : Symbol(B, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 2, 23))
+
+declare function C<T>(
+>C : Symbol(C, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 6, 23))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+  value: T,
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+): T extends string
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+  ? T
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+  : T extends number | bigint | boolean | null | undefined
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+  ? `test_${T}`
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 8, 19))
+
+  : never;
+
+const CTest = C("foo");
+>CTest : Symbol(CTest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 16, 5))
+>C : Symbol(C, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 6, 23))
+
+declare function D<T>(value: T): T extends number ? `test_${T}` : T;
+>D : Symbol(D, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 16, 23))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 18, 19))
+
+const DTest = D("foo");
+>DTest : Symbol(DTest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 20, 5))
+>D : Symbol(D, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 16, 23))
+
+declare function E<T>(value: T): T extends string ? `test_${T}` : T;
+>E : Symbol(E, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 20, 23))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 22, 19))
+
+const ETest = E("foo");
+>ETest : Symbol(ETest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 24, 5))
+>E : Symbol(E, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 20, 23))
+
+declare function F<T>(value: T): T extends number ? `test_${T}` : [T];
+>F : Symbol(F, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 24, 23))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 26, 19))
+
+const FTest1 = F("foo");
+>FTest1 : Symbol(FTest1, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 28, 5))
+>F : Symbol(F, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 24, 23))
+
+const FTest2 = F(42);
+>FTest2 : Symbol(FTest2, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 29, 5))
+>F : Symbol(F, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 24, 23))
+
+declare function G<T>(value: T): T extends string ? `test_${T}` : [T];
+>G : Symbol(G, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 29, 21))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 19))
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 31, 19))
+
+const GTest1 = G("foo");
+>GTest1 : Symbol(GTest1, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 33, 5))
+>G : Symbol(G, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 29, 21))
+
+const GTest2 = G(42);
+>GTest2 : Symbol(GTest2, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 34, 5))
+>G : Symbol(G, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 29, 21))
+
+declare function H<T>(
+>H : Symbol(H, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 34, 21))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 36, 19))
+
+  value: T,
+>value : Symbol(value, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 36, 22))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 36, 19))
+
+): T extends number ? never : `test_${T & string}`;
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 36, 19))
+>T : Symbol(T, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 36, 19))
+
+const HTest = H("foo");
+>HTest : Symbol(HTest, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 40, 5))
+>H : Symbol(H, Decl(returnTypeTopLevelInferenceLiteralDontWiden1.ts, 34, 21))
+

--- a/tests/baselines/reference/returnTypeTopLevelInferenceLiteralDontWiden1.types
+++ b/tests/baselines/reference/returnTypeTopLevelInferenceLiteralDontWiden1.types
@@ -1,0 +1,163 @@
+//// [tests/cases/compiler/returnTypeTopLevelInferenceLiteralDontWiden1.ts] ////
+
+=== returnTypeTopLevelInferenceLiteralDontWiden1.ts ===
+declare function A<T>(value: T): T extends string ? T : never;
+>A : <T>(value: T) => T extends string ? T : never
+>  : ^ ^^     ^^ ^^^^^                            
+>value : T
+>      : ^
+
+const ATest = A("foo");
+>ATest : "foo"
+>      : ^^^^^
+>A("foo") : "foo"
+>         : ^^^^^
+>A : <T>(value: T) => T extends string ? T : never
+>  : ^ ^^     ^^ ^^^^^                            
+>"foo" : "foo"
+>      : ^^^^^
+
+declare function B<T>(value: T): `test_${T & string}`;
+>B : <T>(value: T) => `test_${T & string}`
+>  : ^ ^^     ^^ ^^^^^                    
+>value : T
+>      : ^
+
+const BTest = B("foo");
+>BTest : "test_foo"
+>      : ^^^^^^^^^^
+>B("foo") : "test_foo"
+>         : ^^^^^^^^^^
+>B : <T>(value: T) => `test_${T & string}`
+>  : ^ ^^     ^^ ^^^^^                    
+>"foo" : "foo"
+>      : ^^^^^
+
+declare function C<T>(
+>C : <T>(value: T) => T extends string ? T : T extends number | bigint | boolean | null | undefined ? `test_${T}` : never
+>  : ^ ^^     ^^ ^^^^^                                                                                                   
+
+  value: T,
+>value : T
+>      : ^
+
+): T extends string
+  ? T
+  : T extends number | bigint | boolean | null | undefined
+  ? `test_${T}`
+  : never;
+
+const CTest = C("foo");
+>CTest : "foo"
+>      : ^^^^^
+>C("foo") : "foo"
+>         : ^^^^^
+>C : <T>(value: T) => T extends string ? T : T extends number | bigint | boolean | null | undefined ? `test_${T}` : never
+>  : ^ ^^     ^^ ^^^^^                                                                                                   
+>"foo" : "foo"
+>      : ^^^^^
+
+declare function D<T>(value: T): T extends number ? `test_${T}` : T;
+>D : <T>(value: T) => T extends number ? `test_${T}` : T
+>  : ^ ^^     ^^ ^^^^^                                  
+>value : T
+>      : ^
+
+const DTest = D("foo");
+>DTest : "foo"
+>      : ^^^^^
+>D("foo") : "foo"
+>         : ^^^^^
+>D : <T>(value: T) => T extends number ? `test_${T}` : T
+>  : ^ ^^     ^^ ^^^^^                                  
+>"foo" : "foo"
+>      : ^^^^^
+
+declare function E<T>(value: T): T extends string ? `test_${T}` : T;
+>E : <T>(value: T) => T extends string ? `test_${T}` : T
+>  : ^ ^^     ^^ ^^^^^                                  
+>value : T
+>      : ^
+
+const ETest = E("foo");
+>ETest : "test_foo"
+>      : ^^^^^^^^^^
+>E("foo") : "test_foo"
+>         : ^^^^^^^^^^
+>E : <T>(value: T) => T extends string ? `test_${T}` : T
+>  : ^ ^^     ^^ ^^^^^                                  
+>"foo" : "foo"
+>      : ^^^^^
+
+declare function F<T>(value: T): T extends number ? `test_${T}` : [T];
+>F : <T>(value: T) => T extends number ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>value : T
+>      : ^
+
+const FTest1 = F("foo");
+>FTest1 : ["foo"]
+>       : ^^^^^^^
+>F("foo") : ["foo"]
+>         : ^^^^^^^
+>F : <T>(value: T) => T extends number ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>"foo" : "foo"
+>      : ^^^^^
+
+const FTest2 = F(42);
+>FTest2 : "test_42"
+>       : ^^^^^^^^^
+>F(42) : "test_42"
+>      : ^^^^^^^^^
+>F : <T>(value: T) => T extends number ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>42 : 42
+>   : ^^
+
+declare function G<T>(value: T): T extends string ? `test_${T}` : [T];
+>G : <T>(value: T) => T extends string ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>value : T
+>      : ^
+
+const GTest1 = G("foo");
+>GTest1 : "test_foo"
+>       : ^^^^^^^^^^
+>G("foo") : "test_foo"
+>         : ^^^^^^^^^^
+>G : <T>(value: T) => T extends string ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>"foo" : "foo"
+>      : ^^^^^
+
+const GTest2 = G(42);
+>GTest2 : [42]
+>       : ^^^^
+>G(42) : [42]
+>      : ^^^^
+>G : <T>(value: T) => T extends string ? `test_${T}` : [T]
+>  : ^ ^^     ^^ ^^^^^                                    
+>42 : 42
+>   : ^^
+
+declare function H<T>(
+>H : <T>(value: T) => T extends number ? never : `test_${T & string}`
+>  : ^ ^^     ^^ ^^^^^                                               
+
+  value: T,
+>value : T
+>      : ^
+
+): T extends number ? never : `test_${T & string}`;
+
+const HTest = H("foo");
+>HTest : "test_foo"
+>      : ^^^^^^^^^^
+>H("foo") : "test_foo"
+>         : ^^^^^^^^^^
+>H : <T>(value: T) => T extends number ? never : `test_${T & string}`
+>  : ^ ^^     ^^ ^^^^^                                               
+>"foo" : "foo"
+>      : ^^^^^
+

--- a/tests/cases/compiler/returnTypeTopLevelInferenceLiteralDontWiden1.ts
+++ b/tests/cases/compiler/returnTypeTopLevelInferenceLiteralDontWiden1.ts
@@ -1,0 +1,44 @@
+// @strict: true
+// @noEmit: true
+
+declare function A<T>(value: T): T extends string ? T : never;
+
+const ATest = A("foo");
+
+declare function B<T>(value: T): `test_${T & string}`;
+
+const BTest = B("foo");
+
+declare function C<T>(
+  value: T,
+): T extends string
+  ? T
+  : T extends number | bigint | boolean | null | undefined
+  ? `test_${T}`
+  : never;
+
+const CTest = C("foo");
+
+declare function D<T>(value: T): T extends number ? `test_${T}` : T;
+
+const DTest = D("foo");
+
+declare function E<T>(value: T): T extends string ? `test_${T}` : T;
+
+const ETest = E("foo");
+
+declare function F<T>(value: T): T extends number ? `test_${T}` : [T];
+
+const FTest1 = F("foo");
+const FTest2 = F(42);
+
+declare function G<T>(value: T): T extends string ? `test_${T}` : [T];
+
+const GTest1 = G("foo");
+const GTest2 = G(42);
+
+declare function H<T>(
+  value: T,
+): T extends number ? never : `test_${T & string}`;
+
+const HTest = H("foo");


### PR DESCRIPTION
This patches a surprising difference in the inference behavior in respect to return types:
```ts
declare function test1<T>(value: T): T;

const result1 = test1("foo");
//    ^? const result1: "foo"

declare function test2<T>(value: T): T extends string ? T : never;

const result2 = test2("foo");
//    ^? const result2: string
```

The rule is that `T` has to appear in a top-level position in the return type for its literalness to be preserved. From the user's point of view ,it is in `test2`'s top-level position in the return type. But since `T` in that truthy branch is seen as a  substitution type for the compiler it fails to recognize it.