### PR TITLE
Fixed crash on `ConstructSignature` when computing interactive inlay hints

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -44,6 +44,7 @@ import {
     isCallSignatureDeclaration,
     isConditionalTypeNode,
     isConstructorTypeNode,
+    isConstructSignatureDeclaration,
     isEnumMember,
     isExpressionWithTypeArguments,
     isFunctionDeclaration,
@@ -819,6 +820,15 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
                     break;
                 case SyntaxKind.CallSignature:
                     Debug.assertNode(node, isCallSignatureDeclaration);
+                    visitParametersAndTypeParameters(node);
+                    if (node.type) {
+                        parts.push({ text: ": " });
+                        visitForDisplayParts(node.type);
+                    }
+                    break;
+                case SyntaxKind.ConstructSignature:
+                    Debug.assertNode(node, isConstructSignatureDeclaration);
+                    parts.push({ text: "new " });
                     visitParametersAndTypeParameters(node);
                     if (node.type) {
                         parts.push({ text: ": " });

--- a/tests/baselines/reference/inlayHintsVariableTypes3.baseline
+++ b/tests/baselines/reference/inlayHintsVariableTypes3.baseline
@@ -1,0 +1,69 @@
+// === Inlay Hints ===
+const div = getCtor("div");
+         ^
+{
+  "text": "",
+  "displayParts": [
+    {
+      "text": ": "
+    },
+    {
+      "text": "{"
+    },
+    {
+      "text": " "
+    },
+    {
+      "text": "new "
+    },
+    {
+      "text": "("
+    },
+    {
+      "text": ")"
+    },
+    {
+      "text": ": "
+    },
+    {
+      "text": "DivElement",
+      "span": {
+        "start": 10,
+        "length": 10
+      },
+      "file": "/tests/cases/fourslash/inlayHintsVariableTypes3.ts"
+    },
+    {
+      "text": "; "
+    },
+    {
+      "text": "prototype"
+    },
+    {
+      "text": ": "
+    },
+    {
+      "text": "DivElement",
+      "span": {
+        "start": 10,
+        "length": 10
+      },
+      "file": "/tests/cases/fourslash/inlayHintsVariableTypes3.ts"
+    },
+    {
+      "text": " "
+    },
+    {
+      "text": "}"
+    },
+    {
+      "text": " | "
+    },
+    {
+      "text": "undefined"
+    }
+  ],
+  "position": 260,
+  "kind": "Type",
+  "whitespaceBefore": true
+}

--- a/tests/cases/fourslash/inlayHintsVariableTypes3.ts
+++ b/tests/cases/fourslash/inlayHintsVariableTypes3.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+
+//// interface DivElement {}
+//// declare var DivElementCtor: {
+////   prototype: DivElement;
+////   new(): DivElement;
+//// };
+//// interface ElementMap {
+////   div: typeof DivElementCtor;
+//// }
+//// declare function getCtor<K extends keyof ElementMap>(tagName: K): ElementMap[K] | undefined;
+//// const div = getCtor("div");
+
+verify.baselineInlayHints(undefined, {
+    includeInlayVariableTypeHints: true,
+    interactiveInlayHints: true
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/61965