### PR TITLE
Unwrap `NoInfer`-wrapped unions before conditional type distribution attempt

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20422,6 +20422,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const newMapper = createTypeMapper(root.outerTypeParameters, typeArguments);
                 const checkType = root.checkType;
                 let distributionType = root.isDistributive ? getReducedType(getMappedType(checkType, newMapper)) : undefined;
+                if (distributionType && isNoInferType(distributionType)) {
+                    distributionType = (distributionType as SubstitutionType).baseType;
+                }
                 let narrowingBaseType: Type | undefined;
                 const forNarrowing = distributionType && isNarrowingSubstitutionType(distributionType) && isNarrowableConditionalType(type, mapper);
                 if (forNarrowing) {

--- a/tests/baselines/reference/noInferVsDistributiveConditionalType1.symbols
+++ b/tests/baselines/reference/noInferVsDistributiveConditionalType1.symbols
@@ -1,0 +1,128 @@
+//// [tests/cases/conformance/types/typeRelationships/typeInference/noInferVsDistributiveConditionalType1.ts] ////
+
+=== noInferVsDistributiveConditionalType1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61076
+
+type FooEvent = { type: "FOO" };
+>FooEvent : Symbol(FooEvent, Decl(noInferVsDistributiveConditionalType1.ts, 0, 0))
+>type : Symbol(type, Decl(noInferVsDistributiveConditionalType1.ts, 2, 17))
+
+type BarEvent = { type: "BAR" };
+>BarEvent : Symbol(BarEvent, Decl(noInferVsDistributiveConditionalType1.ts, 2, 32))
+>type : Symbol(type, Decl(noInferVsDistributiveConditionalType1.ts, 3, 17))
+
+type Input = FooEvent | BarEvent;
+>Input : Symbol(Input, Decl(noInferVsDistributiveConditionalType1.ts, 3, 32))
+>FooEvent : Symbol(FooEvent, Decl(noInferVsDistributiveConditionalType1.ts, 0, 0))
+>BarEvent : Symbol(BarEvent, Decl(noInferVsDistributiveConditionalType1.ts, 2, 32))
+
+type Result = Extract<NoInfer<Input>, FooEvent>;
+>Result : Symbol(Result, Decl(noInferVsDistributiveConditionalType1.ts, 5, 33))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>NoInfer : Symbol(NoInfer, Decl(lib.es5.d.ts, --, --))
+>Input : Symbol(Input, Decl(noInferVsDistributiveConditionalType1.ts, 3, 32))
+>FooEvent : Symbol(FooEvent, Decl(noInferVsDistributiveConditionalType1.ts, 0, 0))
+
+type EventObject = {
+>EventObject : Symbol(EventObject, Decl(noInferVsDistributiveConditionalType1.ts, 6, 48))
+
+  type: string;
+>type : Symbol(type, Decl(noInferVsDistributiveConditionalType1.ts, 8, 20))
+
+};
+
+type ActionFunction<
+>ActionFunction : Symbol(ActionFunction, Decl(noInferVsDistributiveConditionalType1.ts, 10, 2))
+
+  TExpressionEvent extends EventObject,
+>TExpressionEvent : Symbol(TExpressionEvent, Decl(noInferVsDistributiveConditionalType1.ts, 12, 20))
+>EventObject : Symbol(EventObject, Decl(noInferVsDistributiveConditionalType1.ts, 6, 48))
+
+  TEvent extends EventObject,
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 13, 39))
+>EventObject : Symbol(EventObject, Decl(noInferVsDistributiveConditionalType1.ts, 6, 48))
+
+> = {
+  (args: { event: TExpressionEvent }): void;
+>args : Symbol(args, Decl(noInferVsDistributiveConditionalType1.ts, 16, 3))
+>event : Symbol(event, Decl(noInferVsDistributiveConditionalType1.ts, 16, 10))
+>TExpressionEvent : Symbol(TExpressionEvent, Decl(noInferVsDistributiveConditionalType1.ts, 12, 20))
+
+  _out_TEvent?: TEvent;
+>_out_TEvent : Symbol(_out_TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 16, 44))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 13, 39))
+
+};
+
+type TransitionsConfig<TEvent extends EventObject> = {
+>TransitionsConfig : Symbol(TransitionsConfig, Decl(noInferVsDistributiveConditionalType1.ts, 18, 2))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 20, 23))
+>EventObject : Symbol(EventObject, Decl(noInferVsDistributiveConditionalType1.ts, 6, 48))
+
+  [K in TEvent["type"]]?: {
+>K : Symbol(K, Decl(noInferVsDistributiveConditionalType1.ts, 21, 3))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 20, 23))
+
+    actions?: ActionFunction<Extract<TEvent, { type: K }>, TEvent>;
+>actions : Symbol(actions, Decl(noInferVsDistributiveConditionalType1.ts, 21, 27))
+>ActionFunction : Symbol(ActionFunction, Decl(noInferVsDistributiveConditionalType1.ts, 10, 2))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 20, 23))
+>type : Symbol(type, Decl(noInferVsDistributiveConditionalType1.ts, 22, 46))
+>K : Symbol(K, Decl(noInferVsDistributiveConditionalType1.ts, 21, 3))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 20, 23))
+
+  };
+};
+
+declare function createMachine<TEvent extends EventObject>(config: {
+>createMachine : Symbol(createMachine, Decl(noInferVsDistributiveConditionalType1.ts, 24, 2))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 26, 31))
+>EventObject : Symbol(EventObject, Decl(noInferVsDistributiveConditionalType1.ts, 6, 48))
+>config : Symbol(config, Decl(noInferVsDistributiveConditionalType1.ts, 26, 59))
+
+  types?: {
+>types : Symbol(types, Decl(noInferVsDistributiveConditionalType1.ts, 26, 68))
+
+    events?: TEvent;
+>events : Symbol(events, Decl(noInferVsDistributiveConditionalType1.ts, 27, 11))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 26, 31))
+
+  };
+  on?: TransitionsConfig<NoInfer<TEvent>>;
+>on : Symbol(on, Decl(noInferVsDistributiveConditionalType1.ts, 29, 4))
+>TransitionsConfig : Symbol(TransitionsConfig, Decl(noInferVsDistributiveConditionalType1.ts, 18, 2))
+>NoInfer : Symbol(NoInfer, Decl(lib.es5.d.ts, --, --))
+>TEvent : Symbol(TEvent, Decl(noInferVsDistributiveConditionalType1.ts, 26, 31))
+
+}): void;
+
+createMachine({
+>createMachine : Symbol(createMachine, Decl(noInferVsDistributiveConditionalType1.ts, 24, 2))
+
+  types: {
+>types : Symbol(types, Decl(noInferVsDistributiveConditionalType1.ts, 33, 15))
+
+    events: {} as Input,
+>events : Symbol(events, Decl(noInferVsDistributiveConditionalType1.ts, 34, 10))
+>Input : Symbol(Input, Decl(noInferVsDistributiveConditionalType1.ts, 3, 32))
+
+  },
+  on: {
+>on : Symbol(on, Decl(noInferVsDistributiveConditionalType1.ts, 36, 4))
+
+    FOO: {
+>FOO : Symbol(FOO, Decl(noInferVsDistributiveConditionalType1.ts, 37, 7))
+
+      actions: ({ event }) => {
+>actions : Symbol(actions, Decl(noInferVsDistributiveConditionalType1.ts, 38, 10))
+>event : Symbol(event, Decl(noInferVsDistributiveConditionalType1.ts, 39, 17))
+
+        event; // { type: "FOO"; }
+>event : Symbol(event, Decl(noInferVsDistributiveConditionalType1.ts, 39, 17))
+
+      },
+    },
+  },
+});
+

--- a/tests/baselines/reference/noInferVsDistributiveConditionalType1.types
+++ b/tests/baselines/reference/noInferVsDistributiveConditionalType1.types
@@ -1,0 +1,141 @@
+//// [tests/cases/conformance/types/typeRelationships/typeInference/noInferVsDistributiveConditionalType1.ts] ////
+
+=== noInferVsDistributiveConditionalType1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61076
+
+type FooEvent = { type: "FOO" };
+>FooEvent : FooEvent
+>         : ^^^^^^^^
+>type : "FOO"
+>     : ^^^^^
+
+type BarEvent = { type: "BAR" };
+>BarEvent : BarEvent
+>         : ^^^^^^^^
+>type : "BAR"
+>     : ^^^^^
+
+type Input = FooEvent | BarEvent;
+>Input : Input
+>      : ^^^^^
+
+type Result = Extract<NoInfer<Input>, FooEvent>;
+>Result : FooEvent
+>       : ^^^^^^^^
+
+type EventObject = {
+>EventObject : EventObject
+>            : ^^^^^^^^^^^
+
+  type: string;
+>type : string
+>     : ^^^^^^
+
+};
+
+type ActionFunction<
+>ActionFunction : ActionFunction<TExpressionEvent, TEvent>
+>               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  TExpressionEvent extends EventObject,
+  TEvent extends EventObject,
+> = {
+  (args: { event: TExpressionEvent }): void;
+>args : { event: TExpressionEvent; }
+>     : ^^^^^^^^^                ^^^
+>event : TExpressionEvent
+>      : ^^^^^^^^^^^^^^^^
+
+  _out_TEvent?: TEvent;
+>_out_TEvent : TEvent | undefined
+>            : ^^^^^^^^^^^^^^^^^^
+
+};
+
+type TransitionsConfig<TEvent extends EventObject> = {
+>TransitionsConfig : TransitionsConfig<TEvent>
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  [K in TEvent["type"]]?: {
+    actions?: ActionFunction<Extract<TEvent, { type: K }>, TEvent>;
+>actions : ActionFunction<Extract<TEvent, { type: K; }>, TEvent> | undefined
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^
+>type : K
+>     : ^
+
+  };
+};
+
+declare function createMachine<TEvent extends EventObject>(config: {
+>createMachine : <TEvent extends EventObject>(config: { types?: { events?: TEvent; }; on?: TransitionsConfig<NoInfer<TEvent>>; }) => void
+>              : ^      ^^^^^^^^^           ^^      ^^                                                                          ^^^^^    
+>config : { types?: { events?: TEvent; }; on?: TransitionsConfig<NoInfer<TEvent>>; }
+>       : ^^^^^^^^^^                    ^^^^^^^                                  ^^^
+
+  types?: {
+>types : { events?: TEvent; } | undefined
+>      : ^^^^^^^^^^^      ^^^^^^^^^^^^^^^
+
+    events?: TEvent;
+>events : TEvent | undefined
+>       : ^^^^^^^^^^^^^^^^^^
+
+  };
+  on?: TransitionsConfig<NoInfer<TEvent>>;
+>on : TransitionsConfig<NoInfer<TEvent>> | undefined
+>   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+}): void;
+
+createMachine({
+>createMachine({  types: {    events: {} as Input,  },  on: {    FOO: {      actions: ({ event }) => {        event; // { type: "FOO"; }      },    },  },}) : void
+>                                                                                                                                                            : ^^^^
+>createMachine : <TEvent extends EventObject>(config: { types?: { events?: TEvent; }; on?: TransitionsConfig<NoInfer<TEvent>>; }) => void
+>              : ^      ^^^^^^^^^           ^^      ^^                                                                          ^^^^^    
+>{  types: {    events: {} as Input,  },  on: {    FOO: {      actions: ({ event }) => {        event; // { type: "FOO"; }      },    },  },} : { types: { events: Input; }; on: { FOO: { actions: ({ event }: { event: FooEvent; }) => void; }; }; }
+>                                                                                                                                             : ^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  types: {
+>types : { events: Input; }
+>      : ^^^^^^^^^^     ^^^
+>{    events: {} as Input,  } : { events: Input; }
+>                             : ^^^^^^^^^^     ^^^
+
+    events: {} as Input,
+>events : Input
+>       : ^^^^^
+>{} as Input : Input
+>            : ^^^^^
+>{} : {}
+>   : ^^
+
+  },
+  on: {
+>on : { FOO: { actions: ({ event }: { event: FooEvent; }) => void; }; }
+>   : ^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    FOO: {      actions: ({ event }) => {        event; // { type: "FOO"; }      },    },  } : { FOO: { actions: ({ event }: { event: FooEvent; }) => void; }; }
+>                                                                                              : ^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    FOO: {
+>FOO : { actions: ({ event }: { event: FooEvent; }) => void; }
+>    : ^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{      actions: ({ event }) => {        event; // { type: "FOO"; }      },    } : { actions: ({ event }: { event: FooEvent; }) => void; }
+>                                                                                : ^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+      actions: ({ event }) => {
+>actions : ({ event }: { event: FooEvent; }) => void
+>        : ^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>({ event }) => {        event; // { type: "FOO"; }      } : ({ event }: { event: FooEvent; }) => void
+>                                                          : ^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>event : FooEvent
+>      : ^^^^^^^^
+
+        event; // { type: "FOO"; }
+>event : FooEvent
+>      : ^^^^^^^^
+
+      },
+    },
+  },
+});
+

--- a/tests/cases/conformance/types/typeRelationships/typeInference/noInferVsDistributiveConditionalType1.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/noInferVsDistributiveConditionalType1.ts
@@ -1,0 +1,48 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/61076
+
+type FooEvent = { type: "FOO" };
+type BarEvent = { type: "BAR" };
+
+type Input = FooEvent | BarEvent;
+type Result = Extract<NoInfer<Input>, FooEvent>;
+
+type EventObject = {
+  type: string;
+};
+
+type ActionFunction<
+  TExpressionEvent extends EventObject,
+  TEvent extends EventObject,
+> = {
+  (args: { event: TExpressionEvent }): void;
+  _out_TEvent?: TEvent;
+};
+
+type TransitionsConfig<TEvent extends EventObject> = {
+  [K in TEvent["type"]]?: {
+    actions?: ActionFunction<Extract<TEvent, { type: K }>, TEvent>;
+  };
+};
+
+declare function createMachine<TEvent extends EventObject>(config: {
+  types?: {
+    events?: TEvent;
+  };
+  on?: TransitionsConfig<NoInfer<TEvent>>;
+}): void;
+
+createMachine({
+  types: {
+    events: {} as Input,
+  },
+  on: {
+    FOO: {
+      actions: ({ event }) => {
+        event; // { type: "FOO"; }
+      },
+    },
+  },
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61076
