### PR TITLE
Fix mistakenly disallowed default export under erasableSyntaxOnly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -47974,7 +47974,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return;
         }
 
-        if (compilerOptions.erasableSyntaxOnly && !(node.flags & NodeFlags.Ambient)) {
+        if (compilerOptions.erasableSyntaxOnly && node.isExportEquals && !(node.flags & NodeFlags.Ambient)) {
             error(node, Diagnostics.This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled);
         }
         const container = node.parent.kind === SyntaxKind.SourceFile ? node.parent : node.parent.parent as ModuleDeclaration;

--- a/tests/baselines/reference/erasableSyntaxOnly.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnly.errors.txt
@@ -1,6 +1,5 @@
 commonjs.cts(1,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 commonjs.cts(2,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-esm.mts(2,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(3,17): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(6,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(10,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
@@ -107,9 +106,7 @@ index.ts(28,12): error TS1294: This syntax is not allowed when 'erasableSyntaxOn
     export = foo;
     
     
-==== esm.mts (1 errors) ====
+==== esm.mts (0 errors) ====
     const foo = 1234;
     export default foo;
-    ~~~~~~~~~~~~~~~~~~~
-!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
     

--- a/tests/baselines/reference/erasableSyntaxOnly.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnly.errors.txt
@@ -1,5 +1,6 @@
 commonjs.cts(1,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 commonjs.cts(2,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+esm.mts(2,1): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(3,17): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(6,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
 index.ts(10,11): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
@@ -104,4 +105,11 @@ index.ts(28,12): error TS1294: This syntax is not allowed when 'erasableSyntaxOn
 ==== other.d.cts (0 errors) ====
     declare function foo(): void;
     export = foo;
+    
+    
+==== esm.mts (1 errors) ====
+    const foo = 1234;
+    export default foo;
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
     

--- a/tests/baselines/reference/erasableSyntaxOnly.js
+++ b/tests/baselines/reference/erasableSyntaxOnly.js
@@ -76,6 +76,11 @@ declare function foo(): void;
 export = foo;
 
 
+//// [esm.mts]
+const foo = 1234;
+export default foo;
+
+
 //// [index.js]
 var MyClassErr = /** @class */ (function () {
     // No parameter properties
@@ -119,3 +124,6 @@ var MyClassOk = /** @class */ (function () {
 "use strict";
 var foo = require("./other.cjs");
 module.exports = foo;
+//// [esm.mjs]
+var foo = 1234;
+export default foo;

--- a/tests/baselines/reference/erasableSyntaxOnly.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnly.symbols
@@ -133,3 +133,11 @@ declare function foo(): void;
 export = foo;
 >foo : Symbol(foo, Decl(other.d.cts, 0, 0))
 
+
+=== esm.mts ===
+const foo = 1234;
+>foo : Symbol(foo, Decl(esm.mts, 0, 5))
+
+export default foo;
+>foo : Symbol(foo, Decl(esm.mts, 0, 5))
+

--- a/tests/baselines/reference/erasableSyntaxOnly.types
+++ b/tests/baselines/reference/erasableSyntaxOnly.types
@@ -179,3 +179,15 @@ export = foo;
 >foo : () => void
 >    : ^^^^^^    
 
+
+=== esm.mts ===
+const foo = 1234;
+>foo : 1234
+>    : ^^^^
+>1234 : 1234
+>     : ^^^^
+
+export default foo;
+>foo : 1234
+>    : ^^^^
+

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
@@ -1,4 +1,3 @@
-esm.d.mts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
 index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
 
 
@@ -68,9 +67,7 @@ index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start 
     export = foo;
     
     
-==== esm.d.mts (1 errors) ====
-    const foo = 1234;
-    ~~~~~
-!!! error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
+==== esm.d.mts (0 errors) ====
+    declare const foo = 1234;
     export default foo;
     

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.errors.txt
@@ -1,3 +1,4 @@
+esm.d.mts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
 index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
 
 
@@ -65,4 +66,11 @@ index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start 
 ==== other.d.cts (0 errors) ====
     declare function foo(): void;
     export = foo;
+    
+    
+==== esm.d.mts (1 errors) ====
+    const foo = 1234;
+    ~~~~~
+!!! error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
+    export default foo;
     

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
@@ -112,3 +112,11 @@ declare function foo(): void;
 export = foo;
 >foo : Symbol(foo, Decl(other.d.cts, 0, 0))
 
+
+=== esm.d.mts ===
+const foo = 1234;
+>foo : Symbol(foo, Decl(esm.d.mts, 0, 5))
+
+export default foo;
+>foo : Symbol(foo, Decl(esm.d.mts, 0, 5))
+

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.symbols
@@ -114,9 +114,9 @@ export = foo;
 
 
 === esm.d.mts ===
-const foo = 1234;
->foo : Symbol(foo, Decl(esm.d.mts, 0, 5))
+declare const foo = 1234;
+>foo : Symbol(foo, Decl(esm.d.mts, 0, 13))
 
 export default foo;
->foo : Symbol(foo, Decl(esm.d.mts, 0, 5))
+>foo : Symbol(foo, Decl(esm.d.mts, 0, 13))
 

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
@@ -154,3 +154,15 @@ export = foo;
 >foo : () => void
 >    : ^^^^^^    
 
+
+=== esm.d.mts ===
+const foo = 1234;
+>foo : 1234
+>    : ^^^^
+>1234 : 1234
+>     : ^^^^
+
+export default foo;
+>foo : 1234
+>    : ^^^^
+

--- a/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
+++ b/tests/baselines/reference/erasableSyntaxOnlyDeclaration.types
@@ -156,7 +156,7 @@ export = foo;
 
 
 === esm.d.mts ===
-const foo = 1234;
+declare const foo = 1234;
 >foo : 1234
 >    : ^^^^
 >1234 : 1234

--- a/tests/cases/compiler/erasableSyntaxOnly.ts
+++ b/tests/cases/compiler/erasableSyntaxOnly.ts
@@ -74,3 +74,8 @@ export = foo;
 // @filename: other.d.cts
 declare function foo(): void;
 export = foo;
+
+
+// @filename: esm.mts
+const foo = 1234;
+export default foo;

--- a/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
+++ b/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
@@ -69,5 +69,5 @@ export = foo;
 
 
 // @filename: esm.d.mts
-const foo = 1234;
+declare const foo = 1234;
 export default foo;

--- a/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
+++ b/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
@@ -66,3 +66,8 @@ export = foo;
 // @filename: other.d.cts
 declare function foo(): void;
 export = foo;
+
+
+// @filename: esm.d.mts
+const foo = 1234;
+export default foo;


### PR DESCRIPTION
I forgot that `export default` and `export =` are the same node, just with an extra marker. Oops.

See https://github.com/microsoft/TypeScript/pull/61175#issuecomment-2664626669.