### PR TITLE
Fix #61429: Fast arithmetic type check for type-parameters upper-bounded by `bigint` fixed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39329,6 +39329,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
         }
+        if (type.flags & TypeFlags.TypeParameter) {
+            // The type could be upper-bounded by (a subtype of) the kind.
+            const upperBound = getConstraintOfType(type);
+            if (upperBound !== undefined && maybeTypeOfKind(upperBound, kind)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/tests/baselines/reference/bigintSubtypingTypeParameter.js
+++ b/tests/baselines/reference/bigintSubtypingTypeParameter.js
@@ -1,0 +1,77 @@
+//// [tests/cases/compiler/bigintSubtypingTypeParameter.ts] ////
+
+//// [bigintSubtypingTypeParameter.ts]
+function bigintSubtypeAdder<T extends bigint>(a: T, b: T): bigint {
+	const sum = a + b;
+	return sum;
+}
+
+function bigintSubtypeDifference<T extends bigint>(a: T, b: T): bigint {
+	const difference = a - b;
+	return difference;
+}
+
+function bigintSubtypeArithmeticNegation<T extends bigint>(a: T): bigint {
+	const negation = -a;
+	return negation;
+}
+
+function bigintSubtypeBitInverse<T extends bigint>(a: T): bigint {
+	const bitInverse = ~a;
+	return bitInverse;
+}
+
+function bigintSubtypeBitand<T extends bigint>(a: T, b: T): bigint {
+	const bitand = a & b;
+	return bitand;
+}
+
+function bigintSubtypeBitor<T extends bigint>(a: T, b: T): bigint {
+	const bitor = a | b;
+	return bitor;
+}
+
+function bigintSubtypeLeftshift<T extends bigint>(a: T, b: T): bigint {
+	const leftshift = a << b;
+	return leftshift;
+}
+
+function bigintSubtypeRightshift<T extends bigint>(a: T, b: T): bigint {
+	const rightshift = a >> b;
+	return rightshift;
+}
+
+
+//// [bigintSubtypingTypeParameter.js]
+function bigintSubtypeAdder(a, b) {
+    var sum = a + b;
+    return sum;
+}
+function bigintSubtypeDifference(a, b) {
+    var difference = a - b;
+    return difference;
+}
+function bigintSubtypeArithmeticNegation(a) {
+    var negation = -a;
+    return negation;
+}
+function bigintSubtypeBitInverse(a) {
+    var bitInverse = ~a;
+    return bitInverse;
+}
+function bigintSubtypeBitand(a, b) {
+    var bitand = a & b;
+    return bitand;
+}
+function bigintSubtypeBitor(a, b) {
+    var bitor = a | b;
+    return bitor;
+}
+function bigintSubtypeLeftshift(a, b) {
+    var leftshift = a << b;
+    return leftshift;
+}
+function bigintSubtypeRightshift(a, b) {
+    var rightshift = a >> b;
+    return rightshift;
+}

--- a/tests/baselines/reference/bigintSubtypingTypeParameter.symbols
+++ b/tests/baselines/reference/bigintSubtypingTypeParameter.symbols
@@ -1,0 +1,133 @@
+//// [tests/cases/compiler/bigintSubtypingTypeParameter.ts] ////
+
+=== bigintSubtypingTypeParameter.ts ===
+function bigintSubtypeAdder<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeAdder : Symbol(bigintSubtypeAdder, Decl(bigintSubtypingTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 0, 28))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 0, 46))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 0, 28))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 0, 51))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 0, 28))
+
+	const sum = a + b;
+>sum : Symbol(sum, Decl(bigintSubtypingTypeParameter.ts, 1, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 0, 46))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 0, 51))
+
+	return sum;
+>sum : Symbol(sum, Decl(bigintSubtypingTypeParameter.ts, 1, 6))
+}
+
+function bigintSubtypeDifference<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeDifference : Symbol(bigintSubtypeDifference, Decl(bigintSubtypingTypeParameter.ts, 3, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 5, 33))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 5, 51))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 5, 33))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 5, 56))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 5, 33))
+
+	const difference = a - b;
+>difference : Symbol(difference, Decl(bigintSubtypingTypeParameter.ts, 6, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 5, 51))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 5, 56))
+
+	return difference;
+>difference : Symbol(difference, Decl(bigintSubtypingTypeParameter.ts, 6, 6))
+}
+
+function bigintSubtypeArithmeticNegation<T extends bigint>(a: T): bigint {
+>bigintSubtypeArithmeticNegation : Symbol(bigintSubtypeArithmeticNegation, Decl(bigintSubtypingTypeParameter.ts, 8, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 10, 41))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 10, 59))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 10, 41))
+
+	const negation = -a;
+>negation : Symbol(negation, Decl(bigintSubtypingTypeParameter.ts, 11, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 10, 59))
+
+	return negation;
+>negation : Symbol(negation, Decl(bigintSubtypingTypeParameter.ts, 11, 6))
+}
+
+function bigintSubtypeBitInverse<T extends bigint>(a: T): bigint {
+>bigintSubtypeBitInverse : Symbol(bigintSubtypeBitInverse, Decl(bigintSubtypingTypeParameter.ts, 13, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 15, 33))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 15, 51))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 15, 33))
+
+	const bitInverse = ~a;
+>bitInverse : Symbol(bitInverse, Decl(bigintSubtypingTypeParameter.ts, 16, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 15, 51))
+
+	return bitInverse;
+>bitInverse : Symbol(bitInverse, Decl(bigintSubtypingTypeParameter.ts, 16, 6))
+}
+
+function bigintSubtypeBitand<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeBitand : Symbol(bigintSubtypeBitand, Decl(bigintSubtypingTypeParameter.ts, 18, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 20, 29))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 20, 47))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 20, 29))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 20, 52))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 20, 29))
+
+	const bitand = a & b;
+>bitand : Symbol(bitand, Decl(bigintSubtypingTypeParameter.ts, 21, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 20, 47))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 20, 52))
+
+	return bitand;
+>bitand : Symbol(bitand, Decl(bigintSubtypingTypeParameter.ts, 21, 6))
+}
+
+function bigintSubtypeBitor<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeBitor : Symbol(bigintSubtypeBitor, Decl(bigintSubtypingTypeParameter.ts, 23, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 25, 28))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 25, 46))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 25, 28))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 25, 51))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 25, 28))
+
+	const bitor = a | b;
+>bitor : Symbol(bitor, Decl(bigintSubtypingTypeParameter.ts, 26, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 25, 46))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 25, 51))
+
+	return bitor;
+>bitor : Symbol(bitor, Decl(bigintSubtypingTypeParameter.ts, 26, 6))
+}
+
+function bigintSubtypeLeftshift<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeLeftshift : Symbol(bigintSubtypeLeftshift, Decl(bigintSubtypingTypeParameter.ts, 28, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 30, 32))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 30, 50))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 30, 32))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 30, 55))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 30, 32))
+
+	const leftshift = a << b;
+>leftshift : Symbol(leftshift, Decl(bigintSubtypingTypeParameter.ts, 31, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 30, 50))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 30, 55))
+
+	return leftshift;
+>leftshift : Symbol(leftshift, Decl(bigintSubtypingTypeParameter.ts, 31, 6))
+}
+
+function bigintSubtypeRightshift<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeRightshift : Symbol(bigintSubtypeRightshift, Decl(bigintSubtypingTypeParameter.ts, 33, 1))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 35, 33))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 35, 51))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 35, 33))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 35, 56))
+>T : Symbol(T, Decl(bigintSubtypingTypeParameter.ts, 35, 33))
+
+	const rightshift = a >> b;
+>rightshift : Symbol(rightshift, Decl(bigintSubtypingTypeParameter.ts, 36, 6))
+>a : Symbol(a, Decl(bigintSubtypingTypeParameter.ts, 35, 51))
+>b : Symbol(b, Decl(bigintSubtypingTypeParameter.ts, 35, 56))
+
+	return rightshift;
+>rightshift : Symbol(rightshift, Decl(bigintSubtypingTypeParameter.ts, 36, 6))
+}
+

--- a/tests/baselines/reference/bigintSubtypingTypeParameter.types
+++ b/tests/baselines/reference/bigintSubtypingTypeParameter.types
@@ -1,0 +1,179 @@
+//// [tests/cases/compiler/bigintSubtypingTypeParameter.ts] ////
+
+=== bigintSubtypingTypeParameter.ts ===
+function bigintSubtypeAdder<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeAdder : <T extends bigint>(a: T, b: T) => bigint
+>                   : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const sum = a + b;
+>sum : bigint
+>    : ^^^^^^
+>a + b : bigint
+>      : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return sum;
+>sum : bigint
+>    : ^^^^^^
+}
+
+function bigintSubtypeDifference<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeDifference : <T extends bigint>(a: T, b: T) => bigint
+>                        : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const difference = a - b;
+>difference : bigint
+>           : ^^^^^^
+>a - b : bigint
+>      : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return difference;
+>difference : bigint
+>           : ^^^^^^
+}
+
+function bigintSubtypeArithmeticNegation<T extends bigint>(a: T): bigint {
+>bigintSubtypeArithmeticNegation : <T extends bigint>(a: T) => bigint
+>                                : ^ ^^^^^^^^^      ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+
+	const negation = -a;
+>negation : bigint
+>         : ^^^^^^
+>-a : bigint
+>   : ^^^^^^
+>a : T
+>  : ^
+
+	return negation;
+>negation : bigint
+>         : ^^^^^^
+}
+
+function bigintSubtypeBitInverse<T extends bigint>(a: T): bigint {
+>bigintSubtypeBitInverse : <T extends bigint>(a: T) => bigint
+>                        : ^ ^^^^^^^^^      ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+
+	const bitInverse = ~a;
+>bitInverse : bigint
+>           : ^^^^^^
+>~a : bigint
+>   : ^^^^^^
+>a : T
+>  : ^
+
+	return bitInverse;
+>bitInverse : bigint
+>           : ^^^^^^
+}
+
+function bigintSubtypeBitand<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeBitand : <T extends bigint>(a: T, b: T) => bigint
+>                    : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const bitand = a & b;
+>bitand : bigint
+>       : ^^^^^^
+>a & b : bigint
+>      : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return bitand;
+>bitand : bigint
+>       : ^^^^^^
+}
+
+function bigintSubtypeBitor<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeBitor : <T extends bigint>(a: T, b: T) => bigint
+>                   : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const bitor = a | b;
+>bitor : bigint
+>      : ^^^^^^
+>a | b : bigint
+>      : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return bitor;
+>bitor : bigint
+>      : ^^^^^^
+}
+
+function bigintSubtypeLeftshift<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeLeftshift : <T extends bigint>(a: T, b: T) => bigint
+>                       : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const leftshift = a << b;
+>leftshift : bigint
+>          : ^^^^^^
+>a << b : bigint
+>       : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return leftshift;
+>leftshift : bigint
+>          : ^^^^^^
+}
+
+function bigintSubtypeRightshift<T extends bigint>(a: T, b: T): bigint {
+>bigintSubtypeRightshift : <T extends bigint>(a: T, b: T) => bigint
+>                        : ^ ^^^^^^^^^      ^^ ^^ ^^ ^^ ^^^^^      
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	const rightshift = a >> b;
+>rightshift : bigint
+>           : ^^^^^^
+>a >> b : bigint
+>       : ^^^^^^
+>a : T
+>  : ^
+>b : T
+>  : ^
+
+	return rightshift;
+>rightshift : bigint
+>           : ^^^^^^
+}
+

--- a/tests/cases/compiler/bigintSubtypingTypeParameter.ts
+++ b/tests/cases/compiler/bigintSubtypingTypeParameter.ts
@@ -1,0 +1,39 @@
+function bigintSubtypeAdder<T extends bigint>(a: T, b: T): bigint {
+	const sum = a + b;
+	return sum;
+}
+
+function bigintSubtypeDifference<T extends bigint>(a: T, b: T): bigint {
+	const difference = a - b;
+	return difference;
+}
+
+function bigintSubtypeArithmeticNegation<T extends bigint>(a: T): bigint {
+	const negation = -a;
+	return negation;
+}
+
+function bigintSubtypeBitInverse<T extends bigint>(a: T): bigint {
+	const bitInverse = ~a;
+	return bitInverse;
+}
+
+function bigintSubtypeBitand<T extends bigint>(a: T, b: T): bigint {
+	const bitand = a & b;
+	return bitand;
+}
+
+function bigintSubtypeBitor<T extends bigint>(a: T, b: T): bigint {
+	const bitor = a | b;
+	return bitor;
+}
+
+function bigintSubtypeLeftshift<T extends bigint>(a: T, b: T): bigint {
+	const leftshift = a << b;
+	return leftshift;
+}
+
+function bigintSubtypeRightshift<T extends bigint>(a: T, b: T): bigint {
+	const rightshift = a >> b;
+	return rightshift;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61429

The `maybeTypeOfKind` function is a simpler version of full type-checking which is used by arithmetic. It is used to determine whether or not operations like `+` and `<<` and `~` are acting on `number` types or `bigint` types.

Previously, the `maybeTypeOfKind` function did not return `true` when an operand has a type `T`, regardless of the bounds of `T`.

This meant that when `maybeTypeOfKind` is passed `T extends bigint` and `bigint`, it returned `false`.

This caused expressions like `a & b` to be assigned the "default" type `number` instead of `bigint`.

----

I added a test which includes a variety of operators acting on such `T extends bigint` values.

----

This is my first PR, so apologies if I'm missing something important. One thing I'm slightly concerned about is the performance impact of this change. I believe that the main reason `maybeTypeOfKind` exists is to use a leaner, lower-cost type checking operation for the extremely common cases of arithmetic. But I'm not sure how to measure the performance impact of this extra check; I suppose that it should be fairly uncommon for arithmetic to act on type parameters, so it's probably quite small in practice, but benchmarks would be nice to confirm that.