### PR TITLE
Don't inherit JSDocs from unrelated base properties onto constructor parameters with the same names

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -121,6 +121,7 @@ import {
     getSnapshotText,
     getSourceFileOfNode,
     getSourceMapper,
+    getSyntacticModifierFlags,
     getTokenPosOfNode,
     getTouchingPropertyName,
     getTouchingToken,
@@ -1051,7 +1052,7 @@ function getDocumentationComment(declarations: readonly Declaration[] | undefine
 }
 
 function findBaseOfDeclaration<T>(checker: TypeChecker, declaration: Declaration, cb: (symbol: Symbol) => T[] | undefined): T[] | undefined {
-    const classOrInterfaceDeclaration = declaration.parent?.kind === SyntaxKind.Constructor ? declaration.parent.parent : declaration.parent;
+    const classOrInterfaceDeclaration = declaration.parent?.kind === SyntaxKind.Constructor && getSyntacticModifierFlags(declaration) & ModifierFlags.AccessibilityModifier ? declaration.parent.parent : declaration.parent;
     if (!classOrInterfaceDeclaration) return;
 
     const isStaticMember = hasStaticModifier(declaration);

--- a/tests/cases/fourslash/jsDocDontInheritFromSameNamedPropertyOnParameter1.ts
+++ b/tests/cases/fourslash/jsDocDontInheritFromSameNamedPropertyOnParameter1.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts" />
+
+// https://github.com/microsoft/TypeScript/issues/62069
+
+//// class Base {
+////   /**
+////    * This is a description of `someField` in the `Base` class.
+////    *
+////    * @deprecated
+////    */
+////   someField: string = "whatever";
+//// }
+////
+//// class Derived extends Base {
+////   constructor(someField: string) {
+////     super();
+////     console.log(someField/*1*/);
+////   }
+//// }
+
+verify.quickInfoAt("1", "(parameter) someField: string", undefined);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/62069