### PR TITLE
Fix flow node improper reuse

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1104,6 +1104,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         // and set it before we descend into nodes that could actually be part of an assignment pattern.
         inAssignmentPattern = false;
         if (checkUnreachable(node)) {
+            if ((node as HasFlowNode).flowNode) {
+                (node as HasFlowNode).flowNode = undefined;
+            }
             bindEachChild(node);
             bindJSDoc(node);
             inAssignmentPattern = saveInAssignmentPattern;

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -21,6 +21,7 @@ import {
     BreakOrContinueStatement,
     CallChain,
     CallExpression,
+    canHaveFlowNode,
     canHaveLocals,
     canHaveSymbol,
     CaseBlock,
@@ -1104,8 +1105,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         // and set it before we descend into nodes that could actually be part of an assignment pattern.
         inAssignmentPattern = false;
         if (checkUnreachable(node)) {
-            if ((node as HasFlowNode).flowNode) {
-                (node as HasFlowNode).flowNode = undefined;
+            if (canHaveFlowNode(node) && node.flowNode) {
+                node.flowNode = undefined;
             }
             bindEachChild(node);
             bindJSDoc(node);

--- a/tests/cases/fourslash/unreachableStatementNodeReuse.ts
+++ b/tests/cases/fourslash/unreachableStatementNodeReuse.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+//// function test() {
+//// 	return /*a*/abc();
+//// 	return;
+//// }
+//// function abc() { }
+
+verify.noErrors();
+
+goTo.marker("a");
+edit.backspace(1);
+verify.numberOfErrorsInCurrentFile(1);
+
+edit.insert(" ");
+verify.noErrors();

--- a/tests/cases/fourslash/unreachableStatementNodeReuse.ts
+++ b/tests/cases/fourslash/unreachableStatementNodeReuse.ts
@@ -1,16 +1,13 @@
 /// <reference path="fourslash.ts" />
 
 //// function test() {
-//// 	return /*a*/abc();
+//// 	return/*a*/abc();
 //// 	return;
 //// }
 //// function abc() { }
 
-verify.noErrors();
-
-goTo.marker("a");
-edit.backspace(1);
 verify.numberOfErrorsInCurrentFile(1);
 
+goTo.marker("a")
 edit.insert(" ");
 verify.noErrors();


### PR DESCRIPTION
Fixes #60597.

The problem is caused by improper handling of node reuse across different versions of a source file. Say we have the following program:

```ts
function test() {
    returnabc();
    return;
}
function abc() { }
```
We'll get a compiler error saying `returnabc` could not be found. And, when we bind the source file, `return` will have its flow node set to a flow call node (corresponding to `returnabc()`).
If we then edit the file to this:
```ts
function test() {
    return abc();
    return;
}
function abc() { }
```
We will reuse the node for `return`. However, because that node is unreachable, the binder will not assign a new flow node to that node, and it will preserve its old flow node. Now, when we check the source file, we expect it to have no errors, but the `return` node will have a flow node for the old file, and that flow node will have a node that corresponds to the `returnabc()` call, and the checker will error on it when it visits that node.

What this PR does is clean up the old flow node in the binder when a node is unreachable, because otherwise the flow node would not be updated.
