### PR TITLE
Ignore `silentNever` in intersections with other meaningful constituents

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17825,6 +17825,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function addTypeToIntersection(typeSet: Map<string, Type>, includes: TypeFlags, type: Type) {
+        if (type === silentNeverType) {
+            return includes;
+        }
         const flags = type.flags;
         if (flags & TypeFlags.Intersection) {
             return addTypesToIntersection(typeSet, includes, (type as IntersectionType).types);

--- a/tests/baselines/reference/silentNeverInIntersections1.symbols
+++ b/tests/baselines/reference/silentNeverInIntersections1.symbols
@@ -1,0 +1,99 @@
+//// [tests/cases/compiler/silentNeverInIntersections1.ts] ////
+
+=== silentNeverInIntersections1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60864
+
+class Variable<U, S extends string> {
+>Variable : Symbol(Variable, Decl(silentNeverInIntersections1.ts, 0, 0))
+>U : Symbol(U, Decl(silentNeverInIntersections1.ts, 2, 15))
+>S : Symbol(S, Decl(silentNeverInIntersections1.ts, 2, 17))
+
+  constructor(public s: S) {}
+>s : Symbol(Variable.s, Decl(silentNeverInIntersections1.ts, 3, 14))
+>S : Symbol(S, Decl(silentNeverInIntersections1.ts, 2, 17))
+
+  u!: U;
+>u : Symbol(Variable.u, Decl(silentNeverInIntersections1.ts, 3, 29))
+>U : Symbol(U, Decl(silentNeverInIntersections1.ts, 2, 15))
+}
+
+function mkGeneric<U, S extends string>(s: S) {
+>mkGeneric : Symbol(mkGeneric, Decl(silentNeverInIntersections1.ts, 5, 1))
+>U : Symbol(U, Decl(silentNeverInIntersections1.ts, 7, 19))
+>S : Symbol(S, Decl(silentNeverInIntersections1.ts, 7, 21))
+>s : Symbol(s, Decl(silentNeverInIntersections1.ts, 7, 40))
+>S : Symbol(S, Decl(silentNeverInIntersections1.ts, 7, 21))
+
+  return new Variable<U, S>(s);
+>Variable : Symbol(Variable, Decl(silentNeverInIntersections1.ts, 0, 0))
+>U : Symbol(U, Decl(silentNeverInIntersections1.ts, 7, 19))
+>S : Symbol(S, Decl(silentNeverInIntersections1.ts, 7, 21))
+>s : Symbol(s, Decl(silentNeverInIntersections1.ts, 7, 40))
+}
+
+type ExactArgNames<GenericType, Constraint> = GenericType & {
+>ExactArgNames : Symbol(ExactArgNames, Decl(silentNeverInIntersections1.ts, 9, 1))
+>GenericType : Symbol(GenericType, Decl(silentNeverInIntersections1.ts, 11, 19))
+>Constraint : Symbol(Constraint, Decl(silentNeverInIntersections1.ts, 11, 31))
+>GenericType : Symbol(GenericType, Decl(silentNeverInIntersections1.ts, 11, 19))
+
+  [K in keyof GenericType]: K extends keyof Constraint ? GenericType[K] : never;
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 12, 3))
+>GenericType : Symbol(GenericType, Decl(silentNeverInIntersections1.ts, 11, 19))
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 12, 3))
+>Constraint : Symbol(Constraint, Decl(silentNeverInIntersections1.ts, 11, 31))
+>GenericType : Symbol(GenericType, Decl(silentNeverInIntersections1.ts, 11, 19))
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 12, 3))
+
+};
+
+type AllowVariables<T> =
+>AllowVariables : Symbol(AllowVariables, Decl(silentNeverInIntersections1.ts, 13, 2))
+>T : Symbol(T, Decl(silentNeverInIntersections1.ts, 15, 20))
+
+  | Variable<T, any>
+>Variable : Symbol(Variable, Decl(silentNeverInIntersections1.ts, 0, 0))
+>T : Symbol(T, Decl(silentNeverInIntersections1.ts, 15, 20))
+
+  | { [K in keyof T]: Variable<T[K], any> | T[K] };
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 17, 7))
+>T : Symbol(T, Decl(silentNeverInIntersections1.ts, 15, 20))
+>Variable : Symbol(Variable, Decl(silentNeverInIntersections1.ts, 0, 0))
+>T : Symbol(T, Decl(silentNeverInIntersections1.ts, 15, 20))
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 17, 7))
+>T : Symbol(T, Decl(silentNeverInIntersections1.ts, 15, 20))
+>K : Symbol(K, Decl(silentNeverInIntersections1.ts, 17, 7))
+
+type TestArgs = {
+>TestArgs : Symbol(TestArgs, Decl(silentNeverInIntersections1.ts, 17, 51))
+
+  someArg: number;
+>someArg : Symbol(someArg, Decl(silentNeverInIntersections1.ts, 19, 17))
+
+};
+
+type TestArgsWithVars = AllowVariables<TestArgs>;
+>TestArgsWithVars : Symbol(TestArgsWithVars, Decl(silentNeverInIntersections1.ts, 21, 2))
+>AllowVariables : Symbol(AllowVariables, Decl(silentNeverInIntersections1.ts, 13, 2))
+>TestArgs : Symbol(TestArgs, Decl(silentNeverInIntersections1.ts, 17, 51))
+
+function takesGeneric<V extends AllowVariables<TestArgs>>(
+>takesGeneric : Symbol(takesGeneric, Decl(silentNeverInIntersections1.ts, 23, 49))
+>V : Symbol(V, Decl(silentNeverInIntersections1.ts, 25, 22))
+>AllowVariables : Symbol(AllowVariables, Decl(silentNeverInIntersections1.ts, 13, 2))
+>TestArgs : Symbol(TestArgs, Decl(silentNeverInIntersections1.ts, 17, 51))
+
+  a: ExactArgNames<V, TestArgs>,
+>a : Symbol(a, Decl(silentNeverInIntersections1.ts, 25, 58))
+>ExactArgNames : Symbol(ExactArgNames, Decl(silentNeverInIntersections1.ts, 9, 1))
+>V : Symbol(V, Decl(silentNeverInIntersections1.ts, 25, 22))
+>TestArgs : Symbol(TestArgs, Decl(silentNeverInIntersections1.ts, 17, 51))
+
+): void {}
+
+let v = takesGeneric({ someArg: mkGeneric("x") });
+>v : Symbol(v, Decl(silentNeverInIntersections1.ts, 29, 3))
+>takesGeneric : Symbol(takesGeneric, Decl(silentNeverInIntersections1.ts, 23, 49))
+>someArg : Symbol(someArg, Decl(silentNeverInIntersections1.ts, 29, 22))
+>mkGeneric : Symbol(mkGeneric, Decl(silentNeverInIntersections1.ts, 5, 1))
+

--- a/tests/baselines/reference/silentNeverInIntersections1.types
+++ b/tests/baselines/reference/silentNeverInIntersections1.types
@@ -1,0 +1,89 @@
+//// [tests/cases/compiler/silentNeverInIntersections1.ts] ////
+
+=== silentNeverInIntersections1.ts ===
+// https://github.com/microsoft/TypeScript/issues/60864
+
+class Variable<U, S extends string> {
+>Variable : Variable<U, S>
+>         : ^^^^^^^^^^^^^^
+
+  constructor(public s: S) {}
+>s : S
+>  : ^
+
+  u!: U;
+>u : U
+>  : ^
+}
+
+function mkGeneric<U, S extends string>(s: S) {
+>mkGeneric : <U, S extends string>(s: S) => Variable<U, S>
+>          : ^ ^^ ^^^^^^^^^      ^^ ^^ ^^^^^^^^^^^^^^^^^^^
+>s : S
+>  : ^
+
+  return new Variable<U, S>(s);
+>new Variable<U, S>(s) : Variable<U, S>
+>                      : ^^^^^^^^^^^^^^
+>Variable : typeof Variable
+>         : ^^^^^^^^^^^^^^^
+>s : S
+>  : ^
+}
+
+type ExactArgNames<GenericType, Constraint> = GenericType & {
+>ExactArgNames : ExactArgNames<GenericType, Constraint>
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  [K in keyof GenericType]: K extends keyof Constraint ? GenericType[K] : never;
+};
+
+type AllowVariables<T> =
+>AllowVariables : AllowVariables<T>
+>               : ^^^^^^^^^^^^^^^^^
+
+  | Variable<T, any>
+  | { [K in keyof T]: Variable<T[K], any> | T[K] };
+
+type TestArgs = {
+>TestArgs : TestArgs
+>         : ^^^^^^^^
+
+  someArg: number;
+>someArg : number
+>        : ^^^^^^
+
+};
+
+type TestArgsWithVars = AllowVariables<TestArgs>;
+>TestArgsWithVars : TestArgsWithVars
+>                 : ^^^^^^^^^^^^^^^^
+
+function takesGeneric<V extends AllowVariables<TestArgs>>(
+>takesGeneric : <V extends AllowVariables<TestArgs>>(a: ExactArgNames<V, TestArgs>) => void
+>             : ^ ^^^^^^^^^                        ^^ ^^                          ^^^^^    
+
+  a: ExactArgNames<V, TestArgs>,
+>a : ExactArgNames<V, TestArgs>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+): void {}
+
+let v = takesGeneric({ someArg: mkGeneric("x") });
+>v : void
+>  : ^^^^
+>takesGeneric({ someArg: mkGeneric("x") }) : void
+>                                          : ^^^^
+>takesGeneric : <V extends AllowVariables<TestArgs>>(a: ExactArgNames<V, TestArgs>) => void
+>             : ^ ^^^^^^^^^                        ^^ ^^                          ^^^^^    
+>{ someArg: mkGeneric("x") } : { someArg: Variable<number, "x">; }
+>                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>someArg : Variable<number, "x">
+>        : ^^^^^^^^^^^^^^^^^^^^^
+>mkGeneric("x") : Variable<number, "x">
+>               : ^^^^^^^^^^^^^^^^^^^^^
+>mkGeneric : <U, S extends string>(s: S) => Variable<U, S>
+>          : ^ ^^ ^^^^^^^^^      ^^ ^^ ^^^^^^^^^^^^^^^^^^^
+>"x" : "x"
+>    : ^^^
+

--- a/tests/cases/compiler/silentNeverInIntersections1.ts
+++ b/tests/cases/compiler/silentNeverInIntersections1.ts
@@ -1,0 +1,33 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/60864
+
+class Variable<U, S extends string> {
+  constructor(public s: S) {}
+  u!: U;
+}
+
+function mkGeneric<U, S extends string>(s: S) {
+  return new Variable<U, S>(s);
+}
+
+type ExactArgNames<GenericType, Constraint> = GenericType & {
+  [K in keyof GenericType]: K extends keyof Constraint ? GenericType[K] : never;
+};
+
+type AllowVariables<T> =
+  | Variable<T, any>
+  | { [K in keyof T]: Variable<T[K], any> | T[K] };
+
+type TestArgs = {
+  someArg: number;
+};
+
+type TestArgsWithVars = AllowVariables<TestArgs>;
+
+function takesGeneric<V extends AllowVariables<TestArgs>>(
+  a: ExactArgNames<V, TestArgs>,
+): void {}
+
+let v = takesGeneric({ someArg: mkGeneric("x") });


### PR DESCRIPTION
I'm not confident in this at all. I'm treating this as an experiment and I wonder if extended tests can reveal some missing test cases that should be added to the codebase.

The problem is that with a `contextualType` like `V["someArg"] | ((number | Variable<number, any>) & V["someArg"])` when `V` gets instantiated with `silentNeverType` the whole thing becomes... well, `silentNeverType`. The repro in question is also somewhat interesting because all the involved types come from `V`:
```ts
type ExactArgNames<GenericType, Constraint> = GenericType & {
  [K in keyof GenericType]: K extends keyof Constraint ? GenericType[K] : never;
};
```

In the code above `GenericType` gets instantiated with `V`. In general, `GenericType` bit gets converted to its constraint when a contextual type of its~ property is requested. But the mapped type that iterated over stays somewhat deferred as `V["someArg"]` and further down the line that creates a problem.

fixes https://github.com/microsoft/TypeScript/issues/60864