### PR TITLE
fix: Remove empty curly brackets while verbatimModuleSyntax is on onl…

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2301,7 +2301,10 @@ export function transformTypeScript(context: TransformationContext): Transformer
         }
         else {
             // Elide named imports if all of its import specifiers are elided and settings allow.
-            const allowEmpty = compilerOptions.verbatimModuleSyntax;
+            // When a default import exists, avoid keeping empty named braces under verbatimModuleSyntax.
+            const parentImportClause = node.parent as ImportClause | undefined;
+            const defaultBindingPresent = !!parentImportClause?.name;
+            const allowEmpty = compilerOptions.verbatimModuleSyntax && !defaultBindingPresent;
             const elements = visitNodes(node.elements, visitImportSpecifier, isImportSpecifier);
             return allowEmpty || some(elements) ? factory.updateNamedImports(node, elements) : undefined;
         }


### PR DESCRIPTION
…y if default import is used with named import

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #62239
