### PR TITLE
Fix GHA badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # TypeScript
 
-[![GitHub Actions CI](https://github.com/microsoft/TypeScript/workflows/CI/badge.svg)](https://github.com/microsoft/TypeScript/actions?query=workflow%3ACI)
+[![CI](https://github.com/microsoft/TypeScript/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/TypeScript/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/typescript.svg)](https://www.npmjs.com/package/typescript)
 [![Downloads](https://img.shields.io/npm/dm/typescript.svg)](https://www.npmjs.com/package/typescript)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/microsoft/TypeScript/badge)](https://securityscorecards.dev/viewer/?uri=github.com/microsoft/TypeScript)


### PR DESCRIPTION
GHA must have changed their badge system; the current badge in the readme points to _all_ builds in CI, which includes PRs, which is unfortunate.

Fix that by copying the new URL from the UI; note that the new thing uses paths.