### PR TITLE
Convert release publishing inputs into parameters

### DIFF
--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -72,60 +72,52 @@ extends:
                     pushd $(Pipeline.Workspace)/tgz
                     ls -lhR
                     mv typescript-*.tgz typescript.tgz
-              - task: CmdLine@2
-                displayName: Rename versioned drop to typescript.tgz
+              - task: Npm@1
+                displayName: npm publish tarball
                 inputs:
-                  script: |
-                    echo ${_REMINDER}
-                    echo ${PUBLISH_TAG}
-                    echo ${RELEASE_TITLE_NAME}
-                    echo ${TAG_NAME}
-              # - task: Npm@1
-              #   displayName: npm publish tarball
-              #   inputs:
-              #     command: custom
-              #     workingDir: $(Pipeline.Workspace)/tgz
-              #     verbose: false
-              #     customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
-              #     # This must match the service connection.
-              #     customEndpoint: Typescript NPM
-              #     publishEndpoint: Typescript NPM
+                  command: custom
+                  workingDir: $(Pipeline.Workspace)/tgz
+                  verbose: false
+                  customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
+                  # This must match the service connection.
+                  customEndpoint: Typescript NPM
+                  publishEndpoint: Typescript NPM
 
-      # - stage: Stage_2
-      #   displayName: Publish git tag
-      #   dependsOn: Stage_1
-      #   jobs:
-      #     - job: Job_1
-      #       displayName: Agent job
-      #       condition: succeeded()
-      #       timeoutInMinutes: 0
-      #       templateContext:
-      #         type: releaseJob
-      #         isProduction: true
-      #         inputs:
-      #           - input: pipelineArtifact
-      #             pipeline: 'tgz'
-      #             artifactName: 'tgz'
-      #             targetPath: '$(Pipeline.Workspace)/tgz'
-      #       steps:
-      #         - checkout: none
-      #         - task: GitHubRelease@1
-      #           displayName: GitHub release (create)
-      #           inputs:
-      #             # This must match the service connection.
-      #             gitHubConnection: typescript-bot connection
-      #             repositoryName: microsoft/TypeScript
-      #             tagSource: userSpecifiedTag
-      #             tag: $(TAG_NAME)
-      #             title: TypeScript $(RELEASE_TITLE_NAME)
-      #             releaseNotesSource: inline
-      #             releaseNotesInline: |
-      #               For release notes, check out the [release announcement]().
-      #               For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
-      #               For the complete list of fixed issues, check out the
-      #               * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
-      #               Downloads are available on:
-      #               * [npm](https://www.npmjs.com/package/typescript)
-      #             assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
-      #             isDraft: true
-      #             addChangeLog: false
+      - stage: Stage_2
+        displayName: Publish git tag
+        dependsOn: Stage_1
+        jobs:
+          - job: Job_1
+            displayName: Agent job
+            condition: succeeded()
+            timeoutInMinutes: 0
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  pipeline: 'tgz'
+                  artifactName: 'tgz'
+                  targetPath: '$(Pipeline.Workspace)/tgz'
+            steps:
+              - checkout: none
+              - task: GitHubRelease@1
+                displayName: GitHub release (create)
+                inputs:
+                  # This must match the service connection.
+                  gitHubConnection: typescript-bot connection
+                  repositoryName: microsoft/TypeScript
+                  tagSource: userSpecifiedTag
+                  tag: $(TAG_NAME)
+                  title: TypeScript $(RELEASE_TITLE_NAME)
+                  releaseNotesSource: inline
+                  releaseNotesInline: |
+                    For release notes, check out the [release announcement]().
+                    For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
+                    For the complete list of fixed issues, check out the
+                    * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
+                    Downloads are available on:
+                    * [npm](https://www.npmjs.com/package/typescript)
+                  assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
+                  isDraft: true
+                  addChangeLog: false

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -64,6 +64,7 @@ extends:
                   artifactName: 'tgz'
                   targetPath: '$(Pipeline.Workspace)/tgz'
             steps:
+              - checkout: none
               - task: CmdLine@2
                 displayName: Rename versioned drop to typescript.tgz
                 inputs:
@@ -107,6 +108,7 @@ extends:
       #             artifactName: 'tgz'
       #             targetPath: '$(Pipeline.Workspace)/tgz'
       #       steps:
+      #         - checkout: none
       #         - task: GitHubRelease@1
       #           displayName: GitHub release (create)
       #           inputs:

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -71,51 +71,59 @@ extends:
                     pushd $(Pipeline.Workspace)/tgz
                     ls -lhR
                     mv typescript-*.tgz typescript.tgz
-              - task: Npm@1
-                displayName: npm publish tarball
+              - task: CmdLine@2
+                displayName: Rename versioned drop to typescript.tgz
                 inputs:
-                  command: custom
-                  workingDir: $(Pipeline.Workspace)/tgz
-                  verbose: false
-                  customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
-                  # This must match the service connection.
-                  customEndpoint: Typescript NPM
-                  publishEndpoint: Typescript NPM
+                  script: |
+                    echo ${_REMINDER}
+                    echo ${PUBLISH_TAG}
+                    echo ${RELEASE_TITLE_NAME}
+                    echo ${TAG_NAME}
+              # - task: Npm@1
+              #   displayName: npm publish tarball
+              #   inputs:
+              #     command: custom
+              #     workingDir: $(Pipeline.Workspace)/tgz
+              #     verbose: false
+              #     customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
+              #     # This must match the service connection.
+              #     customEndpoint: Typescript NPM
+              #     publishEndpoint: Typescript NPM
 
-      - stage: Stage_2
-        displayName: Publish git tag
-        dependsOn: Stage_1
-        jobs:
-          - job: Job_1
-            displayName: Agent job
-            condition: succeeded()
-            timeoutInMinutes: 0
-            templateContext:
-              type: releaseJob
-              isProduction: true
-              inputs:
-                - input: pipelineArtifact
-                  pipeline: 'tgz'
-                  artifactName: 'tgz'
-                  targetPath: '$(Pipeline.Workspace)/tgz'
-            steps:
-              - task: GitHubRelease@1
-                displayName: GitHub release (create)
-                inputs:
-                  # This must match the service connection.
-                  gitHubConnection: typescript-bot connection
-                  repositoryName: microsoft/TypeScript
-                  tagSource: userSpecifiedTag
-                  tag: $(TAG_NAME)
-                  title: TypeScript $(RELEASE_TITLE_NAME)
-                  releaseNotesSource: inline
-                  releaseNotesInline: |
-                    For release notes, check out the [release announcement]().
-                    For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
-                    For the complete list of fixed issues, check out the
-                    * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
-                    Downloads are available on:
-                    * [npm](https://www.npmjs.com/package/typescript)
-                  assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
-                  isDraft: true
-                  addChangeLog: false
+      # - stage: Stage_2
+      #   displayName: Publish git tag
+      #   dependsOn: Stage_1
+      #   jobs:
+      #     - job: Job_1
+      #       displayName: Agent job
+      #       condition: succeeded()
+      #       timeoutInMinutes: 0
+      #       templateContext:
+      #         type: releaseJob
+      #         isProduction: true
+      #         inputs:
+      #           - input: pipelineArtifact
+      #             pipeline: 'tgz'
+      #             artifactName: 'tgz'
+      #             targetPath: '$(Pipeline.Workspace)/tgz'
+      #       steps:
+      #         - task: GitHubRelease@1
+      #           displayName: GitHub release (create)
+      #           inputs:
+      #             # This must match the service connection.
+      #             gitHubConnection: typescript-bot connection
+      #             repositoryName: microsoft/TypeScript
+      #             tagSource: userSpecifiedTag
+      #             tag: $(TAG_NAME)
+      #             title: TypeScript $(RELEASE_TITLE_NAME)
+      #             releaseNotesSource: inline
+      #             releaseNotesInline: |
+      #               For release notes, check out the [release announcement]().
+      #               For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
+      #               For the complete list of fixed issues, check out the
+      #               * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
+      #               Downloads are available on:
+      #               * [npm](https://www.npmjs.com/package/typescript)
+      #             assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
+      #             isDraft: true
+      #             addChangeLog: false

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -1,15 +1,25 @@
 trigger: none
 pr: none
 
+parameters:
+  - name: _REMINDER
+    default: Review & undraft the release at https://github.com/microsoft/TypeScript/releases once it appears!
+  - name: PUBLISH_TAG
+    default: dev
+  - name: RELEASE_TITLE_NAME
+    default: 0.0.0 Test
+  - name: TAG_NAME
+    default: v0.0.0-SetMe
+
 variables:
   - name: _REMINDER
-    value: Review & undraft the release at https://github.com/microsoft/TypeScript/releases once it appears!
+    value: ${{ parameters._REMINDER }}
   - name: PUBLISH_TAG
-    value: dev
+    value: ${{ parameters.PUBLISH_TAG }}
   - name: RELEASE_TITLE_NAME
-    value: 0.0.0 Test
+    value: ${{ parameters.RELEASE_TITLE_NAME }}
   - name: TAG_NAME
-    value: v0.0.0-SetMe
+    value: ${{ parameters.TAG_NAME }}
 
 resources:
   pipelines:

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -78,6 +78,7 @@ extends:
                   workingDir: $(Pipeline.Workspace)/tgz
                   verbose: false
                   customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
+                  # This must match the service connection.
                   customEndpoint: Typescript NPM
                   publishEndpoint: Typescript NPM
 
@@ -101,6 +102,7 @@ extends:
               - task: GitHubRelease@1
                 displayName: GitHub release (create)
                 inputs:
+                  # This must match the service connection.
                   gitHubConnection: typescript-bot connection
                   repositoryName: microsoft/TypeScript
                   tagSource: userSpecifiedTag
@@ -111,7 +113,7 @@ extends:
                     For release notes, check out the [release announcement]().
                     For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
                     For the complete list of fixed issues, check out the
-                    * [fixed issues query for Typescript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
+                    * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
                     Downloads are available on:
                     * [npm](https://www.npmjs.com/package/typescript)
                   assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz


### PR DESCRIPTION
This seems to show up in the UI correctly. I'm hoping this is legal for the pipeline past that.