### PR TITLE
Don't latebind global JS property assignments

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3432,6 +3432,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             bindExportsPropertyAssignment(node as BindableStaticPropertyAssignmentExpression);
         }
         else if (hasDynamicName(node)) {
+            if (!parentSymbol) {
+                return;
+            }
             bindAnonymousDeclaration(node, SymbolFlags.Property | SymbolFlags.Assignment, InternalSymbolName.Computed);
             const sym = bindPotentiallyMissingNamespaces(parentSymbol, node.left.expression, isTopLevelNamespaceAssignment(node.left), /*isPrototypeProperty*/ false, /*containerIsClass*/ false);
             addLateBoundAssignmentDeclarationToSymbol(node, sym);

--- a/tests/baselines/reference/lateboundWindowToplevelAssignment.symbols
+++ b/tests/baselines/reference/lateboundWindowToplevelAssignment.symbols
@@ -8,5 +8,3 @@ window[UPDATE_MARKER_FUNC] = () => {};
 >window : Symbol(window, Decl(lib.dom.d.ts, --, --))
 >UPDATE_MARKER_FUNC : Symbol(UPDATE_MARKER_FUNC, Decl(lateboundWindowToplevelAssignment.js, 0, 5))
 
-// class C { [UPDATE_MARKER_FUNC] = 1 }
-

--- a/tests/baselines/reference/lateboundWindowToplevelAssignment.symbols
+++ b/tests/baselines/reference/lateboundWindowToplevelAssignment.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts] ////
+
+=== lateboundWindowToplevelAssignment.js ===
+const UPDATE_MARKER_FUNC = 'updateMarkerPosition';
+>UPDATE_MARKER_FUNC : Symbol(UPDATE_MARKER_FUNC, Decl(lateboundWindowToplevelAssignment.js, 0, 5))
+
+window[UPDATE_MARKER_FUNC] = () => {};
+>window : Symbol(window, Decl(lib.dom.d.ts, --, --))
+>UPDATE_MARKER_FUNC : Symbol(UPDATE_MARKER_FUNC, Decl(lateboundWindowToplevelAssignment.js, 0, 5))
+
+// class C { [UPDATE_MARKER_FUNC] = 1 }
+

--- a/tests/baselines/reference/lateboundWindowToplevelAssignment.types
+++ b/tests/baselines/reference/lateboundWindowToplevelAssignment.types
@@ -18,5 +18,3 @@ window[UPDATE_MARKER_FUNC] = () => {};
 >() => {} : () => void
 >         : ^^^^^^^^^^
 
-// class C { [UPDATE_MARKER_FUNC] = 1 }
-

--- a/tests/baselines/reference/lateboundWindowToplevelAssignment.types
+++ b/tests/baselines/reference/lateboundWindowToplevelAssignment.types
@@ -1,0 +1,22 @@
+//// [tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts] ////
+
+=== lateboundWindowToplevelAssignment.js ===
+const UPDATE_MARKER_FUNC = 'updateMarkerPosition';
+>UPDATE_MARKER_FUNC : "updateMarkerPosition"
+>                   : ^^^^^^^^^^^^^^^^^^^^^^
+>'updateMarkerPosition' : "updateMarkerPosition"
+>                       : ^^^^^^^^^^^^^^^^^^^^^^
+
+window[UPDATE_MARKER_FUNC] = () => {};
+>window[UPDATE_MARKER_FUNC] = () => {} : () => void
+>                                      : ^^^^^^^^^^
+>window[UPDATE_MARKER_FUNC] : error
+>window : Window & typeof globalThis
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+>UPDATE_MARKER_FUNC : "updateMarkerPosition"
+>                   : ^^^^^^^^^^^^^^^^^^^^^^
+>() => {} : () => void
+>         : ^^^^^^^^^^
+
+// class C { [UPDATE_MARKER_FUNC] = 1 }
+

--- a/tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts
+++ b/tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts
@@ -4,4 +4,3 @@
 // @noEmit: true
 const UPDATE_MARKER_FUNC = 'updateMarkerPosition';
 window[UPDATE_MARKER_FUNC] = () => {};
-// class C { [UPDATE_MARKER_FUNC] = 1 }

--- a/tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts
+++ b/tests/cases/conformance/salsa/lateboundWindowToplevelAssignment.ts
@@ -1,0 +1,7 @@
+// @filename: lateboundWindowToplevelAssignment.js
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+const UPDATE_MARKER_FUNC = 'updateMarkerPosition';
+window[UPDATE_MARKER_FUNC] = () => {};
+// class C { [UPDATE_MARKER_FUNC] = 1 }


### PR DESCRIPTION
Late binding assumes a parent symbol. Currently, the binder does not check whether an assignment declaration has a parent symbol exists before creating a symbol for late binding. The easiest place to encounter this is with `window` assignments, because global (script) files have no symbol, unlike module files:

```js
const X = "X"
window[X] = () => 1
```

It is possible to special-case `window` for late binding similar to the way that it's done for normal binding, or even any top-level assignment declaration in a global file. But I don't think there's enough value. For now, this PR prevents binding entirely for a dynamic name when there is no parent symbol.

Fixes #61583