### PR TITLE
Rename type parameters when they are shadowed.

### DIFF
--- a/src/compiler/expressionToTypeNode.ts
+++ b/src/compiler/expressionToTypeNode.ts
@@ -1122,15 +1122,16 @@ export function createSyntacticTypeNodeBuilder(
         );
     }
     function reuseTypeParameters(typeParameters: NodeArray<TypeParameterDeclaration> | undefined, context: SyntacticTypeNodeBuilderContext) {
-        return typeParameters?.map(tp =>
-            factory.updateTypeParameterDeclaration(
+        return typeParameters?.map(tp => {
+            const { node: tpName } = resolver.trackExistingEntityName(context, tp.name);
+            return factory.updateTypeParameterDeclaration(
                 tp,
                 tp.modifiers?.map(m => reuseNode(context, m)),
-                reuseNode(context, tp.name),
+                tpName,
                 serializeExistingTypeNodeWithFallback(tp.constraint, context),
                 serializeExistingTypeNodeWithFallback(tp.default, context),
-            )
-        );
+            );
+        });
     }
 
     function typeFromObjectLiteralMethod(method: MethodDeclaration, name: PropertyName, context: SyntacticTypeNodeBuilderContext, isConstContext: boolean) {

--- a/tests/baselines/reference/declarationEmitShadowing.js
+++ b/tests/baselines/reference/declarationEmitShadowing.js
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/declarationEmitShadowing.ts] ////
+
+//// [declarationEmitShadowing.ts]
+export class A<T = any> {
+  public readonly ShadowedButDoesNotRequireRenaming = <T>(): T => {
+      return null as any
+  }
+}
+
+export function needsRenameForShadowing<T>() {
+  type A = T
+  return function O<T>(t: A, t2: T) {
+  }
+}
+
+
+//// [declarationEmitShadowing.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.A = void 0;
+exports.needsRenameForShadowing = needsRenameForShadowing;
+var A = /** @class */ (function () {
+    function A() {
+        this.ShadowedButDoesNotRequireRenaming = function () {
+            return null;
+        };
+    }
+    return A;
+}());
+exports.A = A;
+function needsRenameForShadowing() {
+    return function O(t, t2) {
+    };
+}
+
+
+//// [declarationEmitShadowing.d.ts]
+export declare class A<T = any> {
+    readonly ShadowedButDoesNotRequireRenaming: <T_1>() => T_1;
+}
+export declare function needsRenameForShadowing<T>(): <T_1>(t: T, t2: T_1) => void;

--- a/tests/baselines/reference/declarationEmitShadowing.symbols
+++ b/tests/baselines/reference/declarationEmitShadowing.symbols
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/declarationEmitShadowing.ts] ////
+
+=== declarationEmitShadowing.ts ===
+export class A<T = any> {
+>A : Symbol(A, Decl(declarationEmitShadowing.ts, 0, 0))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 0, 15))
+
+  public readonly ShadowedButDoesNotRequireRenaming = <T>(): T => {
+>ShadowedButDoesNotRequireRenaming : Symbol(A.ShadowedButDoesNotRequireRenaming, Decl(declarationEmitShadowing.ts, 0, 25))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 1, 55))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 1, 55))
+
+      return null as any
+  }
+}
+
+export function needsRenameForShadowing<T>() {
+>needsRenameForShadowing : Symbol(needsRenameForShadowing, Decl(declarationEmitShadowing.ts, 4, 1))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 6, 40))
+
+  type A = T
+>A : Symbol(A, Decl(declarationEmitShadowing.ts, 6, 46))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 6, 40))
+
+  return function O<T>(t: A, t2: T) {
+>O : Symbol(O, Decl(declarationEmitShadowing.ts, 8, 8))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 8, 20))
+>t : Symbol(t, Decl(declarationEmitShadowing.ts, 8, 23))
+>A : Symbol(A, Decl(declarationEmitShadowing.ts, 6, 46))
+>t2 : Symbol(t2, Decl(declarationEmitShadowing.ts, 8, 28))
+>T : Symbol(T, Decl(declarationEmitShadowing.ts, 8, 20))
+  }
+}
+

--- a/tests/baselines/reference/declarationEmitShadowing.types
+++ b/tests/baselines/reference/declarationEmitShadowing.types
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/declarationEmitShadowing.ts] ////
+
+=== declarationEmitShadowing.ts ===
+export class A<T = any> {
+>A : A<T>
+>  : ^^^^
+
+  public readonly ShadowedButDoesNotRequireRenaming = <T>(): T => {
+>ShadowedButDoesNotRequireRenaming : <T_1>() => T_1
+>                                  : ^^^^^^^^^^^   
+><T>(): T => {      return null as any  } : <T_1>() => T_1
+>                                         : ^^^^^^^^^^^   
+
+      return null as any
+>null as any : any
+  }
+}
+
+export function needsRenameForShadowing<T>() {
+>needsRenameForShadowing : <T>() => <T_1>(t: T, t2: T_1) => void
+>                        : ^ ^^^^^^^^   ^^   ^^^       ^^^^^^^^^
+
+  type A = T
+>A : T
+>  : ^
+
+  return function O<T>(t: A, t2: T) {
+>function O<T>(t: A, t2: T) {  } : <T_1>(t: T, t2: T_1) => void
+>                                : ^^^^^^ ^^^^^  ^^   ^^^^^^^^^
+>O : <T>(t: T_1, t2: T) => void
+>  : ^ ^^ ^^^^^^^  ^^ ^^^^^^^^^
+>t : T_1
+>  : ^^^
+>t2 : T
+>   : ^
+  }
+}
+

--- a/tests/cases/compiler/declarationEmitShadowing.ts
+++ b/tests/cases/compiler/declarationEmitShadowing.ts
@@ -1,0 +1,13 @@
+// @declaration: true
+
+export class A<T = any> {
+  public readonly ShadowedButDoesNotRequireRenaming = <T>(): T => {
+      return null as any
+  }
+}
+
+export function needsRenameForShadowing<T>() {
+  type A = T
+  return function O<T>(t: A, t2: T) {
+  }
+}


### PR DESCRIPTION
Fixes #61334

Temporary fix. This solution will rename the type parameters. While this solution is valid it is a solution that is incompatible with what a different implementation of declaration emit could produce. This solution always renames the type parameters if they are shadowed even if this is not necessary. A correct solution would only rename them if there was an inference fallback that required access to one of the shadowed parameters.

```ts
export class A<T = any> {
  public readonly ShadowedButDoesNotRequireRenaming = <T>(): T => {
      return null as any
  }
}

export function needsRenameForShadowing<T>() {
  type A = T
  return function O<T>(t: A, t2: T) {
  }
}
```

The first example does not require renaming as the outer `T` is not used in the field type. This example could be emitted by an external tool as well. The second example does require renaming , but it can't be emitted by an external tool anyway so it's not a problem if we rename the type parameters. 

I am working on a fix that does this, but it does seem important to have a fix that emits  a valid declaration file.

