### PR TITLE
Ban import=require and export= under erasableSyntaxOnly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -47830,11 +47830,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         checkGrammarModifiers(node);
-        const isImportEquals = isInternalModuleImportEqualsDeclaration(node);
-        if (compilerOptions.erasableSyntaxOnly && isImportEquals && !(node.flags & NodeFlags.Ambient)) {
+        if (compilerOptions.erasableSyntaxOnly && !(node.flags & NodeFlags.Ambient)) {
             error(node, Diagnostics.This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled);
         }
-        if (isImportEquals || checkExternalImportOrExportDeclaration(node)) {
+        if (isInternalModuleImportEqualsDeclaration(node) || checkExternalImportOrExportDeclaration(node)) {
             checkImportBinding(node);
             markLinkedReferences(node, ReferenceHint.ExportImportEquals);
             if (node.moduleReference.kind !== SyntaxKind.ExternalModuleReference) {
@@ -47975,6 +47974,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return;
         }
 
+        if (compilerOptions.erasableSyntaxOnly && !(node.flags & NodeFlags.Ambient)) {
+            error(node, Diagnostics.This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled);
+        }
         const container = node.parent.kind === SyntaxKind.SourceFile ? node.parent : node.parent.parent as ModuleDeclaration;
         if (container.kind === SyntaxKind.ModuleDeclaration && !isAmbientModule(container)) {
             if (node.isExportEquals) {

--- a/tests/baselines/reference/erasableSyntaxOnly.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnly.errors.txt
@@ -1,3 +1,5 @@
+commonjs.cts(1,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+commonjs.cts(2,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(3,17): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(6,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(10,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
@@ -90,9 +92,13 @@ index.ts(28,12): error TS1294: This syntax is not allowed when 'erasableSyntaxOn
         import FineAlias = EnumInAmbientContext.B;
     }
     
-==== commonjs.cts (0 errors) ====
+==== commonjs.cts (2 errors) ====
     import foo = require("./other.cjs");
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
     export = foo;
+    ~~~~~~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
     
     
 ==== other.d.cts (0 errors) ====

--- a/tests/baselines/reference/erasableSyntaxOnly.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnly.errors.txt
@@ -1,14 +1,14 @@
-erasableSyntaxOnly.ts(3,17): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(6,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(10,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(16,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(17,15): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(22,6): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(26,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-erasableSyntaxOnly.ts(28,12): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(3,17): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(6,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(10,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(16,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(17,15): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(22,6): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(26,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(28,12): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 
 
-==== erasableSyntaxOnly.ts (8 errors) ====
+==== index.ts (8 errors) ====
     class MyClassErr {
         // No parameter properties
         constructor(public foo: string) { }
@@ -89,4 +89,13 @@ erasableSyntaxOnly.ts(28,12): error TS1294: This syntax is not allowed when 'era
     
         import FineAlias = EnumInAmbientContext.B;
     }
+    
+==== commonjs.cts (0 errors) ====
+    import foo = require("./other.cjs");
+    export = foo;
+    
+    
+==== other.d.cts (0 errors) ====
+    declare function foo(): void;
+    export = foo;
     

--- a/tests/baselines/reference/erasableSyntaxOnly.js
+++ b/tests/baselines/reference/erasableSyntaxOnly.js
@@ -1,0 +1,121 @@
+//// [tests/cases/compiler/erasableSyntaxOnly.ts] ////
+
+//// [index.ts]
+class MyClassErr {
+    // No parameter properties
+    constructor(public foo: string) { }
+}
+
+namespace IllegalBecauseInstantiated {
+    export const m = 1;
+}
+
+namespace AlsoIllegalBecauseInstantiated {
+    class PrivateClass {
+
+    }
+}
+
+namespace IllegalBecauseNestedInstantiated {
+    namespace Nested {
+        export const m = 1;
+    }
+}
+
+enum NotLegalEnum {
+    B = 1
+}
+
+import NoGoodAlias = NotLegalEnum.B;
+
+const enum NotLegalConstEnum {
+    C = 2
+}
+
+// No errors after this point
+class MyClassOk {
+    // Not a parameter property, ok
+    constructor(foo: string) { }
+}
+
+// Note for implementors: This should not be an error
+// as this entire namespace block is fully erased
+namespace NotInstantiated {
+    export interface JustAType { }
+    export type ATypeInANamespace = {};
+    namespace Nested {
+        export type ATypeInANamespace = {};
+    }
+}
+declare namespace AmbientIsNotInstantiated {
+    export const stillOk = 12;
+}
+
+declare enum LegalEnum {
+    A = 1
+}
+
+declare namespace AmbientStuff {
+    namespace Nested {
+        export const stillOk = 12;
+    }
+    enum EnumInAmbientContext {
+        B = 1
+    }
+
+    import FineAlias = EnumInAmbientContext.B;
+}
+
+//// [commonjs.cts]
+import foo = require("./other.cjs");
+export = foo;
+
+
+//// [other.d.cts]
+declare function foo(): void;
+export = foo;
+
+
+//// [index.js]
+var MyClassErr = /** @class */ (function () {
+    // No parameter properties
+    function MyClassErr(foo) {
+        this.foo = foo;
+    }
+    return MyClassErr;
+}());
+var IllegalBecauseInstantiated;
+(function (IllegalBecauseInstantiated) {
+    IllegalBecauseInstantiated.m = 1;
+})(IllegalBecauseInstantiated || (IllegalBecauseInstantiated = {}));
+var AlsoIllegalBecauseInstantiated;
+(function (AlsoIllegalBecauseInstantiated) {
+    var PrivateClass = /** @class */ (function () {
+        function PrivateClass() {
+        }
+        return PrivateClass;
+    }());
+})(AlsoIllegalBecauseInstantiated || (AlsoIllegalBecauseInstantiated = {}));
+var IllegalBecauseNestedInstantiated;
+(function (IllegalBecauseNestedInstantiated) {
+    var Nested;
+    (function (Nested) {
+        Nested.m = 1;
+    })(Nested || (Nested = {}));
+})(IllegalBecauseNestedInstantiated || (IllegalBecauseNestedInstantiated = {}));
+var NotLegalEnum;
+(function (NotLegalEnum) {
+    NotLegalEnum[NotLegalEnum["B"] = 1] = "B";
+})(NotLegalEnum || (NotLegalEnum = {}));
+var NoGoodAlias = NotLegalEnum.B;
+// No errors after this point
+var MyClassOk = /** @class */ (function () {
+    // Not a parameter property, ok
+    function MyClassOk(foo) {
+    }
+    return MyClassOk;
+}());
+//// [commonjs.cjs]
+"use strict";
+var foo = require("./other.cjs");
+module.exports = foo;

--- a/tests/baselines/reference/erasableSyntaxOnly.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnly.symbols
@@ -1,120 +1,135 @@
 //// [tests/cases/compiler/erasableSyntaxOnly.ts] ////
 
-=== erasableSyntaxOnly.ts ===
+=== index.ts ===
 class MyClassErr {
->MyClassErr : Symbol(MyClassErr, Decl(erasableSyntaxOnly.ts, 0, 0))
+>MyClassErr : Symbol(MyClassErr, Decl(index.ts, 0, 0))
 
     // No parameter properties
     constructor(public foo: string) { }
->foo : Symbol(MyClassErr.foo, Decl(erasableSyntaxOnly.ts, 2, 16))
+>foo : Symbol(MyClassErr.foo, Decl(index.ts, 2, 16))
 }
 
 namespace IllegalBecauseInstantiated {
->IllegalBecauseInstantiated : Symbol(IllegalBecauseInstantiated, Decl(erasableSyntaxOnly.ts, 3, 1))
+>IllegalBecauseInstantiated : Symbol(IllegalBecauseInstantiated, Decl(index.ts, 3, 1))
 
     export const m = 1;
->m : Symbol(m, Decl(erasableSyntaxOnly.ts, 6, 16))
+>m : Symbol(m, Decl(index.ts, 6, 16))
 }
 
 namespace AlsoIllegalBecauseInstantiated {
->AlsoIllegalBecauseInstantiated : Symbol(AlsoIllegalBecauseInstantiated, Decl(erasableSyntaxOnly.ts, 7, 1))
+>AlsoIllegalBecauseInstantiated : Symbol(AlsoIllegalBecauseInstantiated, Decl(index.ts, 7, 1))
 
     class PrivateClass {
->PrivateClass : Symbol(PrivateClass, Decl(erasableSyntaxOnly.ts, 9, 42))
+>PrivateClass : Symbol(PrivateClass, Decl(index.ts, 9, 42))
 
     }
 }
 
 namespace IllegalBecauseNestedInstantiated {
->IllegalBecauseNestedInstantiated : Symbol(IllegalBecauseNestedInstantiated, Decl(erasableSyntaxOnly.ts, 13, 1))
+>IllegalBecauseNestedInstantiated : Symbol(IllegalBecauseNestedInstantiated, Decl(index.ts, 13, 1))
 
     namespace Nested {
->Nested : Symbol(Nested, Decl(erasableSyntaxOnly.ts, 15, 44))
+>Nested : Symbol(Nested, Decl(index.ts, 15, 44))
 
         export const m = 1;
->m : Symbol(m, Decl(erasableSyntaxOnly.ts, 17, 20))
+>m : Symbol(m, Decl(index.ts, 17, 20))
     }
 }
 
 enum NotLegalEnum {
->NotLegalEnum : Symbol(NotLegalEnum, Decl(erasableSyntaxOnly.ts, 19, 1))
+>NotLegalEnum : Symbol(NotLegalEnum, Decl(index.ts, 19, 1))
 
     B = 1
->B : Symbol(NoGoodAlias, Decl(erasableSyntaxOnly.ts, 21, 19))
+>B : Symbol(NoGoodAlias, Decl(index.ts, 21, 19))
 }
 
 import NoGoodAlias = NotLegalEnum.B;
->NoGoodAlias : Symbol(NoGoodAlias, Decl(erasableSyntaxOnly.ts, 23, 1))
->NotLegalEnum : Symbol(NotLegalEnum, Decl(erasableSyntaxOnly.ts, 19, 1))
->B : Symbol(NoGoodAlias, Decl(erasableSyntaxOnly.ts, 21, 19))
+>NoGoodAlias : Symbol(NoGoodAlias, Decl(index.ts, 23, 1))
+>NotLegalEnum : Symbol(NotLegalEnum, Decl(index.ts, 19, 1))
+>B : Symbol(NoGoodAlias, Decl(index.ts, 21, 19))
 
 const enum NotLegalConstEnum {
->NotLegalConstEnum : Symbol(NotLegalConstEnum, Decl(erasableSyntaxOnly.ts, 25, 36))
+>NotLegalConstEnum : Symbol(NotLegalConstEnum, Decl(index.ts, 25, 36))
 
     C = 2
->C : Symbol(NotLegalConstEnum.C, Decl(erasableSyntaxOnly.ts, 27, 30))
+>C : Symbol(NotLegalConstEnum.C, Decl(index.ts, 27, 30))
 }
 
 // No errors after this point
 class MyClassOk {
->MyClassOk : Symbol(MyClassOk, Decl(erasableSyntaxOnly.ts, 29, 1))
+>MyClassOk : Symbol(MyClassOk, Decl(index.ts, 29, 1))
 
     // Not a parameter property, ok
     constructor(foo: string) { }
->foo : Symbol(foo, Decl(erasableSyntaxOnly.ts, 34, 16))
+>foo : Symbol(foo, Decl(index.ts, 34, 16))
 }
 
 // Note for implementors: This should not be an error
 // as this entire namespace block is fully erased
 namespace NotInstantiated {
->NotInstantiated : Symbol(NotInstantiated, Decl(erasableSyntaxOnly.ts, 35, 1))
+>NotInstantiated : Symbol(NotInstantiated, Decl(index.ts, 35, 1))
 
     export interface JustAType { }
->JustAType : Symbol(JustAType, Decl(erasableSyntaxOnly.ts, 39, 27))
+>JustAType : Symbol(JustAType, Decl(index.ts, 39, 27))
 
     export type ATypeInANamespace = {};
->ATypeInANamespace : Symbol(ATypeInANamespace, Decl(erasableSyntaxOnly.ts, 40, 34))
+>ATypeInANamespace : Symbol(ATypeInANamespace, Decl(index.ts, 40, 34))
 
     namespace Nested {
->Nested : Symbol(Nested, Decl(erasableSyntaxOnly.ts, 41, 39))
+>Nested : Symbol(Nested, Decl(index.ts, 41, 39))
 
         export type ATypeInANamespace = {};
->ATypeInANamespace : Symbol(ATypeInANamespace, Decl(erasableSyntaxOnly.ts, 42, 22))
+>ATypeInANamespace : Symbol(ATypeInANamespace, Decl(index.ts, 42, 22))
     }
 }
 declare namespace AmbientIsNotInstantiated {
->AmbientIsNotInstantiated : Symbol(AmbientIsNotInstantiated, Decl(erasableSyntaxOnly.ts, 45, 1))
+>AmbientIsNotInstantiated : Symbol(AmbientIsNotInstantiated, Decl(index.ts, 45, 1))
 
     export const stillOk = 12;
->stillOk : Symbol(stillOk, Decl(erasableSyntaxOnly.ts, 47, 16))
+>stillOk : Symbol(stillOk, Decl(index.ts, 47, 16))
 }
 
 declare enum LegalEnum {
->LegalEnum : Symbol(LegalEnum, Decl(erasableSyntaxOnly.ts, 48, 1))
+>LegalEnum : Symbol(LegalEnum, Decl(index.ts, 48, 1))
 
     A = 1
->A : Symbol(LegalEnum.A, Decl(erasableSyntaxOnly.ts, 50, 24))
+>A : Symbol(LegalEnum.A, Decl(index.ts, 50, 24))
 }
 
 declare namespace AmbientStuff {
->AmbientStuff : Symbol(AmbientStuff, Decl(erasableSyntaxOnly.ts, 52, 1))
+>AmbientStuff : Symbol(AmbientStuff, Decl(index.ts, 52, 1))
 
     namespace Nested {
->Nested : Symbol(Nested, Decl(erasableSyntaxOnly.ts, 54, 32))
+>Nested : Symbol(Nested, Decl(index.ts, 54, 32))
 
         export const stillOk = 12;
->stillOk : Symbol(stillOk, Decl(erasableSyntaxOnly.ts, 56, 20))
+>stillOk : Symbol(stillOk, Decl(index.ts, 56, 20))
     }
     enum EnumInAmbientContext {
->EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(erasableSyntaxOnly.ts, 57, 5))
+>EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(index.ts, 57, 5))
 
         B = 1
->B : Symbol(FineAlias, Decl(erasableSyntaxOnly.ts, 58, 31))
+>B : Symbol(FineAlias, Decl(index.ts, 58, 31))
     }
 
     import FineAlias = EnumInAmbientContext.B;
->FineAlias : Symbol(FineAlias, Decl(erasableSyntaxOnly.ts, 60, 5))
->EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(erasableSyntaxOnly.ts, 57, 5))
->B : Symbol(FineAlias, Decl(erasableSyntaxOnly.ts, 58, 31))
+>FineAlias : Symbol(FineAlias, Decl(index.ts, 60, 5))
+>EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(index.ts, 57, 5))
+>B : Symbol(FineAlias, Decl(index.ts, 58, 31))
 }
+
+=== commonjs.cts ===
+import foo = require("./other.cjs");
+>foo : Symbol(foo, Decl(commonjs.cts, 0, 0))
+
+export = foo;
+>foo : Symbol(foo, Decl(commonjs.cts, 0, 0))
+
+
+=== other.d.cts ===
+declare function foo(): void;
+>foo : Symbol(foo, Decl(other.d.cts, 0, 0))
+
+export = foo;
+>foo : Symbol(foo, Decl(other.d.cts, 0, 0))
 

--- a/tests/baselines/reference/erasableSyntaxOnly.types
+++ b/tests/baselines/reference/erasableSyntaxOnly.types
@@ -1,6 +1,6 @@
 //// [tests/cases/compiler/erasableSyntaxOnly.ts] ////
 
-=== erasableSyntaxOnly.ts ===
+=== index.ts ===
 class MyClassErr {
 >MyClassErr : MyClassErr
 >           : ^^^^^^^^^^
@@ -159,4 +159,23 @@ declare namespace AmbientStuff {
 >B : EnumInAmbientContext.B
 >  : ^^^^^^^^^^^^^^^^^^^^^^
 }
+
+=== commonjs.cts ===
+import foo = require("./other.cjs");
+>foo : () => void
+>    : ^^^^^^    
+
+export = foo;
+>foo : () => void
+>    : ^^^^^^    
+
+
+=== other.d.cts ===
+declare function foo(): void;
+>foo : () => void
+>    : ^^^^^^    
+
+export = foo;
+>foo : () => void
+>    : ^^^^^^    
 

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
@@ -1,10 +1,12 @@
-decl.d.ts(4,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
+index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
 
 
-==== decl.d.ts (1 errors) ====
-    // Diffs from the other test:
-    // - Parameter properties are already banned in .d.ts files
+==== index.d.cts (0 errors) ====
+    declare function foo(): void;
+    export = foo;
     
+    
+==== index.d.ts (1 errors) ====
     namespace IllegalBecauseInstantiated {
     ~~~~~~~~~
 !!! error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
@@ -54,4 +56,13 @@ decl.d.ts(4,1): error TS1046: Top-level declarations in .d.ts files must start w
     
         import FineAlias = EnumInAmbientContext.B;
     }
+    
+==== commonjs.d.cts (0 errors) ====
+    import foo = require("./other.cjs");
+    export = foo;
+    
+    
+==== other.d.cts (0 errors) ====
+    declare function foo(): void;
+    export = foo;
     

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
@@ -1,94 +1,114 @@
 //// [tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts] ////
 
-=== decl.d.ts ===
-// Diffs from the other test:
-// - Parameter properties are already banned in .d.ts files
+=== index.d.cts ===
+declare function foo(): void;
+>foo : Symbol(foo, Decl(index.d.cts, 0, 0))
 
+export = foo;
+>foo : Symbol(foo, Decl(index.d.cts, 0, 0))
+
+
+=== index.d.ts ===
 namespace IllegalBecauseInstantiated {
->IllegalBecauseInstantiated : Symbol(IllegalBecauseInstantiated, Decl(decl.d.ts, 0, 0))
+>IllegalBecauseInstantiated : Symbol(IllegalBecauseInstantiated, Decl(index.d.ts, 0, 0))
 
     export const m = 1;
->m : Symbol(m, Decl(decl.d.ts, 4, 16))
+>m : Symbol(m, Decl(index.d.ts, 1, 16))
 }
 
 namespace AlsoIllegalBecauseInstantiated {
->AlsoIllegalBecauseInstantiated : Symbol(AlsoIllegalBecauseInstantiated, Decl(decl.d.ts, 5, 1))
+>AlsoIllegalBecauseInstantiated : Symbol(AlsoIllegalBecauseInstantiated, Decl(index.d.ts, 2, 1))
 
     class PrivateClass {
->PrivateClass : Symbol(PrivateClass, Decl(decl.d.ts, 7, 42))
+>PrivateClass : Symbol(PrivateClass, Decl(index.d.ts, 4, 42))
 
     }
 }
 
 enum NotLegalEnum {
->NotLegalEnum : Symbol(NotLegalEnum, Decl(decl.d.ts, 11, 1))
+>NotLegalEnum : Symbol(NotLegalEnum, Decl(index.d.ts, 8, 1))
 
     B = 1
->B : Symbol(NoGoodAlias, Decl(decl.d.ts, 13, 19))
+>B : Symbol(NoGoodAlias, Decl(index.d.ts, 10, 19))
 }
 
 import NoGoodAlias = NotLegalEnum.B;
->NoGoodAlias : Symbol(NoGoodAlias, Decl(decl.d.ts, 15, 1))
->NotLegalEnum : Symbol(NotLegalEnum, Decl(decl.d.ts, 11, 1))
->B : Symbol(NoGoodAlias, Decl(decl.d.ts, 13, 19))
+>NoGoodAlias : Symbol(NoGoodAlias, Decl(index.d.ts, 12, 1))
+>NotLegalEnum : Symbol(NotLegalEnum, Decl(index.d.ts, 8, 1))
+>B : Symbol(NoGoodAlias, Decl(index.d.ts, 10, 19))
 
 const enum NotLegalConstEnum {
->NotLegalConstEnum : Symbol(NotLegalConstEnum, Decl(decl.d.ts, 17, 36))
+>NotLegalConstEnum : Symbol(NotLegalConstEnum, Decl(index.d.ts, 14, 36))
 
     C = 2
->C : Symbol(NotLegalConstEnum.C, Decl(decl.d.ts, 19, 30))
+>C : Symbol(NotLegalConstEnum.C, Decl(index.d.ts, 16, 30))
 }
 
 // No errors after this point
 class MyClassOk {
->MyClassOk : Symbol(MyClassOk, Decl(decl.d.ts, 21, 1))
+>MyClassOk : Symbol(MyClassOk, Decl(index.d.ts, 18, 1))
 
     // Not a parameter property, ok
     constructor(foo: string);
->foo : Symbol(foo, Decl(decl.d.ts, 26, 16))
+>foo : Symbol(foo, Decl(index.d.ts, 23, 16))
 }
 namespace NotInstantiated {
->NotInstantiated : Symbol(NotInstantiated, Decl(decl.d.ts, 27, 1))
+>NotInstantiated : Symbol(NotInstantiated, Decl(index.d.ts, 24, 1))
 
     export interface JustAType { }
->JustAType : Symbol(JustAType, Decl(decl.d.ts, 28, 27))
+>JustAType : Symbol(JustAType, Decl(index.d.ts, 25, 27))
 
     export type ATypeInANamespace = {};
->ATypeInANamespace : Symbol(ATypeInANamespace, Decl(decl.d.ts, 29, 34))
+>ATypeInANamespace : Symbol(ATypeInANamespace, Decl(index.d.ts, 26, 34))
 }
 declare namespace AmbientIsNotInstantiated {
->AmbientIsNotInstantiated : Symbol(AmbientIsNotInstantiated, Decl(decl.d.ts, 31, 1))
+>AmbientIsNotInstantiated : Symbol(AmbientIsNotInstantiated, Decl(index.d.ts, 28, 1))
 
     export const stillOk = 12;
->stillOk : Symbol(stillOk, Decl(decl.d.ts, 33, 16))
+>stillOk : Symbol(stillOk, Decl(index.d.ts, 30, 16))
 }
 
 declare enum LegalEnum {
->LegalEnum : Symbol(LegalEnum, Decl(decl.d.ts, 34, 1))
+>LegalEnum : Symbol(LegalEnum, Decl(index.d.ts, 31, 1))
 
     A = 1
->A : Symbol(LegalEnum.A, Decl(decl.d.ts, 36, 24))
+>A : Symbol(LegalEnum.A, Decl(index.d.ts, 33, 24))
 }
 
 declare namespace AmbientStuff {
->AmbientStuff : Symbol(AmbientStuff, Decl(decl.d.ts, 38, 1))
+>AmbientStuff : Symbol(AmbientStuff, Decl(index.d.ts, 35, 1))
 
     namespace Nested {
->Nested : Symbol(Nested, Decl(decl.d.ts, 40, 32))
+>Nested : Symbol(Nested, Decl(index.d.ts, 37, 32))
 
         export const stillOk = 12;
->stillOk : Symbol(stillOk, Decl(decl.d.ts, 42, 20))
+>stillOk : Symbol(stillOk, Decl(index.d.ts, 39, 20))
     }
     enum EnumInAmbientContext {
->EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(decl.d.ts, 43, 5))
+>EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(index.d.ts, 40, 5))
 
         B = 1
->B : Symbol(FineAlias, Decl(decl.d.ts, 44, 31))
+>B : Symbol(FineAlias, Decl(index.d.ts, 41, 31))
     }
 
     import FineAlias = EnumInAmbientContext.B;
->FineAlias : Symbol(FineAlias, Decl(decl.d.ts, 46, 5))
->EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(decl.d.ts, 43, 5))
->B : Symbol(FineAlias, Decl(decl.d.ts, 44, 31))
+>FineAlias : Symbol(FineAlias, Decl(index.d.ts, 43, 5))
+>EnumInAmbientContext : Symbol(EnumInAmbientContext, Decl(index.d.ts, 40, 5))
+>B : Symbol(FineAlias, Decl(index.d.ts, 41, 31))
 }
+
+=== commonjs.d.cts ===
+import foo = require("./other.cjs");
+>foo : Symbol(foo, Decl(commonjs.d.cts, 0, 0))
+
+export = foo;
+>foo : Symbol(foo, Decl(commonjs.d.cts, 0, 0))
+
+
+=== other.d.cts ===
+declare function foo(): void;
+>foo : Symbol(foo, Decl(other.d.cts, 0, 0))
+
+export = foo;
+>foo : Symbol(foo, Decl(other.d.cts, 0, 0))
 

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
@@ -1,9 +1,16 @@
 //// [tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts] ////
 
-=== decl.d.ts ===
-// Diffs from the other test:
-// - Parameter properties are already banned in .d.ts files
+=== index.d.cts ===
+declare function foo(): void;
+>foo : () => void
+>    : ^^^^^^    
 
+export = foo;
+>foo : () => void
+>    : ^^^^^^    
+
+
+=== index.d.ts ===
 namespace IllegalBecauseInstantiated {
 >IllegalBecauseInstantiated : typeof IllegalBecauseInstantiated
 >                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,4 +134,23 @@ declare namespace AmbientStuff {
 >B : EnumInAmbientContext.B
 >  : ^^^^^^^^^^^^^^^^^^^^^^
 }
+
+=== commonjs.d.cts ===
+import foo = require("./other.cjs");
+>foo : () => void
+>    : ^^^^^^    
+
+export = foo;
+>foo : () => void
+>    : ^^^^^^    
+
+
+=== other.d.cts ===
+declare function foo(): void;
+>foo : () => void
+>    : ^^^^^^    
+
+export = foo;
+>foo : () => void
+>    : ^^^^^^    
 

--- a/tests/cases/compiler/erasableSyntaxOnly.ts
+++ b/tests/cases/compiler/erasableSyntaxOnly.ts
@@ -1,6 +1,6 @@
 // @erasableSyntaxOnly: true
-// @noEmit: true
 
+// @filename: index.ts
 class MyClassErr {
     // No parameter properties
     constructor(public foo: string) { }
@@ -65,3 +65,12 @@ declare namespace AmbientStuff {
 
     import FineAlias = EnumInAmbientContext.B;
 }
+
+// @filename: commonjs.cts
+import foo = require("./other.cjs");
+export = foo;
+
+
+// @filename: other.d.cts
+declare function foo(): void;
+export = foo;

--- a/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
+++ b/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
@@ -1,10 +1,15 @@
 // @erasableSyntaxOnly: true
 // @noEmit: true
-// @filename: decl.d.ts
 
 // Diffs from the other test:
 // - Parameter properties are already banned in .d.ts files
 
+// @filename: index.d.cts
+declare function foo(): void;
+export = foo;
+
+
+// @filename: index.d.ts
 namespace IllegalBecauseInstantiated {
     export const m = 1;
 }
@@ -52,3 +57,12 @@ declare namespace AmbientStuff {
 
     import FineAlias = EnumInAmbientContext.B;
 }
+
+// @filename: commonjs.d.cts
+import foo = require("./other.cjs");
+export = foo;
+
+
+// @filename: other.d.cts
+declare function foo(): void;
+export = foo;


### PR DESCRIPTION
Per discussion; this syntax isn't supported by Node.js/Amaro or `ts-blank-space`, and `export=` is not actually erasable as its transformed syntax is `module.exports=`.

This effectively means you can't write any CJS code under `erasableSyntaxOnly` (without using `const foo = require("foo")` and `module.exports = ...` directly, which do not bind in TS). Perhaps we can make `const foo = require("...")` and `module.exports = ...` bind like they do in JS for TS files in the future.

Updates #59601
Updates #61011