### PR TITLE
Add the `.getNonPrimitiveType()` method to the `TypeChecker`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1836,6 +1836,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getNullType: () => nullType,
         getESSymbolType: () => esSymbolType,
         getNeverType: () => neverType,
+        getNonPrimitiveType: () => nonPrimitiveType,
         getOptionalType: () => optionalType,
         getPromiseType: () => getGlobalPromiseType(/*reportErrors*/ false),
         getPromiseLikeType: () => getGlobalPromiseLikeType(/*reportErrors*/ false),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5286,6 +5286,10 @@ export interface TypeChecker {
      * is `never`. Instead, use `type.flags & TypeFlags.Never`.
      */
     getNeverType(): Type;
+    /**
+     * Gets the intrinsic `object` type.
+     */
+    getNonPrimitiveType(): Type;
     /** @internal */ getOptionalType(): Type;
     /** @internal */ getUnionType(types: Type[], subtypeReduction?: UnionReduction): Type;
     /** @internal */ createArrayType(elementType: Type): Type;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6304,6 +6304,10 @@ declare namespace ts {
          */
         getNeverType(): Type;
         /**
+         * Gets the intrinsic `object` type.
+         */
+        getNonPrimitiveType(): Type;
+        /**
          * Returns true if the "source" type is assignable to the "target" type.
          *
          * ```ts


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61517

This PR is adding the `.getNonPrimitiveType()` method to the `TypeChecker`. Similar to methods like `.getAnyType()` or `.getUndefinedType()`, the returned value of `.getNonPrimitiveType()` is the `Type` of the intrinsic `object` type.

A comment is included to explain what the method does. I think, it might not be clear that `NonPrimitive` is actually the intrinsic `object` type.

I updated the `tests/baselines/reference/api/typescript.d.ts` file. Is that enough for testing, perhaps? I looked around, but can’t find any explicit tests for other methods of the `TypeChecker`.