### PR TITLE
Add types for `String.{matchAll,replaceAll}` with a well known symbol

### DIFF
--- a/src/lib/es2020.symbol.wellknown.d.ts
+++ b/src/lib/es2020.symbol.wellknown.d.ts
@@ -21,3 +21,12 @@ interface RegExp {
      */
     [Symbol.matchAll](str: string): RegExpStringIterator<RegExpMatchArray>;
 }
+
+interface String {
+    /**
+     * Matches a string or an object that supports being matched against, and
+     * returns an iterable of matches containing the results of that search.
+     * @param regexp An object that supports being matched against.
+     */
+    matchAll(matcher: { [Symbol.matchAll](str: string): RegExpStringIterator<RegExpMatchArray> }): RegExpStringIterator<RegExpExecArray>;
+}

--- a/src/lib/es2021.d.ts
+++ b/src/lib/es2021.d.ts
@@ -1,5 +1,6 @@
 /// <reference lib="es2020" />
 /// <reference lib="es2021.promise" />
 /// <reference lib="es2021.string" />
+/// <reference lib="es2021.symbol.wellknown" />
 /// <reference lib="es2021.weakref" />
 /// <reference lib="es2021.intl" />

--- a/src/lib/es2021.string.d.ts
+++ b/src/lib/es2021.string.d.ts
@@ -1,14 +1,16 @@
+/// <reference lib="es2021.symbol.wellknown" />
+
 interface String {
     /**
      * Replace all instances of a substring in a string, using a regular expression or search string.
-     * @param searchValue A string to search for.
+     * @param searchValue An object that supports searching for and replacing matches within a string.
      * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
      */
     replaceAll(searchValue: string | RegExp, replaceValue: string): string;
 
     /**
      * Replace all instances of a substring in a string, using a regular expression or search string.
-     * @param searchValue A string to search for.
+     * @param searchValue An object that supports searching for and replacing matches within a string.
      * @param replacer A function that returns the replacement text.
      */
     replaceAll(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;

--- a/src/lib/es2021.symbol.wellknown.d.ts
+++ b/src/lib/es2021.symbol.wellknown.d.ts
@@ -1,0 +1,17 @@
+/// <reference lib="es2015.symbol.wellknown" />
+
+interface String {
+    /**
+     * Replace all instances of a substring in a string, using an object that supports replacement within a string.
+     * @param searchValue A string to search for.
+     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
+     */
+    replaceAll(searchValue: { [Symbol.replace](string: string, replaceValue: string): string; }, replaceValue: string): string;
+
+    /**
+     * Replace all instances of a substring in a string, using an object that supports replacement within a string.
+     * @param searchValue A string to search for.
+     * @param replacer A function that returns the replacement text.
+     */
+    replaceAll(searchValue: { [Symbol.replace](string: string, replacer: (substring: string, ...args: any[]) => string): string; }, replacer: (substring: string, ...args: any[]) => string): string;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61448
