### PR TITLE
Restore `import defer =` parsing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8392,7 +8392,10 @@ namespace Parser {
             phaseModifier = SyntaxKind.TypeKeyword;
             identifier = isIdentifier() ? parseIdentifier() : undefined;
         }
-        else if (identifier?.escapedText === "defer" && token() !== SyntaxKind.FromKeyword) {
+        else if (
+            identifier?.escapedText === "defer" &&
+            (token() === SyntaxKind.FromKeyword ? !lookAhead(nextTokenIsStringLiteral) : token() !== SyntaxKind.CommaToken && token() !== SyntaxKind.EqualsToken)
+        ) {
             phaseModifier = SyntaxKind.DeferKeyword;
             identifier = isIdentifier() ? parseIdentifier() : undefined;
         }

--- a/tests/baselines/reference/importBindingDefer.js
+++ b/tests/baselines/reference/importBindingDefer.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer.ts] ////
+
+//// [a.ts]
+export default 2;
+
+//// [b.ts]
+import defer from "./a.js";
+
+
+//// [a.js]
+export default 2;
+//// [b.js]
+export {};

--- a/tests/baselines/reference/importBindingDefer.symbols
+++ b/tests/baselines/reference/importBindingDefer.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer from "./a.js";
+>defer : Symbol(defer, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/importBindingDefer.types
+++ b/tests/baselines/reference/importBindingDefer.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer from "./a.js";
+>defer : 2
+>      : ^
+

--- a/tests/baselines/reference/importBindingDefer2.js
+++ b/tests/baselines/reference/importBindingDefer2.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer2.ts] ////
+
+//// [a.ts]
+export default 2;
+
+//// [b.ts]
+import defer, {} from "./a.js";
+
+
+//// [a.js]
+export default 2;
+//// [b.js]
+export {};

--- a/tests/baselines/reference/importBindingDefer2.symbols
+++ b/tests/baselines/reference/importBindingDefer2.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer2.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer, {} from "./a.js";
+>defer : Symbol(defer, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/importBindingDefer2.types
+++ b/tests/baselines/reference/importBindingDefer2.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/importDefer/importBindingDefer2.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer, {} from "./a.js";
+>defer : 2
+>      : ^
+

--- a/tests/baselines/reference/importDeferFromInvalid.errors.txt
+++ b/tests/baselines/reference/importDeferFromInvalid.errors.txt
@@ -1,0 +1,11 @@
+b.ts(1,8): error TS18058: Default imports are not allowed in a deferred import.
+
+
+==== a.ts (0 errors) ====
+    export default 2;
+    
+==== b.ts (1 errors) ====
+    import defer from from "./a.js";
+           ~~~~~~~~~~
+!!! error TS18058: Default imports are not allowed in a deferred import.
+    

--- a/tests/baselines/reference/importDeferFromInvalid.js
+++ b/tests/baselines/reference/importDeferFromInvalid.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/importDefer/importDeferFromInvalid.ts] ////
+
+//// [a.ts]
+export default 2;
+
+//// [b.ts]
+import defer from from "./a.js";
+
+
+//// [a.js]
+export default 2;
+//// [b.js]
+export {};

--- a/tests/baselines/reference/importDeferFromInvalid.symbols
+++ b/tests/baselines/reference/importDeferFromInvalid.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/importDefer/importDeferFromInvalid.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer from from "./a.js";
+>from : Symbol(from, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/importDeferFromInvalid.types
+++ b/tests/baselines/reference/importDeferFromInvalid.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/importDefer/importDeferFromInvalid.ts] ////
+
+=== a.ts ===
+
+export default 2;
+
+=== b.ts ===
+import defer from from "./a.js";
+>from : 2
+>     : ^
+

--- a/tests/baselines/reference/importEqualsBindingDefer.js
+++ b/tests/baselines/reference/importEqualsBindingDefer.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/importDefer/importEqualsBindingDefer.ts] ////
+
+//// [a.ts]
+export = 2;
+
+//// [b.ts]
+import defer = require("./a");
+
+
+//// [a.js]
+"use strict";
+module.exports = 2;
+//// [b.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/importEqualsBindingDefer.symbols
+++ b/tests/baselines/reference/importEqualsBindingDefer.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/importDefer/importEqualsBindingDefer.ts] ////
+
+=== b.ts ===
+import defer = require("./a");
+>defer : Symbol(defer, Decl(b.ts, 0, 0))
+
+=== a.ts ===
+
+export = 2;
+

--- a/tests/baselines/reference/importEqualsBindingDefer.types
+++ b/tests/baselines/reference/importEqualsBindingDefer.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/importDefer/importEqualsBindingDefer.ts] ////
+
+=== b.ts ===
+import defer = require("./a");
+>defer : 2
+>      : ^
+
+=== a.ts ===
+
+export = 2;
+

--- a/tests/cases/conformance/importDefer/importBindingDefer.ts
+++ b/tests/cases/conformance/importDefer/importBindingDefer.ts
@@ -1,0 +1,8 @@
+// @module: esnext
+// @target: es2020
+
+// @filename: a.ts
+export default 2;
+
+// @filename: b.ts
+import defer from "./a.js";

--- a/tests/cases/conformance/importDefer/importBindingDefer2.ts
+++ b/tests/cases/conformance/importDefer/importBindingDefer2.ts
@@ -1,0 +1,8 @@
+// @module: esnext
+// @target: es2020
+
+// @filename: a.ts
+export default 2;
+
+// @filename: b.ts
+import defer, {} from "./a.js";

--- a/tests/cases/conformance/importDefer/importDeferFromInvalid.ts
+++ b/tests/cases/conformance/importDefer/importDeferFromInvalid.ts
@@ -1,0 +1,8 @@
+// @module: esnext
+// @target: es2020
+
+// @filename: a.ts
+export default 2;
+
+// @filename: b.ts
+import defer from from "./a.js";

--- a/tests/cases/conformance/importDefer/importEqualsBindingDefer.ts
+++ b/tests/cases/conformance/importDefer/importEqualsBindingDefer.ts
@@ -1,0 +1,8 @@
+// @module: commonjs
+// @target: es2020
+
+// @filename: a.ts
+export = 2;
+
+// @filename: b.ts
+import defer = require("./a");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/pull/60757#issuecomment-2954299400

I also added a bunch more tests for when using `defer` as a binding identifier in ES import declarations. Note that `import defer from from "foo"` is invalid, but I added a test to verify that it reports the same error as for `import defer foo from "foo"`.

cc @jakebailey