### PR TITLE
Return an error if either the left or right value are of type boolean

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40116,6 +40116,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return sourceType;
     }
 
+    function isBoolean(value: any): boolean {
+        return (value === typeof "boolean");
+    }
+
     /**
      * This is a *shallow* check: An expression is side-effect-free if the
      * evaluation of the expression *itself* cannot produce side effects.
@@ -40612,6 +40616,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     leftType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(leftType, left));
                     rightType = getBaseTypeOfLiteralTypeForComparison(checkNonNullType(rightType, right));
                     reportOperatorErrorUnless((left, right) => {
+                        if (isBoolean(left) || isBoolean(right)) {
+                            return true;
+                        }
                         if (isTypeAny(left) || isTypeAny(right)) {
                             return true;
                         }


### PR DESCRIPTION
Fixes #15506
Check if the values on either side of a greater than (>) or less than symbol (<) are boolean and if so return an error.
