### PR TITLE
Add dedicated `UUID` type definition

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -8403,6 +8403,8 @@ declare var CredentialsContainer: {
     new(): CredentialsContainer;
 };
 
+declare type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
 /**
  * The **`Crypto`** interface represents basic cryptography features available in the current context.
  *
@@ -8428,7 +8430,7 @@ interface Crypto {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
      */
-    randomUUID(): `${string}-${string}-${string}-${string}-${string}`;
+    randomUUID(): UUID;
 }
 
 declare var Crypto: {

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -2728,7 +2728,7 @@ interface Crypto {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
      */
-    randomUUID(): `${string}-${string}-${string}-${string}-${string}`;
+    randomUUID(): UUID;
 }
 
 declare var Crypto: {

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -2703,6 +2703,8 @@ declare var CountQueuingStrategy: {
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
+declare type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
 /**
  * The **`Crypto`** interface represents basic cryptography features available in the current context.
  *


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally  # npx hereby runtests
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #

Hello TypeScript team,

I noticed that there’s no dedicated type definition for `UUID`—it’s currently used as a literal type. To leverage the type checker, I had to declare the type locally, which felt unnecessarily verbose.

This PR proposes adding an explicit `UUID` type definition to improve clarity and reusability.

Thanks in advance for reviewing!
