### PR TITLE
[CI Energy Waste]: Optimize CI workflow by consolidating redundant jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,33 +101,7 @@ jobs:
           disable_search: true
           files: ./coverage/codecov.json
 
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Linter
-        run: npm run lint
-
-  knip:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Unused exports
-        run: npm run knip
-
-  format:
+  quality-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -143,6 +117,12 @@ jobs:
           key: ${{ runner.os }}-dprint-${{ hashFiles('package-lock.json', '.dprint.jsonc') }}
           restore-keys: |
             ${{ runner.os }}-dprint-
+
+      - name: Linter
+        run: npm run lint
+
+      - name: Unused exports
+        run: npm run knip
 
       - name: Check formatting
         run: npx dprint check
@@ -163,7 +143,7 @@ jobs:
       - name: Validate the browser can import TypeScript
         run: npx hereby test-browser-integration
 
-  typecheck:
+  build-and-validate:
     runs-on: ubuntu-latest
 
     steps:
@@ -175,6 +155,67 @@ jobs:
 
       - name: Build src
         run: npx hereby build-src
+
+      - name: Build scripts
+        run: npx hereby scripts
+
+      - name: ESLint tests
+        run: npx hereby run-eslint-rules-tests
+
+      - name: Build tsc
+        run: npx hereby tsc
+
+      - name: Clean
+        run: npx hereby clean-src
+
+      - name: Self build
+        run: npx hereby build-src --built
+
+  baselines:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 'lts/*'
+      - run: npm ci
+
+      - name: Remove all baselines
+        run: rm -rf tests/baselines/reference
+
+      - name: Run tests
+        run: npm test &> /dev/null || exit 0
+
+      - name: Accept baselines
+        run: |
+          npx hereby baseline-accept
+          git add tests/baselines/reference
+
+      - name: Check baselines
+        id: check-baselines
+        run: |
+          function print_diff() {
+            if ! git diff --staged --exit-code --quiet --diff-filter=$1; then
+              echo "$2:"
+              git diff --staged --name-only --diff-filter=$1
+            fi
+          }
+
+          if ! git diff --staged --exit-code --quiet; then
+            print_diff ACR "Missing baselines"
+            print_diff MTUXB "Modified baselines"
+            print_diff D "Unused baselines"
+            git diff --staged > fix_baselines.patch
+            exit 1
+          fi
+
+      - name: Upload baseline diff artifact
+        if: ${{ failure() && steps.check-baselines.conclusion == 'failure' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fix_baselines.patch
+          path: fix_baselines.patch
 
   smoke:
     runs-on: ubuntu-latest
@@ -257,84 +298,3 @@ jobs:
       - run: |
           echo "See $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for more info."
           node ./pr/scripts/checkPackageSize.mjs ./base ./pr >> $GITHUB_STEP_SUMMARY
-
-  misc:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Build scripts
-        run: npx hereby scripts
-
-      - name: ESLint tests
-        run: npx hereby run-eslint-rules-tests
-
-  self-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Build tsc
-        run: npx hereby tsc
-
-      - name: Clean
-        run: npx hereby clean-src
-
-      - name: Self build
-        run: npx hereby build-src --built
-
-  baselines:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Remove all baselines
-        run: rm -rf tests/baselines/reference
-
-      - name: Run tests
-        run: npm test &> /dev/null || exit 0
-
-      - name: Accept baselines
-        run: |
-          npx hereby baseline-accept
-          git add tests/baselines/reference
-
-      - name: Check baselines
-        id: check-baselines
-        run: |
-          function print_diff() {
-            if ! git diff --staged --exit-code --quiet --diff-filter=$1; then
-              echo "$2:"
-              git diff --staged --name-only --diff-filter=$1
-            fi
-          }
-
-          if ! git diff --staged --exit-code --quiet; then
-            print_diff ACR "Missing baselines"
-            print_diff MTUXB "Modified baselines"
-            print_diff D "Unused baselines"
-            git diff --staged > fix_baselines.patch
-            exit 1
-          fi
-
-      - name: Upload baseline diff artifact
-        if: ${{ failure() && steps.check-baselines.conclusion == 'failure' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: fix_baselines.patch
-          path: fix_baselines.patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,34 @@ jobs:
             ${{ runner.os }}-dprint-
 
       - name: Linter
+        id: lint
+        continue-on-error: true
         run: npm run lint
 
       - name: Unused exports
+        id: knip
+        continue-on-error: true
         run: npm run knip
 
       - name: Check formatting
+        id: format
+        continue-on-error: true
         run: npx dprint check
+
+      - name: Report failures
+        if: steps.lint.outcome == 'failure' || steps.knip.outcome == 'failure' || steps.format.outcome == 'failure'
+        run: |
+          echo "Quality check failures detected:"
+          if [ "${{ steps.lint.outcome }}" == "failure" ]; then
+            echo "Linting failed - run 'npm run lint' to see issues"
+          fi
+          if [ "${{ steps.knip.outcome }}" == "failure" ]; then
+            echo "Unused exports detected - run 'npm run knip' to see issues"
+          fi
+          if [ "${{ steps.format.outcome }}" == "failure" ]; then
+            echo "Formatting issues found - run 'npx dprint check' to see issues"
+          fi
+          exit 1
 
   browser-integration:
     runs-on: ubuntu-latest
@@ -154,22 +175,55 @@ jobs:
       - run: npm ci
 
       - name: Build src
+        id: build-src
+        continue-on-error: true
         run: npx hereby build-src
 
       - name: Build scripts
+        id: build-scripts
+        continue-on-error: true
         run: npx hereby scripts
 
       - name: ESLint tests
+        id: eslint-tests
+        continue-on-error: true
         run: npx hereby run-eslint-rules-tests
 
       - name: Build tsc
+        id: build-tsc
+        continue-on-error: true
         run: npx hereby tsc
 
       - name: Clean
+        if: steps.build-tsc.outcome == 'success'
         run: npx hereby clean-src
 
       - name: Self build
+        id: self-build
+        continue-on-error: true
+        if: steps.build-tsc.outcome == 'success'
         run: npx hereby build-src --built
+
+      - name: Report failures
+        if: steps.build-src.outcome == 'failure' || steps.build-scripts.outcome == 'failure' || steps.eslint-tests.outcome == 'failure' || steps.build-tsc.outcome == 'failure' || steps.self-build.outcome == 'failure'
+        run: |
+          echo "Build validation failures detected:"
+          if [ "${{ steps.build-src.outcome }}" == "failure" ]; then
+            echo "Source build failed - run 'npx hereby build-src'"
+          fi
+          if [ "${{ steps.build-scripts.outcome }}" == "failure" ]; then
+            echo "Scripts build failed - run 'npx hereby scripts'"
+          fi
+          if [ "${{ steps.eslint-tests.outcome }}" == "failure" ]; then
+            echo "ESLint rule tests failed - run 'npx hereby run-eslint-rules-tests'"
+          fi
+          if [ "${{ steps.build-tsc.outcome }}" == "failure" ]; then
+            echo "TSC build failed - run 'npx hereby tsc'"
+          fi
+          if [ "${{ steps.self-build.outcome }}" == "failure" ]; then
+            echo "Self build failed - run 'npx hereby build-src --built'"
+          fi
+          exit 1
 
   baselines:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Change context

The CI workflow consumed more than 514 days of compute time (≈740,000 minutes) across all runners in the past year alone. Many jobs included redundant steps such as checkout, setup-node, and npm ci that repeated across 12 separate jobs. For example, `npm ci` alone was run up to 13 times. These redundant setup steps add unnecessary overhead and can each take up to 1–1.5 minutes, inflating overall runtime. For instance, only one simple checkout in one job can take up to 20s of runtime:

<img width="1142" alt="Screenshot 2025-07-07 at 19 26 33" src="https://github.com/user-attachments/assets/aeb18d39-047b-441f-9e8f-488b507fbe00" />

## Change details

### Changes Made

- Merged lint + knip + format into quality-checks
- Merged typecheck + misc + self-check into build-and-validate

### Results

- 12 jobs → 8 jobs (33% reduction)
- 12 fewer setup steps per CI run
- Zero functionality lost

### Redundant steps eliminated

4x actions/checkout
4x actions/setup-node
4x npm ci


## Additional context 

We are a team of researchers from University of Zurich (https://www.ifi.uzh.ch/en/zest.html) currently working on automating energy optimizations in GitHub Actions workflows. This optimization maintains full functionality while reducing computational overhead and energy consumption.

[souhaila.serbout@uzh.ch](mailto:souhaila.serbout@uzh.ch)
