### PR TITLE
Restore repo dispatch for twoslash-repros workflow

### DIFF
--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -3,6 +3,8 @@ name: Twoslash Code Sample Repros
 on:
   schedule:
     - cron: '0 8 * * *'
+  repository_dispatch:
+    types: [run-twoslash-repros]
   workflow_dispatch:
     inputs:
       issue:


### PR DESCRIPTION
I removed this in #57409 without realizing that it's used by TypeScript-Repos-Automation on detection of new fourslash comments.