### PR TITLE
Fixed more ghost errors after LSP requests caching wrong contextual and parameter types

### DIFF
--- a/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction4.ts
+++ b/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction4.ts
@@ -1,0 +1,32 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// type ObjectFromEntries<T> = T extends readonly [
+////   infer Key extends string | number | symbol,
+////   infer Value,
+//// ][]
+////   ? { [key in Key]: Value }
+////   : never;
+////
+//// type KeyValuePairs<T> = {
+////   [K in keyof T]: [K, T[K]];
+//// }[keyof T];
+////
+//// declare function mapObjectEntries<
+////   const T extends object,
+////   const TMapped extends [string | number | symbol, unknown],
+//// >(
+////   obj: T,
+////   mapper: ([a, b]: KeyValuePairs<T>) => TMapped,
+//// ): ObjectFromEntries<TMapped[]>;
+////
+//// mapObjectEntries({ a: 1, b: 2 }, ([x, y]) => ["a/*1*/", y]);
+
+verify.completions({
+    marker: "1",
+    exact: ["a"],
+});
+verify.noErrors();

--- a/tests/cases/fourslash/noErrorsAfterSignatureHelpRequestWithinGenericFunction1.ts
+++ b/tests/cases/fourslash/noErrorsAfterSignatureHelpRequestWithinGenericFunction1.ts
@@ -1,0 +1,118 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+// @target: esnext
+// @lib: esnext
+
+//// export interface Pipeable {
+////   pipe<A, B = never>(this: A, ab: (_: A) => B): B;
+//// }
+////
+//// type Covariant<A> = (_: never) => A;
+////
+//// interface VarianceStruct<out A, out E, out R> {
+////   readonly _V: string;
+////   readonly _A: Covariant<A>;
+////   readonly _E: Covariant<E>;
+////   readonly _R: Covariant<R>;
+//// }
+////
+//// declare const EffectTypeId: unique symbol;
+////
+//// interface Variance<out A, out E, out R> {
+////   readonly [EffectTypeId]: VarianceStruct<A, E, R>;
+//// }
+////
+//// interface Effect<out A, out E = never, out R = never>
+////   extends Variance<A, E, R>,
+////     Pipeable {}
+////
+//// interface Class<Fields> extends Pipeable {
+////   new (): Fields;
+//// }
+////
+//// interface TaggedErrorClass<Tag extends string, Fields> extends Class<Fields> {
+////   readonly _tag: Tag;
+//// }
+////
+//// declare const TaggedError: (identifier?: string) => <
+////   Tag extends string,
+////   Fields
+//// >(
+////   tag: Tag,
+////   fieldsOr: Fields
+//// ) => TaggedErrorClass<
+////   Tag,
+////   {
+////     readonly _tag: Tag;
+////   }
+//// >;
+////
+//// declare const log: (
+////   ...message: ReadonlyArray<any>
+//// ) => Effect<void, never, never>;
+////
+//// export const categoriesKey = "@effect/error/categories";
+////
+//// export declare const withCategory: <Categories extends Array<PropertyKey>>(
+////   ...categories: Categories
+//// ) => <Args extends Array<any>, Ret, C extends { new (...args: Args): Ret }>(
+////   C: C
+//// ) => C & {
+////   new (...args: Args): Ret & {
+////     [categoriesKey]: { [Cat in Categories[number]]: true };
+////   };
+//// };
+////
+//// export type AllKeys<E> = E extends { [categoriesKey]: infer Q }
+////   ? keyof Q
+////   : never;
+//// export type ExtractAll<E, Cats extends PropertyKey> = Cats extends any
+////   ? Extract<E, { [categoriesKey]: { [K in Cats]: any } }>
+////   : never;
+////
+//// export declare const catchCategory: <
+////   E,
+////   const Categories extends Array<AllKeys<E>>,
+////   A2,
+////   E2,
+////   R2
+//// >(
+////   ...args: [
+////     ...Categories,
+////     f: (err: ExtractAll<E, Categories[number]>) => Effect<A2, E2, R2>
+////   ]
+//// ) => <A, R>(
+////   effect: Effect<A, E, R>
+//// ) => Effect<A | A2, E2 | Exclude<E, ExtractAll<E, Categories[number]>>, R | R2>;
+////
+//// class FooError extends TaggedError()("FooError", {}).pipe(
+////   withCategory("domain")
+//// ) {}
+////
+//// class BarError extends TaggedError()("BarError", {}).pipe(
+////   withCategory("system", "domain")
+//// ) {}
+////
+//// class BazError extends TaggedError()("BazError", {}).pipe(
+////   withCategory("system")
+//// ) {}
+////
+//// declare const baz: (
+////   x: number
+//// ) => Effect<never, FooError | BarError | BazError, never>;
+////
+//// export const program = baz(1).pipe(catchCategory("domain",/*1*/ (_) => log(_._tag)));
+
+verify.noErrors();
+goTo.marker("1");
+edit.insert(",");
+verify.signatureHelpPresentForTriggerReason({
+    kind: "characterTyped",
+    triggerCharacter: ",",
+});
+edit.backspace(1);
+verify.signatureHelpPresentForTriggerReason({
+    kind: "retrigger",
+});
+verify.noErrors();


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/58351
fixes https://github.com/microsoft/TypeScript/issues/62183
supersedes https://github.com/microsoft/TypeScript/pull/58378

It's not enough to ignore cached types/signatures on the ancestry path of the location node of the LSP request. All nodes under that ancestry path can potentially cache wrong types and those types should not be carried over to regular checking scenarios. 

This PR chooses a simple solution of ignoring node/symbol links on certain node kinds within the source file of the location node. It might ignore more caches than it has to but the implementation stays fairly straighforward thanks to that.