### PR TITLE
Draft: Add codefix scaffold for undeclared private method

### DIFF
--- a/src/services/codefixes/addMissingMethod.ts
+++ b/src/services/codefixes/addMissingMethod.ts
@@ -1,0 +1,22 @@
+import * as ts from "../../_namespaces/ts";
+import {
+    createCodeFixAction,
+    registerCodeFix,
+    CodeFixContext,
+    textChanges,
+} from "../_utils";
+
+const fixName = "addMissingPrivateMethod";
+
+registerCodeFix({
+    errorCodes: [],
+    getCodeActions: function getCodeActionsToAddPrivateMethod(context: CodeFixContext) {
+        const changes = textChanges.ChangeTracker.with(context, t => {
+            t.insertNodeAtEndOfFile(context.sourceFile, ts.factory.createExpressionStatement(
+                ts.factory.createStringLiteral("Placeholder fix for missing private method")
+            ));
+        });
+
+        return [createCodeFixAction(fixName, changes, "Add missing private method", fixName, undefined)];
+    },
+});


### PR DESCRIPTION
This pull request is related to [Issue #37782](https://github.com/microsoft/TypeScript/issues/37782).

Hi, I am workingon this as part of a software enigneering class project. My goal is to begin implementing a quick fix that declares a missing private method when it’s referenced but not yet defined. My focus is on understanding the TypeScript codefix structure and documenting the setup/learning process.

This is a draft/in-progress pull request. The current implementation includes placeholder logic inside `addMissingMethod.ts` under `src/services/codefixes/`. The current code does not yet attach to a real error code.

Open to any feedback!
