### PR TITLE
Restore AbortSignal.abort

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -2760,7 +2760,7 @@ declare var AbortSignal: {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static)
      */
-    // abort(reason?: any): AbortSignal; - To be re-added in the future
+    abort(reason?: any): AbortSignal;
     /**
      * The **`AbortSignal.any()`** static method takes an iterable of abort signals and returns an AbortSignal.
      *

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -1144,7 +1144,7 @@ declare var AbortSignal: {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static)
      */
-    // abort(reason?: any): AbortSignal; - To be re-added in the future
+    abort(reason?: any): AbortSignal;
     /**
      * The **`AbortSignal.any()`** static method takes an iterable of abort signals and returns an AbortSignal.
      *


### PR DESCRIPTION
It was commented out in the version produced by the types package deployment, but should not be. 

Fixes #62083 
