### PR TITLE
Fix the issue where modifying `extraFileExtensions` through `ProjectService.setHostConfiguration` in the plugin has no effect.

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2935,8 +2935,10 @@ export class ProjectService {
             this.watchWildcards(configFilename, configFileExistenceInfo, project);
         }
         project.enablePluginsWithOptions(compilerOptions);
-        const filesToAdd = parsedCommandLine.fileNames.concat(project.getExternalFiles(ProgramUpdateLevel.Full));
-        this.updateRootAndOptionsOfNonInferredProject(project, filesToAdd, fileNamePropertyReader, compilerOptions, parsedCommandLine.typeAcquisition!, parsedCommandLine.compileOnSave, parsedCommandLine.watchOptions);
+        if (!project.hasPluginSetExtraFileExtensions) {
+            const filesToAdd = parsedCommandLine.fileNames.concat(project.getExternalFiles(ProgramUpdateLevel.Full));
+            this.updateRootAndOptionsOfNonInferredProject(project, filesToAdd, fileNamePropertyReader, compilerOptions, parsedCommandLine.typeAcquisition!, parsedCommandLine.compileOnSave, parsedCommandLine.watchOptions);
+        }
         tracing?.pop();
     }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -376,6 +376,14 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     protected readonly plugins: PluginModuleWithName[] = [];
 
     /**
+     * Used to determine whether enabled plugins have modified extra file extensions through ProjectService.setHostConfiguration
+     * See: https://github.com/microsoft/TypeScript/issues/61302
+     *
+     * @internal
+     */
+    hasPluginSetExtraFileExtensions = false;
+
+    /**
      * This is map from files to unresolved imports in it
      * Maop does not contain entries for files that do not have unresolved imports
      * This helps in containing the set of files to invalidate
@@ -2144,6 +2152,11 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         try {
             if (typeof pluginModuleFactory !== "function") {
                 this.projectService.logger.info(`Skipped loading plugin ${configEntry.name} because it did not expose a proper factory function`);
+                return;
+            }
+
+            if (this.plugins.some(p => p.name === configEntry.name)) {
+                this.hasPluginSetExtraFileExtensions = true;
                 return;
             }
 


### PR DESCRIPTION
If the plugin is enabled before `this.updateRootAndOptionsOfNonInferredProject` and the project service host configuration is changed through `projectService.setHostConfiguration` in the plugin, enabling the plugin will result in a recursive call to `loadConfiguredProject`, then the outer `loadConfiguredProject` will finally call `this.updateRootAndOptionsOfNonInferredProject` with the parameters that before the plug-in was enabled.

Fixes #61302
