### PR TITLE
Contextual typing for return expressions of functions with contextual signatures based on instantiated types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5461,10 +5461,10 @@ export const enum IntersectionFlags {
 // dprint-ignore
 /** @internal */
 export const enum ContextFlags {
-    None           = 0,
-    Signature      = 1 << 0, // Obtaining contextual signature
-    NoConstraints  = 1 << 1, // Don't obtain type variable constraints
-    Completions    = 1 << 2, // Ignore inference to current node and parent nodes out to the containing call for completions
+    None                = 0,
+    ContextualSignature = 1 << 0, // Obtaining contextual signature or checking its return type
+    NoConstraints       = 1 << 1, // Don't obtain type variable constraints
+    Completions         = 1 << 2, // Ignore inference to current node and parent nodes out to the containing call for completions
     SkipBindingPatterns = 1 << 3, // Ignore contextual types applied by binding patterns
 }
 

--- a/tests/baselines/reference/instantiateContextualTypes2.symbols
+++ b/tests/baselines/reference/instantiateContextualTypes2.symbols
@@ -1,0 +1,73 @@
+//// [tests/cases/compiler/instantiateContextualTypes2.ts] ////
+
+=== instantiateContextualTypes2.ts ===
+type ContextStates =
+>ContextStates : Symbol(ContextStates, Decl(instantiateContextualTypes2.ts, 0, 0))
+
+  | {
+      status: "loading";
+>status : Symbol(status, Decl(instantiateContextualTypes2.ts, 1, 5))
+
+      data: null;
+>data : Symbol(data, Decl(instantiateContextualTypes2.ts, 2, 24))
+    }
+  | {
+      status: "success";
+>status : Symbol(status, Decl(instantiateContextualTypes2.ts, 5, 5))
+
+      data: string;
+>data : Symbol(data, Decl(instantiateContextualTypes2.ts, 6, 24))
+
+    };
+
+declare function createStore<TContext>(config: {
+>createStore : Symbol(createStore, Decl(instantiateContextualTypes2.ts, 8, 6))
+>TContext : Symbol(TContext, Decl(instantiateContextualTypes2.ts, 10, 29))
+>config : Symbol(config, Decl(instantiateContextualTypes2.ts, 10, 39))
+
+  context: TContext;
+>context : Symbol(context, Decl(instantiateContextualTypes2.ts, 10, 48))
+>TContext : Symbol(TContext, Decl(instantiateContextualTypes2.ts, 10, 29))
+
+  on: Record<string, (ctx: TContext) => TContext>;
+>on : Symbol(on, Decl(instantiateContextualTypes2.ts, 11, 20))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>ctx : Symbol(ctx, Decl(instantiateContextualTypes2.ts, 12, 22))
+>TContext : Symbol(TContext, Decl(instantiateContextualTypes2.ts, 10, 29))
+>TContext : Symbol(TContext, Decl(instantiateContextualTypes2.ts, 10, 29))
+
+}): void;
+
+const store = createStore({
+>store : Symbol(store, Decl(instantiateContextualTypes2.ts, 15, 5))
+>createStore : Symbol(createStore, Decl(instantiateContextualTypes2.ts, 8, 6))
+
+  context: {
+>context : Symbol(context, Decl(instantiateContextualTypes2.ts, 15, 27))
+
+    status: "loading",
+>status : Symbol(status, Decl(instantiateContextualTypes2.ts, 16, 12))
+
+    data: null,
+>data : Symbol(data, Decl(instantiateContextualTypes2.ts, 17, 22))
+
+  } as ContextStates,
+>ContextStates : Symbol(ContextStates, Decl(instantiateContextualTypes2.ts, 0, 0))
+
+  on: {
+>on : Symbol(on, Decl(instantiateContextualTypes2.ts, 19, 21))
+
+    fetch: (ctx) => ({
+>fetch : Symbol(fetch, Decl(instantiateContextualTypes2.ts, 20, 7))
+>ctx : Symbol(ctx, Decl(instantiateContextualTypes2.ts, 21, 12))
+
+      status: "success",
+>status : Symbol(status, Decl(instantiateContextualTypes2.ts, 21, 22))
+
+      data: "hello",
+>data : Symbol(data, Decl(instantiateContextualTypes2.ts, 22, 24))
+
+    }),
+  },
+});
+

--- a/tests/baselines/reference/instantiateContextualTypes2.types
+++ b/tests/baselines/reference/instantiateContextualTypes2.types
@@ -1,0 +1,108 @@
+//// [tests/cases/compiler/instantiateContextualTypes2.ts] ////
+
+=== instantiateContextualTypes2.ts ===
+type ContextStates =
+>ContextStates : ContextStates
+>              : ^^^^^^^^^^^^^
+
+  | {
+      status: "loading";
+>status : "loading"
+>       : ^^^^^^^^^
+
+      data: null;
+>data : null
+>     : ^^^^
+    }
+  | {
+      status: "success";
+>status : "success"
+>       : ^^^^^^^^^
+
+      data: string;
+>data : string
+>     : ^^^^^^
+
+    };
+
+declare function createStore<TContext>(config: {
+>createStore : <TContext>(config: { context: TContext; on: Record<string, (ctx: TContext) => TContext>; }) => void
+>            : ^        ^^      ^^                                                                       ^^^^^    
+>config : { context: TContext; on: Record<string, (ctx: TContext) => TContext>; }
+>       : ^^^^^^^^^^^        ^^^^^^                                           ^^^
+
+  context: TContext;
+>context : TContext
+>        : ^^^^^^^^
+
+  on: Record<string, (ctx: TContext) => TContext>;
+>on : Record<string, (ctx: TContext) => TContext>
+>   : ^^^^^^^^^^^^^^^^   ^^        ^^^^^        ^
+>ctx : TContext
+>    : ^^^^^^^^
+
+}): void;
+
+const store = createStore({
+>store : void
+>      : ^^^^
+>createStore({  context: {    status: "loading",    data: null,  } as ContextStates,  on: {    fetch: (ctx) => ({      status: "success",      data: "hello",    }),  },}) : void
+>                                                                                                                                                                          : ^^^^
+>createStore : <TContext>(config: { context: TContext; on: Record<string, (ctx: TContext) => TContext>; }) => void
+>            : ^        ^^      ^^                                                                       ^^^^^    
+>{  context: {    status: "loading",    data: null,  } as ContextStates,  on: {    fetch: (ctx) => ({      status: "success",      data: "hello",    }),  },} : { context: ContextStates; on: { fetch: (ctx: ContextStates) => { status: "success"; data: string; }; }; }
+>                                                                                                                                                             : ^^^^^^^^^^^             ^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  context: {
+>context : ContextStates
+>        : ^^^^^^^^^^^^^
+>{    status: "loading",    data: null,  } as ContextStates : ContextStates
+>                                                           : ^^^^^^^^^^^^^
+>{    status: "loading",    data: null,  } : { status: "loading"; data: null; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    status: "loading",
+>status : "loading"
+>       : ^^^^^^^^^
+>"loading" : "loading"
+>          : ^^^^^^^^^
+
+    data: null,
+>data : null
+>     : ^^^^
+
+  } as ContextStates,
+  on: {
+>on : { fetch: (ctx: ContextStates) => { status: "success"; data: string; }; }
+>   : ^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{    fetch: (ctx) => ({      status: "success",      data: "hello",    }),  } : { fetch: (ctx: ContextStates) => { status: "success"; data: string; }; }
+>                                                                              : ^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    fetch: (ctx) => ({
+>fetch : (ctx: ContextStates) => { status: "success"; data: string; }
+>      : ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>(ctx) => ({      status: "success",      data: "hello",    }) : (ctx: ContextStates) => { status: "success"; data: string; }
+>                                                              : ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>ctx : ContextStates
+>    : ^^^^^^^^^^^^^
+>({      status: "success",      data: "hello",    }) : { status: "success"; data: string; }
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{      status: "success",      data: "hello",    } : { status: "success"; data: string; }
+>                                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+      status: "success",
+>status : "success"
+>       : ^^^^^^^^^
+>"success" : "success"
+>          : ^^^^^^^^^
+
+      data: "hello",
+>data : string
+>     : ^^^^^^
+>"hello" : "hello"
+>        : ^^^^^^^
+
+    }),
+  },
+});
+

--- a/tests/cases/compiler/instantiateContextualTypes2.ts
+++ b/tests/cases/compiler/instantiateContextualTypes2.ts
@@ -1,0 +1,30 @@
+// @strict: true
+// @noEmit: true
+
+type ContextStates =
+  | {
+      status: "loading";
+      data: null;
+    }
+  | {
+      status: "success";
+      data: string;
+    };
+
+declare function createStore<TContext>(config: {
+  context: TContext;
+  on: Record<string, (ctx: TContext) => TContext>;
+}): void;
+
+const store = createStore({
+  context: {
+    status: "loading",
+    data: null,
+  } as ContextStates,
+  on: {
+    fetch: (ctx) => ({
+      status: "success",
+      data: "hello",
+    }),
+  },
+});


### PR DESCRIPTION
This makes `instantiateContextualType` call `instantiateInstantiableTypes(contextualType, inferenceContext.nonFixingMapper)` based on the existing (renamed) context flag. But now that flag is used in more scenarios. This flag was originally introduced in https://github.com/microsoft/TypeScript/pull/30568