### PR TITLE
Point TypeScript-Twoslash-Repro-Action back to main branch

### DIFF
--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 'lts/*'
-      - uses: microsoft/TypeScript-Twoslash-Repro-Action@8680b5b290d48a7badbc7ba65971d526c61b86b8 # master
+      - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
         with:
           github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
           issue: ${{ github.event.inputs.issue }}


### PR DESCRIPTION
This action does not need to be pinned; we own it, like we do `microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@master`.

Unpin it so we can pull the latest version (with new changes) instead of bumping the hash repeatedly.