### PR TITLE
Support trailing commas in `typeof import()`

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4551,7 +4551,7 @@ namespace Parser {
         parseExpected(SyntaxKind.OpenParenToken);
         const type = parseType();
         let attributes: ImportAttributes | undefined;
-        if (parseOptional(SyntaxKind.CommaToken)) {
+        if (parseOptional(SyntaxKind.CommaToken) && token() !== SyntaxKind.CloseParenToken) {
             const openBracePosition = scanner.getTokenStart();
             parseExpected(SyntaxKind.OpenBraceToken);
             const currentToken = token();
@@ -4572,6 +4572,7 @@ namespace Parser {
                     );
                 }
             }
+            parseOptional(SyntaxKind.CommaToken);
         }
         parseExpected(SyntaxKind.CloseParenToken);
         const qualifier = parseOptional(SyntaxKind.DotToken) ? parseEntityNameOfTypeReference() : undefined;

--- a/tests/baselines/reference/typeofImportInvalidElision.errors.txt
+++ b/tests/baselines/reference/typeofImportInvalidElision.errors.txt
@@ -1,0 +1,12 @@
+main.ts(1,39): error TS1005: '{' expected.
+
+
+==== input.ts (0 errors) ====
+    export type X = 1;
+    
+==== main.ts (1 errors) ====
+    type T2 = typeof import('./input.js', ,);
+                                          ~
+!!! error TS1005: '{' expected.
+!!! related TS1007 main.ts:1:39: The parser expected to find a '}' to match the '{' token here.
+    

--- a/tests/baselines/reference/typeofImportInvalidElision.js
+++ b/tests/baselines/reference/typeofImportInvalidElision.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/typeofImportInvalidElision.ts] ////
+
+//// [input.ts]
+export type X = 1;
+
+//// [main.ts]
+type T2 = typeof import('./input.js', ,);
+
+
+//// [input.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//// [main.js]

--- a/tests/baselines/reference/typeofImportInvalidElision.symbols
+++ b/tests/baselines/reference/typeofImportInvalidElision.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/typeofImportInvalidElision.ts] ////
+
+=== input.ts ===
+export type X = 1;
+>X : Symbol(X, Decl(input.ts, 0, 0))
+
+=== main.ts ===
+type T2 = typeof import('./input.js', ,);
+>T2 : Symbol(T2, Decl(main.ts, 0, 0))
+

--- a/tests/baselines/reference/typeofImportInvalidElision.types
+++ b/tests/baselines/reference/typeofImportInvalidElision.types
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/typeofImportInvalidElision.ts] ////
+
+=== input.ts ===
+export type X = 1;
+>X : 1
+>  : ^
+
+=== main.ts ===
+type T2 = typeof import('./input.js', ,);
+>T2 : typeof import("input")
+>   : ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/baselines/reference/typeofImportTrailingCommas.js
+++ b/tests/baselines/reference/typeofImportTrailingCommas.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/typeofImportTrailingCommas.ts] ////
+
+//// [input.ts]
+export type X = 1;
+
+//// [main.ts]
+type T1 = typeof import('./input.js',)
+type T2 = typeof import('./input.js', { with: { "resolution-mode": "import" } },);
+
+
+//// [input.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//// [main.js]

--- a/tests/baselines/reference/typeofImportTrailingCommas.symbols
+++ b/tests/baselines/reference/typeofImportTrailingCommas.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/typeofImportTrailingCommas.ts] ////
+
+=== input.ts ===
+export type X = 1;
+>X : Symbol(X, Decl(input.ts, 0, 0))
+
+=== main.ts ===
+type T1 = typeof import('./input.js',)
+>T1 : Symbol(T1, Decl(main.ts, 0, 0))
+
+type T2 = typeof import('./input.js', { with: { "resolution-mode": "import" } },);
+>T2 : Symbol(T2, Decl(main.ts, 0, 38))
+

--- a/tests/baselines/reference/typeofImportTrailingCommas.types
+++ b/tests/baselines/reference/typeofImportTrailingCommas.types
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/typeofImportTrailingCommas.ts] ////
+
+=== input.ts ===
+export type X = 1;
+>X : 1
+>  : ^
+
+=== main.ts ===
+type T1 = typeof import('./input.js',)
+>T1 : typeof import("input")
+>   : ^^^^^^^^^^^^^^^^^^^^^^
+
+type T2 = typeof import('./input.js', { with: { "resolution-mode": "import" } },);
+>T2 : typeof import("input")
+>   : ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/cases/compiler/typeofImportInvalidElision.ts
+++ b/tests/cases/compiler/typeofImportInvalidElision.ts
@@ -1,0 +1,5 @@
+// @filename: input.ts
+export type X = 1;
+
+// @filename: main.ts
+type T2 = typeof import('./input.js', ,);

--- a/tests/cases/compiler/typeofImportTrailingCommas.ts
+++ b/tests/cases/compiler/typeofImportTrailingCommas.ts
@@ -1,0 +1,6 @@
+// @filename: input.ts
+export type X = 1;
+
+// @filename: main.ts
+type T1 = typeof import('./input.js',)
+type T2 = typeof import('./input.js', { with: { "resolution-mode": "import" } },);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61489.

The import attributes proposal added support for trailing commas in dynamic import calls. This PR's aligns TypeScript's type-level `import()` with JavaScript's value-level `import()`.
