### PR TITLE
Type width in error messages

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22475,7 +22475,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             return;
                         }
                     }
-                    message = Diagnostics.Type_0_is_not_assignable_to_type_1;
+
+                    const includesWideTypes = sourceType.length > 30 || targetType.length > 30;
+                    if (compilerOptions.pretty && includesWideTypes) {
+                        message = Diagnostics.Type_Colon_0_is_not_assignable_to_type_Colon_1;
+                    }
+                    else {
+                        message = Diagnostics.Type_0_is_not_assignable_to_type_1;
+                    }
                 }
             }
             else if (

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3991,6 +3991,10 @@
         "category": "Error",
         "code": 2881
     },
+    "Type:\n  {0}\n\nis not assignable to type:\n  {1}\n": {
+        "category": "Error",
+        "code": 2882
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/prettyFormatLongTypes.errors.txt
+++ b/tests/baselines/reference/prettyFormatLongTypes.errors.txt
@@ -1,0 +1,73 @@
+[96mprettyFormatLongTypes.ts[0m:[93m6[0m:[93m1[0m - [91merror[0m[90m TS2882: [0mType:
+  { b: { c: { e: { f: string; }; }; }; }
+
+is not assignable to type:
+  { b: { c: { e: { f: number; }; }; }; }
+
+  The types of 'b.c.e.f' are incompatible between these types.
+    Type 'string' is not assignable to type 'number'.
+
+[7m6[0m a = b;
+[7m [0m [91m~[0m
+[96mprettyFormatLongTypes.ts[0m:[93m9[0m:[93m1[0m - [91merror[0m[90m TS2882: [0mType:
+  string
+
+is not assignable to type:
+  { b: { c: { e: { f: number; }; }; }; }
+
+
+[7m9[0m a = c;
+[7m [0m [91m~[0m
+[96mprettyFormatLongTypes.ts[0m:[93m12[0m:[93m1[0m - [91merror[0m[90m TS2882: [0mType:
+  { b: { c: { e: { f: number; }; }; }; }
+
+is not assignable to type:
+  string
+
+
+[7m12[0m c = a;
+[7m  [0m [91m~[0m
+[96mprettyFormatLongTypes.ts[0m:[93m15[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType 'boolean' is not assignable to type 'string'.
+
+[7m15[0m c = false;
+[7m  [0m [91m~[0m
+
+
+==== prettyFormatLongTypes.ts (4 errors) ====
+    let a = { b: { c: { e: { f: 123 } } } };
+    let b = { b: { c: { e: { f: "123" } } } };
+    let c = "test";
+    
+    // both the source and target types are wide enough enough trigger pretty printing
+    a = b;
+    ~
+!!! error TS2882: Type:
+!!! error TS2882:   { b: { c: { e: { f: string; }; }; }; }
+!!! error TS2882: is not assignable to type:
+!!! error TS2882:   { b: { c: { e: { f: number; }; }; }; }
+!!! error TS2882:   The types of 'b.c.e.f' are incompatible between these types.
+!!! error TS2882:     Type 'string' is not assignable to type 'number'.
+    
+    // only the source type is wide enough to trigger pretty printing
+    a = c;
+    ~
+!!! error TS2882: Type:
+!!! error TS2882:   string
+!!! error TS2882: is not assignable to type:
+!!! error TS2882:   { b: { c: { e: { f: number; }; }; }; }
+    
+    // only the target type is wide enough to trigger pretty printing
+    c = a;
+    ~
+!!! error TS2882: Type:
+!!! error TS2882:   { b: { c: { e: { f: number; }; }; }; }
+!!! error TS2882: is not assignable to type:
+!!! error TS2882:   string
+    
+    // neither the source nor the target type is wide enough to trigger pretty printing
+    c = false;
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'string'.
+    
+Found 4 errors in the same file, starting at: prettyFormatLongTypes.ts[90m:6[0m
+

--- a/tests/baselines/reference/prettyFormatLongTypes.js
+++ b/tests/baselines/reference/prettyFormatLongTypes.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+//// [prettyFormatLongTypes.ts]
+let a = { b: { c: { e: { f: 123 } } } };
+let b = { b: { c: { e: { f: "123" } } } };
+let c = "test";
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+
+
+//// [prettyFormatLongTypes.js]
+var a = { b: { c: { e: { f: 123 } } } };
+var b = { b: { c: { e: { f: "123" } } } };
+var c = "test";
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+// only the source type is wide enough to trigger pretty printing
+a = c;
+// only the target type is wide enough to trigger pretty printing
+c = a;
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;

--- a/tests/baselines/reference/prettyFormatLongTypes.symbols
+++ b/tests/baselines/reference/prettyFormatLongTypes.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+=== prettyFormatLongTypes.ts ===
+let a = { b: { c: { e: { f: 123 } } } };
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 0, 9))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 0, 14))
+>e : Symbol(e, Decl(prettyFormatLongTypes.ts, 0, 19))
+>f : Symbol(f, Decl(prettyFormatLongTypes.ts, 0, 24))
+
+let b = { b: { c: { e: { f: "123" } } } };
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 9))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 1, 14))
+>e : Symbol(e, Decl(prettyFormatLongTypes.ts, 1, 19))
+>f : Symbol(f, Decl(prettyFormatLongTypes.ts, 1, 24))
+
+let c = "test";
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 3))
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+

--- a/tests/baselines/reference/prettyFormatLongTypes.types
+++ b/tests/baselines/reference/prettyFormatLongTypes.types
@@ -1,0 +1,89 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+=== prettyFormatLongTypes.ts ===
+let a = { b: { c: { e: { f: 123 } } } };
+>a : { b: { c: { e: { f: number; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ b: { c: { e: { f: 123 } } } } : { b: { c: { e: { f: number; }; }; }; }
+>                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { c: { e: { f: number; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ c: { e: { f: 123 } } } : { c: { e: { f: number; }; }; }
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>c : { e: { f: number; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>{ e: { f: 123 } } : { e: { f: number; }; }
+>                  : ^^^^^^^^^^^^^^^^^^^^^^
+>e : { f: number; }
+>  : ^^^^^^^^^^^^^^
+>{ f: 123 } : { f: number; }
+>           : ^^^^^^^^^^^^^^
+>f : number
+>  : ^^^^^^
+>123 : 123
+>    : ^^^
+
+let b = { b: { c: { e: { f: "123" } } } };
+>b : { b: { c: { e: { f: string; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ b: { c: { e: { f: "123" } } } } : { b: { c: { e: { f: string; }; }; }; }
+>                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { c: { e: { f: string; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ c: { e: { f: "123" } } } : { c: { e: { f: string; }; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>c : { e: { f: string; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^
+>{ e: { f: "123" } } : { e: { f: string; }; }
+>                    : ^^^^^^^^^^^^^^^^^^^^^^
+>e : { f: string; }
+>  : ^^^^^^^^^^^^^^
+>{ f: "123" } : { f: string; }
+>             : ^^^^^^^^^^^^^^
+>f : string
+>  : ^^^^^^
+>"123" : "123"
+>      : ^^^^^
+
+let c = "test";
+>c : string
+>  : ^^^^^^
+>"test" : "test"
+>       : ^^^^^^
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+>a = b : { b: { c: { e: { f: string; }; }; }; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : { b: { c: { e: { f: number; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : { b: { c: { e: { f: string; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+>a = c : string
+>      : ^^^^^^
+>a : { b: { c: { e: { f: number; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>c : string
+>  : ^^^^^^
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+>c = a : { b: { c: { e: { f: number; }; }; }; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>c : string
+>  : ^^^^^^
+>a : { b: { c: { e: { f: number; }; }; }; }
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+>c = false : false
+>          : ^^^^^
+>c : string
+>  : ^^^^^^
+>false : false
+>      : ^^^^^
+

--- a/tests/cases/compiler/prettyFormatLongTypes.ts
+++ b/tests/cases/compiler/prettyFormatLongTypes.ts
@@ -1,0 +1,17 @@
+// @pretty: true
+
+let a = { b: { c: { e: { f: 123 } } } };
+let b = { b: { c: { e: { f: "123" } } } };
+let c = "test";
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/45896

Currently the complier will print "... is not assignable..." errors on a single line
```
prettyFormatLongTypes.ts: - error TS2882: Type '{ b: { c: { e: { f: string; }; }; }; }' is not assignable to type '{ b: { c: { e: { f: number; }; }; }; }'
 The types of 'b.c.e.f' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.
```

This PR puts types onto their own lines when they are >30 characters in length
```
prettyFormatLongTypes.ts: - error TS2882: Type:
  { b: { c: { e: { f: string; }; }; }; }

is not assignable to type:
  { b: { c: { e: { f: number; }; }; }; }

  The types of 'b.c.e.f' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.
```

This PR is based on https://github.com/microsoft/TypeScript/pull/54832 which was never merged.