### PR TITLE
chore(lib.dom): correct MDN link for requestAnimationFrame and cancel…

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -2879,9 +2879,9 @@ declare var AnimationEvent: {
 };
 
 interface AnimationFrameProvider {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame) */
     cancelAnimationFrame(handle: number): void;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/requestAnimationFrame) */
     requestAnimationFrame(callback: FrameRequestCallback): number;
 }
 


### PR DESCRIPTION
…AnimationFrame

The previous MDN reference for `requestAnimationFrame` was outdated/incorrect. This commit updates it to the current valid MDN URL: https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #61879
