### PR TITLE
Harden `sanitizeLog` against incorrect matches on TypeScript versions.

### DIFF
--- a/src/harness/tsserverLogger.ts
+++ b/src/harness/tsserverLogger.ts
@@ -111,7 +111,7 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/Elapsed::?\s*\d+(?:\.\d+)?ms/g, "Elapsed:: *ms");
     s = s.replace(/"updateGraphDurationMs":\s*\d+(?:\.\d+)?/g, `"updateGraphDurationMs": *`);
     s = s.replace(/"createAutoImportProviderProgramDurationMs":\s*\d+(?:\.\d+)?/g, `"createAutoImportProviderProgramDurationMs": *`);
-    s = s.replace(new RegExp(`\\b${ts.version}\\b`, "g"), "FakeVersion");
+    s = s.replace(new RegExp(`\\b${regExpEscape(ts.version)}\\b`, "g"), "FakeVersion");
     s = s.replace(/getCompletionData: Get current token: \d+(?:\.\d+)?/g, `getCompletionData: Get current token: *`);
     s = s.replace(/getCompletionData: Is inside comment: \d+(?:\.\d+)?/g, `getCompletionData: Is inside comment: *`);
     s = s.replace(/getCompletionData: Get previous token: \d+(?:\.\d+)?/g, `getCompletionData: Get previous token: *`);
@@ -130,7 +130,8 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/"semanticDiag":\s*\d+(?:.\d+)?/g, `"semanticDiag": *`);
     s = s.replace(/"suggestionDiag":\s*\d+(?:.\d+)?/g, `"suggestionDiag": *`);
     s = s.replace(/"regionSemanticDiag":\s*\d+(?:.\d+)?/g, `"regionSemanticDiag": *`);
-    s = s.replace(new RegExp(`\\b@ts${ts.versionMajorMinor}\\b`, "g"), `@tsFakeMajor.Minor`);
+    s = s.replace(new RegExp(`\\b@ts${regExpEscape(ts.versionMajorMinor)}\\b`, "g"), `@tsFakeMajor.Minor`);
+
     s = sanitizeHarnessLSException(s);
     return s;
 }

--- a/src/harness/tsserverLogger.ts
+++ b/src/harness/tsserverLogger.ts
@@ -111,7 +111,7 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/Elapsed::?\s*\d+(?:\.\d+)?ms/g, "Elapsed:: *ms");
     s = s.replace(/"updateGraphDurationMs":\s*\d+(?:\.\d+)?/g, `"updateGraphDurationMs": *`);
     s = s.replace(/"createAutoImportProviderProgramDurationMs":\s*\d+(?:\.\d+)?/g, `"createAutoImportProviderProgramDurationMs": *`);
-    s = replaceAll(s, ts.version, "FakeVersion");
+    s = s.replace(new RegExp(`\\b${ts.version}\\b`, "g"), "FakeVersion");
     s = s.replace(/getCompletionData: Get current token: \d+(?:\.\d+)?/g, `getCompletionData: Get current token: *`);
     s = s.replace(/getCompletionData: Is inside comment: \d+(?:\.\d+)?/g, `getCompletionData: Is inside comment: *`);
     s = s.replace(/getCompletionData: Get previous token: \d+(?:\.\d+)?/g, `getCompletionData: Get previous token: *`);
@@ -130,7 +130,7 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/"semanticDiag":\s*\d+(?:.\d+)?/g, `"semanticDiag": *`);
     s = s.replace(/"suggestionDiag":\s*\d+(?:.\d+)?/g, `"suggestionDiag": *`);
     s = s.replace(/"regionSemanticDiag":\s*\d+(?:.\d+)?/g, `"regionSemanticDiag": *`);
-    s = replaceAll(s, `@ts${ts.versionMajorMinor}`, `@tsFakeMajor.Minor`);
+    s = s.replace(new RegExp(`\\b@ts${ts.versionMajorMinor}\\b`, "g"), `@tsFakeMajor.Minor`);
     s = sanitizeHarnessLSException(s);
     return s;
 }

--- a/src/harness/tsserverLogger.ts
+++ b/src/harness/tsserverLogger.ts
@@ -111,7 +111,7 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/Elapsed::?\s*\d+(?:\.\d+)?ms/g, "Elapsed:: *ms");
     s = s.replace(/"updateGraphDurationMs":\s*\d+(?:\.\d+)?/g, `"updateGraphDurationMs": *`);
     s = s.replace(/"createAutoImportProviderProgramDurationMs":\s*\d+(?:\.\d+)?/g, `"createAutoImportProviderProgramDurationMs": *`);
-    s = s.replace(new RegExp(`\\b${regExpEscape(ts.version)}\\b`, "g"), "FakeVersion");
+    s = s.replace(new RegExp(`\\b${ts.regExpEscape(ts.version)}\\b`, "g"), "FakeVersion");
     s = s.replace(/getCompletionData: Get current token: \d+(?:\.\d+)?/g, `getCompletionData: Get current token: *`);
     s = s.replace(/getCompletionData: Is inside comment: \d+(?:\.\d+)?/g, `getCompletionData: Is inside comment: *`);
     s = s.replace(/getCompletionData: Get previous token: \d+(?:\.\d+)?/g, `getCompletionData: Get previous token: *`);
@@ -130,7 +130,7 @@ export function sanitizeLog(s: string): string {
     s = s.replace(/"semanticDiag":\s*\d+(?:.\d+)?/g, `"semanticDiag": *`);
     s = s.replace(/"suggestionDiag":\s*\d+(?:.\d+)?/g, `"suggestionDiag": *`);
     s = s.replace(/"regionSemanticDiag":\s*\d+(?:.\d+)?/g, `"regionSemanticDiag": *`);
-    s = s.replace(new RegExp(`\\b@ts${regExpEscape(ts.versionMajorMinor)}\\b`, "g"), `@tsFakeMajor.Minor`);
+    s = s.replace(new RegExp(`\\b@ts${ts.regExpEscape(ts.versionMajorMinor)}\\b`, "g"), `@tsFakeMajor.Minor`);
 
     s = sanitizeHarnessLSException(s);
     return s;


### PR DESCRIPTION
# Background

Because we don't want to update every server log baseline on every TypeScript version change, we sanitize server logs based on the current TypeScript version. Specifically, we replace occurrences of the full version with `FakeVersion`, and replace occurrences of the major.minor version with `tsFakeMajor.Minor`.

# Problem

When TypeScript updating to `5.7.3`, the baselines were incorrectly updated because we have a server test with a package at the version `15.7.3`. This is not the first time we hit this issue, and historically we have gotten around it by just changing the version of the test package.

# Proposed Fix

@andrewbranch's suggestion was to switch to a regex and add boundaries to the beginning/end. This doesn't entirely fix the issue, but it does harden the test runner by avoiding a match of `5.7.3` within `15.7.3`.