### PR TITLE
Compute more precise syntactic truthy semantics for comma expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -44715,6 +44715,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return !!(node as StringLiteral | NoSubstitutionTemplateLiteral).text ? PredicateSemantics.Always : PredicateSemantics.Never;
             case SyntaxKind.ConditionalExpression:
                 return getSyntacticTruthySemantics((node as ConditionalExpression).whenTrue) | getSyntacticTruthySemantics((node as ConditionalExpression).whenFalse);
+            case SyntaxKind.BinaryExpression:
+                if ((node as BinaryExpression).operatorToken.kind !== SyntaxKind.CommaToken) {
+                    break;
+                }
+                return getSyntacticTruthySemantics((node as BinaryExpression).right);
             case SyntaxKind.Identifier:
                 if (getResolvedSymbol(node as Identifier) === undefinedSymbol) {
                     return PredicateSemantics.Never;

--- a/tests/baselines/reference/predicateSemantics.errors.txt
+++ b/tests/baselines/reference/predicateSemantics.errors.txt
@@ -14,9 +14,10 @@ predicateSemantics.ts(52,14): error TS2695: Left side of comma operator is unuse
 predicateSemantics.ts(52,14): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 predicateSemantics.ts(70,1): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
 predicateSemantics.ts(71,1): error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+predicateSemantics.ts(75,5): error TS2872: This kind of expression is always truthy.
 
 
-==== predicateSemantics.ts (16 errors) ====
+==== predicateSemantics.ts (17 errors) ====
     declare let cond: any;
     
     // OK: One or other operand is possibly nullish
@@ -120,4 +121,11 @@ predicateSemantics.ts(71,1): error TS2869: Right operand of ?? is unreachable be
     `foo` ?? 32; // error
     ~~~~~
 !!! error TS2869: Right operand of ?? is unreachable because the left operand is never nullish.
+    
+    // https://github.com/microsoft/TypeScript/issues/60822
+    declare function test60822(arg: string, arg2?: string): string | null;
+    if (test60822("foo"), "bar") {} // error
+        ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2872: This kind of expression is always truthy.
+    if (test60822("foo"), test60822("bar")) {} // ok
     

--- a/tests/baselines/reference/predicateSemantics.js
+++ b/tests/baselines/reference/predicateSemantics.js
@@ -73,6 +73,11 @@ tag`foo${1}` ?? 32; // ok
 `foo${1}` ?? 32; // error
 `foo` ?? 32; // error
 
+// https://github.com/microsoft/TypeScript/issues/60822
+declare function test60822(arg: string, arg2?: string): string | null;
+if (test60822("foo"), "bar") {} // error
+if (test60822("foo"), test60822("bar")) {} // ok
+
 
 //// [predicateSemantics.js]
 var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
@@ -140,3 +145,5 @@ var X = /** @class */ (function () {
 (_k = tag(__makeTemplateObject(["foo", ""], ["foo", ""]), 1)) !== null && _k !== void 0 ? _k : 32; // ok
 (_l = "foo".concat(1)) !== null && _l !== void 0 ? _l : 32; // error
 "foo" !== null && "foo" !== void 0 ? "foo" : 32; // error
+if (test60822("foo"), "bar") { } // error
+if (test60822("foo"), test60822("bar")) { } // ok

--- a/tests/baselines/reference/predicateSemantics.symbols
+++ b/tests/baselines/reference/predicateSemantics.symbols
@@ -137,3 +137,16 @@ tag`foo${1}` ?? 32; // ok
 `foo${1}` ?? 32; // error
 `foo` ?? 32; // error
 
+// https://github.com/microsoft/TypeScript/issues/60822
+declare function test60822(arg: string, arg2?: string): string | null;
+>test60822 : Symbol(test60822, Decl(predicateSemantics.ts, 70, 12))
+>arg : Symbol(arg, Decl(predicateSemantics.ts, 73, 27))
+>arg2 : Symbol(arg2, Decl(predicateSemantics.ts, 73, 39))
+
+if (test60822("foo"), "bar") {} // error
+>test60822 : Symbol(test60822, Decl(predicateSemantics.ts, 70, 12))
+
+if (test60822("foo"), test60822("bar")) {} // ok
+>test60822 : Symbol(test60822, Decl(predicateSemantics.ts, 70, 12))
+>test60822 : Symbol(test60822, Decl(predicateSemantics.ts, 70, 12))
+

--- a/tests/baselines/reference/predicateSemantics.types
+++ b/tests/baselines/reference/predicateSemantics.types
@@ -375,3 +375,40 @@ tag`foo${1}` ?? 32; // ok
 >32 : 32
 >   : ^^
 
+// https://github.com/microsoft/TypeScript/issues/60822
+declare function test60822(arg: string, arg2?: string): string | null;
+>test60822 : (arg: string, arg2?: string) => string | null
+>          : ^   ^^      ^^    ^^^      ^^^^^             
+>arg : string
+>    : ^^^^^^
+>arg2 : string
+>     : ^^^^^^
+
+if (test60822("foo"), "bar") {} // error
+>test60822("foo"), "bar" : "bar"
+>                        : ^^^^^
+>test60822("foo") : string
+>                 : ^^^^^^
+>test60822 : (arg: string, arg2?: string) => string | null
+>          : ^   ^^      ^^    ^^^      ^^^^^             
+>"foo" : "foo"
+>      : ^^^^^
+>"bar" : "bar"
+>      : ^^^^^
+
+if (test60822("foo"), test60822("bar")) {} // ok
+>test60822("foo"), test60822("bar") : string
+>                                   : ^^^^^^
+>test60822("foo") : string
+>                 : ^^^^^^
+>test60822 : (arg: string, arg2?: string) => string | null
+>          : ^   ^^      ^^    ^^^      ^^^^^             
+>"foo" : "foo"
+>      : ^^^^^
+>test60822("bar") : string
+>                 : ^^^^^^
+>test60822 : (arg: string, arg2?: string) => string | null
+>          : ^   ^^      ^^    ^^^      ^^^^^             
+>"bar" : "bar"
+>      : ^^^^^
+

--- a/tests/cases/compiler/predicateSemantics.ts
+++ b/tests/cases/compiler/predicateSemantics.ts
@@ -69,3 +69,8 @@ tag`foo${1}` ?? 32; // ok
 
 `foo${1}` ?? 32; // error
 `foo` ?? 32; // error
+
+// https://github.com/microsoft/TypeScript/issues/60822
+declare function test60822(arg: string, arg2?: string): string | null;
+if (test60822("foo"), "bar") {} // error
+if (test60822("foo"), test60822("bar")) {} // ok


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60822

given [the same thing was merged for syntactic nullish semantics](https://github.com/microsoft/TypeScript/pull/60402) (and [its corresponding issue](https://github.com/microsoft/TypeScript/issues/60401) was accepted beforehand), I think it only makes sense to handle this for truthy semantics as well for consistency, cc @jakebailey 