### PR TITLE
Fix `lib.includes('dom')` check in `containerSeemsToBeEmptyDomElement`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34454,7 +34454,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function containerSeemsToBeEmptyDomElement(containingType: Type) {
-        return (compilerOptions.lib && !compilerOptions.lib.includes("dom")) &&
+        return (compilerOptions.lib && !compilerOptions.lib.includes("lib.dom.d.ts")) &&
             everyContainedType(containingType, type => type.symbol && /^(?:EventTarget|Node|(?:HTML[a-zA-Z]*)?Element)$/.test(unescapeLeadingUnderscores(type.symbol.escapedName))) &&
             isEmptyObjectType(containingType);
     }

--- a/tests/baselines/reference/missingDomElement_UsingDomLib.errors.txt
+++ b/tests/baselines/reference/missingDomElement_UsingDomLib.errors.txt
@@ -1,0 +1,10 @@
+missingDomElement_UsingDomLib.ts(3,37): error TS2339: Property 'textContent' does not exist on type 'HTMLMissingElement'.
+
+
+==== missingDomElement_UsingDomLib.ts (1 errors) ====
+    interface HTMLMissingElement {}
+    
+    (({}) as any as HTMLMissingElement).textContent;
+                                        ~~~~~~~~~~~
+!!! error TS2339: Property 'textContent' does not exist on type 'HTMLMissingElement'.
+    

--- a/tests/baselines/reference/missingDomElement_UsingDomLib.js
+++ b/tests/baselines/reference/missingDomElement_UsingDomLib.js
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/missingDomElement_UsingDomLib.ts] ////
+
+//// [missingDomElement_UsingDomLib.ts]
+interface HTMLMissingElement {}
+
+(({}) as any as HTMLMissingElement).textContent;
+
+
+//// [missingDomElement_UsingDomLib.js]
+({}).textContent;

--- a/tests/baselines/reference/missingDomElement_UsingDomLib.symbols
+++ b/tests/baselines/reference/missingDomElement_UsingDomLib.symbols
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/missingDomElement_UsingDomLib.ts] ////
+
+=== missingDomElement_UsingDomLib.ts ===
+interface HTMLMissingElement {}
+>HTMLMissingElement : Symbol(HTMLMissingElement, Decl(missingDomElement_UsingDomLib.ts, 0, 0))
+
+(({}) as any as HTMLMissingElement).textContent;
+>HTMLMissingElement : Symbol(HTMLMissingElement, Decl(missingDomElement_UsingDomLib.ts, 0, 0))
+

--- a/tests/baselines/reference/missingDomElement_UsingDomLib.types
+++ b/tests/baselines/reference/missingDomElement_UsingDomLib.types
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/missingDomElement_UsingDomLib.ts] ////
+
+=== missingDomElement_UsingDomLib.ts ===
+interface HTMLMissingElement {}
+
+(({}) as any as HTMLMissingElement).textContent;
+>(({}) as any as HTMLMissingElement).textContent : any
+>                                                : ^^^
+>(({}) as any as HTMLMissingElement) : HTMLMissingElement
+>                                    : ^^^^^^^^^^^^^^^^^^
+>({}) as any as HTMLMissingElement : HTMLMissingElement
+>                                  : ^^^^^^^^^^^^^^^^^^
+>({}) as any : any
+>            : ^^^
+>({}) : {}
+>     : ^^
+>{} : {}
+>   : ^^
+>textContent : any
+>            : ^^^
+

--- a/tests/cases/compiler/missingDomElement_UsingDomLib.ts
+++ b/tests/cases/compiler/missingDomElement_UsingDomLib.ts
@@ -1,0 +1,5 @@
+// @lib: es5,dom
+
+interface HTMLMissingElement {}
+
+(({}) as any as HTMLMissingElement).textContent;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally `// i did "do-runtests-parallel", hope that's alright`
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61466, just barely passing `provide commensurate value.` (:
There are no other lib.includes(...)-like checks I could find that would be similarly bugged
