### PR TITLE
Deemphasize old JSX transform

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -133,9 +133,9 @@ const compileOnSaveCommandLineOption: CommandLineOption = {
 const jsxOptionMap = new Map(Object.entries({
     "preserve": JsxEmit.Preserve,
     "react-native": JsxEmit.ReactNative,
-    "react": JsxEmit.React,
     "react-jsx": JsxEmit.ReactJSX,
     "react-jsxdev": JsxEmit.ReactJSXDev,
+    "react": JsxEmit.React,
 }));
 
 /** @internal */

--- a/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse empty options of --jsx.js
+++ b/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse empty options of --jsx.js
@@ -7,4 +7,4 @@ FileNames::
 0.ts
 Errors::
 error TS6044: Compiler option 'jsx' expects an argument.
-error TS6046: Argument for '--jsx' option must be: 'preserve', 'react-native', 'react', 'react-jsx', 'react-jsxdev'.
+error TS6046: Argument for '--jsx' option must be: 'preserve', 'react-native', 'react-jsx', 'react-jsxdev', 'react'.

--- a/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of jsx to compiler-options with json api.js
+++ b/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of jsx to compiler-options with json api.js
@@ -27,5 +27,5 @@ CompilerOptions::
   "configFilePath": "/apath/tsconfig.json"
 }
 Errors::
-[91merror[0m[90m TS6046: [0mArgument for '--jsx' option must be: 'preserve', 'react-native', 'react', 'react-jsx', 'react-jsxdev'.
+[91merror[0m[90m TS6046: [0mArgument for '--jsx' option must be: 'preserve', 'react-native', 'react-jsx', 'react-jsxdev', 'react'.
 

--- a/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of jsx to compiler-options with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of jsx to compiler-options with jsonSourceFile api.js
@@ -27,7 +27,7 @@ CompilerOptions::
   "configFilePath": "/apath/tsconfig.json"
 }
 Errors::
-[96mtsconfig.json[0m:[93m7[0m:[93m12[0m - [91merror[0m[90m TS6046: [0mArgument for '--jsx' option must be: 'preserve', 'react-native', 'react', 'react-jsx', 'react-jsxdev'.
+[96mtsconfig.json[0m:[93m7[0m:[93m12[0m - [91merror[0m[90m TS6046: [0mArgument for '--jsx' option must be: 'preserve', 'react-native', 'react-jsx', 'react-jsxdev', 'react'.
 
 [7m7[0m     "jsx": ""
 [7m [0m [91m           ~~[0m


### PR DESCRIPTION
People should choose the new, automatic transform
over the old transform which required a React import.

## Test plan

Applied changes to local `tsc` code and ran `pnpm tsc test.tsx --jsx`:
```console
$ pnpm tsc test.tsx --jsx
error TS6044: Compiler option 'jsx' expects an argument.
error TS6046: Argument for '--jsx' option must be: 'preserve', 'react-native', 'react-jsx', 'react-jsxdev', 'react'.
```

Fixes https://github.com/microsoft/TypeScript/issues/61585

Related:
- https://github.com/microsoft/TypeScript-Website/pull/2994
- https://github.com/microsoft/vscode/pull/246738