### PR TITLE
fix(61258): Renaming namespace with const enum doesn't update enum references

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1302,7 +1302,7 @@ export namespace Core {
         const symbol = node && skipPastExportOrImportSpecifierOrUnion(originalSymbol, node, checker, /*useLocalSymbolForExportSpecifier*/ !isForRenameWithPrefixAndSuffixText(options)) || originalSymbol;
 
         // Compute the meaning from the location and the symbol it references
-        const searchMeaning = node ? getIntersectingMeaningFromDeclarations(node, symbol) : SemanticMeaning.All;
+        const searchMeaning = node && options.use !== FindReferencesUse.Rename ? getIntersectingMeaningFromDeclarations(node, symbol) : SemanticMeaning.All;
         const result: SymbolAndEntries[] = [];
         const state = new State(sourceFiles, sourceFilesSet, node ? getSpecialSearchKind(node) : SpecialSearchKind.None, checker, cancellationToken, searchMeaning, options, result);
 

--- a/tests/baselines/reference/findAllRefs_importType_exportEquals.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefs_importType_exportEquals.baseline.jsonc
@@ -477,16 +477,16 @@
 // === findRenameLocations ===
 // === /a.ts ===
 // <|type /*RENAME*/[|TRENAME|] = number;|>
-// namespace T {
+// <|namespace [|TRENAME|] {
 //     export type U = string;
-// }
+// }|>
 // <|export = [|TRENAME|];|>
 
 
 
 // === findRenameLocations ===
 // === /a.ts ===
-// type T = number;
+// <|type [|TRENAME|] = number;|>
 // <|namespace /*RENAME*/[|TRENAME|] {
 //     export type U = string;
 // }|>

--- a/tests/baselines/reference/renameNamespace.baseline.jsonc
+++ b/tests/baselines/reference/renameNamespace.baseline.jsonc
@@ -1,0 +1,9 @@
+// === findRenameLocations ===
+// === /tests/cases/fourslash/renameNamespace.ts ===
+// <|namespace /*RENAME*/[|NSRENAME|] {
+//     export const enum E {
+//         A = 'a'
+//     }
+// }|>
+// 
+// const a: [|NSRENAME|].E = [|NSRENAME|].E.A;

--- a/tests/cases/fourslash/renameNamespace.ts
+++ b/tests/cases/fourslash/renameNamespace.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts'/>
+
+////namespace /**/NS {
+////    export const enum E {
+////        A = 'a'
+////    }
+////}
+////
+////const a: NS.E = NS.E.A;
+
+verify.baselineRename("", { });


### PR DESCRIPTION
Fixes #61258