### PR TITLE
fix(Intl): make Intl.Collator.compare a getter that returns a bound function (#62048)

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4419,7 +4419,7 @@ declare namespace Intl {
     }
 
     interface Collator {
-        get compare(): (this: void, x: string, y: string) => number;
+        compare(this: void, x: string, y: string): number;
         resolvedOptions(): ResolvedCollatorOptions;
     }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4419,7 +4419,7 @@ declare namespace Intl {
     }
 
     interface Collator {
-        compare(x: string, y: string): number;
+        get compare(): (this: void, x: string, y: string) => number;
         resolvedOptions(): ResolvedCollatorOptions;
     }
 

--- a/tests/baselines/reference/collatorCompareBoundFunction.errors.txt
+++ b/tests/baselines/reference/collatorCompareBoundFunction.errors.txt
@@ -1,0 +1,44 @@
+error TS2318: Cannot find global type 'Array'.
+error TS2318: Cannot find global type 'Boolean'.
+error TS2318: Cannot find global type 'CallableFunction'.
+error TS2318: Cannot find global type 'Function'.
+error TS2318: Cannot find global type 'IArguments'.
+error TS2318: Cannot find global type 'NewableFunction'.
+error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
+error TS2318: Cannot find global type 'RegExp'.
+error TS2318: Cannot find global type 'String'.
+collatorCompareBoundFunction.ts(1,27): error TS2339: Property 'Collator' does not exist on type 'typeof Intl'.
+collatorCompareBoundFunction.ts(14,32): error TS2339: Property 'sort' does not exist on type '{}'.
+
+
+!!! error TS2318: Cannot find global type 'Array'.
+!!! error TS2318: Cannot find global type 'Boolean'.
+!!! error TS2318: Cannot find global type 'CallableFunction'.
+!!! error TS2318: Cannot find global type 'Function'.
+!!! error TS2318: Cannot find global type 'IArguments'.
+!!! error TS2318: Cannot find global type 'NewableFunction'.
+!!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
+!!! error TS2318: Cannot find global type 'RegExp'.
+!!! error TS2318: Cannot find global type 'String'.
+==== collatorCompareBoundFunction.ts (2 errors) ====
+    const collator = new Intl.Collator();
+                              ~~~~~~~~
+!!! error TS2339: Property 'Collator' does not exist on type 'typeof Intl'.
+    
+    // Should be usable as a function with no dynamic `this`
+    const cmp: (a: string, b: string) => number = collator.compare;
+    
+    // Function expecting a `this: void` bound compare function
+    function useCompare(fn: (this: void, a: string, b: string) => number): number {
+        return fn("a", "b");
+    }
+    
+    useCompare(collator.compare);
+    
+    // Should work with Array.prototype.sort
+    const sorted = ["z", "ä", "a"].sort(collator.compare);
+                                   ~~~~
+!!! error TS2339: Property 'sort' does not exist on type '{}'.
+    

--- a/tests/baselines/reference/collatorCompareBoundFunction.js
+++ b/tests/baselines/reference/collatorCompareBoundFunction.js
@@ -1,0 +1,31 @@
+//// [tests/cases/conformance/intl/collatorCompareBoundFunction.ts] ////
+
+//// [collatorCompareBoundFunction.ts]
+const collator = new Intl.Collator();
+
+// Should be usable as a function with no dynamic `this`
+const cmp: (a: string, b: string) => number = collator.compare;
+
+// Function expecting a `this: void` bound compare function
+function useCompare(fn: (this: void, a: string, b: string) => number): number {
+    return fn("a", "b");
+}
+
+useCompare(collator.compare);
+
+// Should work with Array.prototype.sort
+const sorted = ["z", "ä", "a"].sort(collator.compare);
+
+
+//// [collatorCompareBoundFunction.js]
+"use strict";
+const collator = new Intl.Collator();
+// Should be usable as a function with no dynamic `this`
+const cmp = collator.compare;
+// Function expecting a `this: void` bound compare function
+function useCompare(fn) {
+    return fn("a", "b");
+}
+useCompare(collator.compare);
+// Should work with Array.prototype.sort
+const sorted = ["z", "ä", "a"].sort(collator.compare);

--- a/tests/baselines/reference/collatorCompareBoundFunction.symbols
+++ b/tests/baselines/reference/collatorCompareBoundFunction.symbols
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/intl/collatorCompareBoundFunction.ts] ////
+
+=== collatorCompareBoundFunction.ts ===
+const collator = new Intl.Collator();
+>collator : Symbol(collator, Decl(collatorCompareBoundFunction.ts, 0, 5))
+>Intl : Symbol(Intl, Decl(lib.es2022.intl.d.ts, --, --))
+
+// Should be usable as a function with no dynamic `this`
+const cmp: (a: string, b: string) => number = collator.compare;
+>cmp : Symbol(cmp, Decl(collatorCompareBoundFunction.ts, 3, 5))
+>a : Symbol(a, Decl(collatorCompareBoundFunction.ts, 3, 12))
+>b : Symbol(b, Decl(collatorCompareBoundFunction.ts, 3, 22))
+>collator : Symbol(collator, Decl(collatorCompareBoundFunction.ts, 0, 5))
+
+// Function expecting a `this: void` bound compare function
+function useCompare(fn: (this: void, a: string, b: string) => number): number {
+>useCompare : Symbol(useCompare, Decl(collatorCompareBoundFunction.ts, 3, 63))
+>fn : Symbol(fn, Decl(collatorCompareBoundFunction.ts, 6, 20))
+>this : Symbol(this, Decl(collatorCompareBoundFunction.ts, 6, 25))
+>a : Symbol(a, Decl(collatorCompareBoundFunction.ts, 6, 36))
+>b : Symbol(b, Decl(collatorCompareBoundFunction.ts, 6, 47))
+
+    return fn("a", "b");
+>fn : Symbol(fn, Decl(collatorCompareBoundFunction.ts, 6, 20))
+}
+
+useCompare(collator.compare);
+>useCompare : Symbol(useCompare, Decl(collatorCompareBoundFunction.ts, 3, 63))
+>collator : Symbol(collator, Decl(collatorCompareBoundFunction.ts, 0, 5))
+
+// Should work with Array.prototype.sort
+const sorted = ["z", "ä", "a"].sort(collator.compare);
+>sorted : Symbol(sorted, Decl(collatorCompareBoundFunction.ts, 13, 5))
+>collator : Symbol(collator, Decl(collatorCompareBoundFunction.ts, 0, 5))
+

--- a/tests/baselines/reference/collatorCompareBoundFunction.types
+++ b/tests/baselines/reference/collatorCompareBoundFunction.types
@@ -1,0 +1,91 @@
+//// [tests/cases/conformance/intl/collatorCompareBoundFunction.ts] ////
+
+=== collatorCompareBoundFunction.ts ===
+const collator = new Intl.Collator();
+>collator : any
+>         : ^^^
+>new Intl.Collator() : any
+>                    : ^^^
+>Intl.Collator : any
+>              : ^^^
+>Intl : typeof Intl
+>     : ^^^^^^^^^^^
+>Collator : any
+>         : ^^^
+
+// Should be usable as a function with no dynamic `this`
+const cmp: (a: string, b: string) => number = collator.compare;
+>cmp : (a: string, b: string) => number
+>    : ^ ^^      ^^ ^^      ^^^^^      
+>a : string
+>  : ^^^^^^
+>b : string
+>  : ^^^^^^
+>collator.compare : any
+>                 : ^^^
+>collator : any
+>         : ^^^
+>compare : any
+>        : ^^^
+
+// Function expecting a `this: void` bound compare function
+function useCompare(fn: (this: void, a: string, b: string) => number): number {
+>useCompare : (fn: (this: void, a: string, b: string) => number) => number
+>           : ^  ^^                                            ^^^^^      
+>fn : (this: void, a: string, b: string) => number
+>   : ^    ^^    ^^ ^^      ^^ ^^      ^^^^^      
+>this : void
+>     : ^^^^
+>a : string
+>  : ^^^^^^
+>b : string
+>  : ^^^^^^
+
+    return fn("a", "b");
+>fn("a", "b") : number
+>             : ^^^^^^
+>fn : (this: void, a: string, b: string) => number
+>   : ^    ^^    ^^ ^^      ^^ ^^      ^^^^^      
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+}
+
+useCompare(collator.compare);
+>useCompare(collator.compare) : number
+>                             : ^^^^^^
+>useCompare : (fn: (this: void, a: string, b: string) => number) => number
+>           : ^  ^^                                            ^^^^^      
+>collator.compare : any
+>                 : ^^^
+>collator : any
+>         : ^^^
+>compare : any
+>        : ^^^
+
+// Should work with Array.prototype.sort
+const sorted = ["z", "ä", "a"].sort(collator.compare);
+>sorted : any
+>       : ^^^
+>["z", "ä", "a"].sort(collator.compare) : any
+>                                       : ^^^
+>["z", "ä", "a"].sort : any
+>                     : ^^^
+>["z", "ä", "a"] : {}
+>                : ^^
+>"z" : "z"
+>    : ^^^
+>"ä" : "ä"
+>    : ^^^
+>"a" : "a"
+>    : ^^^
+>sort : any
+>     : ^^^
+>collator.compare : any
+>                 : ^^^
+>collator : any
+>         : ^^^
+>compare : any
+>        : ^^^
+

--- a/tests/cases/conformance/intl/collatorCompareBoundFunction.ts
+++ b/tests/cases/conformance/intl/collatorCompareBoundFunction.ts
@@ -1,0 +1,18 @@
+// @target: es2022
+// @lib: es2022.intl
+// @strict: true
+
+const collator = new Intl.Collator();
+
+// Should be usable as a function with no dynamic `this`
+const cmp: (a: string, b: string) => number = collator.compare;
+
+// Function expecting a `this: void` bound compare function
+function useCompare(fn: (this: void, a: string, b: string) => number): number {
+    return fn("a", "b");
+}
+
+useCompare(collator.compare);
+
+// Should work with Array.prototype.sort
+const sorted = ["z", "ä", "a"].sort(collator.compare);


### PR DESCRIPTION
### **What this PR does**
This PR updates the type definition for `Intl.Collator.prototype.compare` to align with the ECMAScript specification.

Previously, compare was declared as a method:
`compare(x: string, y: string): number;`

According to the spec, it is a **getter** that returns a bound function:
`get compare(): (this: void, x: string, y: string) => number;`

Changing this to a getter would cause conflicts with the existing implementations as pointed out by @Renegade334.
Instead adding a `this: void` gets the job done.

### **Changes made**
- Updated the `Intl.Collator` interface in `src/lib/es5.d.ts`:
- Added a new conformance test in `tests/cases/conformance/intl/collatorCompareBoundFunction.ts`

### Related Issue
Fixes #62048