### PR TITLE
Fix quick fix for isolatedDeclarations to keep trailing unknown in generics

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -621,11 +621,7 @@ function endOfRequiredTypeParameters(checker: TypeChecker, type: GenericType): n
     const fullTypeArguments = type.typeArguments;
     const target = type.target;
     for (let cutoff = 0; cutoff < fullTypeArguments.length; cutoff++) {
-        const firstTypeToDrop = fullTypeArguments[cutoff];
-        // Our trick for figuring out if generics have unnecessary defaults by filling in
-        // missing type arguments incorrectly guesses that trailing unknowns are unnneceesary.
-        // Simply bail on trailing unknowns to avoid this case.
-        if ((firstTypeToDrop.getFlags() | TypeFlags.Unknown) === TypeFlags.Unknown) {
+        if (target.localTypeParameters?.[cutoff].constraint === undefined) {
             continue;
         }
         const typeArguments = fullTypeArguments.slice(0, cutoff);

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -621,6 +621,13 @@ function endOfRequiredTypeParameters(checker: TypeChecker, type: GenericType): n
     const fullTypeArguments = type.typeArguments;
     const target = type.target;
     for (let cutoff = 0; cutoff < fullTypeArguments.length; cutoff++) {
+        const firstTypeToDrop = fullTypeArguments[cutoff];
+        // Our trick for figuring out if generics have unnecessary defaults by filling in
+        // missing type arguments incorrectly guesses that trailing unknowns are unnneceesary.
+        // Simply bail on trailing unknowns to avoid this case.
+        if ((firstTypeToDrop.getFlags() | TypeFlags.Unknown) === TypeFlags.Unknown) {
+            continue;
+        }
         const typeArguments = fullTypeArguments.slice(0, cutoff);
         const filledIn = checker.fillMissingTypeArguments(typeArguments, target.typeParameters, cutoff, /*isJavaScriptImplicitAny*/ false);
         if (filledIn.every((fill, i) => fill === fullTypeArguments[i])) {

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports57-generics-doesnt-drop-trailing-unknown.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports57-generics-doesnt-drop-trailing-unknown.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+// @lib: es2015
+////
+////let x: unknown;
+////export const s = new Set([x]);
+////
+
+verify.codeFix({
+    description: "Add annotation of type 'Set<unknown>'",
+    index: 0,
+    newFileContent:
+`
+let x: unknown;
+export const s: Set<unknown> = new Set([x]);
+`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports58-genercs-doesnt-drop-trailing-unknown-2.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports58-genercs-doesnt-drop-trailing-unknown-2.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+// @lib: es2015
+////
+////export const s = new Set<unknown>();
+////
+
+verify.codeFix({
+    description: "Add annotation of type 'Set<unknown>'",
+    index: 0,
+    newFileContent:
+`
+export const s: Set<unknown> = new Set<unknown>();
+`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports59-drops-unneeded-after-unknown.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports59-drops-unneeded-after-unknown.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////
+////export interface Foo<S = string, T = unknown, U = number> {}
+////export function g(x: Foo<number, unknown, number>) { return x; }
+////
+
+verify.codeFix({
+    description: "Add return type 'Foo<number, unknown>'",
+    index: 0,
+    newFileContent:
+`
+export interface Foo<S = string, T = unknown, U = number> {}
+export function g(x: Foo<number, unknown, number>): Foo<number, unknown> { return x; }
+`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports59-drops-unneeded-after-unknown.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports59-drops-unneeded-after-unknown.ts
@@ -8,11 +8,11 @@
 ////
 
 verify.codeFix({
-    description: "Add return type 'Foo<number, unknown>'",
+    description: "Add return type 'Foo<number>'",
     index: 0,
     newFileContent:
 `
 export interface Foo<S = string, T = unknown, U = number> {}
-export function g(x: Foo<number, unknown, number>): Foo<number, unknown> { return x; }
+export function g(x: Foo<number, unknown, number>): Foo<number> { return x; }
 `,
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports60-drops-unneeded-non-trailing-unknown.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports60-drops-unneeded-non-trailing-unknown.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////
+////export interface Foo<S = string, T = unknown> {}
+////export function f(x: Foo<string, unknown>) { return x; }
+////
+
+verify.codeFix({
+    description: "Add return type 'Foo'",
+    index: 0,
+    newFileContent:
+`
+export interface Foo<S = string, T = unknown> {}
+export function f(x: Foo<string, unknown>): Foo { return x; }
+`,
+});


### PR DESCRIPTION
Update `typeToMinimizedReferenceType` helper to avoid dropping trailing `unknown` inside generics.  This avoids a bug where non-optional trailing `unknown` types were incorrectly dropped.

Fixes https://github.com/microsoft/TypeScript/issues/61208