### PR TITLE
Ensure createProgram stops referencing rootNamesOrOptions to ensure oldProgram is GC'd

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1512,9 +1512,10 @@ export function createProgram(createProgramOptions: CreateProgramOptions): Progr
  */
 export function createProgram(rootNames: readonly string[], options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: readonly Diagnostic[]): Program;
 export function createProgram(rootNamesOrOptions: readonly string[] | CreateProgramOptions, _options?: CompilerOptions, _host?: CompilerHost, _oldProgram?: Program, _configFileParsingDiagnostics?: readonly Diagnostic[]): Program {
-    const createProgramOptions = isArray(rootNamesOrOptions) ? createCreateProgramOptions(rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : rootNamesOrOptions; // TODO: GH#18217
-    const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion } = createProgramOptions;
+    let createProgramOptions = isArray(rootNamesOrOptions) ? createCreateProgramOptions(rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : rootNamesOrOptions; // TODO: GH#18217
+    const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion, host: createProgramOptionsHost } = createProgramOptions;
     let { oldProgram } = createProgramOptions;
+    createProgramOptions = undefined!; // Stop referencing this object to ensure GC collects it.
     for (const option of commandLineOptionOfCustomType) {
         if (hasProperty(options, option.name)) {
             if (typeof options[option.name] === "string") {
@@ -1569,7 +1570,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     tracing?.push(tracing.Phase.Program, "createProgram", { configFilePath: options.configFilePath, rootDir: options.rootDir }, /*separateBeginAndEnd*/ true);
     performance.mark("beforeProgram");
 
-    const host = createProgramOptions.host || createCompilerHost(options);
+    const host = createProgramOptionsHost || createCompilerHost(options);
     const configParsingHost = parseConfigHostFromCompilerHostLike(host);
 
     let skipDefaultLib = options.noLib;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1511,11 +1511,14 @@ export function createProgram(createProgramOptions: CreateProgramOptions): Progr
  * @returns A 'Program' object.
  */
 export function createProgram(rootNames: readonly string[], options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: readonly Diagnostic[]): Program;
-export function createProgram(rootNamesOrOptions: readonly string[] | CreateProgramOptions, _options?: CompilerOptions, _host?: CompilerHost, _oldProgram?: Program, _configFileParsingDiagnostics?: readonly Diagnostic[]): Program {
-    let createProgramOptions = isArray(rootNamesOrOptions) ? createCreateProgramOptions(rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : rootNamesOrOptions; // TODO: GH#18217
-    const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion, host: createProgramOptionsHost } = createProgramOptions;
-    let { oldProgram } = createProgramOptions;
-    createProgramOptions = undefined!; // Stop referencing this object to ensure GC collects it.
+export function createProgram(_rootNamesOrOptions: readonly string[] | CreateProgramOptions, _options?: CompilerOptions, _host?: CompilerHost, _oldProgram?: Program, _configFileParsingDiagnostics?: readonly Diagnostic[]): Program {
+    let _createProgramOptions = isArray(_rootNamesOrOptions) ? createCreateProgramOptions(_rootNamesOrOptions, _options!, _host, _oldProgram, _configFileParsingDiagnostics) : _rootNamesOrOptions; // TODO: GH#18217
+    const { rootNames, options, configFileParsingDiagnostics, projectReferences, typeScriptVersion, host: createProgramOptionsHost } = _createProgramOptions;
+    let { oldProgram } = _createProgramOptions;
+    // Stop referencing these objects to ensure GC collects them.
+    _createProgramOptions = undefined!;
+    _rootNamesOrOptions = undefined!;
+
     for (const option of commandLineOptionOfCustomType) {
         if (hasProperty(options, option.name)) {
             if (typeof options[option.name] === "string") {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1828,8 +1828,6 @@ export function createLanguageService(
             projectReferences,
         };
         program = createProgram(options);
-        // Workaround for GC bug in JSC; createProgram does not keep a reference to options, so this is safe.
-        options.oldProgram = undefined;
 
         // 'getOrCreateSourceFile' depends on caching but should be used past this point.
         // After this point, the cache needs to be cleared to allow all collected snapshots to be released

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1828,6 +1828,8 @@ export function createLanguageService(
             projectReferences,
         };
         program = createProgram(options);
+        // Workaround for GC bug in JSC; createProgram does not keep a reference to options, so this is safe.
+        options.oldProgram = undefined;
 
         // 'getOrCreateSourceFile' depends on caching but should be used past this point.
         // After this point, the cache needs to be cleared to allow all collected snapshots to be released


### PR DESCRIPTION
~This is practically the same as #58138, since that seems to be the only thing that works, along with some code to make `createProgram` less likely to _accidentally_ be changed such that this hack breaks something.~

~This is still 100% for sure a JSC GC bug, but I cannot find any reasonable way to fix this besides the original proposed solution.~

The parameter `rootNamesOrOptions` holds a reference to `oldProgram`; we force overwrote `oldProgram` in the local scope, but `rootNamesOrOptions` appears to stay in scope in JSC, so overwrite that too. That and `createProgramOptions` also referenced the variable, so that has to also go.

Fixes #58137