### PR TITLE
Extends the type definitions for MediaTrackSupportedConstraints, MediaTrackConstraints, and MediaTrackSettings to allow echoCancellation to be a string, in addition to a boolean.

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -1113,7 +1113,7 @@ interface MediaTrackCapabilities {
     channelCount?: ULongRange;
     deviceId?: string;
     displaySurface?: string;
-    echoCancellation?: boolean[];
+    echoCancellation?: (boolean|string)[];
     facingMode?: string[];
     frameRate?: DoubleRange;
     groupId?: string;
@@ -1131,7 +1131,7 @@ interface MediaTrackConstraintSet {
     channelCount?: ConstrainULong;
     deviceId?: ConstrainDOMString;
     displaySurface?: ConstrainDOMString;
-    echoCancellation?: ConstrainBoolean;
+    echoCancellation?: ConstrainBoolean|ConstrainDOMString;
     facingMode?: ConstrainDOMString;
     frameRate?: ConstrainDouble;
     groupId?: ConstrainDOMString;
@@ -1153,7 +1153,7 @@ interface MediaTrackSettings {
     channelCount?: number;
     deviceId?: string;
     displaySurface?: string;
-    echoCancellation?: boolean;
+    echoCancellation?: boolean|string;
     facingMode?: string;
     frameRate?: number;
     groupId?: string;


### PR DESCRIPTION
Hi Reviewers,

First of all, I know I shouldn't update this file directly, and I'm not planning to merge this.

According to [the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities#echocancellation), the echoCancellation constraint should be extended to support a DOMString. It looks like TypeScript pulls data from WebIDL and updates src/lib/dom.generated.d.ts directly.

So, does this mean I don't need to do anything and this will be updated automatically in the future?

