### PR TITLE
explicitly disallow `using` in ambient contexts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -52790,17 +52790,28 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const blockScopeFlags = declarationList.flags & NodeFlags.BlockScoped;
-        if ((blockScopeFlags === NodeFlags.Using || blockScopeFlags === NodeFlags.AwaitUsing) && isForInStatement(declarationList.parent)) {
-            return grammarErrorOnNode(
-                declarationList,
-                blockScopeFlags === NodeFlags.Using ?
-                    Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration :
-                    Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration,
-            );
-        }
+        if (blockScopeFlags === NodeFlags.Using || blockScopeFlags === NodeFlags.AwaitUsing) {
+            if (isForInStatement(declarationList.parent)) {
+                return grammarErrorOnNode(
+                    declarationList,
+                    blockScopeFlags === NodeFlags.Using ?
+                        Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration :
+                        Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration,
+                );
+            }
 
-        if (blockScopeFlags === NodeFlags.AwaitUsing) {
-            return checkAwaitGrammar(declarationList);
+            if (declarationList.flags & NodeFlags.Ambient) {
+                return grammarErrorOnNode(
+                    declarationList,
+                    blockScopeFlags === NodeFlags.Using ?
+                        Diagnostics.using_declarations_are_not_allowed_in_ambient_contexts :
+                        Diagnostics.await_using_declarations_are_not_allowed_in_ambient_contexts,
+                );
+            }
+
+            if (blockScopeFlags === NodeFlags.AwaitUsing) {
+                return checkAwaitGrammar(declarationList);
+            }
         }
 
         return false;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1837,6 +1837,14 @@
         "category": "Error",
         "code": 1544
     },
+    "'using' declarations are not allowed in ambient contexts.": {
+        "category": "Error",
+        "code": 1545
+    },
+    "'await using' declarations are not allowed in ambient contexts.": {
+        "category": "Error",
+        "code": 1546
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/tests/baselines/reference/awaitUsingDeclarations.16.errors.txt
+++ b/tests/baselines/reference/awaitUsingDeclarations.16.errors.txt
@@ -1,0 +1,24 @@
+awaitUsingDeclarations.16.ts(2,5): error TS1546: 'await using' declarations are not allowed in ambient contexts.
+awaitUsingDeclarations.16.ts(3,5): error TS1546: 'await using' declarations are not allowed in ambient contexts.
+awaitUsingDeclarations.16.ts(6,5): error TS1546: 'await using' declarations are not allowed in ambient contexts.
+awaitUsingDeclarations.16.ts(7,5): error TS1546: 'await using' declarations are not allowed in ambient contexts.
+
+
+==== awaitUsingDeclarations.16.ts (4 errors) ====
+    declare namespace N {
+        await using x: { [Symbol.asyncDispose](): Promise<void> };
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1546: 'await using' declarations are not allowed in ambient contexts.
+        await using y: null;
+        ~~~~~~~~~~~~~~~~~~~
+!!! error TS1546: 'await using' declarations are not allowed in ambient contexts.
+    }
+    declare module 'M' {
+        await using x: { [Symbol.asyncDispose](): Promise<void> };
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1546: 'await using' declarations are not allowed in ambient contexts.
+        await using y: null;
+        ~~~~~~~~~~~~~~~~~~~
+!!! error TS1546: 'await using' declarations are not allowed in ambient contexts.
+    }
+    

--- a/tests/baselines/reference/awaitUsingDeclarations.16.js
+++ b/tests/baselines/reference/awaitUsingDeclarations.16.js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts] ////
+
+//// [awaitUsingDeclarations.16.ts]
+declare namespace N {
+    await using x: { [Symbol.asyncDispose](): Promise<void> };
+    await using y: null;
+}
+declare module 'M' {
+    await using x: { [Symbol.asyncDispose](): Promise<void> };
+    await using y: null;
+}
+
+
+//// [awaitUsingDeclarations.16.js]

--- a/tests/baselines/reference/usingDeclarations.16.errors.txt
+++ b/tests/baselines/reference/usingDeclarations.16.errors.txt
@@ -1,0 +1,24 @@
+usingDeclarations.16.ts(2,5): error TS1545: 'using' declarations are not allowed in ambient contexts.
+usingDeclarations.16.ts(3,5): error TS1545: 'using' declarations are not allowed in ambient contexts.
+usingDeclarations.16.ts(6,5): error TS1545: 'using' declarations are not allowed in ambient contexts.
+usingDeclarations.16.ts(7,5): error TS1545: 'using' declarations are not allowed in ambient contexts.
+
+
+==== usingDeclarations.16.ts (4 errors) ====
+    declare namespace N {
+        using x: { [Symbol.dispose](): void };
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1545: 'using' declarations are not allowed in ambient contexts.
+        using y: null;
+        ~~~~~~~~~~~~~
+!!! error TS1545: 'using' declarations are not allowed in ambient contexts.
+    }
+    declare module 'M' {
+        using x: { [Symbol.dispose](): void };
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1545: 'using' declarations are not allowed in ambient contexts.
+        using y: null;
+        ~~~~~~~~~~~~~
+!!! error TS1545: 'using' declarations are not allowed in ambient contexts.
+    }
+    

--- a/tests/baselines/reference/usingDeclarations.16.js
+++ b/tests/baselines/reference/usingDeclarations.16.js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.16.ts] ////
+
+//// [usingDeclarations.16.ts]
+declare namespace N {
+    using x: { [Symbol.dispose](): void };
+    using y: null;
+}
+declare module 'M' {
+    using x: { [Symbol.dispose](): void };
+    using y: null;
+}
+
+
+//// [usingDeclarations.16.js]

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts
@@ -1,0 +1,13 @@
+// @target: esnext
+// @module: esnext
+// @lib: esnext
+// @noTypesAndSymbols: true
+
+declare namespace N {
+    await using x: { [Symbol.asyncDispose](): Promise<void> };
+    await using y: null;
+}
+declare module 'M' {
+    await using x: { [Symbol.asyncDispose](): Promise<void> };
+    await using y: null;
+}

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.16.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.16.ts
@@ -1,0 +1,13 @@
+// @target: esnext
+// @module: esnext
+// @lib: esnext
+// @noTypesAndSymbols: true
+
+declare namespace N {
+    using x: { [Symbol.dispose](): void };
+    using y: null;
+}
+declare module 'M' {
+    using x: { [Symbol.dispose](): void };
+    using y: null;
+}


### PR DESCRIPTION
Since it first supported ERM, the compiler has shunned ambient `using`: `declare [await] using` is invalid, and variables appearing in the declaration emit are converted to `const`.

However, there is a blind spot in the checker, and that is when a variable declaration occurs in already-ambient context:
```ts
declare using a: null; // error
declare global {
    using b: null; // not an error
}
namespace N {
    export using c = null; // error
    export declare using d: null; // error
}
declare namespace N {
    using e: null; // not an error
}
```

Technically this doesn't apply to `await using`, as the checker will already complain about an invalid await context, but this PR adds errors on both for consistency.

Closes #61752.