### PR TITLE
Fix RegExpIndicesArray by adding undefined to type definition

### DIFF
--- a/src/lib/es2022.regexp.d.ts
+++ b/src/lib/es2022.regexp.d.ts
@@ -6,7 +6,7 @@ interface RegExpExecArray {
     indices?: RegExpIndicesArray;
 }
 
-interface RegExpIndicesArray extends Array<[number, number]> {
+interface RegExpIndicesArray extends Array<[number, number] | undefined> {
     groups?: {
         [key: string]: [number, number];
     };


### PR DESCRIPTION
Fix https://github.com/microsoft/TypeScript/issues/61078

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61078
