### PR TITLE
Fix findAllReferences for export= namespace with ES6 imports

### DIFF
--- a/tests/cases/fourslash/findAllReferencesExportEqualsNamespace.ts
+++ b/tests/cases/fourslash/findAllReferencesExportEqualsNamespace.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @module: commonjs
+
+// @Filename: /mod.d.ts
+////export = React;
+////
+////declare namespace React {
+////  function /*1*/lazy(): void;
+////}
+
+// @Filename: /index.ts
+////import { /*2*/lazy } from "./mod"
+/////*3*/lazy();
+
+verify.baselineFindAllReferences("1", "2", "3");


### PR DESCRIPTION
Fixes #62348

This fixes findAllReferences for the `export = namespace` + ES6 import pattern.

### Problem
When using:
```typescript
export = React;
declare namespace React { function lazy(): void; }
import { lazy } from "./mod";
```
Find All References doesn't work.

### Solution
Added fallback symbol resolution in findAllReferences.ts for import specifiers when standard resolution fails.

### Testing
Added test case findAllReferencesExportEqualsNamespace.ts. All existing tests pass