### PR TITLE
chore: don't fix TS code actions on save in vscode

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -9,7 +9,10 @@
     // user's settings.json so take precedence.
     "[typescript][typescriptreact][javascript][javascriptreact][json][jsonc][yaml][github-actions-workflow]": {
         "editor.defaultFormatter": "dprint.dprint",
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ts": "never"
+        }
     },
 
     // To ignore commits listed in .git-blame-ignore-revs in GitLens:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

For contributors who have "source.fixAll" enabled at a user level, spurious changes occur when saving files. For example, when I save the `checker.ts`, I get this diff:
```diff
iff --git a/src/compiler/checker.ts b/src/compiler/checker.ts
index 80b61edd36..0a279c773a 100644
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9869,7 +9869,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         // We don't know how to serialize this (nested?) binding element
                         Debug.failBadSyntaxKind(node.parent?.parent || node, "Unhandled binding element grandparent kind in declaration serialization");
-                        break;
                     case SyntaxKind.ShorthandPropertyAssignment:
                         if (node.parent?.parent?.kind === SyntaxKind.BinaryExpression) {
                             // module.exports = { SomeClass }
@@ -10889,7 +10888,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case TypeSystemPropertyName.ParameterInitializerContainsUndefined:
                 return getNodeLinks(target as ParameterDeclaration).parameterInitializerContainsUndefined !== undefined;
         }
-        return Debug.assertNever(propertyName);
     }
 
     /**
@@ -36974,7 +36972,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.BinaryExpression:
                 return resolveInstanceofExpression(node, candidatesOutArray, checkMode);
         }
-        Debug.assertNever(node, "Branch in 'resolveSignature' should be unreachable.");
     }
 
     /**
@@ -39337,7 +39334,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 return getUnaryResultType(operandType);
         }
-        return errorType;
     }
 
     function checkPostfixUnaryExpression(node: PostfixUnaryExpression): Type {
```

*** 

Therefore, explicitly setting "source.fixAll.ts": "never" would be beneficial to contributors