### PR TITLE
Refactor type resolution logic in getTypeOfSymbol for improved readability and maintainability

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12282,31 +12282,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeOfSymbol(symbol: Symbol): Type {
-        // Retrieve the check flags for the given symbol
         const checkFlags = getCheckFlags(symbol);
 
-        // Define a mapping of flag checks to their respective type resolver functions
-        const typeResolvers: [number, (sym: Symbol) => Type][] = [
-            // Check for deferred type symbols
-            [CheckFlags.DeferredType, getTypeOfSymbolWithDeferredType], // Check for instantiated symbols
-            [CheckFlags.Instantiated, getTypeOfInstantiatedSymbol], // Check for mapped symbols (cast to MappedSymbol)
-            [CheckFlags.Mapped, sym => getTypeOfMappedSymbol(sym as MappedSymbol)], // Check for reverse-mapped symbols (cast to ReverseMappedSymbol)
-            [CheckFlags.ReverseMapped, sym => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol)], // Check for variables and properties
-            [SymbolFlags.Variable | SymbolFlags.Property, getTypeOfVariableOrParameterOrProperty], // Check for functions, methods, classes, enums, and value modules
-            [SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, getTypeOfFuncClassEnumModule], // Check for enum members
-            [SymbolFlags.EnumMember, getTypeOfEnumMember], // Check for accessor symbols
-            [SymbolFlags.Accessor, getTypeOfAccessors], // Check for alias symbols
-            [SymbolFlags.Alias, getTypeOfAlias],
-        ];
+        const checkFlagMap = new Map([
+            [CheckFlags.DeferredType, getTypeOfSymbolWithDeferredType],
+            [CheckFlags.Instantiated, getTypeOfInstantiatedSymbol],
+            [CheckFlags.Mapped, (s: Symbol) => getTypeOfMappedSymbol(s as MappedSymbol)],
+            [CheckFlags.ReverseMapped, (s: Symbol) => getTypeOfReverseMappedSymbol(s as ReverseMappedSymbol)],
+        ]);
 
-        // Iterate through the mapping and return the corresponding type if a flag matches
-        for (const [flag, resolver] of typeResolvers) {
-            if ((checkFlags & flag)) {
-                return resolver(symbol);
-            }
+        for (const [flag, fn] of checkFlagMap) {
+            if (checkFlags & flag) return fn(symbol);
         }
 
-        // Return the error type if no conditions match
+        const symbolFlagMap = new Map([
+            [SymbolFlags.Variable | SymbolFlags.Property, getTypeOfVariableOrParameterOrProperty],
+            [SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, getTypeOfFuncClassEnumModule],
+            [SymbolFlags.EnumMember, getTypeOfEnumMember],
+            [SymbolFlags.Accessor, getTypeOfAccessors],
+            [SymbolFlags.Alias, getTypeOfAlias],
+        ]);
+
+        for (const [flag, fn] of symbolFlagMap) {
+            if (symbol.flags & flag) return fn(symbol);
+        }
+
         return errorType;
     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12282,36 +12282,33 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeOfSymbol(symbol: Symbol): Type {
+        // Retrieve the check flags for the given symbol
         const checkFlags = getCheckFlags(symbol);
-        if (checkFlags & CheckFlags.DeferredType) {
-            return getTypeOfSymbolWithDeferredType(symbol);
+    
+        // Define a mapping of flag checks to their respective type resolver functions
+        const typeResolvers: [number, (sym: Symbol) => Type][] = [
+            // Check for deferred type symbols
+            [CheckFlags.DeferredType, getTypeOfSymbolWithDeferredType], // Check for instantiated symbols
+            [CheckFlags.Instantiated, getTypeOfInstantiatedSymbol], // Check for mapped symbols (cast to MappedSymbol)
+            [CheckFlags.Mapped, (sym) => getTypeOfMappedSymbol(sym as MappedSymbol)], // Check for reverse-mapped symbols (cast to ReverseMappedSymbol)
+            [CheckFlags.ReverseMapped, (sym) => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol)], // Check for variables and properties
+            [SymbolFlags.Variable | SymbolFlags.Property, getTypeOfVariableOrParameterOrProperty], // Check for functions, methods, classes, enums, and value modules
+            [SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, getTypeOfFuncClassEnumModule], // Check for enum members
+            [SymbolFlags.EnumMember, getTypeOfEnumMember], // Check for accessor symbols
+            [SymbolFlags.Accessor, getTypeOfAccessors], // Check for alias symbols
+            [SymbolFlags.Alias, getTypeOfAlias],
+        ];
+    
+        // Iterate through the mapping and return the corresponding type if a flag matches
+        for (const [flag, resolver] of typeResolvers) {
+            if ((checkFlags & flag) || (symbol.flags & flag)) {
+                return resolver(symbol);
+            }
         }
-        if (checkFlags & CheckFlags.Instantiated) {
-            return getTypeOfInstantiatedSymbol(symbol);
-        }
-        if (checkFlags & CheckFlags.Mapped) {
-            return getTypeOfMappedSymbol(symbol as MappedSymbol);
-        }
-        if (checkFlags & CheckFlags.ReverseMapped) {
-            return getTypeOfReverseMappedSymbol(symbol as ReverseMappedSymbol);
-        }
-        if (symbol.flags & (SymbolFlags.Variable | SymbolFlags.Property)) {
-            return getTypeOfVariableOrParameterOrProperty(symbol);
-        }
-        if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule)) {
-            return getTypeOfFuncClassEnumModule(symbol);
-        }
-        if (symbol.flags & SymbolFlags.EnumMember) {
-            return getTypeOfEnumMember(symbol);
-        }
-        if (symbol.flags & SymbolFlags.Accessor) {
-            return getTypeOfAccessors(symbol);
-        }
-        if (symbol.flags & SymbolFlags.Alias) {
-            return getTypeOfAlias(symbol);
-        }
+    
+        // Return the error type if no conditions match
         return errorType;
-    }
+    }    
 
     function getNonMissingTypeOfSymbol(symbol: Symbol) {
         return removeMissingType(getTypeOfSymbol(symbol), !!(symbol.flags & SymbolFlags.Optional));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12284,31 +12284,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeOfSymbol(symbol: Symbol): Type {
         // Retrieve the check flags for the given symbol
         const checkFlags = getCheckFlags(symbol);
-    
+
         // Define a mapping of flag checks to their respective type resolver functions
         const typeResolvers: [number, (sym: Symbol) => Type][] = [
             // Check for deferred type symbols
             [CheckFlags.DeferredType, getTypeOfSymbolWithDeferredType], // Check for instantiated symbols
             [CheckFlags.Instantiated, getTypeOfInstantiatedSymbol], // Check for mapped symbols (cast to MappedSymbol)
-            [CheckFlags.Mapped, (sym) => getTypeOfMappedSymbol(sym as MappedSymbol)], // Check for reverse-mapped symbols (cast to ReverseMappedSymbol)
-            [CheckFlags.ReverseMapped, (sym) => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol)], // Check for variables and properties
+            [CheckFlags.Mapped, sym => getTypeOfMappedSymbol(sym as MappedSymbol)], // Check for reverse-mapped symbols (cast to ReverseMappedSymbol)
+            [CheckFlags.ReverseMapped, sym => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol)], // Check for variables and properties
             [SymbolFlags.Variable | SymbolFlags.Property, getTypeOfVariableOrParameterOrProperty], // Check for functions, methods, classes, enums, and value modules
             [SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, getTypeOfFuncClassEnumModule], // Check for enum members
             [SymbolFlags.EnumMember, getTypeOfEnumMember], // Check for accessor symbols
             [SymbolFlags.Accessor, getTypeOfAccessors], // Check for alias symbols
             [SymbolFlags.Alias, getTypeOfAlias],
         ];
-    
+
         // Iterate through the mapping and return the corresponding type if a flag matches
         for (const [flag, resolver] of typeResolvers) {
             if ((checkFlags & flag) || (symbol.flags & flag)) {
                 return resolver(symbol);
             }
         }
-    
+
         // Return the error type if no conditions match
         return errorType;
-    }    
+    }
 
     function getNonMissingTypeOfSymbol(symbol: Symbol) {
         return removeMissingType(getTypeOfSymbol(symbol), !!(symbol.flags & SymbolFlags.Optional));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12282,32 +12282,23 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeOfSymbol(symbol: Symbol): Type {
-        // Retrieve the check flags for the given symbol
         const checkFlags = getCheckFlags(symbol);
 
-        // Define a mapping of flag checks to their respective type resolver functions
-        const typeResolvers: [number, (sym: Symbol) => Type][] = [
-            // Check for deferred type symbols
-            [CheckFlags.DeferredType, getTypeOfSymbolWithDeferredType], // Check for instantiated symbols
-            [CheckFlags.Instantiated, getTypeOfInstantiatedSymbol], // Check for mapped symbols (cast to MappedSymbol)
-            [CheckFlags.Mapped, sym => getTypeOfMappedSymbol(sym as MappedSymbol)], // Check for reverse-mapped symbols (cast to ReverseMappedSymbol)
-            [CheckFlags.ReverseMapped, sym => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol)], // Check for variables and properties
-            [SymbolFlags.Variable | SymbolFlags.Property, getTypeOfVariableOrParameterOrProperty], // Check for functions, methods, classes, enums, and value modules
-            [SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, getTypeOfFuncClassEnumModule], // Check for enum members
-            [SymbolFlags.EnumMember, getTypeOfEnumMember], // Check for accessor symbols
-            [SymbolFlags.Accessor, getTypeOfAccessors], // Check for alias symbols
-            [SymbolFlags.Alias, getTypeOfAlias],
+        const typeResolvers: { flag: number; resolver: (sym: Symbol) => Type; }[] = [
+            { flag: CheckFlags.DeferredType, resolver: getTypeOfSymbolWithDeferredType },
+            { flag: CheckFlags.Instantiated, resolver: getTypeOfInstantiatedSymbol },
+            { flag: CheckFlags.Mapped, resolver: sym => getTypeOfMappedSymbol(sym as MappedSymbol) },
+            { flag: CheckFlags.ReverseMapped, resolver: sym => getTypeOfReverseMappedSymbol(sym as ReverseMappedSymbol) },
+            { flag: SymbolFlags.Variable | SymbolFlags.Property, resolver: getTypeOfVariableOrParameterOrProperty },
+            { flag: SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule, resolver: getTypeOfFuncClassEnumModule },
+            { flag: SymbolFlags.EnumMember, resolver: getTypeOfEnumMember },
+            { flag: SymbolFlags.Accessor, resolver: getTypeOfAccessors },
+            { flag: SymbolFlags.Alias, resolver: getTypeOfAlias },
         ];
 
-        // Iterate through the mapping and return the corresponding type if a flag matches
-        for (const [flag, resolver] of typeResolvers) {
-            if ((checkFlags & flag) || (symbol.flags & flag)) {
-                return resolver(symbol);
-            }
-        }
+        const matchedResolver = typeResolvers.find(({ flag }) => (checkFlags & flag) !== 0 || (symbol.flags & flag) !== 0);
 
-        // Return the error type if no conditions match
-        return errorType;
+        return matchedResolver ? matchedResolver.resolver(symbol) : errorType;
     }
 
     function getNonMissingTypeOfSymbol(symbol: Symbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12296,7 +12296,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             { flag: SymbolFlags.Alias, resolver: getTypeOfAlias },
         ];
 
-        const matchedResolver = typeResolvers.find(({ flag }) => (checkFlags & flag) !== 0 || (symbol.flags & flag) !== 0);
+        const matchedResolver = typeResolvers.find(({ flag }) => (checkFlags & flag) !== 0);
 
         return matchedResolver ? matchedResolver.resolver(symbol) : errorType;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61401 
### 🔹 Improvements:
Better Readability: Uses Map instead of a long chain of ternary operators.
More Maintainable: Easily extendable if new checks need to be added.
Efficient: Iterates over a small set of conditions rather than multiple if statements.
