### PR TITLE
Use jsx language variant for jsx file scanning in getChildren

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4288,6 +4288,7 @@ export interface SourceFileLike {
     lineMap?: readonly number[];
     /** @internal */
     getPositionOfLineAndCharacter?(line: number, character: number, allowEdits?: true): number;
+    languageVariant?: LanguageVariant;
 }
 
 /** @internal */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1595,7 +1595,7 @@ function getJsxClosingTagCompletion(location: Node | undefined, sourceFile: Sour
         switch (node.kind) {
             case SyntaxKind.JsxClosingElement:
                 return true;
-            case SyntaxKind.SlashToken:
+            case SyntaxKind.LessThanSlashToken:
             case SyntaxKind.GreaterThanToken:
             case SyntaxKind.Identifier:
             case SyntaxKind.PropertyAccessExpression:
@@ -3508,7 +3508,7 @@ function getCompletionData(
                         }
                         break;
 
-                    case SyntaxKind.SlashToken:
+                    case SyntaxKind.LessThanSlashToken:
                         if (currentToken.parent.kind === SyntaxKind.JsxSelfClosingElement) {
                             location = currentToken;
                         }
@@ -3518,7 +3518,7 @@ function getCompletionData(
 
             switch (parent.kind) {
                 case SyntaxKind.JsxClosingElement:
-                    if (contextToken.kind === SyntaxKind.SlashToken) {
+                    if (contextToken.kind === SyntaxKind.LessThanSlashToken) {
                         isStartingCloseTag = true;
                         location = contextToken;
                     }
@@ -5805,7 +5805,7 @@ function isValidTrigger(sourceFile: SourceFile, triggerCharacter: CompletionsTri
         case "/":
             return !!contextToken && (isStringLiteralLike(contextToken)
                 ? !!tryGetImportFromModuleSpecifier(contextToken)
-                : contextToken.kind === SyntaxKind.SlashToken && isJsxClosingElement(contextToken.parent));
+                : contextToken.kind === SyntaxKind.LessThanSlashToken && isJsxClosingElement(contextToken.parent));
         case " ":
             return !!contextToken && isImportKeyword(contextToken) && contextToken.parent.kind === SyntaxKind.SourceFile;
         default:

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -504,8 +504,9 @@ function createChildren(node: Node, sourceFile: SourceFileLike | undefined): rea
         });
         return children;
     }
-
+    const languageVariant = (sourceFile as SourceFile)?.languageVariant ?? LanguageVariant.Standard;
     scanner.setText((sourceFile || node.getSourceFile()).text);
+    scanner.setLanguageVariant(languageVariant);
     let pos = node.pos;
     const processNode = (child: Node) => {
         addSyntheticNodes(children, pos, child.pos, node);
@@ -526,6 +527,7 @@ function createChildren(node: Node, sourceFile: SourceFileLike | undefined): rea
     node.forEachChild(processNode, processNodes);
     addSyntheticNodes(children, pos, node.end, node);
     scanner.setText(undefined);
+    scanner.setLanguageVariant(LanguageVariant.Standard);
     return children;
 }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -504,7 +504,7 @@ function createChildren(node: Node, sourceFile: SourceFileLike | undefined): rea
         });
         return children;
     }
-    const languageVariant = (sourceFile as SourceFile)?.languageVariant ?? LanguageVariant.Standard;
+    const languageVariant = sourceFile?.languageVariant ?? LanguageVariant.Standard;
     scanner.setText((sourceFile || node.getSourceFile()).text);
     scanner.setLanguageVariant(languageVariant);
     let pos = node.pos;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1889,7 +1889,7 @@ export function isInsideJsxElementOrAttribute(sourceFile: SourceFile, position: 
     }
 
     // <div>|</div>
-    if (token.kind === SyntaxKind.LessThanToken && token.parent.kind === SyntaxKind.JsxClosingElement) {
+    if (token.kind === SyntaxKind.LessThanSlashToken && token.parent.kind === SyntaxKind.JsxClosingElement) {
         return true;
     }
 
@@ -1934,6 +1934,7 @@ export function isInsideJsxElement(sourceFile: SourceFile, position: number): bo
                 || node.kind === SyntaxKind.CloseBraceToken
                 || node.kind === SyntaxKind.OpenBraceToken
                 || node.kind === SyntaxKind.SlashToken
+                || node.kind === SyntaxKind.LessThanSlashToken
             ) {
                 node = node.parent;
             }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5907,6 +5907,7 @@ declare namespace ts {
      */
     interface SourceFileLike {
         readonly text: string;
+        languageVariant?: LanguageVariant;
     }
     interface SourceFileLike {
         getLineAndCharacterOfPosition(pos: number): LineAndCharacter;

--- a/tests/cases/fourslash/syntacticClassificationsJsx1.ts
+++ b/tests/cases/fourslash/syntacticClassificationsJsx1.ts
@@ -18,7 +18,7 @@ verify.syntacticClassificationsAre(
             c.jsxText(`
     some jsx text
 `),
-        c.punctuation("<"), c.punctuation("/"), c.jsxCloseTagName("div"), c.punctuation(">"), c.punctuation(";"),
+        c.punctuation("</"), c.jsxCloseTagName("div"), c.punctuation(">"), c.punctuation(";"),
     c.keyword("let"), c.identifier("y"), c.operator("="),
         c.punctuation("<"), 
             c.jsxSelfClosingTagName("element"), 

--- a/tests/cases/fourslash/syntacticClassificationsJsx2.ts
+++ b/tests/cases/fourslash/syntacticClassificationsJsx2.ts
@@ -18,7 +18,7 @@ verify.syntacticClassificationsAre(
             c.jsxText(`
     some jsx text
 `),
-        c.punctuation("<"), c.punctuation("/"), c.jsxCloseTagName("div.name"), c.punctuation(">"), c.punctuation(";"),
+        c.punctuation("</"), c.jsxCloseTagName("div.name"), c.punctuation(">"), c.punctuation(";"),
     c.keyword("let"), c.identifier("y"), c.operator("="),
         c.punctuation("<"), 
             c.jsxSelfClosingTagName("element.name"), 


### PR DESCRIPTION
In Corsa, we create a new scanner from a source file when we need to use one in services code. This makes sure the scanner is created with the right language variant that it obtains from the file. In Strada services, for `createChildren()` we reuse the same global scanner with `scanner.setText()`. This means that we scan JSX/TSX files with the standard language variant instead of the JSX language variant. This in turn causes some tests (e.g. `tsxCompletionOnClosingTagWithoutJSX1`) to fail in Corsa, because, for instance, `</div>` is scanned as `<`, `/`>, `div`, `>` (standard language variant) instead of `</`, `div`, `>` (JSX language variant).

This PR fixes this in Strada so that we use the right language variant when obtaining children. The necessary adjustments in completions code can then be ported to Corsa to fix this difference.