### PR TITLE
Add missing Float16Array constructors

### DIFF
--- a/src/lib/esnext.float16.d.ts
+++ b/src/lib/esnext.float16.d.ts
@@ -356,6 +356,8 @@ interface Float16ArrayConstructor {
     new (length?: number): Float16Array<ArrayBuffer>;
     new (array: ArrayLike<number> | Iterable<number>): Float16Array<ArrayBuffer>;
     new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Float16Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Float16Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Float16Array<ArrayBuffer>;
 
     /**
      * The size in bytes of each element in the array.

--- a/tests/cases/compiler/typedArrayConstructorOverloads.ts
+++ b/tests/cases/compiler/typedArrayConstructorOverloads.ts
@@ -12,6 +12,7 @@ type TypedArrayConstructor =
     | Uint16ArrayConstructor
     | Int32ArrayConstructor
     | Uint32ArrayConstructor
+    | Float16ArrayConstructor
     | Float32ArrayConstructor
     | Float64ArrayConstructor
     | BigInt64ArrayConstructor


### PR DESCRIPTION
These 2 constructor overloads appear to be missing. You can find similar overloads for other typed array constructors in `es6.d.ts`

<!--
Thank you for submitting a pull request!

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `main` branch
* [X] You've successfully run `hereby runtests` locally
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #62343
