### PR TITLE
Don't ignore completions at source file locations

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2738,78 +2738,76 @@ export function getCompletionEntriesFromSymbols(
 
     function shouldIncludeSymbol(symbol: Symbol, symbolToSortTextMap: SymbolSortTextMap): boolean {
         let allFlags = symbol.flags;
-        if (!isSourceFile(location)) {
-            // export = /**/ here we want to get all meanings, so any symbol is ok
-            if (isExportAssignment(location.parent)) {
-                return true;
-            }
-            // Filter out variables from their own initializers
-            // `const a = /* no 'a' here */`
-            if (closestSymbolDeclaration && tryCast(closestSymbolDeclaration, isVariableDeclaration)) {
-                if (symbol.valueDeclaration === closestSymbolDeclaration) {
-                    return false;
-                }
-                // const { a } = /* no 'a' here */;
-                if (isBindingPattern(closestSymbolDeclaration.name) && closestSymbolDeclaration.name.elements.some(e => e === symbol.valueDeclaration)) {
-                    return false;
-                }
-            }
-
-            // Filter out current and latter parameters from defaults
-            // `function f(a = /* no 'a' and 'b' here */, b) { }` or
-            // `function f<T = /* no 'T' and 'T2' here */>(a: T, b: T2) { }`
-            const symbolDeclaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
-            if (closestSymbolDeclaration && symbolDeclaration) {
-                if (isParameter(closestSymbolDeclaration) && isParameter(symbolDeclaration)) {
-                    const parameters = closestSymbolDeclaration.parent.parameters;
-                    if (symbolDeclaration.pos >= closestSymbolDeclaration.pos && symbolDeclaration.pos < parameters.end) {
-                        return false;
-                    }
-                }
-                else if (isTypeParameterDeclaration(closestSymbolDeclaration) && isTypeParameterDeclaration(symbolDeclaration)) {
-                    if (closestSymbolDeclaration === symbolDeclaration && contextToken?.kind === SyntaxKind.ExtendsKeyword) {
-                        // filter out the directly self-recursive type parameters
-                        // `type A<K extends /* no 'K' here*/> = K`
-                        return false;
-                    }
-                    if (isInTypeParameterDefault(contextToken) && !isInferTypeNode(closestSymbolDeclaration.parent)) {
-                        const typeParameters = closestSymbolDeclaration.parent.typeParameters;
-                        if (typeParameters && symbolDeclaration.pos >= closestSymbolDeclaration.pos && symbolDeclaration.pos < typeParameters.end) {
-                            return false;
-                        }
-                    }
-                }
-            }
-
-            // External modules can have global export declarations that will be
-            // available as global keywords in all scopes. But if the external module
-            // already has an explicit export and user only wants to user explicit
-            // module imports then the global keywords will be filtered out so auto
-            // import suggestions will win in the completion
-            const symbolOrigin = skipAlias(symbol, typeChecker);
-            // We only want to filter out the global keywords
-            // Auto Imports are not available for scripts so this conditional is always false
-            if (
-                !!sourceFile.externalModuleIndicator
-                && !compilerOptions.allowUmdGlobalAccess
-                && symbolToSortTextMap[getSymbolId(symbol)] === SortText.GlobalsOrKeywords
-                && (symbolToSortTextMap[getSymbolId(symbolOrigin)] === SortText.AutoImportSuggestions
-                    || symbolToSortTextMap[getSymbolId(symbolOrigin)] === SortText.LocationPriority)
-            ) {
+        // export = /**/ here we want to get all meanings, so any symbol is ok
+        if (location.parent && isExportAssignment(location.parent)) {
+            return true;
+        }
+        // Filter out variables from their own initializers
+        // `const a = /* no 'a' here */`
+        if (closestSymbolDeclaration && tryCast(closestSymbolDeclaration, isVariableDeclaration)) {
+            if (symbol.valueDeclaration === closestSymbolDeclaration) {
                 return false;
             }
-
-            allFlags |= getCombinedLocalAndExportSymbolFlags(symbolOrigin);
-
-            // import m = /**/ <-- It can only access namespace (if typing import = x. this would get member symbols and not namespace)
-            if (isInRightSideOfInternalImportEqualsDeclaration(location)) {
-                return !!(allFlags & SymbolFlags.Namespace);
+            // const { a } = /* no 'a' here */;
+            if (isBindingPattern(closestSymbolDeclaration.name) && closestSymbolDeclaration.name.elements.some(e => e === symbol.valueDeclaration)) {
+                return false;
             }
+        }
 
-            if (isTypeOnlyLocation) {
-                // It's a type, but you can reach it by namespace.type as well
-                return symbolCanBeReferencedAtTypeLocation(symbol, typeChecker);
+        // Filter out current and latter parameters from defaults
+        // `function f(a = /* no 'a' and 'b' here */, b) { }` or
+        // `function f<T = /* no 'T' and 'T2' here */>(a: T, b: T2) { }`
+        const symbolDeclaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+        if (closestSymbolDeclaration && symbolDeclaration) {
+            if (isParameter(closestSymbolDeclaration) && isParameter(symbolDeclaration)) {
+                const parameters = closestSymbolDeclaration.parent.parameters;
+                if (symbolDeclaration.pos >= closestSymbolDeclaration.pos && symbolDeclaration.pos < parameters.end) {
+                    return false;
+                }
             }
+            else if (isTypeParameterDeclaration(closestSymbolDeclaration) && isTypeParameterDeclaration(symbolDeclaration)) {
+                if (closestSymbolDeclaration === symbolDeclaration && contextToken?.kind === SyntaxKind.ExtendsKeyword) {
+                    // filter out the directly self-recursive type parameters
+                    // `type A<K extends /* no 'K' here*/> = K`
+                    return false;
+                }
+                if (isInTypeParameterDefault(contextToken) && !isInferTypeNode(closestSymbolDeclaration.parent)) {
+                    const typeParameters = closestSymbolDeclaration.parent.typeParameters;
+                    if (typeParameters && symbolDeclaration.pos >= closestSymbolDeclaration.pos && symbolDeclaration.pos < typeParameters.end) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // External modules can have global export declarations that will be
+        // available as global keywords in all scopes. But if the external module
+        // already has an explicit export and user only wants to user explicit
+        // module imports then the global keywords will be filtered out so auto
+        // import suggestions will win in the completion
+        const symbolOrigin = skipAlias(symbol, typeChecker);
+        // We only want to filter out the global keywords
+        // Auto Imports are not available for scripts so this conditional is always false
+        if (
+            !!sourceFile.externalModuleIndicator
+            && !compilerOptions.allowUmdGlobalAccess
+            && symbolToSortTextMap[getSymbolId(symbol)] === SortText.GlobalsOrKeywords
+            && (symbolToSortTextMap[getSymbolId(symbolOrigin)] === SortText.AutoImportSuggestions
+                || symbolToSortTextMap[getSymbolId(symbolOrigin)] === SortText.LocationPriority)
+        ) {
+            return false;
+        }
+
+        allFlags |= getCombinedLocalAndExportSymbolFlags(symbolOrigin);
+
+        // import m = /**/ <-- It can only access namespace (if typing import = x. this would get member symbols and not namespace)
+        if (isInRightSideOfInternalImportEqualsDeclaration(location)) {
+            return !!(allFlags & SymbolFlags.Namespace);
+        }
+
+        if (isTypeOnlyLocation) {
+            // It's a type, but you can reach it by namespace.type as well
+            return symbolCanBeReferencedAtTypeLocation(symbol, typeChecker);
         }
 
         // expressions are value space (which includes the value namespaces)

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -520,6 +520,9 @@ function getMeaningFromRightHandSideOfImportEquals(node: Node): SemanticMeaning 
 
 /** @internal */
 export function isInRightSideOfInternalImportEqualsDeclaration(node: Node): boolean {
+    if (!node.parent) {
+        return false;
+    }
     while (node.parent.kind === SyntaxKind.QualifiedName) {
         node = node.parent;
     }

--- a/tests/baselines/reference/tsserver/completions/in-project-reference-setup-with-path-mapping-with-existing-import-without-includeCompletionsForModuleExports.js
+++ b/tests/baselines/reference/tsserver/completions/in-project-reference-setup-with-path-mapping-with-existing-import-without-includeCompletionsForModuleExports.js
@@ -408,6 +408,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -814,19 +820,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           }
         ],
         "defaultCommitCharacters": [
@@ -899,6 +892,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -1305,19 +1304,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           }
         ],
         "defaultCommitCharacters": [
@@ -1402,6 +1388,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -1808,19 +1800,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           }
         ],
         "defaultCommitCharacters": [
@@ -1923,6 +1902,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -2329,19 +2314,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           }
         ],
         "defaultCommitCharacters": [

--- a/tests/baselines/reference/tsserver/completions/in-project-reference-setup-with-path-mapping-with-existing-import.js
+++ b/tests/baselines/reference/tsserver/completions/in-project-reference-setup-with-path-mapping-with-existing-import.js
@@ -437,6 +437,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -843,19 +849,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           },
           {
             "name": "MyHelper",
@@ -967,6 +960,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -1373,19 +1372,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           },
           {
             "name": "MyHelper",
@@ -1565,6 +1551,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -1971,19 +1963,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           },
           {
             "name": "MyHelper",
@@ -2114,6 +2093,12 @@ Info seq  [hh:mm:ss:mss] response:
         "isNewIdentifierLocation": false,
         "entries": [
           {
+            "name": "MyClass",
+            "kind": "alias",
+            "kindModifiers": "export",
+            "sortText": "11"
+          },
+          {
             "name": "abstract",
             "kind": "keyword",
             "kindModifiers": "",
@@ -2520,19 +2505,6 @@ Info seq  [hh:mm:ss:mss] response:
             "kind": "keyword",
             "kindModifiers": "",
             "sortText": "15"
-          },
-          {
-            "name": "MyClass",
-            "kind": "class",
-            "kindModifiers": "export",
-            "sortText": "16",
-            "source": "/user/username/projects/shared/src/index",
-            "hasAction": true,
-            "data": {
-              "exportName": "MyClass",
-              "exportMapKey": "7 * MyClass ",
-              "fileName": "/user/username/projects/shared/src/index.ts"
-            }
           }
         ],
         "defaultCommitCharacters": [

--- a/tests/cases/fourslash/asOperatorCompletion2.ts
+++ b/tests/cases/fourslash/asOperatorCompletion2.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+//// type T = number;
+//// var x;
+//// var y = x as /**/
+////
+
+verify.completions({ marker: "", includes: "T" });
+

--- a/tests/cases/fourslash/asOperatorCompletion3.ts
+++ b/tests/cases/fourslash/asOperatorCompletion3.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+//// type T = number;
+//// var x;
+//// var y = x as /**/ // comment
+
+verify.completions({ marker: "", includes: "T" });
+


### PR DESCRIPTION
When investigating Corsa's completions, I learned that it can't find completions for this case:
https://github.com/microsoft/typescript-go/blob/6e03d625d15ccaf727cb9a44b455eefb16f3d450/internal/fourslash/tests/gen/asOperatorCompletion_test.go#L13

In Corsa, there is no EndOfFileToken included in the SourceFile (yet? see https://github.com/microsoft/typescript-go/pull/1257 ) and thus that token can't be found as the location (computed by `getTouchingPropertyName(sourceFile, position)`). So the `location` becomes simply the `SourceFile` itself.

But then, it turns out those completions stop working in Strada as soon as we include an extra newline at the end of the file, or if we add a comment after the `as`. In such situations, the found location becomes the `SourceFile`. I can't find a reason why the SourceFile locations would be deliberately ignored by this whole `shouldIncludeSymbol` function. Only 2 paths in it are actually considering `location` at all. I have a feeling, this condition might have been put in place to avoid checking `location.parent` as that's `undefined` for `SourceFile`s.