### PR TITLE
Check expression operand equivalence in isMatchingReference before computing property key equivalence

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27184,9 +27184,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ElementAccessExpression:
                 const sourcePropertyName = getAccessedPropertyName(source as AccessExpression);
                 if (sourcePropertyName !== undefined) {
-                    const targetPropertyName = isAccessExpression(target) ? getAccessedPropertyName(target) : undefined;
-                    if (targetPropertyName !== undefined) {
-                        return targetPropertyName === sourcePropertyName && isMatchingReference((source as AccessExpression).expression, (target as AccessExpression).expression);
+                    if (isAccessExpression(target) && isMatchingReference((source as AccessExpression).expression, target.expression)) {
+                        const targetPropertyName = isAccessExpression(target) ? getAccessedPropertyName(target) : undefined;
+                        if (targetPropertyName !== undefined) {
+                            return targetPropertyName === sourcePropertyName;
+                        }
                     }
                 }
                 if (isElementAccessExpression(source) && isElementAccessExpression(target) && isIdentifier(source.argumentExpression) && isIdentifier(target.argumentExpression)) {

--- a/tests/baselines/reference/circularRefFromClassMember.js
+++ b/tests/baselines/reference/circularRefFromClassMember.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/circularRefFromClassMember.ts] ////
+
+//// [circularRefFromClassMember.ts]
+// Test for #61606
+
+const result: boolean[] = [];
+class Test {
+    n: 42 | "" = 42 as any;
+    foo(): void {
+        if (this.n === "") {
+            return;
+        }
+        for (let i = 0; i < 1; i++) {
+            const localN = this.n;
+            const localN_alias = localN;
+            result[localN_alias] = true;
+        }
+    }
+}
+
+
+//// [circularRefFromClassMember.js]
+// Test for #61606
+var result = [];
+var Test = /** @class */ (function () {
+    function Test() {
+        this.n = 42;
+    }
+    Test.prototype.foo = function () {
+        if (this.n === "") {
+            return;
+        }
+        for (var i = 0; i < 1; i++) {
+            var localN = this.n;
+            var localN_alias = localN;
+            result[localN_alias] = true;
+        }
+    };
+    return Test;
+}());

--- a/tests/baselines/reference/circularRefFromClassMember.symbols
+++ b/tests/baselines/reference/circularRefFromClassMember.symbols
@@ -1,0 +1,46 @@
+//// [tests/cases/compiler/circularRefFromClassMember.ts] ////
+
+=== circularRefFromClassMember.ts ===
+// Test for #61606
+
+const result: boolean[] = [];
+>result : Symbol(result, Decl(circularRefFromClassMember.ts, 2, 5))
+
+class Test {
+>Test : Symbol(Test, Decl(circularRefFromClassMember.ts, 2, 29))
+
+    n: 42 | "" = 42 as any;
+>n : Symbol(Test.n, Decl(circularRefFromClassMember.ts, 3, 12))
+
+    foo(): void {
+>foo : Symbol(Test.foo, Decl(circularRefFromClassMember.ts, 4, 27))
+
+        if (this.n === "") {
+>this.n : Symbol(Test.n, Decl(circularRefFromClassMember.ts, 3, 12))
+>this : Symbol(Test, Decl(circularRefFromClassMember.ts, 2, 29))
+>n : Symbol(Test.n, Decl(circularRefFromClassMember.ts, 3, 12))
+
+            return;
+        }
+        for (let i = 0; i < 1; i++) {
+>i : Symbol(i, Decl(circularRefFromClassMember.ts, 9, 16))
+>i : Symbol(i, Decl(circularRefFromClassMember.ts, 9, 16))
+>i : Symbol(i, Decl(circularRefFromClassMember.ts, 9, 16))
+
+            const localN = this.n;
+>localN : Symbol(localN, Decl(circularRefFromClassMember.ts, 10, 17))
+>this.n : Symbol(Test.n, Decl(circularRefFromClassMember.ts, 3, 12))
+>this : Symbol(Test, Decl(circularRefFromClassMember.ts, 2, 29))
+>n : Symbol(Test.n, Decl(circularRefFromClassMember.ts, 3, 12))
+
+            const localN_alias = localN;
+>localN_alias : Symbol(localN_alias, Decl(circularRefFromClassMember.ts, 11, 17))
+>localN : Symbol(localN, Decl(circularRefFromClassMember.ts, 10, 17))
+
+            result[localN_alias] = true;
+>result : Symbol(result, Decl(circularRefFromClassMember.ts, 2, 5))
+>localN_alias : Symbol(localN_alias, Decl(circularRefFromClassMember.ts, 11, 17))
+        }
+    }
+}
+

--- a/tests/baselines/reference/circularRefFromClassMember.types
+++ b/tests/baselines/reference/circularRefFromClassMember.types
@@ -1,0 +1,87 @@
+//// [tests/cases/compiler/circularRefFromClassMember.ts] ////
+
+=== circularRefFromClassMember.ts ===
+// Test for #61606
+
+const result: boolean[] = [];
+>result : boolean[]
+>       : ^^^^^^^^^
+>[] : undefined[]
+>   : ^^^^^^^^^^^
+
+class Test {
+>Test : Test
+>     : ^^^^
+
+    n: 42 | "" = 42 as any;
+>n : "" | 42
+>  : ^^^^^^^
+>42 as any : any
+>42 : 42
+>   : ^^
+
+    foo(): void {
+>foo : () => void
+>    : ^^^^^^    
+
+        if (this.n === "") {
+>this.n === "" : boolean
+>              : ^^^^^^^
+>this.n : "" | 42
+>       : ^^^^^^^
+>this : this
+>     : ^^^^
+>n : "" | 42
+>  : ^^^^^^^
+>"" : ""
+>   : ^^
+
+            return;
+        }
+        for (let i = 0; i < 1; i++) {
+>i : number
+>  : ^^^^^^
+>0 : 0
+>  : ^
+>i < 1 : boolean
+>      : ^^^^^^^
+>i : number
+>  : ^^^^^^
+>1 : 1
+>  : ^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+
+            const localN = this.n;
+>localN : 42
+>       : ^^
+>this.n : 42
+>       : ^^
+>this : this
+>     : ^^^^
+>n : 42
+>  : ^^
+
+            const localN_alias = localN;
+>localN_alias : 42
+>             : ^^
+>localN : 42
+>       : ^^
+
+            result[localN_alias] = true;
+>result[localN_alias] = true : true
+>                            : ^^^^
+>result[localN_alias] : boolean
+>                     : ^^^^^^^
+>result : boolean[]
+>       : ^^^^^^^^^
+>localN_alias : 42
+>             : ^^
+>true : true
+>     : ^^^^
+        }
+    }
+}
+

--- a/tests/cases/compiler/circularRefFromClassMember.ts
+++ b/tests/cases/compiler/circularRefFromClassMember.ts
@@ -1,0 +1,16 @@
+// Test for #61606
+
+const result: boolean[] = [];
+class Test {
+    n: 42 | "" = 42 as any;
+    foo(): void {
+        if (this.n === "") {
+            return;
+        }
+        for (let i = 0; i < 1; i++) {
+            const localN = this.n;
+            const localN_alias = localN;
+            result[localN_alias] = true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #61606. Need PR results to see if this is worth it or not.

Update: Seems good?