### PR TITLE
Improve `.origin` preservation in `getNarrowedTypeWorker`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29342,17 +29342,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // We first attempt to filter the current type, narrowing constituents as appropriate and removing
             // constituents that are unrelated to the candidate.
             const isRelated = checkDerived ? isTypeDerivedFrom : isTypeSubtypeOf;
-            const keyPropertyName = type.flags & TypeFlags.Union ? getKeyPropertyName(type as UnionType) : undefined;
-            const discriminantMatchingType = keyPropertyName ?
-                mapType(candidate, c => {
-                    const discriminant = keyPropertyName && getTypeOfPropertyOfType(c, keyPropertyName);
-                    return (discriminant && getConstituentTypeForKeyType(type as UnionType, discriminant)) ?? neverType;
-                }) :
-                neverType;
             let matchedCandidates: Type[] = [];
-            let narrowedType = mapType(
-                !(discriminantMatchingType.flags & TypeFlags.Never) ? discriminantMatchingType : type,
-                t => mapType(
+            let narrowedType = mapType(type, t =>
+                mapType(
                     candidate,
                     c => {
                         const directlyRelated = checkDerived ?
@@ -29363,8 +29355,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         return directlyRelated;
                     },
-                ),
-            );
+                ));
             if (matchedCandidates.length !== countTypes(candidate)) {
                 narrowedType = getUnionType([
                     narrowedType,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29342,9 +29342,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // We first attempt to filter the current type, narrowing constituents as appropriate and removing
             // constituents that are unrelated to the candidate.
             const isRelated = checkDerived ? isTypeDerivedFrom : isTypeSubtypeOf;
+            const keyPropertyName = type.flags & TypeFlags.Union ? getKeyPropertyName(type as UnionType) : undefined;
+            const discriminantMatchingType = keyPropertyName ?
+                mapType(candidate, c => {
+                    const discriminant = keyPropertyName && getTypeOfPropertyOfType(c, keyPropertyName);
+                    return (discriminant && getConstituentTypeForKeyType(type as UnionType, discriminant)) ?? neverType;
+                }) :
+                neverType;
             let matchedCandidates: Type[] = [];
-            let narrowedType = mapType(type, t =>
-                mapType(
+            let narrowedType = mapType(
+                !(discriminantMatchingType.flags & TypeFlags.Never) ? discriminantMatchingType : type,
+                t => mapType(
                     candidate,
                     c => {
                         const directlyRelated = checkDerived ?
@@ -29355,7 +29363,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         return directlyRelated;
                     },
-                ));
+                ),
+            );
             if (matchedCandidates.length !== countTypes(candidate)) {
                 narrowedType = getUnionType([
                     narrowedType,

--- a/tests/baselines/reference/controlFlowOptionalChain.types
+++ b/tests/baselines/reference/controlFlowOptionalChain.types
@@ -2857,12 +2857,12 @@ function f30(o: Thing | undefined) {
 >    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         o.foo;
->o.foo : NonNullable<string | number | undefined>
->      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>o.foo : string | number
+>      : ^^^^^^^^^^^^^^^
 >o : Thing
 >  : ^^^^^
->foo : NonNullable<string | number | undefined>
->    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>foo : string | number
+>    : ^^^^^^^^^^^^^^^
     }
 }
 

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.js
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.js
@@ -15,6 +15,7 @@ type Result<A, E> =
 
 declare const isResult: (u: unknown) => u is Result<any, any>;
 
+// return type: Result<A, E> | "ok"
 export const fn = <A, E>(inp: Result<A, E> | string) =>
   isResult(inp) ? inp : "ok";
 
@@ -24,6 +25,7 @@ export const fn = <A, E>(inp: Result<A, E> | string) =>
 // https://github.com/microsoft/TypeScript/issues/61581
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.fn = void 0;
+// return type: Result<A, E> | "ok"
 var fn = function (inp) {
     return isResult(inp) ? inp : "ok";
 };

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.js
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.js
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/narrowingUnionByUnionCandidate1.ts] ////
+
+//// [narrowingUnionByUnionCandidate1.ts]
+// https://github.com/microsoft/TypeScript/issues/61581
+
+type Result<A, E> =
+  | {
+      readonly _tag: "Ok";
+      readonly value: A;
+    }
+  | {
+      readonly _tag: "Fail";
+      readonly error: E;
+    };
+
+declare const isResult: (u: unknown) => u is Result<any, any>;
+
+export const fn = <A, E>(inp: Result<A, E> | string) =>
+  isResult(inp) ? inp : "ok";
+
+
+//// [narrowingUnionByUnionCandidate1.js]
+"use strict";
+// https://github.com/microsoft/TypeScript/issues/61581
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fn = void 0;
+var fn = function (inp) {
+    return isResult(inp) ? inp : "ok";
+};
+exports.fn = fn;
+
+
+//// [narrowingUnionByUnionCandidate1.d.ts]
+type Result<A, E> = {
+    readonly _tag: "Ok";
+    readonly value: A;
+} | {
+    readonly _tag: "Fail";
+    readonly error: E;
+};
+export declare const fn: <A, E>(inp: Result<A, E> | string) => Result<A, E> | "ok";
+export {};

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.symbols
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.symbols
@@ -32,17 +32,18 @@ declare const isResult: (u: unknown) => u is Result<any, any>;
 >u : Symbol(u, Decl(narrowingUnionByUnionCandidate1.ts, 12, 25))
 >Result : Symbol(Result, Decl(narrowingUnionByUnionCandidate1.ts, 0, 0))
 
+// return type: Result<A, E> | "ok"
 export const fn = <A, E>(inp: Result<A, E> | string) =>
->fn : Symbol(fn, Decl(narrowingUnionByUnionCandidate1.ts, 14, 12))
->A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 14, 19))
->E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 14, 21))
->inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
+>fn : Symbol(fn, Decl(narrowingUnionByUnionCandidate1.ts, 15, 12))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 15, 19))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 15, 21))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 15, 25))
 >Result : Symbol(Result, Decl(narrowingUnionByUnionCandidate1.ts, 0, 0))
->A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 14, 19))
->E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 14, 21))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 15, 19))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 15, 21))
 
   isResult(inp) ? inp : "ok";
 >isResult : Symbol(isResult, Decl(narrowingUnionByUnionCandidate1.ts, 12, 13))
->inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
->inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 15, 25))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 15, 25))
 

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.symbols
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.symbols
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/narrowingUnionByUnionCandidate1.ts] ////
+
+=== narrowingUnionByUnionCandidate1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61581
+
+type Result<A, E> =
+>Result : Symbol(Result, Decl(narrowingUnionByUnionCandidate1.ts, 0, 0))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 2, 12))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 2, 14))
+
+  | {
+      readonly _tag: "Ok";
+>_tag : Symbol(_tag, Decl(narrowingUnionByUnionCandidate1.ts, 3, 5))
+
+      readonly value: A;
+>value : Symbol(value, Decl(narrowingUnionByUnionCandidate1.ts, 4, 26))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 2, 12))
+    }
+  | {
+      readonly _tag: "Fail";
+>_tag : Symbol(_tag, Decl(narrowingUnionByUnionCandidate1.ts, 7, 5))
+
+      readonly error: E;
+>error : Symbol(error, Decl(narrowingUnionByUnionCandidate1.ts, 8, 28))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 2, 14))
+
+    };
+
+declare const isResult: (u: unknown) => u is Result<any, any>;
+>isResult : Symbol(isResult, Decl(narrowingUnionByUnionCandidate1.ts, 12, 13))
+>u : Symbol(u, Decl(narrowingUnionByUnionCandidate1.ts, 12, 25))
+>u : Symbol(u, Decl(narrowingUnionByUnionCandidate1.ts, 12, 25))
+>Result : Symbol(Result, Decl(narrowingUnionByUnionCandidate1.ts, 0, 0))
+
+export const fn = <A, E>(inp: Result<A, E> | string) =>
+>fn : Symbol(fn, Decl(narrowingUnionByUnionCandidate1.ts, 14, 12))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 14, 19))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 14, 21))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
+>Result : Symbol(Result, Decl(narrowingUnionByUnionCandidate1.ts, 0, 0))
+>A : Symbol(A, Decl(narrowingUnionByUnionCandidate1.ts, 14, 19))
+>E : Symbol(E, Decl(narrowingUnionByUnionCandidate1.ts, 14, 21))
+
+  isResult(inp) ? inp : "ok";
+>isResult : Symbol(isResult, Decl(narrowingUnionByUnionCandidate1.ts, 12, 13))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
+>inp : Symbol(inp, Decl(narrowingUnionByUnionCandidate1.ts, 14, 25))
+

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.types
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.types
@@ -33,6 +33,7 @@ declare const isResult: (u: unknown) => u is Result<any, any>;
 >u : unknown
 >  : ^^^^^^^
 
+// return type: Result<A, E> | "ok"
 export const fn = <A, E>(inp: Result<A, E> | string) =>
 >fn : <A, E>(inp: Result<A, E> | string) => Result<A, E> | "ok"
 >   : ^ ^^ ^^   ^^                     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/baselines/reference/narrowingUnionByUnionCandidate1.types
+++ b/tests/baselines/reference/narrowingUnionByUnionCandidate1.types
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/narrowingUnionByUnionCandidate1.ts] ////
+
+=== narrowingUnionByUnionCandidate1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61581
+
+type Result<A, E> =
+>Result : Result<A, E>
+>       : ^^^^^^^^^^^^
+
+  | {
+      readonly _tag: "Ok";
+>_tag : "Ok"
+>     : ^^^^
+
+      readonly value: A;
+>value : A
+>      : ^
+    }
+  | {
+      readonly _tag: "Fail";
+>_tag : "Fail"
+>     : ^^^^^^
+
+      readonly error: E;
+>error : E
+>      : ^
+
+    };
+
+declare const isResult: (u: unknown) => u is Result<any, any>;
+>isResult : (u: unknown) => u is Result<any, any>
+>         : ^ ^^       ^^^^^                     
+>u : unknown
+>  : ^^^^^^^
+
+export const fn = <A, E>(inp: Result<A, E> | string) =>
+>fn : <A, E>(inp: Result<A, E> | string) => Result<A, E> | "ok"
+>   : ^ ^^ ^^   ^^                     ^^^^^^^^^^^^^^^^^^^^^^^^
+><A, E>(inp: Result<A, E> | string) =>  isResult(inp) ? inp : "ok" : <A, E>(inp: Result<A, E> | string) => Result<A, E> | "ok"
+>                                                                  : ^ ^^ ^^   ^^                     ^^^^^^^^^^^^^^^^^^^^^^^^
+>inp : string | Result<A, E>
+>    : ^^^^^^^^^^^^^^^^^^^^^
+
+  isResult(inp) ? inp : "ok";
+>isResult(inp) ? inp : "ok" : Result<A, E> | "ok"
+>                           : ^^^^^^^^^^^^^^^^^^^
+>isResult(inp) : boolean
+>              : ^^^^^^^
+>isResult : (u: unknown) => u is Result<any, any>
+>         : ^ ^^       ^^^^^                     
+>inp : string | Result<A, E>
+>    : ^^^^^^^^^^^^^^^^^^^^^
+>inp : Result<A, E>
+>    : ^^^^^^^^^^^^
+>"ok" : "ok"
+>     : ^^^^
+

--- a/tests/baselines/reference/narrowingUnionToUnion.types
+++ b/tests/baselines/reference/narrowingUnionToUnion.types
@@ -557,8 +557,8 @@ if (isEmpty(test)) {
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^
 
     test;  // EmptyString
->test : EmptyString
->     : ^^^^^^^^^^^
+>test : "" | null | undefined
+>     : ^^^^^^^^^^^^^^^^^^^^^
 }
 
 // Repro from #43825

--- a/tests/cases/compiler/narrowingUnionByUnionCandidate1.ts
+++ b/tests/cases/compiler/narrowingUnionByUnionCandidate1.ts
@@ -15,5 +15,6 @@ type Result<A, E> =
 
 declare const isResult: (u: unknown) => u is Result<any, any>;
 
+// return type: Result<A, E> | "ok"
 export const fn = <A, E>(inp: Result<A, E> | string) =>
   isResult(inp) ? inp : "ok";

--- a/tests/cases/compiler/narrowingUnionByUnionCandidate1.ts
+++ b/tests/cases/compiler/narrowingUnionByUnionCandidate1.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @declaration: true
+
+// https://github.com/microsoft/TypeScript/issues/61581
+
+type Result<A, E> =
+  | {
+      readonly _tag: "Ok";
+      readonly value: A;
+    }
+  | {
+      readonly _tag: "Fail";
+      readonly error: E;
+    };
+
+declare const isResult: (u: unknown) => u is Result<any, any>;
+
+export const fn = <A, E>(inp: Result<A, E> | string) =>
+  isResult(inp) ? inp : "ok";


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61581