### PR TITLE
Fixed types of parenthesized expressions at locations with `@satisfies` and `@type` mix

### DIFF
--- a/tests/baselines/reference/checkJsdocSatisfiesTag1.types
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag1.types
@@ -60,8 +60,8 @@ const t3 = /** @satisfies {T1} */ ({});
 const t4 = /** @satisfies {T2} */ ({ a: "a" });
 >t4 : T2
 >   : ^^
->({ a: "a" }) : T2
->             : ^^
+>({ a: "a" }) : { a: "a"; }
+>             : ^^^^^^^^^^^
 >{ a: "a" } : { a: "a"; }
 >           : ^^^^^^^^^^^
 >a : "a"
@@ -74,7 +74,7 @@ const t5 = /** @satisfies {T3} */((m) => m.substring(0));
 >t5 : (m: string) => string
 >   : ^ ^^      ^^^^^      
 >((m) => m.substring(0)) : (m: string) => string
->                        : ^ ^^      ^^^^^      
+>                        : ^ ^^^^^^^^^^^^^^^^^^^
 >(m) => m.substring(0) : (m: string) => string
 >                      : ^ ^^^^^^^^^^^^^^^^^^^
 >m : string

--- a/tests/baselines/reference/checkJsdocSatisfiesTag11.errors.txt
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag11.errors.txt
@@ -1,8 +1,7 @@
 /a.js(13,5): error TS1223: 'satisfies' tag already specified.
-/a.js(18,5): error TS1223: 'satisfies' tag already specified.
 
 
-==== /a.js (2 errors) ====
+==== /a.js (1 errors) ====
     /**
      * @typedef {Object} T1
      * @property {number} a
@@ -23,8 +22,6 @@
     
     /**
      * @satisfies {number}
-        ~~~~~~~~~
-!!! error TS1223: 'satisfies' tag already specified.
      */
     const t2 = /** @satisfies {number} */ (1);
     

--- a/tests/baselines/reference/checkJsdocSatisfiesTag16.errors.txt
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag16.errors.txt
@@ -1,0 +1,35 @@
+/a.js(9,17): error TS1360: Type 'number' does not satisfy the expected type 'string'.
+/a.js(12,5): error TS1360: Type 'number' does not satisfy the expected type 'string'.
+/a.js(17,5): error TS1360: Type 'number' does not satisfy the expected type 'string'.
+/a.js(19,17): error TS1360: Type 'number' does not satisfy the expected type 'string'.
+
+
+==== /a.js (4 errors) ====
+    /**
+     * @satisfies {number}
+     */
+    const t1 = /** @satisfies {number} */ (1);
+    
+    /**
+     * @satisfies {number}
+     */
+    const t2 = /** @satisfies {string} */ (1);
+                    ~~~~~~~~~
+!!! error TS1360: Type 'number' does not satisfy the expected type 'string'.
+    
+    /**
+     * @satisfies {string}
+        ~~~~~~~~~
+!!! error TS1360: Type 'number' does not satisfy the expected type 'string'.
+     */
+    const t3 = /** @satisfies {number} */ (1);
+    
+    /**
+     * @satisfies {string}
+        ~~~~~~~~~
+!!! error TS1360: Type 'number' does not satisfy the expected type 'string'.
+     */
+    const t4 = /** @satisfies {string} */ (1);
+                    ~~~~~~~~~
+!!! error TS1360: Type 'number' does not satisfy the expected type 'string'.
+    

--- a/tests/baselines/reference/checkJsdocSatisfiesTag16.symbols
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag16.symbols
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag16.ts] ////
+
+=== /a.js ===
+/**
+ * @satisfies {number}
+ */
+const t1 = /** @satisfies {number} */ (1);
+>t1 : Symbol(t1, Decl(a.js, 3, 5))
+
+/**
+ * @satisfies {number}
+ */
+const t2 = /** @satisfies {string} */ (1);
+>t2 : Symbol(t2, Decl(a.js, 8, 5))
+
+/**
+ * @satisfies {string}
+ */
+const t3 = /** @satisfies {number} */ (1);
+>t3 : Symbol(t3, Decl(a.js, 13, 5))
+
+/**
+ * @satisfies {string}
+ */
+const t4 = /** @satisfies {string} */ (1);
+>t4 : Symbol(t4, Decl(a.js, 18, 5))
+

--- a/tests/baselines/reference/checkJsdocSatisfiesTag16.types
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag16.types
@@ -1,0 +1,47 @@
+//// [tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag16.ts] ////
+
+=== /a.js ===
+/**
+ * @satisfies {number}
+ */
+const t1 = /** @satisfies {number} */ (1);
+>t1 : 1
+>   : ^
+>(1) : 1
+>    : ^
+>1 : 1
+>  : ^
+
+/**
+ * @satisfies {number}
+ */
+const t2 = /** @satisfies {string} */ (1);
+>t2 : 1
+>   : ^
+>(1) : 1
+>    : ^
+>1 : 1
+>  : ^
+
+/**
+ * @satisfies {string}
+ */
+const t3 = /** @satisfies {number} */ (1);
+>t3 : 1
+>   : ^
+>(1) : 1
+>    : ^
+>1 : 1
+>  : ^
+
+/**
+ * @satisfies {string}
+ */
+const t4 = /** @satisfies {string} */ (1);
+>t4 : 1
+>   : ^
+>(1) : 1
+>    : ^
+>1 : 1
+>  : ^
+

--- a/tests/baselines/reference/checkJsdocSatisfiesTag3.types
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag3.types
@@ -5,8 +5,8 @@
 let obj = /** @satisfies {{ g(s: string): void } & Record<string, unknown>} */ ({
 >obj : { f(s: string): void; } & Record<string, unknown>
 >    : ^^^^ ^^      ^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->({    f(s) { }, // "incorrect" implicit any on 's'    g(s) { }}) : { f(s: string): void; } & Record<string, unknown>
->                                                                 : ^^^^ ^^      ^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>({    f(s) { }, // "incorrect" implicit any on 's'    g(s) { }}) : { f(s: any): void; g(s: string): void; }
+>                                                                 : ^^^^ ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^
 >{    f(s) { }, // "incorrect" implicit any on 's'    g(s) { }} : { f(s: any): void; g(s: string): void; }
 >                                                               : ^^^^ ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^
 

--- a/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag16.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag16.ts
@@ -1,0 +1,26 @@
+// @strict: true
+// @allowJS: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: /a.js
+
+/**
+ * @satisfies {number}
+ */
+const t1 = /** @satisfies {number} */ (1);
+
+/**
+ * @satisfies {number}
+ */
+const t2 = /** @satisfies {string} */ (1);
+
+/**
+ * @satisfies {string}
+ */
+const t3 = /** @satisfies {number} */ (1);
+
+/**
+ * @satisfies {string}
+ */
+const t4 = /** @satisfies {string} */ (1);


### PR DESCRIPTION
see https://github.com/microsoft/typescript-go/pull/1157/files/e9100512827813e64556ef3d1fadd36e606d8677#r2139735507

cc @sandersn @jakebailey 