### PR TITLE
fix: diagnostic message for class name 'Object' when targeting different ECMAScript versions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46569,7 +46569,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             languageVersion >= ScriptTarget.ES5 && name.escapedText === "Object"
             && host.getEmitModuleFormatOfFile(getSourceFileOfNode(name)) < ModuleKind.ES2015
         ) {
-            error(name, Diagnostics.Class_name_cannot_be_Object_when_targeting_ES5_with_module_0, ModuleKind[moduleKind]); // https://github.com/Microsoft/TypeScript/issues/17494
+            error(name, Diagnostics.Class_name_cannot_be_Object_when_targeting_ES5_and_above_with_module_0, ModuleKind[moduleKind]); // https://github.com/Microsoft/TypeScript/issues/17494
         }
     }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3419,7 +3419,7 @@
         "category": "Error",
         "code": 2724
     },
-    "Class name cannot be 'Object' when targeting ES5 with module {0}.": {
+    "Class name cannot be 'Object' when targeting ES5 and above with module {0}.": {
         "category": "Error",
         "code": 2725
     },

--- a/tests/baselines/reference/checkForObjectTooStrict.errors.txt
+++ b/tests/baselines/reference/checkForObjectTooStrict.errors.txt
@@ -1,4 +1,4 @@
-checkForObjectTooStrict.ts(3,18): error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+checkForObjectTooStrict.ts(3,18): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
 
 
 ==== checkForObjectTooStrict.ts (1 errors) ====
@@ -6,7 +6,7 @@ checkForObjectTooStrict.ts(3,18): error TS2725: Class name cannot be 'Object' wh
     
         export class Object {
                      ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
     
         }
     

--- a/tests/baselines/reference/exportClassNameWithObjectAMD.errors.txt
+++ b/tests/baselines/reference/exportClassNameWithObjectAMD.errors.txt
@@ -1,8 +1,8 @@
-exportClassNameWithObjectAMD.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 with module AMD.
+exportClassNameWithObjectAMD.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module AMD.
 
 
 ==== exportClassNameWithObjectAMD.ts (1 errors) ====
     export class Object {}
                  ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module AMD.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module AMD.
     

--- a/tests/baselines/reference/exportClassNameWithObjectCommonJS.errors.txt
+++ b/tests/baselines/reference/exportClassNameWithObjectCommonJS.errors.txt
@@ -1,8 +1,8 @@
-exportClassNameWithObjectCommonJS.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+exportClassNameWithObjectCommonJS.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
 
 
 ==== exportClassNameWithObjectCommonJS.ts (1 errors) ====
     export class Object {}
                  ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
     

--- a/tests/baselines/reference/exportClassNameWithObjectSystem.errors.txt
+++ b/tests/baselines/reference/exportClassNameWithObjectSystem.errors.txt
@@ -1,8 +1,8 @@
-exportClassNameWithObjectSystem.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 with module System.
+exportClassNameWithObjectSystem.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module System.
 
 
 ==== exportClassNameWithObjectSystem.ts (1 errors) ====
     export class Object {}
                  ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module System.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module System.
     

--- a/tests/baselines/reference/exportClassNameWithObjectUMD.errors.txt
+++ b/tests/baselines/reference/exportClassNameWithObjectUMD.errors.txt
@@ -1,8 +1,8 @@
-exportClassNameWithObjectUMD.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 with module UMD.
+exportClassNameWithObjectUMD.ts(1,14): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module UMD.
 
 
 ==== exportClassNameWithObjectUMD.ts (1 errors) ====
     export class Object {}
                  ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module UMD.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module UMD.
     

--- a/tests/baselines/reference/exportDefaultClassNameWithObject.errors.txt
+++ b/tests/baselines/reference/exportDefaultClassNameWithObject.errors.txt
@@ -1,8 +1,8 @@
-exportDefaultClassNameWithObject.ts(1,22): error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+exportDefaultClassNameWithObject.ts(1,22): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
 
 
 ==== exportDefaultClassNameWithObject.ts (1 errors) ====
     export default class Object {}
                          ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
     

--- a/tests/baselines/reference/instanceofOperator.errors.txt
+++ b/tests/baselines/reference/instanceofOperator.errors.txt
@@ -1,4 +1,4 @@
-instanceofOperator.ts(7,11): error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+instanceofOperator.ts(7,11): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
 instanceofOperator.ts(12,5): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
 instanceofOperator.ts(15,20): error TS2359: The right-hand side of an 'instanceof' expression must be either of type 'any', a class, function, or other type assignable to the 'Function' interface type, or an object type with a 'Symbol.hasInstance' method.
 instanceofOperator.ts(16,23): error TS2359: The right-hand side of an 'instanceof' expression must be either of type 'any', a class, function, or other type assignable to the 'Function' interface type, or an object type with a 'Symbol.hasInstance' method.
@@ -15,7 +15,7 @@ instanceofOperator.ts(21,5): error TS2358: The left-hand side of an 'instanceof'
     module test {
         class Object { }
               ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module CommonJS.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
         var obj: Object;
     
     

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node16).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node16.
+subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node16.
 subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node16.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node16.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node18).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node18.
+subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node18.
 subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node18.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node18.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node20).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node20.
+subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node20.
 subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node20.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node20.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=nodenext).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module NodeNext.
+subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module NodeNext.
 subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.js(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module NodeNext.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module NodeNext.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node16).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.ts(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.ts(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node16.
+subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node16.
 subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node16.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node16.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node18).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.ts(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.ts(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node18.
+subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node18.
 subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node18.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node18.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=node20).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.ts(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.ts(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node20.
+subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node20.
 subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node20.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module Node20.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.

--- a/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesGeneratedNameCollisions(module=nodenext).errors.txt
@@ -1,6 +1,6 @@
 subfolder/index.ts(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 subfolder/index.ts(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
-subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module NodeNext.
+subfolder/index.ts(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module NodeNext.
 subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
 
 
@@ -14,7 +14,7 @@ subfolder/index.ts(5,14): error TS1216: Identifier expected. '__esModule' is res
 !!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
           ~~~~~~
-!!! error TS2725: Class name cannot be 'Object' when targeting ES5 with module NodeNext.
+!!! error TS2725: Class name cannot be 'Object' when targeting ES5 and above with module NodeNext.
     export const __esModule = false;
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes: https://github.com/microsoft/TypeScript/issues/61270
