### PR TITLE
Use better context scope for class constructor implementation signatures in JS files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16217,6 +16217,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return typeParameter.constraint === noConstraintType ? undefined : typeParameter.constraint;
     }
 
+    function getSignatureTypeParameterHost(typeParameter: TypeParameter) {
+        const tp = getDeclarationOfKind<TypeParameterDeclaration>(typeParameter.symbol, SyntaxKind.TypeParameter)!;
+        return isJSDocTemplateTag(tp.parent) ? getEffectiveJSDocHost(tp.parent) : tp.parent;
+    }
+
     function getParentSymbolOfTypeParameter(typeParameter: TypeParameter): Symbol | undefined {
         const tp = getDeclarationOfKind<TypeParameterDeclaration>(typeParameter.symbol, SyntaxKind.TypeParameter)!;
         const host = isJSDocTemplateTag(tp.parent) ? getEffectiveContainerForJSDocTemplateTag(tp.parent) : tp.parent;
@@ -36138,8 +36143,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (candidate.typeParameters) {
                     // If we are *inside the body of candidate*, we need to create a clone of `candidate` with differing type parameter identities,
                     // so our inference results for this call doesn't pollute expression types referencing the outer type parameter!
-                    const paramLocation = candidate.typeParameters[0].symbol.declarations?.[0]?.parent;
-                    const candidateParameterContext = paramLocation || (candidate.declaration && isConstructorDeclaration(candidate.declaration) ? candidate.declaration.parent : candidate.declaration);
+                    const paramHost = getSignatureTypeParameterHost(candidate.typeParameters[0]);
+                    const candidateParameterContext = paramHost || (candidate.declaration && isConstructorDeclaration(candidate.declaration) ? candidate.declaration.parent : candidate.declaration);
                     if (candidateParameterContext && findAncestor(node, a => a === candidateParameterContext)) {
                         candidate = getImplementationSignature(candidate);
                     }

--- a/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.symbols
+++ b/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.symbols
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts] ////
+
+=== inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts ===
+class S<T> {
+>S : Symbol(S, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 0))
+>T : Symbol(T, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 8))
+
+  set: Set<T>;
+>set : Symbol(S.set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 12))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>T : Symbol(T, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 8))
+
+  constructor(set: Set<T>) {
+>set : Symbol(set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 3, 14))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>T : Symbol(T, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 8))
+
+    this.set = set;
+>this.set : Symbol(S.set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 12))
+>this : Symbol(S, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 0))
+>set : Symbol(S.set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 12))
+>set : Symbol(set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 3, 14))
+  }
+
+  array() {
+>array : Symbol(S.array, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 5, 3))
+
+    return new S(new Set([...this.set].map((item) => [item])));
+>S : Symbol(S, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 0))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>[...this.set].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>this.set : Symbol(S.set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 12))
+>this : Symbol(S, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 0))
+>set : Symbol(S.set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 12))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>item : Symbol(item, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 8, 44))
+>item : Symbol(item, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 8, 44))
+  }
+}
+
+function sArray<T>(set: Set<T>) {
+>sArray : Symbol(sArray, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 10, 1))
+>T : Symbol(T, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 12, 16))
+>set : Symbol(set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 12, 19))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>T : Symbol(T, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 12, 16))
+
+  return new S(new Set([...set].map((item) => [item])));
+>S : Symbol(S, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 0, 0))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>[...set].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>set : Symbol(set, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 12, 19))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>item : Symbol(item, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 13, 37))
+>item : Symbol(item, Decl(inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts, 13, 37))
+}
+

--- a/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.types
+++ b/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.types
@@ -1,0 +1,109 @@
+//// [tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts] ////
+
+=== Performance Stats ===
+Type Count: 1,000
+Instantiation count: 2,500
+
+=== inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts ===
+class S<T> {
+>S : S<T>
+>  : ^^^^
+
+  set: Set<T>;
+>set : Set<T>
+>    : ^^^^^^
+
+  constructor(set: Set<T>) {
+>set : Set<T>
+>    : ^^^^^^
+
+    this.set = set;
+>this.set = set : Set<T>
+>               : ^^^^^^
+>this.set : Set<T>
+>         : ^^^^^^
+>this : this
+>     : ^^^^
+>set : Set<T>
+>    : ^^^^^^
+>set : Set<T>
+>    : ^^^^^^
+  }
+
+  array() {
+>array : () => S<T[]>
+>      : ^^^^^^^^^^^^
+
+    return new S(new Set([...this.set].map((item) => [item])));
+>new S(new Set([...this.set].map((item) => [item]))) : S<T[]>
+>                                                    : ^^^^^^
+>S : typeof S
+>  : ^^^^^^^^
+>new Set([...this.set].map((item) => [item])) : Set<T[]>
+>                                             : ^^^^^^^^
+>Set : SetConstructor
+>    : ^^^^^^^^^^^^^^
+>[...this.set].map((item) => [item]) : T[][]
+>                                    : ^^^^^
+>[...this.set].map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>                  : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>[...this.set] : T[]
+>              : ^^^
+>...this.set : T
+>            : ^
+>this.set : Set<T>
+>         : ^^^^^^
+>this : this
+>     : ^^^^
+>set : Set<T>
+>    : ^^^^^^
+>map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>    : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>(item) => [item] : (item: T) => T[]
+>                 : ^    ^^^^^^^^^^^
+>item : T
+>     : ^
+>[item] : T[]
+>       : ^^^
+>item : T
+>     : ^
+  }
+}
+
+function sArray<T>(set: Set<T>) {
+>sArray : <T>(set: Set<T>) => S<T[]>
+>       : ^ ^^   ^^      ^^^^^^^^^^^
+>set : Set<T>
+>    : ^^^^^^
+
+  return new S(new Set([...set].map((item) => [item])));
+>new S(new Set([...set].map((item) => [item]))) : S<T[]>
+>                                               : ^^^^^^
+>S : typeof S
+>  : ^^^^^^^^
+>new Set([...set].map((item) => [item])) : Set<T[]>
+>                                        : ^^^^^^^^
+>Set : SetConstructor
+>    : ^^^^^^^^^^^^^^
+>[...set].map((item) => [item]) : T[][]
+>                               : ^^^^^
+>[...set].map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>             : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>[...set] : T[]
+>         : ^^^
+>...set : T
+>       : ^
+>set : Set<T>
+>    : ^^^^^^
+>map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>    : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>(item) => [item] : (item: T) => T[]
+>                 : ^    ^^^^^^^^^^^
+>item : T
+>     : ^
+>[item] : T[]
+>       : ^^^
+>item : T
+>     : ^
+}
+

--- a/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.symbols
+++ b/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.symbols
@@ -1,0 +1,65 @@
+//// [tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.ts] ////
+
+=== index.js ===
+// https://github.com/microsoft/TypeScript/issues/60988
+
+/**
+ * @template [T = any]
+ */
+class S {
+>S : Symbol(S, Decl(index.js, 0, 0))
+
+	/**
+	 * @type {Set<T>}
+	 */
+	set;
+>set : Symbol(S.set, Decl(index.js, 5, 9))
+
+	/**
+	 * @param {Set<T>} set
+	 */
+	constructor(set) {
+>set : Symbol(set, Decl(index.js, 15, 13))
+
+		this.set = set;
+>this.set : Symbol(S.set, Decl(index.js, 5, 9))
+>this : Symbol(S, Decl(index.js, 0, 0))
+>set : Symbol(S.set, Decl(index.js, 5, 9))
+>set : Symbol(set, Decl(index.js, 15, 13))
+	}
+
+	array() {
+>array : Symbol(S.array, Decl(index.js, 17, 2))
+
+		return new S(new Set([...this.set].map(item => [item])));
+>S : Symbol(S, Decl(index.js, 0, 0))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>[...this.set].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>this.set : Symbol(S.set, Decl(index.js, 5, 9))
+>this : Symbol(S, Decl(index.js, 0, 0))
+>set : Symbol(S.set, Decl(index.js, 5, 9))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>item : Symbol(item, Decl(index.js, 20, 41))
+>item : Symbol(item, Decl(index.js, 20, 41))
+	}
+}
+
+/**
+ * @template [T = any]
+ * @param {Set<T>} set
+ */
+const sArray = (set) => {
+>sArray : Symbol(sArray, Decl(index.js, 28, 5))
+>set : Symbol(set, Decl(index.js, 28, 16))
+
+	return new S(new Set([...set].map(item => [item])));
+>S : Symbol(S, Decl(index.js, 0, 0))
+>Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.esnext.collection.d.ts, --, --))
+>[...set].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>set : Symbol(set, Decl(index.js, 28, 16))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>item : Symbol(item, Decl(index.js, 29, 35))
+>item : Symbol(item, Decl(index.js, 29, 35))
+
+};
+

--- a/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.types
+++ b/tests/baselines/reference/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.types
@@ -1,0 +1,127 @@
+//// [tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.ts] ////
+
+=== Performance Stats ===
+Type Count: 1,000
+Instantiation count: 2,500
+
+=== index.js ===
+// https://github.com/microsoft/TypeScript/issues/60988
+
+/**
+ * @template [T = any]
+ */
+class S {
+>S : S<T>
+>  : ^^^^
+
+	/**
+	 * @type {Set<T>}
+	 */
+	set;
+>set : Set<T>
+>    : ^^^^^^
+
+	/**
+	 * @param {Set<T>} set
+	 */
+	constructor(set) {
+>set : Set<T>
+>    : ^^^^^^
+
+		this.set = set;
+>this.set = set : Set<T>
+>               : ^^^^^^
+>this.set : Set<T>
+>         : ^^^^^^
+>this : this
+>     : ^^^^
+>set : Set<T>
+>    : ^^^^^^
+>set : Set<T>
+>    : ^^^^^^
+	}
+
+	array() {
+>array : () => S<T[]>
+>      : ^^^^^^^^^^^^
+
+		return new S(new Set([...this.set].map(item => [item])));
+>new S(new Set([...this.set].map(item => [item]))) : S<T[]>
+>                                                  : ^^^^^^
+>S : typeof S
+>  : ^^^^^^^^
+>new Set([...this.set].map(item => [item])) : Set<T[]>
+>                                           : ^^^^^^^^
+>Set : SetConstructor
+>    : ^^^^^^^^^^^^^^
+>[...this.set].map(item => [item]) : T[][]
+>                                  : ^^^^^
+>[...this.set].map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>                  : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>[...this.set] : T[]
+>              : ^^^
+>...this.set : T
+>            : ^
+>this.set : Set<T>
+>         : ^^^^^^
+>this : this
+>     : ^^^^
+>set : Set<T>
+>    : ^^^^^^
+>map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>    : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>item => [item] : (item: T) => T[]
+>               : ^    ^^^^^^^^^^^
+>item : T
+>     : ^
+>[item] : T[]
+>       : ^^^
+>item : T
+>     : ^
+	}
+}
+
+/**
+ * @template [T = any]
+ * @param {Set<T>} set
+ */
+const sArray = (set) => {
+>sArray : <T = any>(set: Set<T>) => S<T[]>
+>       : ^ ^^^^^^^^   ^^      ^^^^^^^^^^^
+>(set) => {	return new S(new Set([...set].map(item => [item])));} : <T = any>(set: Set<T>) => S<T[]>
+>                                                                 : ^ ^^^^^^^^   ^^      ^^^^^^^^^^^
+>set : Set<T>
+>    : ^^^^^^
+
+	return new S(new Set([...set].map(item => [item])));
+>new S(new Set([...set].map(item => [item]))) : S<T[]>
+>                                             : ^^^^^^
+>S : typeof S
+>  : ^^^^^^^^
+>new Set([...set].map(item => [item])) : Set<T[]>
+>                                      : ^^^^^^^^
+>Set : SetConstructor
+>    : ^^^^^^^^^^^^^^
+>[...set].map(item => [item]) : T[][]
+>                             : ^^^^^
+>[...set].map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>             : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>[...set] : T[]
+>         : ^^^
+>...set : T
+>       : ^
+>set : Set<T>
+>    : ^^^^^^
+>map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+>    : ^ ^^          ^^^     ^^^^^     ^^      ^^     ^^^^^^^^^^^^^       ^^^   ^^^^^^^^
+>item => [item] : (item: T) => T[]
+>               : ^    ^^^^^^^^^^^
+>item : T
+>     : ^
+>[item] : T[]
+>       : ^^^
+>item : T
+>     : ^
+
+};
+

--- a/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts
+++ b/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult2.ts
@@ -1,0 +1,20 @@
+// @strict: true
+// @noEmit: true
+// @target: esnext
+// @lib: esnext
+
+class S<T> {
+  set: Set<T>;
+
+  constructor(set: Set<T>) {
+    this.set = set;
+  }
+
+  array() {
+    return new S(new Set([...this.set].map((item) => [item])));
+  }
+}
+
+function sArray<T>(set: Set<T>) {
+  return new S(new Set([...set].map((item) => [item])));
+}

--- a/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.ts
+++ b/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResultJsDoc1.ts
@@ -1,0 +1,40 @@
+// @strict: true
+// @noEmit: true
+// @target: esnext
+// @lib: esnext
+// @checkJs: true
+// @allowJs: true
+
+// @filename: index.js
+
+// https://github.com/microsoft/TypeScript/issues/60988
+
+/**
+ * @template [T = any]
+ */
+class S {
+
+	/**
+	 * @type {Set<T>}
+	 */
+	set;
+
+	/**
+	 * @param {Set<T>} set
+	 */
+	constructor(set) {
+		this.set = set;
+	}
+
+	array() {
+		return new S(new Set([...this.set].map(item => [item])));
+	}
+}
+
+/**
+ * @template [T = any]
+ * @param {Set<T>} set
+ */
+const sArray = (set) => {
+	return new S(new Set([...set].map(item => [item])));
+};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/60988 , it fixes a regression from https://github.com/microsoft/TypeScript/pull/57403 that was not addressed by https://github.com/microsoft/TypeScript/pull/58168 