### PR TITLE
fix `Intl.Segments#containing` return value type

### DIFF
--- a/src/lib/es2022.intl.d.ts
+++ b/src/lib/es2022.intl.d.ts
@@ -11,15 +11,27 @@ declare namespace Intl {
         granularity?: "grapheme" | "word" | "sentence" | undefined;
     }
 
+    /**
+     * The `Intl.Segmenter` object enables locale-sensitive text segmentation, enabling you to get meaningful items (graphemes, words or sentences) from a string.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter)
+     */
     interface Segmenter {
         /**
          * Returns `Segments` object containing the segments of the input string, using the segmenter's locale and granularity.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment)
          *
          * @param input - The text to be segmented as a `string`.
          *
          * @returns A new iterable Segments object containing the segments of the input string, using the segmenter's locale and granularity.
          */
         segment(input: string): Segments;
+        /**
+         * The `resolvedOptions()` method of `Intl.Segmenter` instances returns a new object with properties reflecting the options computed during initialization of this `Segmenter` object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/resolvedOptions)
+         * */
         resolvedOptions(): ResolvedSegmenterOptions;
     }
 
@@ -32,13 +44,20 @@ declare namespace Intl {
         [Symbol.iterator](): SegmentIterator<T>;
     }
 
+    /**
+     * A `Segments` object is an iterable collection of the segments of a text string. It is returned by a call to the `segment()` method of an `Intl.Segmenter` object.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments)
+     */
     interface Segments {
         /**
          * Returns an object describing the segment in the original string that includes the code unit at a specified index.
          *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/containing)
+         *
          * @param codeUnitIndex - A number specifying the index of the code unit in the original input string. If the value is omitted, it defaults to `0`.
          */
-        containing(codeUnitIndex?: number): SegmentData;
+        containing(codeUnitIndex?: number): SegmentData | undefined;
 
         /** Returns an iterator to iterate over the segments. */
         [Symbol.iterator](): SegmentIterator<SegmentData>;
@@ -58,6 +77,11 @@ declare namespace Intl {
         isWordLike?: boolean;
     }
 
+    /**
+     * The `Intl.Segmenter` object enables locale-sensitive text segmentation, enabling you to get meaningful items (graphemes, words or sentences) from a string.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter)
+     */
     const Segmenter: {
         prototype: Segmenter;
 

--- a/src/lib/es2022.intl.d.ts
+++ b/src/lib/es2022.intl.d.ts
@@ -31,7 +31,7 @@ declare namespace Intl {
          * The `resolvedOptions()` method of `Intl.Segmenter` instances returns a new object with properties reflecting the options computed during initialization of this `Segmenter` object.
          *
          * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/resolvedOptions)
-         * */
+         */
         resolvedOptions(): ResolvedSegmenterOptions;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61235
