### PR TITLE
Add extra test cases for fixed `reportNonexistentProperty` crashes

### DIFF
--- a/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.errors.txt
+++ b/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.errors.txt
@@ -1,0 +1,16 @@
+index.js(5,21): error TS2339: Property 'fn' does not exist on type '{ (...args: any[]): void; readonly name: string; }'.
+
+
+==== index.js (1 errors) ====
+    export function test(fn) {
+      const composed = function (...args) { }
+    
+      Object.defineProperty(composed, 'name', {
+        value: composed.fn + '_test'
+                        ~~
+!!! error TS2339: Property 'fn' does not exist on type '{ (...args: any[]): void; readonly name: string; }'.
+      })
+    
+      return composed
+    }
+    

--- a/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.js
+++ b/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.js
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.ts] ////
+
+//// [index.js]
+export function test(fn) {
+  const composed = function (...args) { }
+
+  Object.defineProperty(composed, 'name', {
+    value: composed.fn + '_test'
+  })
+
+  return composed
+}
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.test = test;
+function test(fn) {
+    var composed = function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    };
+    Object.defineProperty(composed, 'name', {
+        value: composed.fn + '_test'
+    });
+    return composed;
+}
+
+
+//// [index.d.ts]
+export function test(fn: any): {
+    (...args: any[]): void;
+    readonly name: string;
+};

--- a/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.symbols
+++ b/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.ts] ////
+
+=== index.js ===
+export function test(fn) {
+>test : Symbol(test, Decl(index.js, 0, 0))
+>fn : Symbol(fn, Decl(index.js, 0, 21))
+
+  const composed = function (...args) { }
+>composed : Symbol(composed, Decl(index.js, 1, 7))
+>args : Symbol(args, Decl(index.js, 1, 29))
+
+  Object.defineProperty(composed, 'name', {
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>composed : Symbol(composed, Decl(index.js, 1, 7))
+>'name' : Symbol(composed.name, Decl(index.js, 1, 41))
+
+    value: composed.fn + '_test'
+>value : Symbol(value, Decl(index.js, 3, 43))
+>composed : Symbol(composed, Decl(index.js, 1, 7))
+
+  })
+
+  return composed
+>composed : Symbol(composed, Decl(index.js, 1, 7))
+}
+

--- a/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.types
+++ b/tests/baselines/reference/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.types
@@ -1,0 +1,54 @@
+//// [tests/cases/compiler/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.ts] ////
+
+=== index.js ===
+export function test(fn) {
+>test : (fn: any) => { (...args: any[]): void; readonly name: string; }
+>     : ^  ^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fn : any
+>   : ^^^
+
+  const composed = function (...args) { }
+>composed : { (...args: any[]): void; readonly name: string; }
+>         : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>function (...args) { } : { (...args: any[]): void; readonly name: string; }
+>                       : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>args : any[]
+>     : ^^^^^
+
+  Object.defineProperty(composed, 'name', {
+>Object.defineProperty(composed, 'name', {    value: composed.fn + '_test'  }) : { (...args: any[]): void; readonly name: string; }
+>                                                                              : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Object.defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>                      : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>Object : ObjectConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
+>               : ^ ^^ ^^ ^^ ^^           ^^          ^^                                  ^^^^^ 
+>composed : { (...args: any[]): void; readonly name: string; }
+>         : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'name' : "name"
+>       : ^^^^^^
+>{    value: composed.fn + '_test'  } : { value: string; }
+>                                     : ^^^^^^^^^^^^^^^^^^
+
+    value: composed.fn + '_test'
+>value : string
+>      : ^^^^^^
+>composed.fn + '_test' : string
+>                      : ^^^^^^
+>composed.fn : any
+>            : ^^^
+>composed : { (...args: any[]): void; readonly name: string; }
+>         : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>fn : any
+>   : ^^^
+>'_test' : "_test"
+>        : ^^^^^^^
+
+  })
+
+  return composed
+>composed : { (...args: any[]): void; readonly name: string; }
+>         : ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+

--- a/tests/baselines/reference/findAllRefsNonexistentPropertyNoCrash1.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsNonexistentPropertyNoCrash1.baseline.jsonc
@@ -1,0 +1,50 @@
+// === findAllReferences ===
+// === /tests/cases/fourslash/src/parser.js ===
+// --- (line: 10) skipped ---
+//       variable: function () {
+//         let name;
+// 
+//         if (parserInput.currentChar() === "[|{| isInString: true |}@|]") {
+//           return name[1];
+//         }
+//       },
+// --- (line: 18) skipped ---
+
+// === /tests/cases/fourslash/./src/parser.js ===
+// --- (line: 10) skipped ---
+//       variable: function () {
+//         let name;
+// 
+//         if (parserInput.currentChar() === "/*FIND ALL REFS*/@") {
+//           return name[1];
+//         }
+//       },
+// --- (line: 18) skipped ---
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/src/parser.js ===
+  // --- (line: 10) skipped ---
+  //       variable: function () {
+  //         let name;
+  // 
+  //         if (parserInput.currentChar() === "[|@|]") {
+  //           return name[1];
+  //         }
+  //       },
+  // --- (line: 18) skipped ---
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "var",
+    "name": "@",
+    "displayParts": [
+     {
+      "text": "\"@\"",
+      "kind": "stringLiteral"
+     }
+    ]
+   }
+  ]

--- a/tests/cases/compiler/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.ts
+++ b/tests/cases/compiler/checkingObjectDefinePropertyOnFunctionNonexistentPropertyNoCrash1.ts
@@ -1,0 +1,16 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @outDir: dist
+
+// @filename: index.js
+
+export function test(fn) {
+  const composed = function (...args) { }
+
+  Object.defineProperty(composed, 'name', {
+    value: composed.fn + '_test'
+  })
+
+  return composed
+}

--- a/tests/cases/fourslash/findAllRefsNonexistentPropertyNoCrash1.ts
+++ b/tests/cases/fourslash/findAllRefsNonexistentPropertyNoCrash1.ts
@@ -1,0 +1,51 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+
+// @filename: ./src/parser-input.js
+//// export default () => {
+////   let input;
+////
+////   const parserInput = {};
+////
+////   parserInput.currentChar = () => input.charAt(parserInput.i);
+////
+////   parserInput.end = () => {
+////     const isFinished = parserInput.i >= input.length;
+////
+////     return {
+////       isFinished,
+////       furthest: parserInput.i,
+////     };
+////   };
+////
+////   return parserInput;
+//// };
+
+// @filename: ./src/parser.js
+//// import getParserInput from "./parser-input";
+////
+//// const Parser = function Parser(context, imports, fileInfo, currentIndex) {
+////   currentIndex = currentIndex || 0;
+////   let parsers;
+////   const parserInput = getParserInput();
+////
+////   return {
+////     parserInput,
+////     parsers: (parsers = {
+////       variable: function () {
+////         let name;
+////
+////         if (parserInput.currentChar() === "/*1*/@") {
+////           return name[1];
+////         }
+////       },
+////     }),
+////   };
+//// };
+////
+//// export default Parser;
+
+verify.baselineFindAllReferences("1");


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/60336
closes https://github.com/microsoft/TypeScript/issues/55889

both were fixed by @weswigham in https://github.com/microsoft/TypeScript/pull/60683