### PR TITLE
Fix errors on type assertions in erasableSyntaxOnly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37316,8 +37316,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 grammarErrorOnNode(node, Diagnostics.This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Use_an_as_expression_instead);
             }
             if (compilerOptions.erasableSyntaxOnly) {
-                const start = node.type.pos - "<".length;
-                const end = skipTrivia(file.text, node.type.end) + ">".length;
+                const start = skipTrivia(file.text, node.pos);
+                const end = node.expression.pos;
                 diagnostics.add(createFileDiagnostic(file, start, end - start, Diagnostics.This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled));
             }
         }

--- a/tests/baselines/reference/erasableSyntaxOnly2.errors.txt
+++ b/tests/baselines/reference/erasableSyntaxOnly2.errors.txt
@@ -1,0 +1,24 @@
+index.ts(1,10): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(1,19): error TS1005: '>' expected.
+index.ts(2,9): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(2,18): error TS1005: '>' expected.
+index.ts(3,9): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+index.ts(3,17): error TS1005: '>' expected.
+
+
+==== index.ts (6 errors) ====
+    let a = (<unknown function foo() {});
+             ~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+                      ~~~~~~~~
+!!! error TS1005: '>' expected.
+    let b = <unknown 123;
+            ~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+                     ~~~
+!!! error TS1005: '>' expected.
+    let c = <unknown
+            ~~~~~~~~
+!!! error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+                    
+!!! error TS1005: '>' expected.

--- a/tests/baselines/reference/erasableSyntaxOnly2.js
+++ b/tests/baselines/reference/erasableSyntaxOnly2.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/erasableSyntaxOnly2.ts] ////
+
+//// [index.ts]
+let a = (<unknown function foo() {});
+let b = <unknown 123;
+let c = <unknown
+
+//// [index.js]
+var a = function foo() { };
+var b = 123;
+var c = ;

--- a/tests/baselines/reference/erasableSyntaxOnly2.symbols
+++ b/tests/baselines/reference/erasableSyntaxOnly2.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/erasableSyntaxOnly2.ts] ////
+
+=== index.ts ===
+let a = (<unknown function foo() {});
+>a : Symbol(a, Decl(index.ts, 0, 3))
+>foo : Symbol(foo, Decl(index.ts, 0, 17))
+
+let b = <unknown 123;
+>b : Symbol(b, Decl(index.ts, 1, 3))
+
+let c = <unknown
+>c : Symbol(c, Decl(index.ts, 2, 3))
+

--- a/tests/baselines/reference/erasableSyntaxOnly2.types
+++ b/tests/baselines/reference/erasableSyntaxOnly2.types
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/erasableSyntaxOnly2.ts] ////
+
+=== index.ts ===
+let a = (<unknown function foo() {});
+>a : unknown
+>  : ^^^^^^^
+>(<unknown function foo() {}) : unknown
+>                             : ^^^^^^^
+><unknown function foo() {} : unknown
+>                           : ^^^^^^^
+>function foo() {} : () => void
+>                  : ^^^^^^^^^^
+>foo : () => void
+>    : ^^^^^^^^^^
+
+let b = <unknown 123;
+>b : unknown
+>  : ^^^^^^^
+><unknown 123 : unknown
+>             : ^^^^^^^
+>123 : 123
+>    : ^^^
+
+let c = <unknown
+>c : unknown
+>  : ^^^^^^^
+><unknown : unknown
+>         : ^^^^^^^
+> : any
+> : ^^^
+

--- a/tests/cases/compiler/erasableSyntaxOnly2.ts
+++ b/tests/cases/compiler/erasableSyntaxOnly2.ts
@@ -1,0 +1,6 @@
+// @erasableSyntaxOnly: true
+
+// @filename: index.ts
+let a = (<unknown function foo() {});
+let b = <unknown 123;
+let c = <unknown


### PR DESCRIPTION
Brings in fixes/simplifications mentioned in https://github.com/microsoft/TypeScript/pull/61244#discussion_r2004348678 and https://github.com/microsoft/TypeScript/pull/61320#discussion_r2004343942.