### PR TITLE
Revert #54442 and add a testcase

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36414,7 +36414,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // reorderCandidates fills up the candidates array directly
         reorderCandidates(signatures, candidates, callChainFlags);
         if (!isJsxOpenFragment) {
-            Debug.assert(candidates.length, "Revert #54442 and add a testcase with whatever triggered this");
+            if (!candidates.length) {
+                if (reportErrors) {
+                    diagnostics.add(getDiagnosticForCallNode(node, Diagnostics.Call_target_does_not_contain_any_signatures));
+                }
+                return resolveErrorCall(node);
+            }
         }
         const args = getEffectiveCallArguments(node);
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2080,6 +2080,10 @@
         "category": "Error",
         "code": 2345
     },
+    "Call target does not contain any signatures.": {
+        "category": "Error",
+        "code": 2346
+    },
     "Untyped function calls may not accept type arguments.": {
         "category": "Error",
         "code": 2347

--- a/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.errors.txt
+++ b/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.errors.txt
@@ -1,0 +1,17 @@
+interfaceMergeWithNonGenericTypeArguments.ts(4,34): error TS2315: Type 'SomeBaseClass' is not generic.
+interfaceMergeWithNonGenericTypeArguments.ts(6,3): error TS2346: Call target does not contain any signatures.
+
+
+==== interfaceMergeWithNonGenericTypeArguments.ts (2 errors) ====
+    export class SomeBaseClass { }
+    export interface SomeInterface { }
+    export interface MergedClass extends SomeInterface { }
+    export class MergedClass extends SomeBaseClass<any> {
+                                     ~~~~~~~~~~~~~~~~~~
+!!! error TS2315: Type 'SomeBaseClass' is not generic.
+    	public constructor() {
+    		super();
+    		~~~~~
+!!! error TS2346: Call target does not contain any signatures.
+    	}
+    }

--- a/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.js
+++ b/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts] ////
+
+//// [interfaceMergeWithNonGenericTypeArguments.ts]
+export class SomeBaseClass { }
+export interface SomeInterface { }
+export interface MergedClass extends SomeInterface { }
+export class MergedClass extends SomeBaseClass<any> {
+	public constructor() {
+		super();
+	}
+}
+
+//// [interfaceMergeWithNonGenericTypeArguments.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MergedClass = exports.SomeBaseClass = void 0;
+var SomeBaseClass = /** @class */ (function () {
+    function SomeBaseClass() {
+    }
+    return SomeBaseClass;
+}());
+exports.SomeBaseClass = SomeBaseClass;
+var MergedClass = /** @class */ (function (_super) {
+    __extends(MergedClass, _super);
+    function MergedClass() {
+        return _super.call(this) || this;
+    }
+    return MergedClass;
+}(SomeBaseClass));
+exports.MergedClass = MergedClass;

--- a/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.symbols
+++ b/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts] ////
+
+=== interfaceMergeWithNonGenericTypeArguments.ts ===
+export class SomeBaseClass { }
+>SomeBaseClass : Symbol(SomeBaseClass, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 0, 0))
+
+export interface SomeInterface { }
+>SomeInterface : Symbol(SomeInterface, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 0, 30))
+
+export interface MergedClass extends SomeInterface { }
+>MergedClass : Symbol(MergedClass, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 1, 34), Decl(interfaceMergeWithNonGenericTypeArguments.ts, 2, 54))
+>SomeInterface : Symbol(SomeInterface, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 0, 30))
+
+export class MergedClass extends SomeBaseClass<any> {
+>MergedClass : Symbol(MergedClass, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 1, 34), Decl(interfaceMergeWithNonGenericTypeArguments.ts, 2, 54))
+>SomeBaseClass : Symbol(SomeBaseClass, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 0, 0))
+
+	public constructor() {
+		super();
+>super : Symbol(SomeBaseClass, Decl(interfaceMergeWithNonGenericTypeArguments.ts, 0, 0))
+	}
+}

--- a/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.types
+++ b/tests/baselines/reference/interfaceMergeWithNonGenericTypeArguments.types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts] ////
+
+=== interfaceMergeWithNonGenericTypeArguments.ts ===
+export class SomeBaseClass { }
+>SomeBaseClass : SomeBaseClass
+>              : ^^^^^^^^^^^^^
+
+export interface SomeInterface { }
+export interface MergedClass extends SomeInterface { }
+export class MergedClass extends SomeBaseClass<any> {
+>MergedClass : MergedClass
+>            : ^^^^^^^^^^^
+>SomeBaseClass : SomeInterface
+>              : ^^^^^^^^^^^^^
+
+	public constructor() {
+		super();
+>super() : void
+>        : ^^^^
+>super : typeof SomeBaseClass
+>      : ^^^^^^^^^^^^^^^^^^^^
+	}
+}

--- a/tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts
+++ b/tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts
@@ -1,0 +1,8 @@
+export class SomeBaseClass { }
+export interface SomeInterface { }
+export interface MergedClass extends SomeInterface { }
+export class MergedClass extends SomeBaseClass<any> {
+	public constructor() {
+		super();
+	}
+}


### PR DESCRIPTION
Fixes #61438, reverts #54442

*Maybe* it's possible to get into this codepath in a way that doesn't trigger a different error elsewhere, thus the error isn't technically needed, but I wouldn't really want to bet on it. Issuing two errors is nonharmful.