### PR TITLE
Restrict indexed accesses on nonpublic fields of concrete types the same way we do generic ones

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42066,6 +42066,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkIndexedAccessIndexType(type: Type, accessNode: IndexedAccessTypeNode | ElementAccessExpression) {
         if (!(type.flags & TypeFlags.IndexedAccess)) {
+            if (isIndexedAccessTypeNode(accessNode)) {
+                const indexType = getTypeFromTypeNode(accessNode.indexType);
+                const objectType = getTypeFromTypeNode(accessNode.objectType);
+                const propertyName = getPropertyNameFromIndex(indexType, accessNode);
+                if (propertyName) {
+                    const propertySymbol = forEachType(getApparentType(objectType), t => getPropertyOfType(t, propertyName));
+                    if (propertySymbol && getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.NonPublicAccessibilityModifier) {
+                        error(accessNode, Diagnostics.Private_or_protected_member_0_cannot_be_accessed_via_indexed_access, unescapeLeadingUnderscores(propertyName));
+                        return errorType;
+                    }
+                }
+            }
             return type;
         }
         // Check if the index type is assignable to 'keyof T' for the object type.
@@ -42085,14 +42097,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             return type;
         }
-        if (isGenericObjectType(objectType)) {
-            const propertyName = getPropertyNameFromIndex(indexType, accessNode);
-            if (propertyName) {
-                const propertySymbol = forEachType(getApparentType(objectType), t => getPropertyOfType(t, propertyName));
-                if (propertySymbol && getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.NonPublicAccessibilityModifier) {
-                    error(accessNode, Diagnostics.Private_or_protected_member_0_cannot_be_accessed_on_a_type_parameter, unescapeLeadingUnderscores(propertyName));
-                    return errorType;
-                }
+        const propertyName = getPropertyNameFromIndex(indexType, accessNode);
+        if (propertyName) {
+            const propertySymbol = forEachType(getApparentType(objectType), t => getPropertyOfType(t, propertyName));
+            if (propertySymbol && getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.NonPublicAccessibilityModifier) {
+                error(accessNode, Diagnostics.Private_or_protected_member_0_cannot_be_accessed_on_a_type_parameter, unescapeLeadingUnderscores(propertyName));
+                return errorType;
             }
         }
         error(accessNode, Diagnostics.Type_0_cannot_be_used_to_index_type_1, typeToString(indexType), typeToString(objectType));

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4436,6 +4436,10 @@
         "category": "Error",
         "code": 4128
     },
+    "Private or protected member '{0}' cannot be accessed via indexed access.": {
+        "category": "Error",
+        "code": 4129
+    },
 
     "The current host does not support the '{0}' option.": {
         "category": "Error",

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -748,7 +748,13 @@ export type ConfiguredProjectToAnyReloadKind = Map<
 >;
 
 /** @internal */
-export type DefaultConfiguredProjectResult = ReturnType<ProjectService["tryFindDefaultConfiguredProjectForOpenScriptInfoOrClosedFileInfo"]>;
+export interface DefaultConfiguredProjectResult {
+    defaultProject: ConfiguredProject | undefined;
+    tsconfigProject: ConfiguredProject | undefined;
+    sentConfigDiag: Set<ConfiguredProject>;
+    seenProjects: ConfigureProjectToLoadKind;
+    seenConfigs: Set<NormalizedPath> | undefined;
+};
 
 /** @internal */
 export interface FindCreateOrLoadConfiguredProjectResult {
@@ -4534,7 +4540,7 @@ export class ProjectService {
         allowDeferredClosed?: boolean,
         /** Used with ConfiguredProjectLoadKind.Reload to check if this project was already reloaded */
         reloadedProjects?: ConfiguredProjectToAnyReloadKind,
-    ) {
+    ): DefaultConfiguredProjectResult {
         const infoIsOpenScriptInfo = isOpenScriptInfo(info);
         const optimizedKind = toConfiguredProjectLoadOptimized(kind);
         const seenProjects: ConfigureProjectToLoadKind = new Map();

--- a/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.errors.txt
+++ b/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.errors.txt
@@ -1,0 +1,15 @@
+indexedAccessOfConcreteNonpublicFields.ts(4,22): error TS4129: Private or protected member '_property' cannot be accessed via indexed access.
+indexedAccessOfConcreteNonpublicFields.ts(4,47): error TS4129: Private or protected member '_property2' cannot be accessed via indexed access.
+
+
+==== indexedAccessOfConcreteNonpublicFields.ts (2 errors) ====
+    export class Foo {
+        private _property: string = '';
+        protected _property2: string = '';
+        constructor(arg: Foo['_property'], other: Foo['_property2']) {
+                         ~~~~~~~~~~~~~~~~
+!!! error TS4129: Private or protected member '_property' cannot be accessed via indexed access.
+                                                  ~~~~~~~~~~~~~~~~~
+!!! error TS4129: Private or protected member '_property2' cannot be accessed via indexed access.
+        }
+    }

--- a/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.js
+++ b/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/indexedAccessOfConcreteNonpublicFields.ts] ////
+
+//// [indexedAccessOfConcreteNonpublicFields.ts]
+export class Foo {
+    private _property: string = '';
+    protected _property2: string = '';
+    constructor(arg: Foo['_property'], other: Foo['_property2']) {
+    }
+}
+
+//// [indexedAccessOfConcreteNonpublicFields.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+var Foo = /** @class */ (function () {
+    function Foo(arg, other) {
+        this._property = '';
+        this._property2 = '';
+    }
+    return Foo;
+}());
+exports.Foo = Foo;
+
+
+//// [indexedAccessOfConcreteNonpublicFields.d.ts]
+export declare class Foo {
+    private _property;
+    protected _property2: string;
+    constructor(arg: Foo['_property'], other: Foo['_property2']);
+}

--- a/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.symbols
+++ b/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/indexedAccessOfConcreteNonpublicFields.ts] ////
+
+=== indexedAccessOfConcreteNonpublicFields.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(indexedAccessOfConcreteNonpublicFields.ts, 0, 0))
+
+    private _property: string = '';
+>_property : Symbol(Foo._property, Decl(indexedAccessOfConcreteNonpublicFields.ts, 0, 18))
+
+    protected _property2: string = '';
+>_property2 : Symbol(Foo._property2, Decl(indexedAccessOfConcreteNonpublicFields.ts, 1, 35))
+
+    constructor(arg: Foo['_property'], other: Foo['_property2']) {
+>arg : Symbol(arg, Decl(indexedAccessOfConcreteNonpublicFields.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(indexedAccessOfConcreteNonpublicFields.ts, 0, 0))
+>other : Symbol(other, Decl(indexedAccessOfConcreteNonpublicFields.ts, 3, 38))
+>Foo : Symbol(Foo, Decl(indexedAccessOfConcreteNonpublicFields.ts, 0, 0))
+    }
+}

--- a/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.types
+++ b/tests/baselines/reference/indexedAccessOfConcreteNonpublicFields.types
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/indexedAccessOfConcreteNonpublicFields.ts] ////
+
+=== indexedAccessOfConcreteNonpublicFields.ts ===
+export class Foo {
+>Foo : Foo
+>    : ^^^
+
+    private _property: string = '';
+>_property : string
+>          : ^^^^^^
+>'' : ""
+>   : ^^
+
+    protected _property2: string = '';
+>_property2 : string
+>           : ^^^^^^
+>'' : ""
+>   : ^^
+
+    constructor(arg: Foo['_property'], other: Foo['_property2']) {
+>arg : string
+>    : ^^^^^^
+>other : string
+>      : ^^^^^^
+    }
+}

--- a/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
@@ -1,3 +1,5 @@
+keyofAndIndexedAccess.ts(173,14): error TS4129: Private or protected member 'y' cannot be accessed via indexed access.
+keyofAndIndexedAccess.ts(174,14): error TS4129: Private or protected member 'z' cannot be accessed via indexed access.
 keyofAndIndexedAccess.ts(205,24): error TS2322: Type 'T[keyof T]' is not assignable to type 'object'.
   Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
     Type 'T[string]' is not assignable to type 'object'.
@@ -15,7 +17,7 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
       Type 'T[string]' is not assignable to type '{}'.
 
 
-==== keyofAndIndexedAccess.ts (5 errors) ====
+==== keyofAndIndexedAccess.ts (7 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -189,7 +191,11 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
     function f40(c: C) {
         type X = C["x"];
         type Y = C["y"];
+                 ~~~~~~
+!!! error TS4129: Private or protected member 'y' cannot be accessed via indexed access.
         type Z = C["z"];
+                 ~~~~~~
+!!! error TS4129: Private or protected member 'z' cannot be accessed via indexed access.
         let x: X = c["x"];
         let y: Y = c["y"];
         let z: Z = c["z"];

--- a/tests/baselines/reference/unionPropertyOfProtectedAndIntersectionProperty.errors.txt
+++ b/tests/baselines/reference/unionPropertyOfProtectedAndIntersectionProperty.errors.txt
@@ -1,7 +1,10 @@
+unionPropertyOfProtectedAndIntersectionProperty.ts(18,11): error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
+unionPropertyOfProtectedAndIntersectionProperty.ts(19,11): error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
 unionPropertyOfProtectedAndIntersectionProperty.ts(19,23): error TS2339: Property 'foo' does not exist on type 'Foo | Bar'.
+unionPropertyOfProtectedAndIntersectionProperty.ts(20,11): error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
 
 
-==== unionPropertyOfProtectedAndIntersectionProperty.ts (1 errors) ====
+==== unionPropertyOfProtectedAndIntersectionProperty.ts (4 errors) ====
     class Foo {
       protected foo = 0;
     }
@@ -20,10 +23,16 @@ unionPropertyOfProtectedAndIntersectionProperty.ts(19,23): error TS2339: Propert
     // that shows the direct result of the change:
     
     type _3 = (Foo & Bar)['foo'];         // Ok
+              ~~~~~~~~~~~~~~~~~~
+!!! error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
     type _4 = (Foo | Bar)['foo'];         // Error
+              ~~~~~~~~~~~~~~~~~~
+!!! error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
                           ~~~~~
 !!! error TS2339: Property 'foo' does not exist on type 'Foo | Bar'.
     type _5 = (Foo | (Foo & Bar))['foo']; // Prev error, now ok
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS4129: Private or protected member 'foo' cannot be accessed via indexed access.
     
     // V[P] in `Nothing<V[P]>` is the substitution type `V[P] & Foo`. When
     // checking if that's assignable to `Foo` in the constraint of `Nothing`,

--- a/tests/cases/compiler/indexedAccessOfConcreteNonpublicFields.ts
+++ b/tests/cases/compiler/indexedAccessOfConcreteNonpublicFields.ts
@@ -1,0 +1,7 @@
+// @declaration: true
+export class Foo {
+    private _property: string = '';
+    protected _property2: string = '';
+    constructor(arg: Foo['_property'], other: Foo['_property2']) {
+    }
+}


### PR DESCRIPTION
Historically, we've allowed these accesses because they resolve to a concrete type (even if the inspection of privates was pretty suspect) which is then what usually appears in declaration emit - but we retain type nodes as written quite a lot now, so it's a bit more problematic now, as we easily retain references to private members with elided types. As-is, I apply the check for both private and protected members for concrete types, since that's what we already errored on for generic indexed accesses, but technically protected members don't have quite the same issue since they're never elided, so if we wanted to we could choose to only error on access of private members on concrete types.

Fixes #60230
