### PR TITLE
Fix JSDoc for Array#sort, TypedArray#sort and Array#toSorted methods

### DIFF
--- a/src/lib/es2023.array.d.ts
+++ b/src/lib/es2023.array.d.ts
@@ -31,7 +31,7 @@ interface Array<T> {
      * Returns a copy of an array with its elements sorted.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
      * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
-     * value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
      * ```ts
      * [11, 2, 22, 1].toSorted((a, b) => a - b) // [1, 2, 11, 22]
      * ```
@@ -109,7 +109,7 @@ interface ReadonlyArray<T> {
      * Copies and sorts the array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
      * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
-     * value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
      * ```ts
      * [11, 2, 22, 1].toSorted((a, b) => a - b) // [1, 2, 11, 22]
      * ```

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1366,7 +1366,7 @@ interface Array<T> {
      * This method mutates the array and returns a reference to the same array.
      * @param compareFn Function used to determine the order of the elements. It is expected to return
      * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
-     * value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
      * ```ts
      * [11,2,22,1].sort((a, b) => a - b)
      * ```

--- a/tests/baselines/reference/completionEntryForUnionMethod.baseline
+++ b/tests/baselines/reference/completionEntryForUnionMethod.baseline
@@ -4190,7 +4190,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "Function used to determine the order of the elements. It is expected to return\na negative value if the first argument is less than the second argument, zero if they're equal, and a positive\nvalue otherwise. If omitted, the elements are sorted in ascending, ASCII character order.\n```ts\n[11,2,22,1].sort((a, b) => a - b)\n```",
+                  "text": "Function used to determine the order of the elements. It is expected to return\na negative value if the first argument is less than the second argument, zero if they're equal, and a positive\nvalue otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.\n```ts\n[11,2,22,1].sort((a, b) => a - b)\n```",
                   "kind": "text"
                 }
               ]

--- a/tests/baselines/reference/goToTypeDefinition_arrayType.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_arrayType.baseline.jsonc
@@ -78,7 +78,7 @@
 //      * This method mutates the array and returns a reference to the same array.
 //      * @param compareFn Function used to determine the order of the elements. It is expected to return
 //      * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
-//      * value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.
+//      * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
 //      * ```ts
 //      * [11,2,22,1].sort((a, b) => a - b)
 //      * ```
@@ -331,7 +331,7 @@
 //      * This method mutates the array and returns a reference to the same array.
 //      * @param compareFn Function used to determine the order of the elements. It is expected to return
 //      * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
-//      * value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.
+//      * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
 //      * ```ts
 //      * [11,2,22,1].sort((a, b) => a - b)
 //      * ```

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -1068,7 +1068,7 @@ interface Array<T> {
 
     /**
       * Sorts an array.
-      * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
+      * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
       */
     sort(compareFn?: (a: T, b: T) => number): T[];
 
@@ -1612,7 +1612,7 @@ interface Int8Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Int8Array;
 
@@ -1885,7 +1885,7 @@ interface Uint8Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Uint8Array;
 
@@ -2159,7 +2159,7 @@ interface Uint8ClampedArray {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Uint8ClampedArray;
 
@@ -2432,7 +2432,7 @@ interface Int16Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Int16Array;
 
@@ -2706,7 +2706,7 @@ interface Uint16Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Uint16Array;
 
@@ -2979,7 +2979,7 @@ interface Int32Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Int32Array;
 
@@ -3252,7 +3252,7 @@ interface Uint32Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Uint32Array;
 
@@ -3525,7 +3525,7 @@ interface Float32Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Float32Array;
 
@@ -3799,7 +3799,7 @@ interface Float64Array {
     /**
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If
-      * omitted, the elements are sorted in ascending, ASCII character order.
+      * omitted, the elements are sorted in ascending, numerical order.
       */
     sort(compareFn?: (a: number, b: number) => number): Float64Array;
 


### PR DESCRIPTION
Fixes #60978

The description in the JSDoc comment for the ES2023 `toSorted` method is incorrect. The default sorting order for JavaScript arrays is not ASCII character order but UTF-16 code unit order. This applies to both `Array.prototype.sort` and `Array.prototype.toSorted`.
Further the default sort order for `TypedArray.prototype.sort` is numerical order.

**Summary of changes**

1. `Array.prototype.sort`: Updated JSDoc to mention UTF-16 code unit order.
2. `TypedArray.prototype.sort`: Updated JSDoc to mention numerical order.
3. `Array.prototype.toSorted`: Updated JSDoc to mention UTF-16 code unit order.

