### PR TITLE
Improve release publisher pipeline

### DIFF
--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -22,8 +22,6 @@ parameters:
     default: v0.0.0-SetMe
 
 variables:
-  - name: _REMINDER
-    value: ${{ parameters._REMINDER }}
   - name: PUBLISH_TAG
     value: ${{ parameters.PUBLISH_TAG }}
   - name: RELEASE_TITLE_NAME

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -128,5 +128,5 @@ extends:
                     * [npm](https://www.npmjs.com/package/typescript)
                     -->
                   assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
-                  isDraft: $[ not(eq(variables['PUBLISH_TAG'], 'latest')) ]
+                  isDraft: ${{ eq(parameters.PUBLISH_TAG, 'latest') }}
                   addChangeLog: false

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -3,12 +3,22 @@ pr: none
 
 parameters:
   - name: _REMINDER
-    default: Review & undraft the release at https://github.com/microsoft/TypeScript/releases once it appears!
+    displayName: Review & undraft the release at https://github.com/microsoft/TypeScript/releases once it appears!
+    type: boolean
+    default: false
   - name: PUBLISH_TAG
+    displayName: npm publish tag
     default: dev
+    values:
+      - dev
+      - beta
+      - rc
+      - latest
   - name: RELEASE_TITLE_NAME
+    displayName: GitHub release title name
     default: 0.0.0 Test
   - name: TAG_NAME
+    displayName: Git tag name
     default: v0.0.0-SetMe
 
 variables:

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -109,12 +109,14 @@ extends:
                   title: TypeScript $(RELEASE_TITLE_NAME)
                   releaseNotesSource: inline
                   releaseNotesInline: |
+                    <!--
                     For release notes, check out the [release announcement]().
                     For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
                     For the complete list of fixed issues, check out the
                     * [fixed issues query for TypeScript $(TAG_NAME)](https://github.com/microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%22TypeScript+3.3%22+is%3Aclosed+).
                     Downloads are available on:
                     * [npm](https://www.npmjs.com/package/typescript)
+                    -->
                   assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
-                  isDraft: true
+                  isDraft: $[ not(eq(variables['PUBLISH_TAG'], 'latest')) ]
                   addChangeLog: false

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -119,7 +119,7 @@ extends:
                   title: TypeScript $(RELEASE_TITLE_NAME)
                   releaseNotesSource: inline
                   releaseNotesInline: |
-                    <!--
+                    <!---
                     For release notes, check out the [release announcement]().
                     For new features, check out the [What's new in TypeScript $(TAG_NAME)]().
                     For the complete list of fixed issues, check out the

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -48,7 +48,7 @@ extends:
 
     stages:
       - stage: Publish
-        displayName: Publish tarball
+        displayName: Publish
         jobs:
           - job: tarball
             displayName: Publish tarball

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -76,12 +76,12 @@ extends:
             steps:
               - checkout: none
               - task: CmdLine@2
-                displayName: Rename versioned drop to typescript.tgz
+                displayName: Copy versioned drop to typescript.tgz
                 inputs:
                   script: |
                     pushd $(Pipeline.Workspace)/tgz
                     ls -lhR
-                    mv typescript-*.tgz typescript.tgz
+                    cp typescript-*.tgz typescript.tgz
               - task: Npm@1
                 displayName: npm publish tarball
                 inputs:
@@ -89,7 +89,7 @@ extends:
                   workingDir: $(Pipeline.Workspace)/tgz
                   verbose: false
                   customCommand: publish $(Pipeline.Workspace)/tgz/typescript.tgz --tag $(PUBLISH_TAG)
-                  # This must match the service connection.
+                  # This must match the service connection name.
                   customEndpoint: Typescript NPM
                   publishEndpoint: Typescript NPM
 
@@ -111,7 +111,7 @@ extends:
               - task: GitHubRelease@1
                 displayName: GitHub release (create)
                 inputs:
-                  # This must match the service connection.
+                  # This must match the service connection name.
                   gitHubConnection: typescript-bot connection
                   repositoryName: microsoft/TypeScript
                   tagSource: userSpecifiedTag

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -126,5 +126,5 @@ extends:
                     * [npm](https://www.npmjs.com/package/typescript)
                     -->
                   assets: $(Pipeline.Workspace)/tgz/**/typescript-*.tgz
-                  isDraft: ${{ eq(parameters.PUBLISH_TAG, 'latest') }}
+                  isDraft: ${{ not(eq(parameters.PUBLISH_TAG, 'latest')) }}
                   addChangeLog: false

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -5,7 +5,7 @@ parameters:
   - name: _REMINDER
     displayName: Review & undraft the release at https://github.com/microsoft/TypeScript/releases once it appears!
     type: boolean
-    default: false
+    default: true
   - name: PUBLISH_TAG
     displayName: npm publish tag
     default: dev

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -50,7 +50,7 @@ extends:
       - stage: Publish
         displayName: Publish tarball
         jobs:
-          - job: npm
+          - job: tarball
             displayName: Publish tarball
             condition: succeeded()
             timeoutInMinutes: 0
@@ -84,7 +84,8 @@ extends:
                   publishEndpoint: Typescript NPM
 
           - job: github
-            displayName: Publish git tag
+            displayName: Create github release
+            dependsOn: tarball
             condition: succeeded()
             timeoutInMinutes: 0
             templateContext:

--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -47,11 +47,11 @@ extends:
         os: windows
 
     stages:
-      - stage: Stage_1
+      - stage: Publish
         displayName: Publish tarball
         jobs:
-          - job: Job_1
-            displayName: Agent job
+          - job: npm
+            displayName: Publish tarball
             condition: succeeded()
             timeoutInMinutes: 0
             templateContext:
@@ -83,12 +83,8 @@ extends:
                   customEndpoint: Typescript NPM
                   publishEndpoint: Typescript NPM
 
-      - stage: Stage_2
-        displayName: Publish git tag
-        dependsOn: Stage_1
-        jobs:
-          - job: Job_1
-            displayName: Agent job
+          - job: github
+            displayName: Publish git tag
             condition: succeeded()
             timeoutInMinutes: 0
             templateContext:


### PR DESCRIPTION
- Merge stages
- Use parameter features (descriptions, values)
- Always publish GitHub release instantly on publishes to latest npm tag