### PR TITLE
Inconsistent types between Document scrollingElement and documentElement

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -8091,7 +8091,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      */
     readonly scripts: HTMLCollectionOf<HTMLScriptElement>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/scrollingElement) */
-    readonly scrollingElement: Element | null;
+    readonly scrollingElement: Document['documentElement'] | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/timeline) */
     readonly timeline: DocumentTimeline;
     /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/60838
