### PR TITLE
Fixed crash on `ComputedPropertyName` when computing interactive inlay hints

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -42,6 +42,7 @@ import {
     isBindingPattern,
     isCallExpression,
     isCallSignatureDeclaration,
+    isComputedPropertyName,
     isConditionalTypeNode,
     isConstructorTypeNode,
     isEnumMember,
@@ -875,6 +876,12 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
                 case SyntaxKind.ThisType:
                     Debug.assertNode(node, isThisTypeNode);
                     parts.push({ text: "this" });
+                    break;
+                case SyntaxKind.ComputedPropertyName:
+                    Debug.assertNode(node, isComputedPropertyName);
+                    parts.push({ text: "[" });
+                    visitForDisplayParts(node.expression);
+                    parts.push({ text: "]" });
                     break;
                 default:
                     Debug.failBadSyntaxKind(node);

--- a/tests/baselines/reference/inlayHintsFunctionParameterTypes5.baseline
+++ b/tests/baselines/reference/inlayHintsFunctionParameterTypes5.baseline
@@ -1,0 +1,46 @@
+// === Inlay Hints ===
+test((state) => {});
+           ^
+{
+  "text": "",
+  "displayParts": [
+    {
+      "text": ": "
+    },
+    {
+      "text": "{"
+    },
+    {
+      "text": " "
+    },
+    {
+      "text": "["
+    },
+    {
+      "text": "STATE_SIGNAL",
+      "span": {
+        "start": 14,
+        "length": 12
+      },
+      "file": "/tests/cases/fourslash/inlayHintsFunctionParameterTypes5.ts"
+    },
+    {
+      "text": "]"
+    },
+    {
+      "text": ": "
+    },
+    {
+      "text": "unknown"
+    },
+    {
+      "text": " "
+    },
+    {
+      "text": "}"
+    }
+  ],
+  "position": 143,
+  "kind": "Type",
+  "whitespaceBefore": true
+}

--- a/tests/cases/fourslash/inlayHintsFunctionParameterTypes5.ts
+++ b/tests/cases/fourslash/inlayHintsFunctionParameterTypes5.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// https://github.com/microsoft/TypeScript/issues/61845
+
+//// declare const STATE_SIGNAL: unique symbol;
+////
+//// declare function test(
+////   cb: (state: { [STATE_SIGNAL]: unknown }) => void,
+//// ): unknown;
+////
+//// test((state) => {});
+
+verify.baselineInlayHints(undefined, {
+    includeInlayFunctionParameterTypeHints: true,
+    interactiveInlayHints: true,
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61845