### PR TITLE
Fixed BADCLIENT error message

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -3068,8 +3068,8 @@ export class Session<TMessage = string> implements EventSender {
                 ...ls.getSemanticDiagnostics(file),
                 ...ls.getSuggestionDiagnostics(file),
             ]
-            .filter(d => decodedTextSpanIntersectsWith(startPosition, endPosition - startPosition, d.start!, d.length!))
-            .map(d => d.code);
+                .filter(d => decodedTextSpanIntersectsWith(startPosition, endPosition - startPosition, d.start!, d.length!))
+                .map(d => d.code);
             const badCode = args.errorCodes.find(c => !existingDiagCodes.includes(c));
             if (badCode !== undefined) {
                 e.message += `\nAdditional information: BADCLIENT: Bad error code, ${badCode} not found in range ${startPosition}..${endPosition} (found: ${existingDiagCodes.join(", ")})`;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -3058,18 +3058,21 @@ export class Session<TMessage = string> implements EventSender {
             codeActions = project.getLanguageService().getCodeFixesAtPosition(file, startPosition, endPosition, args.errorCodes, this.getFormatOptions(file), this.getPreferences(file));
         }
         catch (e) {
+            if (!(e instanceof Error)) {
+                e = new Error(e);
+            }
+
             const ls = project.getLanguageService();
             const existingDiagCodes = [
                 ...ls.getSyntacticDiagnostics(file),
                 ...ls.getSemanticDiagnostics(file),
                 ...ls.getSuggestionDiagnostics(file),
-            ].map(d =>
-                decodedTextSpanIntersectsWith(startPosition, endPosition - startPosition, d.start!, d.length!)
-                && d.code
-            );
+            ]
+            .filter(d => decodedTextSpanIntersectsWith(startPosition, endPosition - startPosition, d.start!, d.length!))
+            .map(d => d.code);
             const badCode = args.errorCodes.find(c => !existingDiagCodes.includes(c));
             if (badCode !== undefined) {
-                e.message = `BADCLIENT: Bad error code, ${badCode} not found in range ${startPosition}..${endPosition} (found: ${existingDiagCodes.join(", ")}); could have caused this error:\n${e.message}`;
+                e.message += `\nAdditional information: BADCLIENT: Bad error code, ${badCode} not found in range ${startPosition}..${endPosition} (found: ${existingDiagCodes.join(", ")})`;
             }
             throw e;
         }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -3058,9 +3058,7 @@ export class Session<TMessage = string> implements EventSender {
             codeActions = project.getLanguageService().getCodeFixesAtPosition(file, startPosition, endPosition, args.errorCodes, this.getFormatOptions(file), this.getPreferences(file));
         }
         catch (e) {
-            if (!(e instanceof Error)) {
-                e = new Error(e);
-            }
+            const error = e instanceof Error ? e : new Error(e);
 
             const ls = project.getLanguageService();
             const existingDiagCodes = [
@@ -3072,9 +3070,9 @@ export class Session<TMessage = string> implements EventSender {
                 .map(d => d.code);
             const badCode = args.errorCodes.find(c => !existingDiagCodes.includes(c));
             if (badCode !== undefined) {
-                e.message += `\nAdditional information: BADCLIENT: Bad error code, ${badCode} not found in range ${startPosition}..${endPosition} (found: ${existingDiagCodes.join(", ")})`;
+                error.message += `\nAdditional information: BADCLIENT: Bad error code, ${badCode} not found in range ${startPosition}..${endPosition} (found: ${existingDiagCodes.join(", ")})`;
             }
-            throw e;
+            throw error;
         }
         return simplifiedResult ? codeActions.map(codeAction => this.mapCodeFixAction(codeAction)) : codeActions;
     }


### PR DESCRIPTION
There's been an increase in telemetry reports on this error message, but the content is missing the exception message and the diagnostics codes.

i.e.
```
Error processing request. BADCLIENT: Bad error code, 7044 not found in range 139412..139415 (found: false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, fals...
```

This PR filter out the boolean values only to show the codes and repositions the exception message to the beginning because of truncation.

Also, all of the "exception messages" received are blank. I suspect that the exception is not an error, so I have added to check for the instance of Error as well.
