### PR TITLE
lib.es2017: Move `SharedArrayBuffer[Symbol.species]` onto constructor interface

### DIFF
--- a/src/lib/es2017.sharedmemory.d.ts
+++ b/src/lib/es2017.sharedmemory.d.ts
@@ -11,13 +11,13 @@ interface SharedArrayBuffer {
      * Returns a section of an SharedArrayBuffer.
      */
     slice(begin?: number, end?: number): SharedArrayBuffer;
-    readonly [Symbol.species]: SharedArrayBuffer;
     readonly [Symbol.toStringTag]: "SharedArrayBuffer";
 }
 
 interface SharedArrayBufferConstructor {
     readonly prototype: SharedArrayBuffer;
     new (byteLength?: number): SharedArrayBuffer;
+    readonly [Symbol.species]: SharedArrayBufferConstructor;
 }
 declare var SharedArrayBuffer: SharedArrayBufferConstructor;
 

--- a/tests/baselines/reference/useSharedArrayBuffer4.js
+++ b/tests/baselines/reference/useSharedArrayBuffer4.js
@@ -3,13 +3,13 @@
 //// [useSharedArrayBuffer4.ts]
 var foge = new SharedArrayBuffer(1024);
 var bar = foge.slice(1, 10);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
 var len = foge.byteLength;
+var species = SharedArrayBuffer[Symbol.species];
 
 //// [useSharedArrayBuffer4.js]
 var foge = new SharedArrayBuffer(1024);
 var bar = foge.slice(1, 10);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
 var len = foge.byteLength;
+var species = SharedArrayBuffer[Symbol.species];

--- a/tests/baselines/reference/useSharedArrayBuffer4.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer4.symbols
@@ -11,23 +11,23 @@ var bar = foge.slice(1, 10);
 >foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
 >slice : Symbol(SharedArrayBuffer.slice, Decl(lib.es2017.sharedmemory.d.ts, --, --))
 
-var species = foge[Symbol.species];
->species : Symbol(species, Decl(useSharedArrayBuffer4.ts, 2, 3))
->foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
->Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
-
 var stringTag = foge[Symbol.toStringTag];
->stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer4.ts, 3, 3))
+>stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer4.ts, 2, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 var len = foge.byteLength;
->len : Symbol(len, Decl(useSharedArrayBuffer4.ts, 4, 3))
+>len : Symbol(len, Decl(useSharedArrayBuffer4.ts, 3, 3))
 >foge.byteLength : Symbol(SharedArrayBuffer.byteLength, Decl(lib.es2017.sharedmemory.d.ts, --, --))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
 >byteLength : Symbol(SharedArrayBuffer.byteLength, Decl(lib.es2017.sharedmemory.d.ts, --, --))
+
+var species = SharedArrayBuffer[Symbol.species];
+>species : Symbol(species, Decl(useSharedArrayBuffer4.ts, 4, 3))
+>SharedArrayBuffer : Symbol(SharedArrayBuffer, Decl(lib.es2017.sharedmemory.d.ts, --, --), Decl(lib.es2017.sharedmemory.d.ts, --, --))
+>Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/useSharedArrayBuffer4.types
+++ b/tests/baselines/reference/useSharedArrayBuffer4.types
@@ -27,20 +27,6 @@ var bar = foge.slice(1, 10);
 >10 : 10
 >   : ^^
 
-var species = foge[Symbol.species];
->species : SharedArrayBuffer
->        : ^^^^^^^^^^^^^^^^^
->foge[Symbol.species] : SharedArrayBuffer
->                     : ^^^^^^^^^^^^^^^^^
->foge : SharedArrayBuffer
->     : ^^^^^^^^^^^^^^^^^
->Symbol.species : unique symbol
->               : ^^^^^^^^^^^^^
->Symbol : SymbolConstructor
->       : ^^^^^^^^^^^^^^^^^
->species : unique symbol
->        : ^^^^^^^^^^^^^
-
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : "SharedArrayBuffer"
 >          : ^^^^^^^^^^^^^^^^^^^
@@ -64,4 +50,18 @@ var len = foge.byteLength;
 >     : ^^^^^^^^^^^^^^^^^
 >byteLength : number
 >           : ^^^^^^
+
+var species = SharedArrayBuffer[Symbol.species];
+>species : SharedArrayBufferConstructor
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>SharedArrayBuffer[Symbol.species] : SharedArrayBufferConstructor
+>                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>SharedArrayBuffer : SharedArrayBufferConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Symbol.species : unique symbol
+>               : ^^^^^^^^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>species : unique symbol
+>        : ^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/useSharedArrayBuffer5.js
+++ b/tests/baselines/reference/useSharedArrayBuffer5.js
@@ -2,10 +2,10 @@
 
 //// [useSharedArrayBuffer5.ts]
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
+var species = SharedArrayBuffer[Symbol.species];
 
 //// [useSharedArrayBuffer5.js]
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
+var species = SharedArrayBuffer[Symbol.species];

--- a/tests/baselines/reference/useSharedArrayBuffer5.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer5.symbols
@@ -5,17 +5,17 @@ var foge = new SharedArrayBuffer(1024);
 >foge : Symbol(foge, Decl(useSharedArrayBuffer5.ts, 0, 3))
 >SharedArrayBuffer : Symbol(SharedArrayBuffer, Decl(lib.es2017.sharedmemory.d.ts, --, --), Decl(lib.es2017.sharedmemory.d.ts, --, --))
 
-var species = foge[Symbol.species];
->species : Symbol(species, Decl(useSharedArrayBuffer5.ts, 1, 3))
->foge : Symbol(foge, Decl(useSharedArrayBuffer5.ts, 0, 3))
->Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
-
 var stringTag = foge[Symbol.toStringTag];
->stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer5.ts, 2, 3))
+>stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer5.ts, 1, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer5.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+var species = SharedArrayBuffer[Symbol.species];
+>species : Symbol(species, Decl(useSharedArrayBuffer5.ts, 2, 3))
+>SharedArrayBuffer : Symbol(SharedArrayBuffer, Decl(lib.es2017.sharedmemory.d.ts, --, --), Decl(lib.es2017.sharedmemory.d.ts, --, --))
+>Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/useSharedArrayBuffer5.types
+++ b/tests/baselines/reference/useSharedArrayBuffer5.types
@@ -11,20 +11,6 @@ var foge = new SharedArrayBuffer(1024);
 >1024 : 1024
 >     : ^^^^
 
-var species = foge[Symbol.species];
->species : SharedArrayBuffer
->        : ^^^^^^^^^^^^^^^^^
->foge[Symbol.species] : SharedArrayBuffer
->                     : ^^^^^^^^^^^^^^^^^
->foge : SharedArrayBuffer
->     : ^^^^^^^^^^^^^^^^^
->Symbol.species : unique symbol
->               : ^^^^^^^^^^^^^
->Symbol : SymbolConstructor
->       : ^^^^^^^^^^^^^^^^^
->species : unique symbol
->        : ^^^^^^^^^^^^^
-
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : "SharedArrayBuffer"
 >          : ^^^^^^^^^^^^^^^^^^^
@@ -38,4 +24,18 @@ var stringTag = foge[Symbol.toStringTag];
 >       : ^^^^^^^^^^^^^^^^^
 >toStringTag : unique symbol
 >            : ^^^^^^^^^^^^^
+
+var species = SharedArrayBuffer[Symbol.species];
+>species : SharedArrayBufferConstructor
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>SharedArrayBuffer[Symbol.species] : SharedArrayBufferConstructor
+>                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>SharedArrayBuffer : SharedArrayBufferConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Symbol.species : unique symbol
+>               : ^^^^^^^^^^^^^
+>Symbol : SymbolConstructor
+>       : ^^^^^^^^^^^^^^^^^
+>species : unique symbol
+>        : ^^^^^^^^^^^^^
 

--- a/tests/cases/conformance/es2017/useSharedArrayBuffer4.ts
+++ b/tests/cases/conformance/es2017/useSharedArrayBuffer4.ts
@@ -3,6 +3,6 @@
 
 var foge = new SharedArrayBuffer(1024);
 var bar = foge.slice(1, 10);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
 var len = foge.byteLength;
+var species = SharedArrayBuffer[Symbol.species];

--- a/tests/cases/conformance/es2017/useSharedArrayBuffer5.ts
+++ b/tests/cases/conformance/es2017/useSharedArrayBuffer5.ts
@@ -2,5 +2,5 @@
 // @lib: es6,es2017.sharedmemory
 
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
 var stringTag = foge[Symbol.toStringTag];
+var species = SharedArrayBuffer[Symbol.species];


### PR DESCRIPTION
Some test failures from #60150 inadvertently flagged up that the `SharedArrayBuffer[Symbol.species]` getter was placed onto the object prototype rather than the constructor in lib.es2017 (a very popular language feature, clearly...)
