### PR TITLE
Make error span first line only for non-block arrow functions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2448,7 +2448,7 @@ export function scanTokenAtPosition(sourceFile: SourceFile, pos: number): Syntax
 
 function getErrorSpanForArrowFunction(sourceFile: SourceFile, node: ArrowFunction): TextSpan {
     const pos = skipTrivia(sourceFile.text, node.pos);
-    if (node.body && node.body.kind === SyntaxKind.Block) {
+    if (node.body) {
         const { line: startLine } = getLineAndCharacterOfPosition(sourceFile, node.body.pos);
         const { line: endLine } = getLineAndCharacterOfPosition(sourceFile, node.body.end);
         if (startLine < endLine) {

--- a/tests/baselines/reference/arrowFunctionErrorSpan.errors.txt
+++ b/tests/baselines/reference/arrowFunctionErrorSpan.errors.txt
@@ -108,8 +108,7 @@ arrowFunctionErrorSpan.ts(52,3): error TS2345: Argument of type '(_: any) => num
     // body is not a block
     f(_ => 1 +
       ~~~~~~~~
-        2);
-    ~~~~~
 !!! error TS2345: Argument of type '(_: any) => number' is not assignable to parameter of type '() => number'.
 !!! error TS2345:   Target signature provides too few arguments. Expected 1 or more, but got 0.
+        2);
     

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -44,20 +44,16 @@ file.tsx(39,15): error TS2322: Type '(user: IUser) => Element' is not assignable
                 
                 { user => (
                   ~~~~~~~~~
-                    <h1>{ user.Name }</h1>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                ) }
-    ~~~~~~~~~~~~~
 !!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'boolean | any[] | ReactChild'.
 !!! related TS6212 file.tsx:36:15: Did you mean to call this expression?
+                    <h1>{ user.Name }</h1>
+                ) }
                 { user => (
                   ~~~~~~~~~
-                    <h1>{ user.Name }</h1>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                ) }
-    ~~~~~~~~~~~~~
 !!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'boolean | any[] | ReactChild'.
 !!! related TS6212 file.tsx:39:15: Did you mean to call this expression?
+                    <h1>{ user.Name }</h1>
+                ) }
             </FetchUser>
         );
     }


### PR DESCRIPTION
Similar to https://github.com/microsoft/TypeScript/pull/60799, this should make the error span less noisy.

We were already doing this for block bodies, and I don't see any reason why we wouldn't also do it for non-block bodies. In my experience it's very common to have long multi-line non-block arrow functions, especially when using the `pipe` function.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Towards https://github.com/microsoft/TypeScript/issues/57866.
