### PR TITLE
[moveToFile] Fix symbols with empty `declarations` being treated as importable

### DIFF
--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -886,7 +886,7 @@ export function getUsageInfo(oldFile: SourceFile, toMove: readonly Statement[], 
     const unusedImportsFromOldFile = new Set<Symbol>();
     for (const statement of toMove) {
         forEachReference(statement, checker, enclosingRange, (symbol, isValidTypeOnlyUseSite) => {
-            if (!symbol.declarations) {
+            if (!some(symbol.declarations)) {
                 return;
             }
             if (existingTargetLocals.has(skipAlias(symbol, checker))) {

--- a/tests/cases/fourslash/moveToFile_undefined.ts
+++ b/tests/cases/fourslash/moveToFile_undefined.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @module: esnext
+// @moduleResolution: bundler
+
+// @Filename: /orig.ts
+//// [|export const variable = undefined;|]
+
+verify.moveToFile({
+    newFileContents: {
+      "/orig.ts": "",
+      "/new.ts": "export const variable = undefined;\n"
+    },
+    interactiveRefactorArguments: { targetFile: "/new.ts" },
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #60783
