### PR TITLE
Mark the inherited any-based index signature so it can be elided in declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2151,6 +2151,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var silentNeverSignature = createSignature(/*declaration*/ undefined, /*typeParameters*/ undefined, /*thisParameter*/ undefined, emptyArray, silentNeverType, /*resolvedTypePredicate*/ undefined, 0, SignatureFlags.None);
 
     var enumNumberIndexInfo = createIndexInfo(numberType, stringType, /*isReadonly*/ true);
+    var anyBaseTypeIndexInfo = createIndexInfo(stringType, anyType, /*isReadonly*/ false);
 
     var iterationTypesCache = new Map<string, IterationTypes>(); // cache for common IterationTypes instances
     var noIterationTypes: IterationTypes = {
@@ -13454,7 +13455,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 addInheritedMembers(members, getPropertiesOfType(instantiatedBaseType));
                 callSignatures = concatenate(callSignatures, getSignaturesOfType(instantiatedBaseType, SignatureKind.Call));
                 constructSignatures = concatenate(constructSignatures, getSignaturesOfType(instantiatedBaseType, SignatureKind.Construct));
-                const inheritedIndexInfos = instantiatedBaseType !== anyType ? getIndexInfosOfType(instantiatedBaseType) : [createIndexInfo(stringType, anyType, /*isReadonly*/ false)];
+                const inheritedIndexInfos = instantiatedBaseType !== anyType ? getIndexInfosOfType(instantiatedBaseType) : [anyBaseTypeIndexInfo];
                 indexInfos = concatenate(indexInfos, filter(inheritedIndexInfos, info => !findIndexInfo(indexInfos, info.keyType)));
             }
         }
@@ -13986,7 +13987,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 addInheritedMembers(members, getPropertiesOfType(baseConstructorType));
             }
             else if (baseConstructorType === anyType) {
-                baseConstructorIndexInfo = createIndexInfo(stringType, anyType, /*isReadonly*/ false);
+                baseConstructorIndexInfo = anyBaseTypeIndexInfo;
             }
         }
 
@@ -50781,6 +50782,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     result ||= [];
                     for (const info of infoList!) {
                         if (info.declaration) continue;
+                        if (info === anyBaseTypeIndexInfo) continue; // inherited, but looks like a late-bound signature because it has no declarations
                         const node = nodeBuilder.indexInfoToIndexSignatureDeclaration(info, enclosing, flags, internalFlags, tracker);
                         if (node && infoList === staticInfos) {
                             (((node as Mutable<typeof node>).modifiers ||= factory.createNodeArray()) as MutableNodeArray<Modifier>).unshift(factory.createModifier(SyntaxKind.StaticKeyword));

--- a/tests/baselines/reference/declarationEmitClassInherritsAny.js
+++ b/tests/baselines/reference/declarationEmitClassInherritsAny.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/declarationEmitClassInherritsAny.ts] ////
+
+//// [declarationEmitClassInherritsAny.ts]
+const anyThing = class {} as any;
+export class Foo extends anyThing {}
+
+//// [declarationEmitClassInherritsAny.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+var anyThing = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}());
+var Foo = /** @class */ (function (_super) {
+    __extends(Foo, _super);
+    function Foo() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Foo;
+}(anyThing));
+exports.Foo = Foo;
+
+
+//// [declarationEmitClassInherritsAny.d.ts]
+declare const anyThing: any;
+export declare class Foo extends anyThing {
+}
+export {};

--- a/tests/baselines/reference/declarationEmitClassInherritsAny.symbols
+++ b/tests/baselines/reference/declarationEmitClassInherritsAny.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/declarationEmitClassInherritsAny.ts] ////
+
+=== declarationEmitClassInherritsAny.ts ===
+const anyThing = class {} as any;
+>anyThing : Symbol(anyThing, Decl(declarationEmitClassInherritsAny.ts, 0, 5))
+
+export class Foo extends anyThing {}
+>Foo : Symbol(Foo, Decl(declarationEmitClassInherritsAny.ts, 0, 33))
+>anyThing : Symbol(anyThing, Decl(declarationEmitClassInherritsAny.ts, 0, 5))
+

--- a/tests/baselines/reference/declarationEmitClassInherritsAny.types
+++ b/tests/baselines/reference/declarationEmitClassInherritsAny.types
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/declarationEmitClassInherritsAny.ts] ////
+
+=== declarationEmitClassInherritsAny.ts ===
+const anyThing = class {} as any;
+>anyThing : any
+>class {} as any : any
+>class {} : typeof (Anonymous class)
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+export class Foo extends anyThing {}
+>Foo : Foo
+>    : ^^^
+>anyThing : any
+

--- a/tests/cases/compiler/declarationEmitClassInherritsAny.ts
+++ b/tests/cases/compiler/declarationEmitClassInherritsAny.ts
@@ -1,0 +1,3 @@
+// @declaration: true
+const anyThing = class {} as any;
+export class Foo extends anyThing {}


### PR DESCRIPTION
So they're not mistaken for late-bound index infos. Including them in the emit is functionally harmless in normal checking modes, since they *are* actually on the type, but under partial/single-file modes there may be extra `any`s from things imported from missing files and including these would spoil the emit.

Fixed #60383.