### PR TITLE
Fixing slow paste with spinner

### DIFF
--- a/src/services/preparePasteEdits.ts
+++ b/src/services/preparePasteEdits.ts
@@ -2,7 +2,14 @@ import {
     findAncestor,
     forEachChild,
     getTokenAtPosition,
+    isBindingElement,
     isIdentifier,
+    isImportClause,
+    isImportDeclaration,
+    isImportEqualsDeclaration,
+    isImportSpecifier,
+    isNamedImports,
+    isNamespaceImport,
     rangeContainsPosition,
     rangeContainsRange,
     SourceFile,
@@ -25,6 +32,12 @@ export function preparePasteEdits(
             ancestorNode => rangeContainsRange(ancestorNode, range),
         );
         if (!enclosingNode) return;
+        if (
+            isImportSpecifier(enclosingNode) || isImportClause(enclosingNode) || isNamespaceImport(enclosingNode) || isImportEqualsDeclaration(enclosingNode)
+            || isBindingElement(enclosingNode) || isImportDeclaration(enclosingNode) || isNamedImports(enclosingNode)
+        ) {
+            return;
+        }
         forEachChild(enclosingNode, function checkNameResolution(node) {
             if (shouldProvidePasteEdits) return;
             if (isIdentifier(node) && rangeContainsPosition(range, node.getStart(sourceFile))) {

--- a/tests/cases/fourslash/preparePasteEdits_returnFalse.ts
+++ b/tests/cases/fourslash/preparePasteEdits_returnFalse.ts
@@ -1,11 +1,14 @@
 /// <reference path='./fourslash.ts' />
 
 // @Filename: /file1.ts
+//// import [|{abc}|] from "./file2";
 //// [|const a = 1;|]
 //// [|function foo() {
 ////     console.log("testing");}|]
 //// [|//This is a comment|]
 
+// @Filename: /file2.ts
+//// export const abc = 1;
 verify.preparePasteEdits({
     copiedFromFile: "/file1.ts",
     copiedTextRange: test.ranges(),


### PR DESCRIPTION
This pr fixes https://github.com/microsoft/TypeScript/issues/60485 by making `preparePasteEdits` return false if an import statement is selected. This is a fix for now that will stop the spinner, but I will be working on https://github.com/microsoft/TypeScript/issues/59841 that would enable `pasteEdits` to fix import specifiers and will also take care of this delay.