### PR TITLE
Use strict subtype relation in `getCommonSupertype`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25349,7 +25349,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const candidate = reduceLeft(types, (s, t) => isTypeStrictSubtypeOf(s, t) ? t : s)!;
         return every(types, t => t === candidate || isTypeStrictSubtypeOf(t, candidate)) ?
             candidate :
-            reduceLeft(types, (s, t) => isTypeAssignableTo(s, t) ? t : s)!;
+            reduceLeft(types, (s, t) => isTypeSubtypeOf(s, t) ? t : s)!;
     }
 
     // Return the leftmost type for which no type to the right is a subtype.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25340,7 +25340,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // right is a supertype.
         const superTypeOrUnion = literalTypesWithSameBaseType(primaryTypes) ?
             getUnionType(primaryTypes) :
-            reduceLeft(primaryTypes, (s, t) => isTypeSubtypeOf(s, t) ? t : s)!;
+            reduceLeft(primaryTypes, (s, t) => isTypeStrictSubtypeOf(s, t) ? t : s)!;
         // Add any nullable types that occurred in the candidates back to the result.
         return primaryTypes === types ? superTypeOrUnion : getNullableType(superTypeOrUnion, getCombinedTypeFlags(types) & TypeFlags.Nullable);
     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25340,12 +25340,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // right is a supertype.
         const superTypeOrUnion = literalTypesWithSameBaseType(primaryTypes) ?
             getUnionType(primaryTypes) :
-            getSingleCommonSupertype(primaryTypes)
+            getSingleCommonSupertype(primaryTypes);
         // Add any nullable types that occurred in the candidates back to the result.
         return primaryTypes === types ? superTypeOrUnion : getNullableType(superTypeOrUnion, getCombinedTypeFlags(types) & TypeFlags.Nullable);
     }
 
     function getSingleCommonSupertype(types: Type[]) {
+        // First, find the leftmost type for which no type to the right is a strict supertype, and if that
+        // type is a strict supertype of all other candidates, return it. Otherwise, return the leftmost type
+        // for which no type to the right is a (regular) supertype.
         const candidate = reduceLeft(types, (s, t) => isTypeStrictSubtypeOf(s, t) ? t : s)!;
         return every(types, t => t === candidate || isTypeStrictSubtypeOf(t, candidate)) ?
             candidate :

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25340,9 +25340,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // right is a supertype.
         const superTypeOrUnion = literalTypesWithSameBaseType(primaryTypes) ?
             getUnionType(primaryTypes) :
-            reduceLeft(primaryTypes, (s, t) => isTypeStrictSubtypeOf(s, t) ? t : s)!;
+            getSingleCommonSupertype(primaryTypes)
         // Add any nullable types that occurred in the candidates back to the result.
         return primaryTypes === types ? superTypeOrUnion : getNullableType(superTypeOrUnion, getCombinedTypeFlags(types) & TypeFlags.Nullable);
+    }
+
+    function getSingleCommonSupertype(types: Type[]) {
+        const candidate = reduceLeft(types, (s, t) => isTypeStrictSubtypeOf(s, t) ? t : s)!;
+        return every(types, t => t === candidate || isTypeStrictSubtypeOf(t, candidate)) ?
+            candidate :
+            reduceLeft(types, (s, t) => isTypeAssignableTo(s, t) ? t : s)!;
     }
 
     // Return the leftmost type for which no type to the right is a subtype.


### PR DESCRIPTION
This PR modifies our `getCommonSupertype` algorithm as follows: When picking a best common supertype, first check if one and only one candidate is a strict supertype of all other candidates, and if so go with that candidate. Otherwise, do what we did before, i.e. go with the leftmost candidate for which no candidate to the right is a supertype.