### PR TITLE
support quick info and go to definition on mapped keys

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14221,6 +14221,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const stripOptional = strictNullChecks && !isOptional && modifiersProp && modifiersProp.flags & SymbolFlags.Optional;
                     const lateFlag: CheckFlags = modifiersProp ? getIsLateCheckFlag(modifiersProp) : 0;
                     const prop = createSymbol(SymbolFlags.Property | (isOptional ? SymbolFlags.Optional : 0), propName, lateFlag | CheckFlags.Mapped | (isReadonly ? CheckFlags.Readonly : 0) | (stripOptional ? CheckFlags.StripOptional : 0)) as MappedSymbol;
+                    prop.parent = mappedType.symbol;
                     prop.links.mappedType = type;
                     prop.links.nameType = propNameType;
                     prop.links.keyType = keyType;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4408,6 +4408,7 @@ namespace Parser {
 
     function parseMappedType() {
         const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
         parseExpected(SyntaxKind.OpenBraceToken);
         let readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined;
         if (token() === SyntaxKind.ReadonlyKeyword || token() === SyntaxKind.PlusToken || token() === SyntaxKind.MinusToken) {
@@ -4431,7 +4432,10 @@ namespace Parser {
         parseSemicolon();
         const members = parseList(ParsingContext.TypeMembers, parseTypeMember);
         parseExpected(SyntaxKind.CloseBraceToken);
-        return finishNode(factory.createMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, type, members), pos);
+        return withJSDoc(
+            finishNode(factory.createMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, type, members), pos),
+            hasJSDoc
+        ) ;
     }
 
     function parseTupleElementType() {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1258,7 +1258,8 @@ export type HasJSDoc =
     | VariableDeclaration
     | VariableStatement
     | WhileStatement
-    | WithStatement;
+    | WithStatement
+    | MappedTypeNode;
 
 export type HasType =
     | SignatureDeclaration
@@ -2339,7 +2340,7 @@ export interface IndexedAccessTypeNode extends TypeNode {
     readonly indexType: TypeNode;
 }
 
-export interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
+export interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer, JSDocContainer {
     readonly kind: SyntaxKind.MappedType;
     readonly readonlyToken?: ReadonlyKeyword | PlusToken | MinusToken;
     readonly typeParameter: TypeParameterDeclaration;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2699,7 +2699,8 @@ export function getJSDocCommentRanges(node: Node, text: string): CommentRange[] 
             node.kind === SyntaxKind.ArrowFunction ||
             node.kind === SyntaxKind.ParenthesizedExpression ||
             node.kind === SyntaxKind.VariableDeclaration ||
-            node.kind === SyntaxKind.ExportSpecifier) ?
+            node.kind === SyntaxKind.ExportSpecifier ||
+            node.kind === SyntaxKind.MappedType) ?
         concatenate(getTrailingCommentRanges(text, node.pos), getLeadingCommentRanges(text, node.pos)) :
         getLeadingCommentRanges(text, node.pos);
     // True if the comment starts with '/**' but not if it is '/**/'
@@ -4538,6 +4539,7 @@ export function canHaveJSDoc(node: Node): node is HasJSDoc {
         case SyntaxKind.VariableStatement:
         case SyntaxKind.WhileStatement:
         case SyntaxKind.WithStatement:
+        case SyntaxKind.MappedType:
             return true;
         default:
             return false;

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -5,6 +5,7 @@ import {
     AssignmentOperatorToken,
     CallLikeExpression,
     canHaveSymbol,
+    CheckFlags,
     concatenate,
     createTextSpan,
     createTextSpanFromBounds,
@@ -74,6 +75,7 @@ import {
     isRightSideOfPropertyAccess,
     isStaticModifier,
     isSwitchStatement,
+    isTransientSymbol,
     isTypeAliasDeclaration,
     isTypeReferenceNode,
     isVariableDeclaration,
@@ -595,7 +597,8 @@ function isExpandoDeclaration(node: Declaration): boolean {
 }
 
 function getDefinitionFromSymbol(typeChecker: TypeChecker, symbol: Symbol, node: Node, failedAliasResolution?: boolean, declarationFilter?: (d: Declaration) => boolean): DefinitionInfo[] | undefined {
-    const filteredDeclarations = declarationFilter !== undefined ? filter(symbol.declarations, declarationFilter) : symbol.declarations;
+    const declarations = isTransientSymbol(symbol) && symbol.links.checkFlags & CheckFlags.Mapped && !symbol.declarations?.length ? symbol.links.syntheticOrigin?.declarations : symbol.declarations;
+    const filteredDeclarations = declarationFilter !== undefined ? filter(declarations, declarationFilter) : declarations;
     // If we have a declaration filter, we are looking for specific declaration(s), so we should not return prematurely.
     const signatureDefinition = !declarationFilter && (getConstructSignatureDefinition() || getCallSignatureDefinition());
     if (signatureDefinition) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -346,6 +346,7 @@ import {
     updateSourceFile,
     UserPreferences,
     VariableDeclaration,
+    CheckFlags,
 } from "./_namespaces/ts.js";
 import * as NavigateTo from "./_namespaces/ts.NavigateTo.js";
 import * as NavigationBar from "./_namespaces/ts.NavigationBar.js";
@@ -721,7 +722,10 @@ class SymbolObject implements Symbol {
         if (!this.documentationComment) {
             this.documentationComment = emptyArray; // Set temporarily to avoid an infinite loop finding inherited docs
 
-            if (!this.declarations && isTransientSymbol(this) && this.links.target && isTransientSymbol(this.links.target) && this.links.target.links.tupleLabelDeclaration) {
+            if (!this.declarations && isTransientSymbol(this) && this.links.checkFlags & CheckFlags.Mapped && this.parent?.declarations && some(this.parent?.declarations, decl => hasJSDocInheritDocTag(decl))) {
+                this.documentationComment = getDocumentationComment(this.parent?.declarations.concat(this.links.syntheticOrigin?.declarations || emptyArray), checker);
+            }
+            else if (!this.declarations && isTransientSymbol(this) && this.links.target && isTransientSymbol(this.links.target) && this.links.target.links.tupleLabelDeclaration) {
                 const labelDecl = this.links.target.links.tupleLabelDeclaration;
                 this.documentationComment = getDocumentationComment([labelDecl], checker);
             }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4387,7 +4387,8 @@ declare namespace ts {
         | VariableDeclaration
         | VariableStatement
         | WhileStatement
-        | WithStatement;
+        | WithStatement
+        | MappedTypeNode;
     type HasType = SignatureDeclaration | VariableDeclaration | ParameterDeclaration | PropertySignature | PropertyDeclaration | TypePredicateNode | ParenthesizedTypeNode | TypeOperatorNode | MappedTypeNode | AssertionExpression | TypeAliasDeclaration | JSDocTypeExpression | JSDocNonNullableType | JSDocNullableType | JSDocOptionalType | JSDocVariadicType;
     type HasTypeArguments = CallExpression | NewExpression | TaggedTemplateExpression | JsxOpeningElement | JsxSelfClosingElement;
     type HasInitializer = HasExpressionInitializer | ForStatement | ForInStatement | ForOfStatement | JsxAttribute;
@@ -4806,7 +4807,7 @@ declare namespace ts {
         readonly objectType: TypeNode;
         readonly indexType: TypeNode;
     }
-    interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
+    interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer, JSDocContainer {
         readonly kind: SyntaxKind.MappedType;
         readonly readonlyToken?: ReadonlyKeyword | PlusToken | MinusToken;
         readonly typeParameter: TypeParameterDeclaration;

--- a/tests/baselines/reference/goToDefinition_filteringGenericMappedType.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinition_filteringGenericMappedType.baseline.jsonc
@@ -20,7 +20,7 @@
    {
     "kind": "property",
     "name": "id",
-    "containerName": "",
+    "containerName": "__type",
     "isLocal": false,
     "isAmbient": false,
     "unverified": false,

--- a/tests/baselines/reference/goToDefinition_filteringMappedType.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinition_filteringMappedType.baseline.jsonc
@@ -9,7 +9,7 @@
    {
     "kind": "property",
     "name": "a",
-    "containerName": "",
+    "containerName": "filtered",
     "isLocal": false,
     "isAmbient": false,
     "unverified": false,

--- a/tests/baselines/reference/goToDefinition_mappedType2.baseline.jsonc
+++ b/tests/baselines/reference/goToDefinition_mappedType2.baseline.jsonc
@@ -1,0 +1,28 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/goToDefinition_mappedType2.ts ===
+// interface Foo {
+//     <|[|property|]: string|>
+// }
+// 
+// type JustMapIt<T> = {[P in keyof T]: 0}
+// --- (line: 6) skipped ---
+
+// --- (line: 11) skipped ---
+// 
+// {
+//     let gotoDef!: MapItWithRemap<Foo>
+//     gotoDef./*GOTO DEF*/mapped_property
+// }
+
+  // === Details ===
+  [
+   {
+    "kind": "property",
+    "name": "mapped_property",
+    "containerName": "__type",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]

--- a/tests/baselines/reference/quickInfoMappedType3.baseline
+++ b/tests/baselines/reference/quickInfoMappedType3.baseline
@@ -1,0 +1,403 @@
+// === QuickInfo ===
+=== /tests/cases/fourslash/quickInfoMappedType3.ts ===
+// type Getters<Type> =  /** @inheritDoc desc on Getters */  {
+//   [Property in keyof Type as `get${Capitalize<
+//     string & Property
+//   >}`]: () => Type[Property];
+// };
+// 
+// interface Person {
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's name.
+//    * @example "John Doe"
+//    */
+//   name: string;
+// 
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's Age.
+//    * @example 30
+//    */
+//   age: number;
+// 
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's Location.
+//    * @example "Brazil"
+//    */
+//   location: string;
+// }
+// 
+// type LazyPerson = Getters<Person>;
+// 
+// const me: LazyPerson = {
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getName: () => "Jake Carter",
+//   ^^^^^^^
+// | ----------------------------------------------------------------------
+// | (property) getName: () => string
+// | desc on Getters
+// | Person's name.
+// | ----------------------------------------------------------------------
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getAge: () => 35,
+//   ^^^^^^
+// | ----------------------------------------------------------------------
+// | (property) getAge: () => number
+// | desc on Getters
+// | Person's Age.
+// | ----------------------------------------------------------------------
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getLocation: () => "United States",
+//   ^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | (property) getLocation: () => string
+// | desc on Getters
+// | Person's Location.
+// | ----------------------------------------------------------------------
+// };
+// 
+// // ❌ When hovering here, the documentation is NOT displayed.
+// me.getName();
+//    ^^^^^^^
+// | ----------------------------------------------------------------------
+// | (property) getName: () => string
+// | desc on Getters
+// | Person's name.
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoMappedType3.ts",
+      "position": 747,
+      "name": "1"
+    },
+    "item": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 747,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "getName",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "desc on Getters",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "Person's name.",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoMappedType3.ts",
+      "position": 842,
+      "name": "2"
+    },
+    "item": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 842,
+        "length": 6
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "getAge",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "desc on Getters",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "Person's Age.",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoMappedType3.ts",
+      "position": 925,
+      "name": "3"
+    },
+    "item": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 925,
+        "length": 11
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "getLocation",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "desc on Getters",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "Person's Location.",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoMappedType3.ts",
+      "position": 1029,
+      "name": "4"
+    },
+    "item": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1029,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "getName",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "desc on Getters",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "Person's name.",
+          "kind": "text"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/goToDefinition_mappedType2.ts
+++ b/tests/cases/fourslash/goToDefinition_mappedType2.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+////interface Foo {
+////    /*def*/property: string
+////}
+////
+////type JustMapIt<T> = {[P in keyof T]: 0}
+////type MapItWithRemap<T> = {[P in keyof T as P extends string ? `mapped_${P}` : never]: 0}
+////
+////{
+////    let gotoDef!: JustMapIt<Foo>
+////    gotoDef.property
+////}
+////
+////{
+////    let gotoDef!: MapItWithRemap<Foo>
+////    gotoDef.[|/*ref*/mapped_property|]
+////}
+
+
+verify.baselineGoToDefinition("ref");

--- a/tests/cases/fourslash/quickInfoMappedType2.ts
+++ b/tests/cases/fourslash/quickInfoMappedType2.ts
@@ -1,0 +1,18 @@
+/// <reference path="./fourslash.ts"/>
+
+////type ToGet<T> = T extends string ? `get${Capitalize<T>}` : never;
+////type Getters<T> = /** @inheritDoc desc on Getters */ { 
+////    [P in keyof T as ToGet<P>]: () => T[P]
+////};
+////
+////type Y = {
+////    /** hello  */
+////    d: string;
+////}
+////
+////type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+////
+////declare let y: T50;
+////y.get/*3*/D;
+
+verify.quickInfoAt("3", "(property) getD: () => string", "desc on Getters\nhello");

--- a/tests/cases/fourslash/quickInfoMappedType3.ts
+++ b/tests/cases/fourslash/quickInfoMappedType3.ts
@@ -1,0 +1,46 @@
+/// <reference path="./fourslash.ts"/>
+
+////type Getters<Type> =  /** @inheritDoc desc on Getters */  {
+////  [Property in keyof Type as `get${Capitalize<
+////    string & Property
+////  >}`]: () => Type[Property];
+////};
+////
+////interface Person {
+////  // ✅ When hovering here, the documentation is displayed, as it should.
+////  /**
+////   * Person's name.
+////   * @example "John Doe"
+////   */
+////  name: string;
+////
+////  // ✅ When hovering here, the documentation is displayed, as it should.
+////  /**
+////   * Person's Age.
+////   * @example 30
+////   */
+////  age: number;
+////
+////  // ✅ When hovering here, the documentation is displayed, as it should.
+////  /**
+////   * Person's Location.
+////   * @example "Brazil"
+////   */
+////  location: string;
+////}
+////
+////type LazyPerson = Getters<Person>;
+////
+////const me: LazyPerson = {
+////  // ❌ When hovering here, the documentation is NOT displayed.
+////  /*1*/getName: () => "Jake Carter",
+////  // ❌ When hovering here, the documentation is NOT displayed.
+////  /*2*/getAge: () => 35,
+////  // ❌ When hovering here, the documentation is NOT displayed.
+////  /*3*/getLocation: () => "United States",
+////};
+////
+////// ❌ When hovering here, the documentation is NOT displayed.
+////me./*4*/getName();
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoMappedType4.ts
+++ b/tests/cases/fourslash/quickInfoMappedType4.ts
@@ -1,0 +1,20 @@
+/// <reference path="./fourslash.ts"/>
+
+////type ToGet<T> = T extends string ? `get${Capitalize<T>}` : never;
+////type Getters<T> = { 
+////    /** @inheritDoc desc on Getters */
+////    [P in keyof T as ToGet<P>]: () => T[P]
+////    
+////     };
+////
+////type Y = {
+////    /** hello  */
+////    d: string;
+////}
+////
+////type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+////
+////declare let y: T50;
+////y.get/*3*/D;
+
+verify.quickInfoAt("3", "(property) getD: () => string", undefined);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #50715, Fixes #56019

As mentioned in this comment on GitHub (https://github.com/microsoft/TypeScript/issues/50715#issuecomment-1491168623), the `@inheritDoc` tag is necessary to enable features like quick info and go to definition.
