### PR TITLE
Unify the way anonymous class symbols are printed in error messages

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24237,13 +24237,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const privateIdentifierDescription = unmatchedProperty.valueDeclaration.name.escapedText;
                 const symbolTableKey = getSymbolNameForPrivateIdentifier(source.symbol, privateIdentifierDescription);
                 if (symbolTableKey && getPropertyOfType(source, symbolTableKey)) {
-                    const sourceName = factory.getDeclarationName(source.symbol.valueDeclaration);
-                    const targetName = factory.getDeclarationName(target.symbol.valueDeclaration);
                     reportError(
                         Diagnostics.Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2,
                         diagnosticName(privateIdentifierDescription),
-                        diagnosticName(sourceName.escapedText === "" ? anon : sourceName),
-                        diagnosticName(targetName.escapedText === "" ? anon : targetName),
+                        symbolToString(source.symbol),
+                        symbolToString(target.symbol),
                     );
                     return;
                 }
@@ -34681,7 +34679,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 right,
                 Diagnostics.Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier,
                 diagName,
-                diagnosticName(typeClass.name || anon),
+                symbolToString(typeClass.symbol),
             );
             return true;
         }

--- a/tests/baselines/reference/privateNameMethodClassExpression.errors.txt
+++ b/tests/baselines/reference/privateNameMethodClassExpression.errors.txt
@@ -1,5 +1,5 @@
-privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class '(anonymous)' because it has a private identifier.
-privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class '(anonymous)' because it has a private identifier.
+privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
+privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
 
 
 ==== privateNameMethodClassExpression.ts (2 errors) ====
@@ -13,9 +13,9 @@ privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is 
     console.log(C.getInstance().getField());
     C.getInstance().#method; // Error
                     ~~~~~~~
-!!! error TS18013: Property '#method' is not accessible outside class '(anonymous)' because it has a private identifier.
+!!! error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
     C.getInstance().#field; // Error
                     ~~~~~~
-!!! error TS18013: Property '#field' is not accessible outside class '(anonymous)' because it has a private identifier.
+!!! error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
     
     

--- a/tests/baselines/reference/privateNameMethodClassExpression2.errors.txt
+++ b/tests/baselines/reference/privateNameMethodClassExpression2.errors.txt
@@ -1,0 +1,19 @@
+privateNameMethodClassExpression2.ts(5,6): error TS18013: Property '#method' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+privateNameMethodClassExpression2.ts(9,6): error TS18013: Property '#field' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+
+
+==== privateNameMethodClassExpression2.ts (2 errors) ====
+    new (class {
+      #method() {
+        return 42;
+      }
+    })().#method; // error
+         ~~~~~~~
+!!! error TS18013: Property '#method' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+    
+    new (class {
+      #field = 42;
+    })().#field; // error
+         ~~~~~~
+!!! error TS18013: Property '#field' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+    

--- a/tests/baselines/reference/privateNameMethodClassExpression2.symbols
+++ b/tests/baselines/reference/privateNameMethodClassExpression2.symbols
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/privateNameMethodClassExpression2.ts] ////
+
+=== privateNameMethodClassExpression2.ts ===
+new (class {
+  #method() {
+>#method : Symbol((Anonymous class).#method, Decl(privateNameMethodClassExpression2.ts, 0, 12))
+
+    return 42;
+  }
+})().#method; // error
+
+new (class {
+  #field = 42;
+>#field : Symbol((Anonymous class).#field, Decl(privateNameMethodClassExpression2.ts, 6, 12))
+
+})().#field; // error
+

--- a/tests/baselines/reference/privateNameMethodClassExpression2.types
+++ b/tests/baselines/reference/privateNameMethodClassExpression2.types
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/privateNameMethodClassExpression2.ts] ////
+
+=== privateNameMethodClassExpression2.ts ===
+new (class {
+>new (class {  #method() {    return 42;  }})().#method : any
+>                                                       : ^^^
+>new (class {  #method() {    return 42;  }})() : (Anonymous class)
+>                                               : ^^^^^^^^^^^^^^^^^
+>(class {  #method() {    return 42;  }}) : typeof (Anonymous class)
+>                                         : ^^^^^^^^^^^^^^^^^^^^^^^^
+>class {  #method() {    return 42;  }} : typeof (Anonymous class)
+>                                       : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  #method() {
+>#method : () => number
+>        : ^^^^^^^^^^^^
+
+    return 42;
+>42 : 42
+>   : ^^
+  }
+})().#method; // error
+
+new (class {
+>new (class {  #field = 42;})().#field : any
+>                                      : ^^^
+>new (class {  #field = 42;})() : (Anonymous class)
+>                               : ^^^^^^^^^^^^^^^^^
+>(class {  #field = 42;}) : typeof (Anonymous class)
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^
+>class {  #field = 42;} : typeof (Anonymous class)
+>                       : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  #field = 42;
+>#field : number
+>       : ^^^^^^
+>42 : 42
+>   : ^^
+
+})().#field; // error
+

--- a/tests/baselines/reference/privateNamesUnique-6.errors.txt
+++ b/tests/baselines/reference/privateNamesUnique-6.errors.txt
@@ -1,0 +1,17 @@
+privateNamesUnique-6.ts(6,7): error TS2322: Type '(Anonymous class)' is not assignable to type 'A'.
+  Property '#foo' in type '(Anonymous class)' refers to a different member that cannot be accessed from within type 'A'.
+
+
+==== privateNamesUnique-6.ts (1 errors) ====
+    class A {
+      #foo: number;
+    }
+    
+    // error
+    const test: A = new (class {
+          ~~~~
+!!! error TS2322: Type '(Anonymous class)' is not assignable to type 'A'.
+!!! error TS2322:   Property '#foo' in type '(Anonymous class)' refers to a different member that cannot be accessed from within type 'A'.
+      #foo: number;
+    })();
+    

--- a/tests/baselines/reference/privateNamesUnique-6.symbols
+++ b/tests/baselines/reference/privateNamesUnique-6.symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/privateNamesUnique-6.ts] ////
+
+=== privateNamesUnique-6.ts ===
+class A {
+>A : Symbol(A, Decl(privateNamesUnique-6.ts, 0, 0))
+
+  #foo: number;
+>#foo : Symbol(A.#foo, Decl(privateNamesUnique-6.ts, 0, 9))
+}
+
+// error
+const test: A = new (class {
+>test : Symbol(test, Decl(privateNamesUnique-6.ts, 5, 5))
+>A : Symbol(A, Decl(privateNamesUnique-6.ts, 0, 0))
+
+  #foo: number;
+>#foo : Symbol((Anonymous class).#foo, Decl(privateNamesUnique-6.ts, 5, 28))
+
+})();
+

--- a/tests/baselines/reference/privateNamesUnique-6.types
+++ b/tests/baselines/reference/privateNamesUnique-6.types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/privateNamesUnique-6.ts] ////
+
+=== privateNamesUnique-6.ts ===
+class A {
+>A : A
+>  : ^
+
+  #foo: number;
+>#foo : number
+>     : ^^^^^^
+}
+
+// error
+const test: A = new (class {
+>test : A
+>     : ^
+>new (class {  #foo: number;})() : (Anonymous class)
+>                                : ^^^^^^^^^^^^^^^^^
+>(class {  #foo: number;}) : typeof (Anonymous class)
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^
+>class {  #foo: number;} : typeof (Anonymous class)
+>                        : ^^^^^^^^^^^^^^^^^^^^^^^^
+
+  #foo: number;
+>#foo : number
+>     : ^^^^^^
+
+})();
+

--- a/tests/cases/compiler/privateNameMethodClassExpression2.ts
+++ b/tests/cases/compiler/privateNameMethodClassExpression2.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @target: es2015
+// @noEmit: true
+
+new (class {
+  #method() {
+    return 42;
+  }
+})().#method; // error
+
+new (class {
+  #field = 42;
+})().#field; // error

--- a/tests/cases/compiler/privateNamesUnique-6.ts
+++ b/tests/cases/compiler/privateNamesUnique-6.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @strictPropertyInitialization: false
+// @target: es6
+// @noEmit: true
+
+class A {
+  #foo: number;
+}
+
+// error
+const test: A = new (class {
+  #foo: number;
+})();


### PR DESCRIPTION
ports https://github.com/microsoft/typescript-go/pull/731
cc @jakebailey 