### PR TITLE
Fix type `curve` property in `WaveShaperNode`

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -33764,7 +33764,7 @@ interface WaveShaperNode extends AudioNode {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WaveShaperNode/curve)
      */
-    curve: Float32Array<ArrayBuffer> | null;
+    curve: Float32Array | null;
     /**
      * The `oversample` property of the WaveShaperNode interface is an enumerated value indicating if oversampling must be used.
      *


### PR DESCRIPTION
### Overview

Setting `Float32Array` to `curve` property in `WaveShaperNode`, typescript@5.9.2 build is failed. (Screenshot is below).

<img width="1178" height="199" alt="" src="https://github.com/user-attachments/assets/5517a44f-2670-416d-84aa-a0e05df1c481" />

Refer to [W3C Web Audio API Specification](https://www.w3.org/TR/webaudio/#WaveShaperNode-attributes), `curve` property type is not `Float32Array<ArrayBuffer>`  but `Float32Array`.

By the way, typescript@5.8.3 was not this problem. Therefore, it seems that there is degression on 5.9.x.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
