### PR TITLE
docs(lib): add @throws JSDoc for JSON methods

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1140,6 +1140,7 @@ interface JSON {
      * @param text A valid JSON string.
      * @param reviver A function that transforms the results. This function is called for each member of the object.
      * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     * @throws {SyntaxError} If `text` is not valid JSON.
      */
     parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
     /**
@@ -1147,6 +1148,7 @@ interface JSON {
      * @param value A JavaScript value, usually an object or array, to be converted.
      * @param replacer A function that transforms the results.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+     * @throws {TypeError} If a circular reference is found or a BigInt value is encountered.
      */
     stringify(value: any, replacer?: (this: any, key: string, value: any) => any, space?: string | number): string;
     /**
@@ -1154,6 +1156,7 @@ interface JSON {
      * @param value A JavaScript value, usually an object or array, to be converted.
      * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+     * @throws {TypeError} If a circular reference is found or a BigInt value is encountered.
      */
     stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
 }

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1148,7 +1148,7 @@ interface JSON {
      * @param value A JavaScript value, usually an object or array, to be converted.
      * @param replacer A function that transforms the results.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-     * @throws {TypeError} If a circular reference is found or a BigInt value is encountered.
+     * @throws {TypeError} If a circular reference or a BigInt value is found.
      */
     stringify(value: any, replacer?: (this: any, key: string, value: any) => any, space?: string | number): string;
     /**

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1156,7 +1156,7 @@ interface JSON {
      * @param value A JavaScript value, usually an object or array, to be converted.
      * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-     * @throws {TypeError} If a circular reference is found or a BigInt value is encountered.
+     * @throws {TypeError} If a circular reference or a BigInt value is found.
      */
     stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
 }


### PR DESCRIPTION
**Adds `@throws` JSDoc documentation to `JSON.parse` and `JSON.stringify` to clarify their potential error behavior.**  
This helps developers better understand the runtime exceptions these methods may produce, and improves IDE support/documentation.

Related to #43528

#### Alignment with TypeScript Design Goals:
- **(2)** Provide a structuring mechanism for larger pieces of code.  
- **(10)** Be a cross-platform development tool.

#### Test Criteria
This PR only introduces documentation changes in `.d.ts` files.  
It does not affect runtime behavior or type system behavior, and therefore does not require test cases.

Would like feedback on whether this direction makes sense for error documentation in the TypeScript repo.