### PR TITLE
Allow parameters to be contextually-typed based on contextual rest instantiated using return mapper

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39547,7 +39547,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             inferFromAnnotatedParametersAndReturn(signature, contextualSignature, inferenceContext!);
                             const restType = getEffectiveRestType(contextualSignature);
                             if (restType && restType.flags & TypeFlags.TypeParameter) {
-                                instantiatedContextualSignature = instantiateSignature(contextualSignature, inferenceContext!.nonFixingMapper);
+                                const info = find(inferenceContext!.inferences, info => info.typeParameter === restType);
+                                const mapper = combineTypeMappers(info && !hasInferenceCandidates(info) ? inferenceContext!.returnMapper : undefined, inferenceContext!.nonFixingMapper);
+                                instantiatedContextualSignature = instantiateSignature(contextualSignature, mapper);
                             }
                         }
                         instantiatedContextualSignature ||= inferenceContext ?

--- a/tests/baselines/reference/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.symbols
+++ b/tests/baselines/reference/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.symbols
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts] ////
+
+=== contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts ===
+// https://github.com/microsoft/TypeScript/issues/62336
+
+declare function call<T>(fn: (a: string, b: T) => unknown): (b: T) => unknown;
+>call : Symbol(call, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 0, 0))
+>T : Symbol(T, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 22))
+>fn : Symbol(fn, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 25))
+>a : Symbol(a, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 30))
+>b : Symbol(b, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 40))
+>T : Symbol(T, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 22))
+>b : Symbol(b, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 61))
+>T : Symbol(T, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 22))
+
+declare function fn<Args extends any[]>(
+>fn : Symbol(fn, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 78))
+>Args : Symbol(Args, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 4, 20))
+
+  fn: (...args: Args) => unknown,
+>fn : Symbol(fn, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 4, 40))
+>args : Symbol(args, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 5, 7))
+>Args : Symbol(Args, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 4, 20))
+
+): (...args: Args) => unknown;
+>args : Symbol(args, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 6, 4))
+>Args : Symbol(Args, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 4, 20))
+
+call(
+>call : Symbol(call, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 0, 0))
+
+  fn(function (a, b: number) {
+>fn : Symbol(fn, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 2, 78))
+>a : Symbol(a, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 9, 15))
+>b : Symbol(b, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 9, 17))
+
+    a; // string
+>a : Symbol(a, Decl(contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts, 9, 15))
+
+  }),
+);
+

--- a/tests/baselines/reference/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.types
+++ b/tests/baselines/reference/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.types
@@ -1,0 +1,56 @@
+//// [tests/cases/compiler/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts] ////
+
+=== contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts ===
+// https://github.com/microsoft/TypeScript/issues/62336
+
+declare function call<T>(fn: (a: string, b: T) => unknown): (b: T) => unknown;
+>call : <T>(fn: (a: string, b: T) => unknown) => (b: T) => unknown
+>     : ^ ^^  ^^                            ^^^^^                 
+>fn : (a: string, b: T) => unknown
+>   : ^ ^^      ^^ ^^ ^^^^^       
+>a : string
+>  : ^^^^^^
+>b : T
+>  : ^
+>b : T
+>  : ^
+
+declare function fn<Args extends any[]>(
+>fn : <Args extends any[]>(fn: (...args: Args) => unknown) => (...args: Args) => unknown
+>   : ^    ^^^^^^^^^     ^^  ^^                          ^^^^^                          
+
+  fn: (...args: Args) => unknown,
+>fn : (...args: Args) => unknown
+>   : ^^^^    ^^    ^^^^^       
+>args : Args
+>     : ^^^^
+
+): (...args: Args) => unknown;
+>args : Args
+>     : ^^^^
+
+call(
+>call(  fn(function (a, b: number) {    a; // string  }),) : (b: number) => unknown
+>                                                          : ^ ^^^^^^^^^^^^^       
+>call : <T>(fn: (a: string, b: T) => unknown) => (b: T) => unknown
+>     : ^ ^^  ^^                            ^^^^^                 
+
+  fn(function (a, b: number) {
+>fn(function (a, b: number) {    a; // string  }) : (a: string, b: number) => unknown
+>                                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^       
+>fn : <Args extends any[]>(fn: (...args: Args) => unknown) => (...args: Args) => unknown
+>   : ^    ^^^^^^^^^     ^^  ^^                          ^^^^^                          
+>function (a, b: number) {    a; // string  } : (a: string, b: number) => void
+>                                             : ^ ^^^^^^^^^^ ^^      ^^^^^^^^^
+>a : string
+>  : ^^^^^^
+>b : number
+>  : ^^^^^^
+
+    a; // string
+>a : string
+>  : ^^^^^^
+
+  }),
+);
+

--- a/tests/cases/compiler/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts
+++ b/tests/cases/compiler/contextuallyTypeParametersUsingInstantiantedRestReturnMapper1.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/62336
+
+declare function call<T>(fn: (a: string, b: T) => unknown): (b: T) => unknown;
+
+declare function fn<Args extends any[]>(
+  fn: (...args: Args) => unknown,
+): (...args: Args) => unknown;
+
+call(
+  fn(function (a, b: number) {
+    a; // string
+  }),
+);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/62336