### PR TITLE
Fixed Japanese translations for messages 1259, 2556, 2620, 2621, 2706, and 18046

### DIFF
--- a/src/loc/lcl/jpn/diagnosticMessages/diagnosticMessages.generated.json.lcl
+++ b/src/loc/lcl/jpn/diagnosticMessages/diagnosticMessages.generated.json.lcl
@@ -901,7 +901,7 @@
         <Str Cat="Text">
           <Val><![CDATA[A spread argument must either have a tuple type or be passed to a rest parameter.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[spread 引数には、組の種類を指定するか、rest パラメーターに渡す必要があります。]]></Val>
+            <Val><![CDATA[spread 引数は、タプルを指定するか、rest パラメーターに渡す必要があります。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
@@ -9610,7 +9610,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Module '{0}' can only be default-imported using the '{1}' flag]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[モジュール '{0}' は、'{1}' フラグを使用して既定でのみインポートできます]]></Val>
+            <Val><![CDATA[モジュール '{0}' は、'{1}' フラグを使用した場合のみ、デフォルト インポートできます]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
@@ -12625,7 +12625,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Required type parameters may not follow optional type parameters.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[必須の型パラメーターの後に、オプションの型パラメーターを続けることはできません。]]></Val>
+            <Val><![CDATA[オプションの型パラメーターの後に、必須の型パラメーターを続けることはできません。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
@@ -14242,7 +14242,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Target allows only {0} element(s) but source may have more.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[ターゲットには {0} 個の要素のみを使用できますが、ソースにはそれより多くを指定できます。]]></Val>
+            <Val><![CDATA[ターゲットには {0} 個の要素のみ使用できますが、ソースの要素の数はそれより多いかもしれません。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
@@ -14251,7 +14251,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Target requires {0} element(s) but source may have fewer.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[ターゲットには {0} 個の要素が必要ですが、ソースに指定する数はそれより少なくても構いません。]]></Val>
+            <Val><![CDATA[ターゲットには {0} 個の要素が必要ですが、ソースの要素の数はそれより少ないかもしれません。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
@@ -18076,7 +18076,7 @@
         <Str Cat="Text">
           <Val><![CDATA['{0}' is of type 'unknown'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA['{0}''は 'unknown' 型です。]]></Val>
+            <Val><![CDATA['{0}' は 'unknown' 型です。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53337

## Testing

I did not add unit tests for this change because:

- Previous changes to this file have not included test additions, following the established pattern for locale-specific message updates
- I manually verified the fix by running `/path/to/TypeScript/built/local/tsc.js --locale ja` locally and confirmed that the expected error messages are displayed correctly

The change is a straightforward localization fix that aligns the Japanese error message with the English version, and manual testing confirms the expected behavior.
