### PR TITLE
Don't widen unique symbols annotated by effective type nodes in JS files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11821,7 +11821,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             // always widen a 'unique symbol' type if the type was created for a different declaration.
-            if (type.flags & TypeFlags.UniqueESSymbol && (isBindingElement(declaration) || !declaration.type) && type.symbol !== getSymbolOfDeclaration(declaration)) {
+            if (type.flags & TypeFlags.UniqueESSymbol && (isBindingElement(declaration) || !tryGetTypeFromEffectiveTypeNode(declaration)) && type.symbol !== getSymbolOfDeclaration(declaration)) {
                 type = esSymbolType;
             }
 

--- a/tests/baselines/reference/uniqueSymbolJs2.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolJs2.errors.txt
@@ -1,0 +1,15 @@
+/index.js(9,1): error TS2367: This comparison appears to be unintentional because the types 'typeof x' and 'typeof y' have no overlap.
+
+
+==== /index.js (1 errors) ====
+    /** @type {unique symbol} */
+    const x = Symbol()
+    /** @type {unique symbol} */
+    const y = Symbol()
+    
+    /** @type {typeof x} */
+    let z = x
+    
+    z == y // error
+    ~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'typeof x' and 'typeof y' have no overlap.

--- a/tests/baselines/reference/uniqueSymbolJs2.js
+++ b/tests/baselines/reference/uniqueSymbolJs2.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/uniqueSymbolJs2.ts] ////
+
+//// [index.js]
+/** @type {unique symbol} */
+const x = Symbol()
+/** @type {unique symbol} */
+const y = Symbol()
+
+/** @type {typeof x} */
+let z = x
+
+z == y // error
+
+//// [index.js]
+"use strict";
+/** @type {unique symbol} */
+var x = Symbol();
+/** @type {unique symbol} */
+var y = Symbol();
+/** @type {typeof x} */
+var z = x;
+z == y; // error
+
+
+//// [index.d.ts]
+/** @type {unique symbol} */
+declare const x: unique symbol;
+/** @type {unique symbol} */
+declare const y: unique symbol;
+/** @type {typeof x} */
+declare let z: typeof x;

--- a/tests/baselines/reference/uniqueSymbolJs2.symbols
+++ b/tests/baselines/reference/uniqueSymbolJs2.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/uniqueSymbolJs2.ts] ////
+
+=== /index.js ===
+/** @type {unique symbol} */
+const x = Symbol()
+>x : Symbol(x, Decl(index.js, 1, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+/** @type {unique symbol} */
+const y = Symbol()
+>y : Symbol(y, Decl(index.js, 3, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+/** @type {typeof x} */
+let z = x
+>z : Symbol(z, Decl(index.js, 6, 3))
+>x : Symbol(x, Decl(index.js, 1, 5))
+
+z == y // error
+>z : Symbol(z, Decl(index.js, 6, 3))
+>y : Symbol(y, Decl(index.js, 3, 5))
+

--- a/tests/baselines/reference/uniqueSymbolJs2.types
+++ b/tests/baselines/reference/uniqueSymbolJs2.types
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/uniqueSymbolJs2.ts] ////
+
+=== /index.js ===
+/** @type {unique symbol} */
+const x = Symbol()
+>x : unique symbol
+>  : ^^^^^^^^^^^^^
+>Symbol() : unique symbol
+>         : ^^^^^^^^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+
+/** @type {unique symbol} */
+const y = Symbol()
+>y : unique symbol
+>  : ^^^^^^^^^^^^^
+>Symbol() : unique symbol
+>         : ^^^^^^^^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+
+/** @type {typeof x} */
+let z = x
+>z : unique symbol
+>  : ^^^^^^^^^^^^^
+>x : unique symbol
+>  : ^^^^^^^^^^^^^
+
+z == y // error
+>z == y : boolean
+>       : ^^^^^^^
+>z : unique symbol
+>  : ^^^^^^^^^^^^^
+>y : unique symbol
+>  : ^^^^^^^^^^^^^
+

--- a/tests/cases/compiler/uniqueSymbolJs2.ts
+++ b/tests/cases/compiler/uniqueSymbolJs2.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @lib: esnext
+// @allowJS: true
+// @checkJs: true
+// @declaration: true
+// @outDir: dist
+
+// https://github.com/microsoft/TypeScript/issues/61170
+
+// @filename: /index.js
+/** @type {unique symbol} */
+const x = Symbol()
+/** @type {unique symbol} */
+const y = Symbol()
+
+/** @type {typeof x} */
+let z = x
+
+z == y // error


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61170