### PR TITLE
Fix incorrect name in new release pipeline

### DIFF
--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -23,7 +23,7 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
       name: TypeScript-AzurePipelines-EO


### PR DESCRIPTION
I should have copied it from the other yaml, instead of trusting that the conversion script did the right thing...