### PR TITLE
Write path normalization without array allocations

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -735,7 +735,10 @@ function simpleNormalizePath(path: string): string | undefined {
         return path;
     }
     // Some paths only require cleanup of `/./` or leading `./`
-    const simplified = path.replace(/\/\.\//g, "/").replace(/^\.\//, "");
+    let simplified = path.replace(/\/\.\//g, "/");
+    if (simplified.startsWith("./")) {
+        simplified = simplified.slice(2);
+    }
     if (simplified !== path) {
         path = simplified;
         if (!relativePathSegmentRegExp.test(path)) {

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -720,6 +720,7 @@ export function getNormalizedAbsolutePath(path: string, currentDirectory: string
 
 /** @internal */
 export function normalizePath(path: string): string {
+    path = normalizeSlashes(path);
     let normalized = simpleNormalizePath(path);
     if (normalized !== undefined) {
         return normalized;
@@ -729,7 +730,6 @@ export function normalizePath(path: string): string {
 }
 
 function simpleNormalizePath(path: string): string | undefined {
-    path = normalizeSlashes(path);
     // Most paths don't require normalization
     if (!relativePathSegmentRegExp.test(path)) {
         return path;

--- a/src/testRunner/unittests/paths.ts
+++ b/src/testRunner/unittests/paths.ts
@@ -317,9 +317,24 @@ describe("unittests:: core paths", () => {
         assert.strictEqual(ts.getNormalizedAbsolutePath("", ""), "");
         assert.strictEqual(ts.getNormalizedAbsolutePath(".", ""), "");
         assert.strictEqual(ts.getNormalizedAbsolutePath("./", ""), "");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("./a", ""), "a");
         // Strangely, these do not normalize to the empty string.
         assert.strictEqual(ts.getNormalizedAbsolutePath("..", ""), "..");
         assert.strictEqual(ts.getNormalizedAbsolutePath("../", ""), "..");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("../..", ""), "../..");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("../../", ""), "../..");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("./..", ""), "..");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("../../a/..", ""), "../..");
+
+        // More .. segments
+        assert.strictEqual(ts.getNormalizedAbsolutePath("src/ts/foo/../../../bar/bar.ts", ""), "bar/bar.ts");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("src/ts/foo/../../..", ""), "");
+        // not a real URL root!
+        assert.strictEqual(ts.getNormalizedAbsolutePath("file:/Users/matb/projects/san/../../../../../../typings/@epic/Core.d.ts", ""), "../typings/@epic/Core.d.ts");
+        // the root is `file://Users/`
+        assert.strictEqual(ts.getNormalizedAbsolutePath("file://Users/matb/projects/san/../../../../../../typings/@epic/Core.d.ts", ""), "file://Users/typings/@epic/Core.d.ts");
+        // this is real
+        assert.strictEqual(ts.getNormalizedAbsolutePath("file:///Users/matb/projects/san/../../../../../../typings/@epic/Core.d.ts", ""), "file:///typings/@epic/Core.d.ts");
 
         // Interaction between relative paths and currentDirectory.
         assert.strictEqual(ts.getNormalizedAbsolutePath("", "/home"), "/home");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Related: #60633 
Alternative to #60755

Despite the good benchmarks, I didn’t see any measurable impact in real-world `updateGraphWorker` duration on my M2 Mac Mini. However, since that was a GC hot spot for @dbaeumer and #60755 improved things some, this may do even better for him.

<details><summary><code>bench.js</code></summary>

```js
const ts = require("./built/local/typescript");
const ts_old = require("./node_modules/typescript");
const { Suite } = require("bench-node");

const suite = new Suite();

suite.add("normalizePath_old", () => {
  runScenarios(ts_old.normalizePath);
});

suite.add("normalizePath_new", () => {
  runScenarios(ts.normalizePath);
});

suite.add("getNormalizedAbsolutePath_old", () => {
  runScenarios(ts_old.getNormalizedAbsolutePath);
});

suite.add("getNormalizedAbsolutePath_new", () => {
  runScenarios(ts.getNormalizedAbsolutePath);
});

suite.run();

function runScenarios(normalize) {
  normalize("/", "");
  normalize("/.", "");
  normalize("/./", "");
  normalize("/../", "");
  normalize("/a", "");
  normalize("/a/", "");
  normalize("/a/.", "");
  normalize("/a/foo.", "");
  normalize("/a/./", "");
  normalize("/a/./b", "");
  normalize("/a/./b/", "");
  normalize("/a/..", "");
  normalize("/a/../", "");
  normalize("/a/../", "");
  normalize("/a/../b", "");
  normalize("/a/../b/", "");
  normalize("/a/..", "");
  normalize("/a/..", "/");
  normalize("/a/..", "b/");
  normalize("/a/..", "/b");
  normalize("/a/.", "b");
  normalize("/a/.", ".");

  // Tests as above, but with backslashes.
  normalize("\\", "");
  normalize("\\.", "");
  normalize("\\.\\", "");
  normalize("\\..\\", "");
  normalize("\\a\\.\\", "");
  normalize("\\a\\.\\b", "");
  normalize("\\a\\.\\b\\", "");
  normalize("\\a\\..", "");
  normalize("\\a\\..\\", "");
  normalize("\\a\\..\\", "");
  normalize("\\a\\..\\b", "");
  normalize("\\a\\..\\b\\", "");
  normalize("\\a\\..", "");
  normalize("\\a\\..", "\\");
  normalize("\\a\\..", "b\\");
  normalize("\\a\\..", "\\b");
  normalize("\\a\\.", "b");
  normalize("\\a\\.", ".");

  // Relative paths on an empty currentDirectory.
  normalize("", "");
  normalize(".", "");
  normalize("./", "");
  normalize("./a", "");
  // Strangely, these do not normalize to the empty string.
  normalize("..", "");
  normalize("../", "");
  normalize("../..", "");
  normalize("../../", "");
  normalize("./..", "");
  normalize("../../a/..", "");

  // Interaction between relative paths and currentDirectory.
  normalize("", "/home");
  normalize(".", "/home");
  normalize("./", "/home");
  normalize("..", "/home");
  normalize("../", "/home");
  normalize("a", "b");
  normalize("a", "b/c");

  // Base names starting or ending with a dot do not affect normalization.
  normalize(".a", "");
  normalize("..a", "");
  normalize("a.", "");
  normalize("a..", "");

  normalize("/base/./.a", "");
  normalize("/base/../.a", "");
  normalize("/base/./..a", "");
  normalize("/base/../..a", "");
  normalize("/base/./..a/b", "");
  normalize("/base/../..a/b", "");

  normalize("/base/./a.", "");
  normalize("/base/../a.", "");
  normalize("/base/./a..", "");
  normalize("/base/../a..", "");
  normalize("/base/./a../b", "");
  normalize("/base/../a../b", "");

  // Consecutive intermediate slashes are normalized to a single slash.
  normalize("a//b", "");
  normalize("a///b", "");
  normalize("a/b//c", "");
  normalize("/a/b//c", "");
  normalize("//a/b//c", "");

  // Backslashes are converted to slashes,
  // and then consecutive intermediate slashes are normalized to a single slash
  normalize("a\\\\b", "");
  normalize("a\\\\\\b", "");
  normalize("a\\b\\\\c", "");
  normalize("\\a\\b\\\\c", "");
  normalize("\\\\a\\b\\\\c", "");

  // The same occurs for mixed slashes.
  normalize("a/\\b", "");
  normalize("a\\/b", "");
  normalize("a\\/\\b", "");
  normalize("a\\b//c", "");
  normalize("\\a\\b\\\\c", "");
  normalize("\\\\a\\b\\\\c", "");
}
```
</details>

```
npm i --no-save bench-node
npm run build
node --allow-natives-syntax bench.js   
                                              
normalizePath_old                             x 49,990 ops/sec (13 runs sampled) v8-never-optimize=true min..max=(19.15us...20.48us)
normalizePath_new                             x 125,800 ops/sec (11 runs sampled) v8-never-optimize=true min..max=(7.80us...8.27us)
getNormalizedAbsolutePath_old                 x 55,493 ops/sec (12 runs sampled) v8-never-optimize=true min..max=(17.17us...18.45us)
getNormalizedAbsolutePath_new                 x 125,567 ops/sec (10 runs sampled) v8-never-optimize=true min..max=(7.90us...8.03us)
```