### PR TITLE
fix(60562): Missing Go to definition links when accessing properties after jsdoc typecast

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -35,6 +35,7 @@ import {
     getPropertySymbolsFromContextualType,
     getTargetLabel,
     getTextOfPropertyName,
+    getTokenAtPosition,
     getTouchingPropertyName,
     getTouchingToken,
     hasEffectiveModifier,
@@ -449,7 +450,7 @@ function getFirstTypeArgumentDefinitions(typeChecker: TypeChecker, type: Type, n
 /// Goto type
 /** @internal */
 export function getTypeDefinitionAtPosition(typeChecker: TypeChecker, sourceFile: SourceFile, position: number): readonly DefinitionInfo[] | undefined {
-    const node = getTouchingPropertyName(sourceFile, position);
+    const node = getTokenAtPosition(sourceFile, position);
     if (node === sourceFile) {
         return undefined;
     }

--- a/tests/baselines/reference/goToTypeDefinition_typedef.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_typedef.baseline.jsonc
@@ -5,8 +5,13 @@
 //  * @property {number} x
 //  |]*/
 // 
+// /** @typedef {{ name: string }} Foo */
 // /** @type {I} */
-// const /*GOTO TYPE*/i = { x: 0 };
+// const /*GOTO TYPE*/a = { x: 0 };
+// 
+// const b = /** @type {Foo} */({});
+// const c = /** @type {Foo} */({}).name;
+// const d = /** @type {Foo} */({})['name'];
 
   // === Details ===
   [
@@ -15,6 +20,96 @@
     "name": "__type",
     "containerName": "",
     "isLocal": true,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.js ===
+// /**
+//  * @typedef {object} I
+//  * @property {number} x
+//  */
+// 
+// /** <|@typedef {{ name: string }} [|Foo|]|> */
+// /** @type {I} */
+// const a = { x: 0 };
+// 
+// const b = /** @type {/*GOTO TYPE*/Foo} */({});
+// const c = /** @type {Foo} */({}).name;
+// const d = /** @type {Foo} */({})['name'];
+
+  // === Details ===
+  [
+   {
+    "kind": "type",
+    "name": "Foo",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.js ===
+// /**
+//  * @typedef {object} I
+//  * @property {number} x
+//  */
+// 
+// /** <|@typedef {{ name: string }} [|Foo|]|> */
+// /** @type {I} */
+// const a = { x: 0 };
+// 
+// const b = /** @type {Foo} */({});
+// const c = /** @type {/*GOTO TYPE*/Foo} */({}).name;
+// const d = /** @type {Foo} */({})['name'];
+
+  // === Details ===
+  [
+   {
+    "kind": "type",
+    "name": "Foo",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToType ===
+// === /a.js ===
+// /**
+//  * @typedef {object} I
+//  * @property {number} x
+//  */
+// 
+// /** <|@typedef {{ name: string }} [|Foo|]|> */
+// /** @type {I} */
+// const a = { x: 0 };
+// 
+// const b = /** @type {Foo} */({});
+// const c = /** @type {Foo} */({}).name;
+// const d = /** @type {/*GOTO TYPE*/Foo} */({})['name'];
+
+  // === Details ===
+  [
+   {
+    "kind": "type",
+    "name": "Foo",
+    "containerName": "",
+    "isLocal": false,
     "isAmbient": false,
     "unverified": false,
     "failedAliasResolution": false

--- a/tests/baselines/reference/tsserver/fourslashServer/typedefinition01.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/typedefinition01.js
@@ -156,25 +156,5 @@ Info seq  [hh:mm:ss:mss] response:
       "command": "typeDefinition",
       "request_seq": 1,
       "success": true,
-      "body": [
-        {
-          "file": "/tests/cases/fourslash/server/a.ts",
-          "start": {
-            "line": 1,
-            "offset": 14
-          },
-          "end": {
-            "line": 1,
-            "offset": 17
-          },
-          "contextStart": {
-            "line": 1,
-            "offset": 1
-          },
-          "contextEnd": {
-            "line": 1,
-            "offset": 20
-          }
-        }
-      ]
+      "body": []
     }

--- a/tests/baselines/reference/typedefinition01.baseline.jsonc
+++ b/tests/baselines/reference/typedefinition01.baseline.jsonc
@@ -1,17 +1,4 @@
 // === goToType ===
-// === /tests/cases/fourslash/server/a.ts ===
-// export class [|Foo|] {}
-
 // === /tests/cases/fourslash/server/b.ts ===
 // import n = require('./a');
 // var x/*GOTO TYPE*/ = new n.Foo();
-
-  // === Details ===
-  [
-   {
-    "containerKind": "",
-    "containerName": "",
-    "kind": "",
-    "name": ""
-   }
-  ]

--- a/tests/cases/fourslash/goToTypeDefinition_typedef.ts
+++ b/tests/cases/fourslash/goToTypeDefinition_typedef.ts
@@ -8,7 +8,13 @@
 //// * @property {number} x
 //// */
 ////
-/////** @type {I} */
-////const /*ref*/i = { x: 0 };
+/////** @typedef {{ name: string }} Foo */
 
-verify.baselineGoToType("ref");
+/////** @type {I} */
+////const /*a*/a = { x: 0 };
+////
+////const b = /** @type {/*b*/Foo} */({});
+////const c = /** @type {/*c*/Foo} */({}).name;
+////const d = /** @type {/*d*/Foo} */({})['name'];
+
+verify.baselineGoToType("a", "b", "c", "d");


### PR DESCRIPTION
Fixes #60562