### PR TITLE
Clear out checker-level stacks on pop

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32742,9 +32742,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function popContextualType() {
         contextualTypeCount--;
         // Clear out the popped element's referenced objects.
-        contextualTypeNodes[contextualTypeCount] = undefined as any;
+        contextualTypeNodes[contextualTypeCount] = undefined!;
         contextualTypes[contextualTypeCount] = undefined;
-        contextualIsCache[contextualTypeCount] = undefined as any;
+        contextualIsCache[contextualTypeCount] = undefined!;
     }
 
     function findContextualNode(node: Node, includeCaches: boolean) {
@@ -32764,7 +32764,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function popInferenceContext() {
         inferenceContextCount--;
-        inferenceContextNodes[inferenceContextCount] = undefined as any;
+        inferenceContextNodes[inferenceContextCount] = undefined!;
         inferenceContexts[inferenceContextCount] = undefined;
     }
 
@@ -32785,7 +32785,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function popActiveMapper() {
         activeTypeMappersCount--;
         // Clear out the popped element's referenced objects.
-        activeTypeMappers[activeTypeMappersCount] = undefined as any;
+        activeTypeMappers[activeTypeMappersCount] = undefined!;
         activeTypeMappersCaches[activeTypeMappersCount].clear();
     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32741,6 +32741,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function popContextualType() {
         contextualTypeCount--;
+        // Clear out the popped element's referenced objects.
+        contextualTypeNodes[contextualTypeCount] = undefined as any;
+        contextualTypes[contextualTypeCount] = undefined;
+        contextualIsCache[contextualTypeCount] = undefined as any;
     }
 
     function findContextualNode(node: Node, includeCaches: boolean) {
@@ -32760,6 +32764,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function popInferenceContext() {
         inferenceContextCount--;
+        inferenceContextNodes[inferenceContextCount] = undefined as any;
+        inferenceContexts[inferenceContextCount] = undefined;
     }
 
     function getInferenceContext(node: Node) {
@@ -32772,12 +32778,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function pushActiveMapper(mapper: TypeMapper) {
         activeTypeMappers[activeTypeMappersCount] = mapper;
-        activeTypeMappersCaches[activeTypeMappersCount] = new Map();
+        activeTypeMappersCaches[activeTypeMappersCount] ??= new Map();
         activeTypeMappersCount++;
     }
 
     function popActiveMapper() {
         activeTypeMappersCount--;
+        // Clear out the popped element's referenced objects.
+        activeTypeMappers[activeTypeMappersCount] = undefined as any;
+        activeTypeMappersCaches[activeTypeMappersCount].clear();
     }
 
     function findActiveMapper(mapper: TypeMapper) {


### PR DESCRIPTION
These global-ish stacks left their references behind on pop. If the contents are ephemeral (sometimes happens with types, mappers), they'll be held indefinitely.

See also:

- https://github.com/microsoft/typescript-go/pull/1358#discussion_r2191073208
- https://github.com/microsoft/TypeScript/pull/61505