### PR TITLE
Add IntegerTypedArray type for use with crypto.getRandomValues

### DIFF
--- a/src/lib/es2020.bigint.d.ts
+++ b/src/lib/es2020.bigint.d.ts
@@ -706,6 +706,11 @@ interface BigUint64ArrayConstructor {
 }
 declare var BigUint64Array: BigUint64ArrayConstructor;
 
+interface IntegerTypedArrayTypes {
+    BigInt64Array: BigInt64Array;
+    BigUint64Array: BigUint64Array;
+}
+
 interface DataView<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Gets the BigInt64 value at the specified byte offset from the start of the view. There is

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4389,6 +4389,21 @@ interface Float64ArrayConstructor {
 }
 declare var Float64Array: Float64ArrayConstructor;
 
+/**
+ * Stores types to be used with crypto.getRandomValues
+ */
+interface IntegerTypedArrayTypes {
+    Int8Array: Int8Array;
+    Int16Array: Int16Array;
+    Int32Array: Int32Array;
+    Uint8Array: Uint8Array;
+    Uint16Array: Uint16Array;
+    Uint32Array: Uint32Array;
+    Uint8ClampedArray: Uint8ClampedArray;
+}
+
+type IntegerTypedArray = IntegerTypedArrayTypes[keyof IntegerTypedArrayTypes];
+
 /////////////////////////////
 /// ECMAScript Internationalization API
 /////////////////////////////


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Towards https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1194

The current DOM types `<T extends ArrayBufferView | null>` are wrong for `crypto.getRandomValues`. `null` is never accepted, and `ArrayBufferView` is too broad as float arrays also aren't accepted.

However, fixing in `TypeScript-DOM-lib-generator` requires conditional inclusion of `BigInt64Array | BigUint64Array` depending on ES2020 availability. I don't think there's a way to fix that within `TypeScript-DOM-lib-generator` without this upstream change in `TypeScript`.