### PR TITLE
Properly discriminate by pattern literal types in `isTypeInvalidDueToUnionDiscriminant`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14453,7 +14453,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const nameType = property.name && (isJsxNamespacedName(property.name) ? getStringLiteralType(getTextOfJsxAttributeName(property.name)) : getLiteralTypeFromPropertyName(property.name));
             const name = nameType && isTypeUsableAsPropertyName(nameType) ? getPropertyNameFromType(nameType) : undefined;
             const expected = name === undefined ? undefined : getTypeOfPropertyOfType(contextualType, name);
-            return !!expected && isLiteralType(expected) && !isTypeAssignableTo(getTypeOfNode(property), expected);
+            return !!expected && (isLiteralType(expected) || isPatternLiteralType(expected)) && !isTypeAssignableTo(getTypeOfNode(property), expected);
         });
     }
 

--- a/tests/cases/fourslash/completionsDiscriminatedUnion2.ts
+++ b/tests/cases/fourslash/completionsDiscriminatedUnion2.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+
+//// type A = {
+////   id: `A:${string}`;
+////   a: number;
+//// };
+////
+//// type B = {
+////   id: `B:${string}`;
+////   b: number;
+//// };
+////
+//// function foo<T extends A | B>(item: T): void {}
+////
+//// foo({ id: "B:", /**/ });
+
+verify.completions({ marker: "", exact: ["b"] });


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61347