### PR TITLE
Defer checking subexpressions of binary expressions with known boolean result type

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2655,6 +2655,11 @@ export interface AssignmentExpression<TOperator extends AssignmentOperatorToken>
     readonly operatorToken: TOperator;
 }
 
+/** @internal */
+export interface NullishCoalesceExpression extends BinaryExpression {
+    readonly operatorToken: Token<SyntaxKind.QuestionQuestionToken>;
+}
+
 export interface ObjectDestructuringAssignment extends AssignmentExpression<EqualsToken> {
     readonly left: ObjectLiteralExpression;
 }

--- a/tests/baselines/reference/controlFlowInferFromExpressionsReturningBoolean1.symbols
+++ b/tests/baselines/reference/controlFlowInferFromExpressionsReturningBoolean1.symbols
@@ -1,0 +1,149 @@
+//// [tests/cases/conformance/controlFlow/controlFlowInferFromExpressionsReturningBoolean1.ts] ////
+
+=== controlFlowInferFromExpressionsReturningBoolean1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60130
+
+function assert<C>(c: C): asserts c {
+>assert : Symbol(assert, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 0, 0))
+>C : Symbol(C, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 2, 16))
+>c : Symbol(c, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 2, 19))
+>C : Symbol(C, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 2, 16))
+>c : Symbol(c, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 2, 19))
+
+  if (!c) {
+>c : Symbol(c, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 2, 19))
+
+    throw new TypeError("Assertion failed");
+>TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+  }
+}
+
+export function test1(lines: string[]): string[] {
+>test1 : Symbol(test1, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 6, 1))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 8, 22))
+
+  let func: {
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+
+    name: string;
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 13))
+
+    lines: string[];
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 10, 17))
+
+  } | null = null;
+
+  for (const line of lines) {
+>line : Symbol(line, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 14, 12))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 8, 22))
+
+    if (Math.random() < 0.5) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+      func = {
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+
+        name: "qwer",
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 16, 14))
+
+        lines: [line],
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 17, 21))
+>line : Symbol(line, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 14, 12))
+
+      };
+    } else {
+      assert(func);
+>assert : Symbol(assert, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 0, 0))
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+
+      const { name, lines } = func;
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 22, 13))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 22, 19))
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+
+      lines.push(line);
+>lines.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 22, 19))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>line : Symbol(line, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 14, 12))
+
+      assert(name !== "abc");
+>assert : Symbol(assert, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 0, 0))
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 22, 13))
+    }
+  }
+  if (func) return func.lines;
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+>func.lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 10, 17))
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 9, 5))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 10, 17))
+
+  return lines;
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 8, 22))
+}
+
+declare function inferStuff<T>(arg: T, checkStuff?: boolean): T;
+>inferStuff : Symbol(inferStuff, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 29, 1))
+>T : Symbol(T, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 28))
+>arg : Symbol(arg, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 31))
+>T : Symbol(T, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 28))
+>checkStuff : Symbol(checkStuff, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 38))
+>T : Symbol(T, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 28))
+
+export function test2(lines: string[]): string[] {
+>test2 : Symbol(test2, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 31, 64))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 33, 22))
+
+  let func: {
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 5))
+
+    name: string;
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 13))
+
+  } | null = null;
+
+  for (const _ of lines) {
+>_ : Symbol(_, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 38, 12))
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 33, 22))
+
+    if (Math.random() < 0.5) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+      func = {
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 5))
+
+        name: "qwer",
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 40, 14))
+
+      };
+    } else {
+      if (func) {
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 5))
+
+        const { name } = func;
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 45, 15))
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 5))
+
+        func = inferStuff(
+>func : Symbol(func, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 34, 5))
+>inferStuff : Symbol(inferStuff, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 29, 1))
+          {
+            name: "other",
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 47, 11))
+
+          },
+          name === "abc",
+>name : Symbol(name, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 45, 15))
+
+        );
+      }
+    }
+  }
+
+  return lines;
+>lines : Symbol(lines, Decl(controlFlowInferFromExpressionsReturningBoolean1.ts, 33, 22))
+}

--- a/tests/baselines/reference/controlFlowInferFromExpressionsReturningBoolean1.types
+++ b/tests/baselines/reference/controlFlowInferFromExpressionsReturningBoolean1.types
@@ -1,0 +1,254 @@
+//// [tests/cases/conformance/controlFlow/controlFlowInferFromExpressionsReturningBoolean1.ts] ////
+
+=== controlFlowInferFromExpressionsReturningBoolean1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60130
+
+function assert<C>(c: C): asserts c {
+>assert : <C>(c: C) => asserts c
+>       : ^ ^^ ^^ ^^^^^         
+>c : C
+>  : ^
+
+  if (!c) {
+>!c : boolean
+>   : ^^^^^^^
+>c : C
+>  : ^
+
+    throw new TypeError("Assertion failed");
+>new TypeError("Assertion failed") : TypeError
+>                                  : ^^^^^^^^^
+>TypeError : TypeErrorConstructor
+>          : ^^^^^^^^^^^^^^^^^^^^
+>"Assertion failed" : "Assertion failed"
+>                   : ^^^^^^^^^^^^^^^^^^
+  }
+}
+
+export function test1(lines: string[]): string[] {
+>test1 : (lines: string[]) => string[]
+>      : ^     ^^        ^^^^^        
+>lines : string[]
+>      : ^^^^^^^^
+
+  let func: {
+>func : { name: string; lines: string[]; } | null
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^^^^^^^^
+
+    name: string;
+>name : string
+>     : ^^^^^^
+
+    lines: string[];
+>lines : string[]
+>      : ^^^^^^^^
+
+  } | null = null;
+
+  for (const line of lines) {
+>line : string
+>     : ^^^^^^
+>lines : string[]
+>      : ^^^^^^^^
+
+    if (Math.random() < 0.5) {
+>Math.random() < 0.5 : boolean
+>                    : ^^^^^^^
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+>0.5 : 0.5
+>    : ^^^
+
+      func = {
+>func = {        name: "qwer",        lines: [line],      } : { name: string; lines: string[]; }
+>                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>func : { name: string; lines: string[]; } | null
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^^^^^^^^
+>{        name: "qwer",        lines: [line],      } : { name: string; lines: string[]; }
+>                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        name: "qwer",
+>name : string
+>     : ^^^^^^
+>"qwer" : "qwer"
+>       : ^^^^^^
+
+        lines: [line],
+>lines : string[]
+>      : ^^^^^^^^
+>[line] : string[]
+>       : ^^^^^^^^
+>line : string
+>     : ^^^^^^
+
+      };
+    } else {
+      assert(func);
+>assert(func) : void
+>             : ^^^^
+>assert : <C>(c: C) => asserts c
+>       : ^ ^^ ^^ ^^^^^         
+>func : { name: string; lines: string[]; } | null
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^^^^^^^^
+
+      const { name, lines } = func;
+>name : string
+>     : ^^^^^^
+>lines : string[]
+>      : ^^^^^^^^
+>func : { name: string; lines: string[]; }
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^
+
+      lines.push(line);
+>lines.push(line) : number
+>                 : ^^^^^^
+>lines.push : (...items: string[]) => number
+>           : ^^^^     ^^^^^^^^^^^^^^^      
+>lines : string[]
+>      : ^^^^^^^^
+>push : (...items: string[]) => number
+>     : ^^^^     ^^^^^^^^^^^^^^^      
+>line : string
+>     : ^^^^^^
+
+      assert(name !== "abc");
+>assert(name !== "abc") : void
+>                       : ^^^^
+>assert : <C>(c: C) => asserts c
+>       : ^ ^^ ^^ ^^^^^         
+>name !== "abc" : boolean
+>               : ^^^^^^^
+>name : string
+>     : ^^^^^^
+>"abc" : "abc"
+>      : ^^^^^
+    }
+  }
+  if (func) return func.lines;
+>func : { name: string; lines: string[]; } | null
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^^^^^^^^
+>func.lines : string[]
+>           : ^^^^^^^^
+>func : { name: string; lines: string[]; }
+>     : ^^^^^^^^      ^^^^^^^^^        ^^^
+>lines : string[]
+>      : ^^^^^^^^
+
+  return lines;
+>lines : string[]
+>      : ^^^^^^^^
+}
+
+declare function inferStuff<T>(arg: T, checkStuff?: boolean): T;
+>inferStuff : <T>(arg: T, checkStuff?: boolean) => T
+>           : ^ ^^   ^^ ^^          ^^^       ^^^^^ 
+>arg : T
+>    : ^
+>checkStuff : boolean | undefined
+>           : ^^^^^^^^^^^^^^^^^^^
+
+export function test2(lines: string[]): string[] {
+>test2 : (lines: string[]) => string[]
+>      : ^     ^^        ^^^^^        
+>lines : string[]
+>      : ^^^^^^^^
+
+  let func: {
+>func : { name: string; } | null
+>     : ^^^^^^^^      ^^^^^^^^^^
+
+    name: string;
+>name : string
+>     : ^^^^^^
+
+  } | null = null;
+
+  for (const _ of lines) {
+>_ : string
+>  : ^^^^^^
+>lines : string[]
+>      : ^^^^^^^^
+
+    if (Math.random() < 0.5) {
+>Math.random() < 0.5 : boolean
+>                    : ^^^^^^^
+>Math.random() : number
+>              : ^^^^^^
+>Math.random : () => number
+>            : ^^^^^^      
+>Math : Math
+>     : ^^^^
+>random : () => number
+>       : ^^^^^^      
+>0.5 : 0.5
+>    : ^^^
+
+      func = {
+>func = {        name: "qwer",      } : { name: string; }
+>                                     : ^^^^^^^^^^^^^^^^^
+>func : { name: string; } | null
+>     : ^^^^^^^^      ^^^^^^^^^^
+>{        name: "qwer",      } : { name: string; }
+>                              : ^^^^^^^^^^^^^^^^^
+
+        name: "qwer",
+>name : string
+>     : ^^^^^^
+>"qwer" : "qwer"
+>       : ^^^^^^
+
+      };
+    } else {
+      if (func) {
+>func : { name: string; } | null
+>     : ^^^^^^^^      ^^^^^^^^^^
+
+        const { name } = func;
+>name : string
+>     : ^^^^^^
+>func : { name: string; }
+>     : ^^^^^^^^      ^^^
+
+        func = inferStuff(
+>func = inferStuff(          {            name: "other",          },          name === "abc",        ) : { name: string; }
+>                                                                                                      : ^^^^^^^^^^^^^^^^^
+>func : { name: string; } | null
+>     : ^^^^^^^^      ^^^^^^^^^^
+>inferStuff(          {            name: "other",          },          name === "abc",        ) : { name: string; }
+>                                                                                               : ^^^^^^^^^^^^^^^^^
+>inferStuff : <T>(arg: T, checkStuff?: boolean) => T
+>           : ^ ^^   ^^ ^^          ^^^       ^^^^^ 
+          {
+>{            name: "other",          } : { name: string; }
+>                                       : ^^^^^^^^^^^^^^^^^
+
+            name: "other",
+>name : string
+>     : ^^^^^^
+>"other" : "other"
+>        : ^^^^^^^
+
+          },
+          name === "abc",
+>name === "abc" : boolean
+>               : ^^^^^^^
+>name : string
+>     : ^^^^^^
+>"abc" : "abc"
+>      : ^^^^^
+
+        );
+      }
+    }
+  }
+
+  return lines;
+>lines : string[]
+>      : ^^^^^^^^
+}

--- a/tests/baselines/reference/narrowingInCaseClauseAfterCaseClauseWithReturn.types
+++ b/tests/baselines/reference/narrowingInCaseClauseAfterCaseClauseWithReturn.types
@@ -94,7 +94,7 @@ function test1(arg: string | undefined) {
 }
 
 function test2(arg: string | undefined) {
->test2 : (arg: string | undefined) => "Not A, B, C or D" | "D" | "A, B or C"
+>test2 : (arg: string | undefined) => "Not A, B, C or D" | "A, B or C" | "D"
 >      : ^   ^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >arg : string | undefined
 >    : ^^^^^^^^^^^^^^^^^^

--- a/tests/cases/conformance/controlFlow/controlFlowInferFromExpressionsReturningBoolean1.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowInferFromExpressionsReturningBoolean1.ts
@@ -1,0 +1,61 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/60130
+
+function assert<C>(c: C): asserts c {
+  if (!c) {
+    throw new TypeError("Assertion failed");
+  }
+}
+
+export function test1(lines: string[]): string[] {
+  let func: {
+    name: string;
+    lines: string[];
+  } | null = null;
+
+  for (const line of lines) {
+    if (Math.random() < 0.5) {
+      func = {
+        name: "qwer",
+        lines: [line],
+      };
+    } else {
+      assert(func);
+      const { name, lines } = func;
+      lines.push(line);
+      assert(name !== "abc");
+    }
+  }
+  if (func) return func.lines;
+  return lines;
+}
+
+declare function inferStuff<T>(arg: T, checkStuff?: boolean): T;
+
+export function test2(lines: string[]): string[] {
+  let func: {
+    name: string;
+  } | null = null;
+
+  for (const _ of lines) {
+    if (Math.random() < 0.5) {
+      func = {
+        name: "qwer",
+      };
+    } else {
+      if (func) {
+        const { name } = func;
+        func = inferStuff(
+          {
+            name: "other",
+          },
+          name === "abc",
+        );
+      }
+    }
+  }
+
+  return lines;
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60130

This PR removes the mechanism introduced in https://github.com/microsoft/TypeScript/pull/54380 in favor of using the older `checkDeferredNode` mechanism that allows the compiler to avoid an extra set of redundant errors.

