### PR TITLE
Cache started nonexistent property error checks to prevent reentrancy in the check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34465,6 +34465,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function reportNonexistentProperty(propNode: Identifier | PrivateIdentifier, containingType: Type, isUncheckedJS: boolean) {
+        const links = getNodeLinks(propNode);
+        const cache = (links.nonExistentPropCheckCache ||= new Set());
+        const key = `${getTypeId(containingType)}|${isUncheckedJS}`;
+        if (cache.has(key)) {
+            return;
+        }
+        cache.add(key);
         let errorInfo: DiagnosticMessageChain | undefined;
         let relatedInfo: Diagnostic | undefined;
         if (!isPrivateIdentifier(propNode) && containingType.flags & TypeFlags.Union && !(containingType.flags & TypeFlags.Primitive)) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6254,6 +6254,7 @@ export interface NodeLinks {
     potentialUnusedRenamedBindingElementsInTypes?: BindingElement[];
     externalHelpersModule?: Symbol;     // Resolved symbol for the external helpers module
     instantiationExpressionTypes?: Map<number, Type>; // Cache of instantiation expression types for the node
+    nonExistentPropCheckCache?: Set<string>;
 }
 
 /** @internal */

--- a/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.errors.txt
+++ b/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.errors.txt
@@ -1,0 +1,16 @@
+checkingObjectWithThisInNamePositionNoCrash.ts(2,5): error TS7023: 'doit' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+checkingObjectWithThisInNamePositionNoCrash.ts(4,19): error TS2339: Property 'a' does not exist on type '{ doit(): { [x: number]: string; }; }'.
+
+
+==== checkingObjectWithThisInNamePositionNoCrash.ts (2 errors) ====
+    export const thing = {
+        doit() {
+        ~~~~
+!!! error TS7023: 'doit' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+            return {
+                [this.a]: "", // should refer to the outer object with the doit method, notably not present
+                      ~
+!!! error TS2339: Property 'a' does not exist on type '{ doit(): { [x: number]: string; }; }'.
+            }
+        }
+    }

--- a/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.js
+++ b/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts] ////
+
+//// [checkingObjectWithThisInNamePositionNoCrash.ts]
+export const thing = {
+    doit() {
+        return {
+            [this.a]: "", // should refer to the outer object with the doit method, notably not present
+        }
+    }
+}
+
+//// [checkingObjectWithThisInNamePositionNoCrash.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.thing = void 0;
+exports.thing = {
+    doit: function () {
+        var _a;
+        return _a = {},
+            _a[this.a] = "",
+            _a;
+    }
+};
+
+
+//// [checkingObjectWithThisInNamePositionNoCrash.d.ts]
+export declare const thing: {
+    doit(): {
+        [x: number]: string;
+    };
+};

--- a/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.symbols
+++ b/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.symbols
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts] ////
+
+=== checkingObjectWithThisInNamePositionNoCrash.ts ===
+export const thing = {
+>thing : Symbol(thing, Decl(checkingObjectWithThisInNamePositionNoCrash.ts, 0, 12))
+
+    doit() {
+>doit : Symbol(doit, Decl(checkingObjectWithThisInNamePositionNoCrash.ts, 0, 22))
+
+        return {
+            [this.a]: "", // should refer to the outer object with the doit method, notably not present
+>[this.a] : Symbol([this.a], Decl(checkingObjectWithThisInNamePositionNoCrash.ts, 2, 16))
+>this : Symbol(thing, Decl(checkingObjectWithThisInNamePositionNoCrash.ts, 0, 20))
+        }
+    }
+}

--- a/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.types
+++ b/tests/baselines/reference/checkingObjectWithThisInNamePositionNoCrash.types
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts] ////
+
+=== checkingObjectWithThisInNamePositionNoCrash.ts ===
+export const thing = {
+>thing : { doit(): { [x: number]: string; }; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    doit() {        return {            [this.a]: "", // should refer to the outer object with the doit method, notably not present        }    }} : { doit(): { [x: number]: string; }; }
+>                                                                                                                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    doit() {
+>doit : () => { [x: number]: string; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        return {
+>{            [this.a]: "", // should refer to the outer object with the doit method, notably not present        } : { [x: number]: string; }
+>                                                                                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+            [this.a]: "", // should refer to the outer object with the doit method, notably not present
+>[this.a] : string
+>         : ^^^^^^
+>this.a : any
+>       : ^^^
+>this : { doit(): { [x: number]: string; }; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : any
+>  : ^^^
+>"" : ""
+>   : ^^
+        }
+    }
+}

--- a/tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts
+++ b/tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts
@@ -1,0 +1,9 @@
+// @strict: true
+// @declaration: true
+export const thing = {
+    doit() {
+        return {
+            [this.a]: "", // should refer to the outer object with the doit method, notably not present
+        }
+    }
+}


### PR DESCRIPTION
Fixes #60564

None of the expression types made while looking at the structure for this check are cached (courtesy of using `getRegularTypeOfExpression` instead of `checkExpressionCached` in `serializeTypeOfExpression`, which is itself done to handle freshness correctly), so the diagnostic check itself needs to be cached to prevent reentrancy when reporting on a circularly referential structure.