### PR TITLE
Properly propagate `silentNeverType` in unions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17723,7 +17723,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (typeSet.length === 0) {
                 return includes & TypeFlags.Null ? includes & TypeFlags.IncludesNonWideningType ? nullType : nullWideningType :
                     includes & TypeFlags.Undefined ? includes & TypeFlags.IncludesNonWideningType ? undefinedType : undefinedWideningType :
-                    neverType;
+                    contains(types, silentNeverType) ? silentNeverType : neverType;
             }
         }
         if (!origin && includes & TypeFlags.Union) {

--- a/tests/baselines/reference/silentNeverPropagation.js
+++ b/tests/baselines/reference/silentNeverPropagation.js
@@ -27,6 +27,12 @@ breaks.state.a
 breaks.state.z
 breaks.foo()
 
+declare function inner<T1, t2>(t1: T1, t2: t2): T1 | t2;
+declare function outer<T1, T2>(m: T1 | T2): [T1, T2];
+
+const outerResult = outer(
+    inner({ a: 12 }, { foo() { return true } })
+);
 
 //// [silentNeverPropagation.js]
 "use strict";
@@ -35,6 +41,7 @@ var breaks = convert(createModule({ a: 12 }, { foo: function () { return true; }
 breaks.state.a;
 breaks.state.z;
 breaks.foo();
+var outerResult = outer(inner({ a: 12 }, { foo: function () { return true; } }));
 
 
 //// [silentNeverPropagation.d.ts]
@@ -56,3 +63,14 @@ declare const breaks: ModuleWithState<{
 }> & {
     foo(): true;
 };
+declare function inner<T1, t2>(t1: T1, t2: t2): T1 | t2;
+declare function outer<T1, T2>(m: T1 | T2): [T1, T2];
+declare const outerResult: [{
+    a: number;
+} | {
+    foo(): true;
+}, {
+    a: number;
+} | {
+    foo(): true;
+}];

--- a/tests/baselines/reference/silentNeverPropagation.symbols
+++ b/tests/baselines/reference/silentNeverPropagation.symbols
@@ -84,3 +84,34 @@ breaks.foo()
 >breaks : Symbol(breaks, Decl(silentNeverPropagation.ts, 18, 5))
 >foo : Symbol(foo, Decl(silentNeverPropagation.ts, 19, 29))
 
+declare function inner<T1, t2>(t1: T1, t2: t2): T1 | t2;
+>inner : Symbol(inner, Decl(silentNeverPropagation.ts, 24, 12))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 26, 23))
+>t2 : Symbol(t2, Decl(silentNeverPropagation.ts, 26, 26), Decl(silentNeverPropagation.ts, 26, 38))
+>t1 : Symbol(t1, Decl(silentNeverPropagation.ts, 26, 31))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 26, 23))
+>t2 : Symbol(t2, Decl(silentNeverPropagation.ts, 26, 26), Decl(silentNeverPropagation.ts, 26, 38))
+>t2 : Symbol(t2, Decl(silentNeverPropagation.ts, 26, 26), Decl(silentNeverPropagation.ts, 26, 38))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 26, 23))
+>t2 : Symbol(t2, Decl(silentNeverPropagation.ts, 26, 26), Decl(silentNeverPropagation.ts, 26, 38))
+
+declare function outer<T1, T2>(m: T1 | T2): [T1, T2];
+>outer : Symbol(outer, Decl(silentNeverPropagation.ts, 26, 56))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 27, 23))
+>T2 : Symbol(T2, Decl(silentNeverPropagation.ts, 27, 26))
+>m : Symbol(m, Decl(silentNeverPropagation.ts, 27, 31))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 27, 23))
+>T2 : Symbol(T2, Decl(silentNeverPropagation.ts, 27, 26))
+>T1 : Symbol(T1, Decl(silentNeverPropagation.ts, 27, 23))
+>T2 : Symbol(T2, Decl(silentNeverPropagation.ts, 27, 26))
+
+const outerResult = outer(
+>outerResult : Symbol(outerResult, Decl(silentNeverPropagation.ts, 29, 5))
+>outer : Symbol(outer, Decl(silentNeverPropagation.ts, 26, 56))
+
+    inner({ a: 12 }, { foo() { return true } })
+>inner : Symbol(inner, Decl(silentNeverPropagation.ts, 24, 12))
+>a : Symbol(a, Decl(silentNeverPropagation.ts, 30, 11))
+>foo : Symbol(foo, Decl(silentNeverPropagation.ts, 30, 22))
+
+);

--- a/tests/baselines/reference/silentNeverPropagation.types
+++ b/tests/baselines/reference/silentNeverPropagation.types
@@ -109,3 +109,44 @@ breaks.foo()
 >foo : () => true
 >    : ^^^^^^^^^^
 
+declare function inner<T1, t2>(t1: T1, t2: t2): T1 | t2;
+>inner : <T1, t2>(t1: T1, t2: t2) => T1 | t2
+>      : ^  ^^  ^^  ^^  ^^  ^^  ^^^^^       
+>t1 : T1
+>   : ^^
+>t2 : t2
+>   : ^^
+
+declare function outer<T1, T2>(m: T1 | T2): [T1, T2];
+>outer : <T1, T2>(m: T1 | T2) => [T1, T2]
+>      : ^  ^^  ^^ ^^       ^^^^^        
+>m : T1 | T2
+>  : ^^^^^^^
+
+const outerResult = outer(
+>outerResult : [{ a: number; } | { foo(): true; }, { a: number; } | { foo(): true; }]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>outer(    inner({ a: 12 }, { foo() { return true } })) : [{ a: number; } | { foo(): true; }, { a: number; } | { foo(): true; }]
+>                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>outer : <T1, T2>(m: T1 | T2) => [T1, T2]
+>      : ^  ^^  ^^ ^^       ^^^^^        
+
+    inner({ a: 12 }, { foo() { return true } })
+>inner({ a: 12 }, { foo() { return true } }) : { a: number; } | { foo(): true; }
+>                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>inner : <T1, t2>(t1: T1, t2: t2) => T1 | t2
+>      : ^  ^^  ^^  ^^  ^^  ^^  ^^^^^       
+>{ a: 12 } : { a: number; }
+>          : ^^^^^^^^^^^^^^
+>a : number
+>  : ^^^^^^
+>12 : 12
+>   : ^^
+>{ foo() { return true } } : { foo(): true; }
+>                          : ^^^^^^^^^^^^^^^^
+>foo : () => true
+>    : ^^^^^^^^^^
+>true : true
+>     : ^^^^
+
+);

--- a/tests/cases/compiler/silentNeverPropagation.ts
+++ b/tests/cases/compiler/silentNeverPropagation.ts
@@ -26,3 +26,10 @@ const breaks = convert(
 breaks.state.a
 breaks.state.z
 breaks.foo()
+
+declare function inner<T1, t2>(t1: T1, t2: t2): T1 | t2;
+declare function outer<T1, T2>(m: T1 | T2): [T1, T2];
+
+const outerResult = outer(
+    inner({ a: 12 }, { foo() { return true } })
+);


### PR DESCRIPTION
When investigating some other issue and debugging it I noticed that `silentNeverType | silentNeverType` was reduced to a regular `never`. I think this is a mistake and this PR basically applies the same fix as the one done for intersections here: https://github.com/microsoft/TypeScript/pull/45073