### PR TITLE
Walk all outer expression kinds before comitting to the return type of a symbol call

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37245,7 +37245,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Treat any call to the global 'Symbol' function that is part of a const variable or readonly property
         // as a fresh unique symbol literal type.
         if (returnType.flags & TypeFlags.ESSymbolLike && isSymbolOrSymbolForCall(node)) {
-            return getESSymbolLikeTypeForNode(walkUpParenthesizedExpressions(node.parent));
+            return getESSymbolLikeTypeForNode(walkUpOuterExpressions(node));
         }
         if (
             node.kind === SyntaxKind.CallExpression && !node.questionDotToken && node.parent.kind === SyntaxKind.ExpressionStatement &&

--- a/tests/baselines/reference/uniqueSymbols.js
+++ b/tests/baselines/reference/uniqueSymbols.js
@@ -268,6 +268,10 @@ function funcInferredReturnType(obj: { method(p: typeof s): void }) {
     return obj;
 }
 
+// https://github.com/microsoft/TypeScript/issues/61070
+const bar = Symbol('bar') satisfies symbol;
+let bar2 = Symbol('bar2') satisfies symbol;
+
 
 //// [uniqueSymbols.js]
 // declarations with call initializer
@@ -458,3 +462,6 @@ const ce0 = class {
 function funcInferredReturnType(obj) {
     return obj;
 }
+// https://github.com/microsoft/TypeScript/issues/61070
+const bar = Symbol('bar');
+let bar2 = Symbol('bar2');

--- a/tests/baselines/reference/uniqueSymbols.symbols
+++ b/tests/baselines/reference/uniqueSymbols.symbols
@@ -863,3 +863,12 @@ function funcInferredReturnType(obj: { method(p: typeof s): void }) {
 >obj : Symbol(obj, Decl(uniqueSymbols.ts, 263, 32))
 }
 
+// https://github.com/microsoft/TypeScript/issues/61070
+const bar = Symbol('bar') satisfies symbol;
+>bar : Symbol(bar, Decl(uniqueSymbols.ts, 268, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+let bar2 = Symbol('bar2') satisfies symbol;
+>bar2 : Symbol(bar2, Decl(uniqueSymbols.ts, 269, 3))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -1443,3 +1443,28 @@ function funcInferredReturnType(obj: { method(p: typeof s): void }) {
 >    : ^^^^^^^^^ ^^        ^^^    ^^^
 }
 
+// https://github.com/microsoft/TypeScript/issues/61070
+const bar = Symbol('bar') satisfies symbol;
+>bar : unique symbol
+>    : ^^^^^^^^^^^^^
+>Symbol('bar') satisfies symbol : unique symbol
+>                               : ^^^^^^^^^^^^^
+>Symbol('bar') : unique symbol
+>              : ^^^^^^^^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>'bar' : "bar"
+>      : ^^^^^
+
+let bar2 = Symbol('bar2') satisfies symbol;
+>bar2 : symbol
+>     : ^^^^^^
+>Symbol('bar2') satisfies symbol : symbol
+>                                : ^^^^^^
+>Symbol('bar2') : symbol
+>               : ^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>'bar2' : "bar2"
+>       : ^^^^^^
+

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
@@ -269,3 +269,7 @@ const ce0 = class {
 function funcInferredReturnType(obj: { method(p: typeof s): void }) {
     return obj;
 }
+
+// https://github.com/microsoft/TypeScript/issues/61070
+const bar = Symbol('bar') satisfies symbol;
+let bar2 = Symbol('bar2') satisfies symbol;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61070