### PR TITLE
Cherry-pick #60402, #60440, #60616 into release-5.7

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39783,6 +39783,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         switch (node.kind) {
             case SyntaxKind.AwaitExpression:
             case SyntaxKind.CallExpression:
+            case SyntaxKind.TaggedTemplateExpression:
             case SyntaxKind.ElementAccessExpression:
             case SyntaxKind.MetaProperty:
             case SyntaxKind.NewExpression:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39784,6 +39784,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.AwaitExpression:
             case SyntaxKind.CallExpression:
             case SyntaxKind.ElementAccessExpression:
+            case SyntaxKind.MetaProperty:
             case SyntaxKind.NewExpression:
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.YieldExpression:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39801,6 +39801,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     case SyntaxKind.AmpersandAmpersandToken:
                     case SyntaxKind.AmpersandAmpersandEqualsToken:
                         return PredicateSemantics.Sometimes;
+                    case SyntaxKind.CommaToken:
+                        return getSyntacticNullishnessSemantics((node as BinaryExpression).right);
                 }
                 return PredicateSemantics.Never;
             case SyntaxKind.ConditionalExpression:

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -12,9 +12,11 @@ predicateSemantics.ts(36,8): error TS2872: This kind of expression is always tru
 predicateSemantics.ts(51,14): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 predicateSemantics.ts(52,14): error TS2695: Left side of comma operator is unused and has no side effects.
 predicateSemantics.ts(52,14): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+predicateSemantics.ts(70,1): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+predicateSemantics.ts(71,1): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 
 
-==== predicateSemantics.ts (14 errors) ====
+==== predicateSemantics.ts (16 errors) ====
     declare let cond: any;
     
     // OK: One or other operand is possibly nullish
@@ -103,4 +105,19 @@ predicateSemantics.ts(52,14): error TS2869: Right operand of ?? is unreachable b
         const p = new.target ?? 32;
       }
     }
+    
+    // https://github.com/microsoft/TypeScript/issues/60614
+    declare function tag<T>(
+      strings: TemplateStringsArray,
+      ...values: number[]
+    ): T | null;
+    
+    tag`foo${1}` ?? 32; // ok
+    
+    `foo${1}` ?? 32; // error
+    ~~~~~~~~~
+!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+    `foo` ?? 32; // error
+    ~~~~~
+!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
     

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -9,9 +9,12 @@ predicateSemantics.ts(33,8): error TS2872: This kind of expression is always tru
 predicateSemantics.ts(34,11): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(35,8): error TS2872: This kind of expression is always truthy.
 predicateSemantics.ts(36,8): error TS2872: This kind of expression is always truthy.
+predicateSemantics.ts(51,14): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+predicateSemantics.ts(52,14): error TS2695: Left side of comma operator is unused and has no side effects.
+predicateSemantics.ts(52,14): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 
 
-==== predicateSemantics.ts (11 errors) ====
+==== predicateSemantics.ts (14 errors) ====
     declare let cond: any;
     
     // OK: One or other operand is possibly nullish
@@ -78,3 +81,19 @@ predicateSemantics.ts(36,8): error TS2872: This kind of expression is always tru
         // Should be OK
         return this ?? 0;
     }
+    
+    // https://github.com/microsoft/TypeScript/issues/60401
+    {
+      const maybe = null as true | null;
+      let i = 0;
+      const d = (i++, maybe) ?? true; // ok
+      const e = (i++, i++) ?? true; // error
+                 ~~~~~~~~
+!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+      const f = (maybe, i++) ?? true; // error
+                 ~~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                 ~~~~~~~~~~
+!!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+    }
+    

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -97,3 +97,10 @@ predicateSemantics.ts(52,14): error TS2869: Right operand of ?? is unreachable b
 !!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
     }
     
+    // https://github.com/microsoft/TypeScript/issues/60439
+    class X {
+      constructor() {
+        const p = new.target ?? 32;
+      }
+    }
+    

--- a/tests/baselines/reference/predicateSemantics.js
+++ b/tests/baselines/reference/predicateSemantics.js
@@ -62,9 +62,24 @@ class X {
   }
 }
 
+// https://github.com/microsoft/TypeScript/issues/60614
+declare function tag<T>(
+  strings: TemplateStringsArray,
+  ...values: number[]
+): T | null;
+
+tag`foo${1}` ?? 32; // ok
+
+`foo${1}` ?? 32; // error
+`foo` ?? 32; // error
+
 
 //// [predicateSemantics.js]
-var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
 // OK: One or other operand is possibly nullish
 var test1 = (_a = (cond ? undefined : 32)) !== null && _a !== void 0 ? _a : "possibly reached";
 // Not OK: Both operands nullish
@@ -122,3 +137,6 @@ var X = /** @class */ (function () {
     }
     return X;
 }());
+(_k = tag(__makeTemplateObject(["foo", ""], ["foo", ""]), 1)) !== null && _k !== void 0 ? _k : 32; // ok
+(_l = "foo".concat(1)) !== null && _l !== void 0 ? _l : 32; // error
+"foo" !== null && "foo" !== void 0 ? "foo" : 32; // error

--- a/tests/baselines/reference/predicateSemantics.js
+++ b/tests/baselines/reference/predicateSemantics.js
@@ -46,8 +46,18 @@ function foo(this: Object | undefined) {
     return this ?? 0;
 }
 
+// https://github.com/microsoft/TypeScript/issues/60401
+{
+  const maybe = null as true | null;
+  let i = 0;
+  const d = (i++, maybe) ?? true; // ok
+  const e = (i++, i++) ?? true; // error
+  const f = (maybe, i++) ?? true; // error
+}
+
+
 //// [predicateSemantics.js]
-var _a, _b, _c, _d, _e, _f;
+var _a, _b, _c, _d, _e, _f, _g, _h, _j;
 // OK: One or other operand is possibly nullish
 var test1 = (_a = (cond ? undefined : 32)) !== null && _a !== void 0 ? _a : "possibly reached";
 // Not OK: Both operands nullish
@@ -87,4 +97,12 @@ console.log((cond || undefined) && 1 / cond);
 function foo() {
     // Should be OK
     return this !== null && this !== void 0 ? this : 0;
+}
+// https://github.com/microsoft/TypeScript/issues/60401
+{
+    var maybe = null;
+    var i = 0;
+    var d = (_g = (i++, maybe)) !== null && _g !== void 0 ? _g : true; // ok
+    var e = (_h = (i++, i++)) !== null && _h !== void 0 ? _h : true; // error
+    var f = (_j = (maybe, i++)) !== null && _j !== void 0 ? _j : true; // error
 }

--- a/tests/baselines/reference/predicateSemantics.js
+++ b/tests/baselines/reference/predicateSemantics.js
@@ -55,6 +55,13 @@ function foo(this: Object | undefined) {
   const f = (maybe, i++) ?? true; // error
 }
 
+// https://github.com/microsoft/TypeScript/issues/60439
+class X {
+  constructor() {
+    const p = new.target ?? 32;
+  }
+}
+
 
 //// [predicateSemantics.js]
 var _a, _b, _c, _d, _e, _f, _g, _h, _j;
@@ -106,3 +113,12 @@ function foo() {
     var e = (_h = (i++, i++)) !== null && _h !== void 0 ? _h : true; // error
     var f = (_j = (maybe, i++)) !== null && _j !== void 0 ? _j : true; // error
 }
+// https://github.com/microsoft/TypeScript/issues/60439
+var X = /** @class */ (function () {
+    function X() {
+        var _newTarget = this.constructor;
+        var _a;
+        var p = (_a = _newTarget) !== null && _a !== void 0 ? _a : 32;
+    }
+    return X;
+}());

--- a/tests/baselines/reference/predicateSemantics.symbols
+++ b/tests/baselines/reference/predicateSemantics.symbols
@@ -116,3 +116,24 @@ class X {
   }
 }
 
+// https://github.com/microsoft/TypeScript/issues/60614
+declare function tag<T>(
+>tag : Symbol(tag, Decl(predicateSemantics.ts, 59, 1))
+>T : Symbol(T, Decl(predicateSemantics.ts, 62, 21))
+
+  strings: TemplateStringsArray,
+>strings : Symbol(strings, Decl(predicateSemantics.ts, 62, 24))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.es5.d.ts, --, --))
+
+  ...values: number[]
+>values : Symbol(values, Decl(predicateSemantics.ts, 63, 32))
+
+): T | null;
+>T : Symbol(T, Decl(predicateSemantics.ts, 62, 21))
+
+tag`foo${1}` ?? 32; // ok
+>tag : Symbol(tag, Decl(predicateSemantics.ts, 59, 1))
+
+`foo${1}` ?? 32; // error
+`foo` ?? 32; // error
+

--- a/tests/baselines/reference/predicateSemantics.symbols
+++ b/tests/baselines/reference/predicateSemantics.symbols
@@ -79,3 +79,28 @@ function foo(this: Object | undefined) {
     return this ?? 0;
 >this : Symbol(this, Decl(predicateSemantics.ts, 40, 13))
 }
+
+// https://github.com/microsoft/TypeScript/issues/60401
+{
+  const maybe = null as true | null;
+>maybe : Symbol(maybe, Decl(predicateSemantics.ts, 47, 7))
+
+  let i = 0;
+>i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
+
+  const d = (i++, maybe) ?? true; // ok
+>d : Symbol(d, Decl(predicateSemantics.ts, 49, 7))
+>i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
+>maybe : Symbol(maybe, Decl(predicateSemantics.ts, 47, 7))
+
+  const e = (i++, i++) ?? true; // error
+>e : Symbol(e, Decl(predicateSemantics.ts, 50, 7))
+>i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
+>i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
+
+  const f = (maybe, i++) ?? true; // error
+>f : Symbol(f, Decl(predicateSemantics.ts, 51, 7))
+>maybe : Symbol(maybe, Decl(predicateSemantics.ts, 47, 7))
+>i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
+}
+

--- a/tests/baselines/reference/predicateSemantics.symbols
+++ b/tests/baselines/reference/predicateSemantics.symbols
@@ -104,3 +104,15 @@ function foo(this: Object | undefined) {
 >i : Symbol(i, Decl(predicateSemantics.ts, 48, 5))
 }
 
+// https://github.com/microsoft/TypeScript/issues/60439
+class X {
+>X : Symbol(X, Decl(predicateSemantics.ts, 52, 1))
+
+  constructor() {
+    const p = new.target ?? 32;
+>p : Symbol(p, Decl(predicateSemantics.ts, 57, 9))
+>new.target : Symbol(X, Decl(predicateSemantics.ts, 52, 1))
+>target : Symbol(X, Decl(predicateSemantics.ts, 52, 1))
+  }
+}
+

--- a/tests/baselines/reference/predicateSemantics.types
+++ b/tests/baselines/reference/predicateSemantics.types
@@ -328,3 +328,50 @@ class X {
   }
 }
 
+// https://github.com/microsoft/TypeScript/issues/60614
+declare function tag<T>(
+>tag : <T>(strings: TemplateStringsArray, ...values: number[]) => T | null
+>    : ^ ^^       ^^                    ^^^^^      ^^        ^^^^^        
+
+  strings: TemplateStringsArray,
+>strings : TemplateStringsArray
+>        : ^^^^^^^^^^^^^^^^^^^^
+
+  ...values: number[]
+>values : number[]
+>       : ^^^^^^^^
+
+): T | null;
+
+tag`foo${1}` ?? 32; // ok
+>tag`foo${1}` ?? 32 : unknown
+>                   : ^^^^^^^
+>tag`foo${1}` : unknown
+>             : ^^^^^^^
+>tag : <T>(strings: TemplateStringsArray, ...values: number[]) => T | null
+>    : ^ ^^       ^^                    ^^^^^      ^^        ^^^^^        
+>`foo${1}` : string
+>          : ^^^^^^
+>1 : 1
+>  : ^
+>32 : 32
+>   : ^^
+
+`foo${1}` ?? 32; // error
+>`foo${1}` ?? 32 : 32 | "foo1"
+>                : ^^^^^^^^^^^
+>`foo${1}` : "foo1"
+>          : ^^^^^^
+>1 : 1
+>  : ^
+>32 : 32
+>   : ^^
+
+`foo` ?? 32; // error
+>`foo` ?? 32 : 32 | "foo"
+>            : ^^^^^^^^^^
+>`foo` : "foo"
+>      : ^^^^^
+>32 : 32
+>   : ^^
+

--- a/tests/baselines/reference/predicateSemantics.types
+++ b/tests/baselines/reference/predicateSemantics.types
@@ -234,3 +234,77 @@ function foo(this: Object | undefined) {
 >0 : 0
 >  : ^
 }
+
+// https://github.com/microsoft/TypeScript/issues/60401
+{
+  const maybe = null as true | null;
+>maybe : true
+>      : ^^^^
+>null as true | null : true
+>                    : ^^^^
+>true : true
+>     : ^^^^
+
+  let i = 0;
+>i : number
+>  : ^^^^^^
+>0 : 0
+>  : ^
+
+  const d = (i++, maybe) ?? true; // ok
+>d : true
+>  : ^^^^
+>(i++, maybe) ?? true : true
+>                     : ^^^^
+>(i++, maybe) : true
+>             : ^^^^
+>i++, maybe : true
+>           : ^^^^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+>maybe : true
+>      : ^^^^
+>true : true
+>     : ^^^^
+
+  const e = (i++, i++) ?? true; // error
+>e : number | true
+>  : ^^^^^^^^^^^^^
+>(i++, i++) ?? true : number | true
+>                   : ^^^^^^^^^^^^^
+>(i++, i++) : number
+>           : ^^^^^^
+>i++, i++ : number
+>         : ^^^^^^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+>true : true
+>     : ^^^^
+
+  const f = (maybe, i++) ?? true; // error
+>f : number | true
+>  : ^^^^^^^^^^^^^
+>(maybe, i++) ?? true : number | true
+>                     : ^^^^^^^^^^^^^
+>(maybe, i++) : number
+>             : ^^^^^^
+>maybe, i++ : number
+>           : ^^^^^^
+>maybe : true
+>      : ^^^^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+>true : true
+>     : ^^^^
+}
+

--- a/tests/baselines/reference/predicateSemantics.types
+++ b/tests/baselines/reference/predicateSemantics.types
@@ -308,3 +308,23 @@ function foo(this: Object | undefined) {
 >     : ^^^^
 }
 
+// https://github.com/microsoft/TypeScript/issues/60439
+class X {
+>X : X
+>  : ^
+
+  constructor() {
+    const p = new.target ?? 32;
+>p : 32 | typeof X
+>  : ^^^^^^^^^^^^^
+>new.target ?? 32 : 32 | typeof X
+>                 : ^^^^^^^^^^^^^
+>new.target : typeof X
+>           : ^^^^^^^^
+>target : typeof X
+>       : ^^^^^^^^
+>32 : 32
+>   : ^^
+  }
+}
+

--- a/tests/cases/compiler/predicateSemantics.ts
+++ b/tests/cases/compiler/predicateSemantics.ts
@@ -58,3 +58,14 @@ class X {
     const p = new.target ?? 32;
   }
 }
+
+// https://github.com/microsoft/TypeScript/issues/60614
+declare function tag<T>(
+  strings: TemplateStringsArray,
+  ...values: number[]
+): T | null;
+
+tag`foo${1}` ?? 32; // ok
+
+`foo${1}` ?? 32; // error
+`foo` ?? 32; // error

--- a/tests/cases/compiler/predicateSemantics.ts
+++ b/tests/cases/compiler/predicateSemantics.ts
@@ -51,3 +51,10 @@ function foo(this: Object | undefined) {
   const e = (i++, i++) ?? true; // error
   const f = (maybe, i++) ?? true; // error
 }
+
+// https://github.com/microsoft/TypeScript/issues/60439
+class X {
+  constructor() {
+    const p = new.target ?? 32;
+  }
+}

--- a/tests/cases/compiler/predicateSemantics.ts
+++ b/tests/cases/compiler/predicateSemantics.ts
@@ -42,3 +42,12 @@ function foo(this: Object | undefined) {
     // Should be OK
     return this ?? 0;
 }
+
+// https://github.com/microsoft/TypeScript/issues/60401
+{
+  const maybe = null as true | null;
+  let i = 0;
+  const d = (i++, maybe) ?? true; // ok
+  const e = (i++, i++) ?? true; // error
+  const f = (maybe, i++) ?? true; // error
+}


### PR DESCRIPTION
These are all fixes related to syntactic nullish checks.

Pulling these into one PR since their tests are all the same file and it'd be a pain to do each individually except with a hand merge.