### PR TITLE
Add a new `baseline` lib

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -251,6 +251,8 @@ const libEntries: [string, string][] = [
     ["esnext.typedarrays", "lib.esnext.typedarrays.d.ts"],
     ["esnext.error", "lib.esnext.error.d.ts"],
     ["esnext.sharedmemory", "lib.esnext.sharedmemory.d.ts"],
+    // Baseline Widely Available
+    ["baseline", "lib.baseline.d.ts"],
     ["decorators", "lib.decorators.d.ts"],
     ["decorators.legacy", "lib.decorators.legacy.d.ts"],
 ];

--- a/src/lib/baseline.d.ts
+++ b/src/lib/baseline.d.ts
@@ -1,0 +1,68 @@
+/// <reference lib="es5" />
+
+// ES2015
+/// <reference lib="es2015.core" />
+/// <reference lib="es2015.symbol" />
+/// <reference lib="es2015.symbol.wellknown" />
+/// <reference lib="es2015.iterable" />
+/// <reference lib="es2015.collection" />
+/// <reference lib="es2015.promise" />
+/// <reference lib="es2015.proxy" />
+/// <reference lib="es2015.reflect" />
+/// <reference lib="es2015.generator" />
+
+// ES2016
+/// <reference lib="es2016.array.include" />
+
+// ES2017
+/// <reference lib="es2017.object" />
+/// <reference lib="es2017.string" />
+/// <reference lib="es2017.sharedmemory" />
+/// <reference lib="es2017.intl" />
+/// <reference lib="es2017.typedarrays" />
+
+// ES2018
+/// <reference lib="es2018.asyncgenerator" />
+/// <reference lib="es2018.asynciterable" />
+/// <reference lib="es2018.promise" />
+/// <reference lib="es2018.regexp" />
+/// <reference lib="es2018.intl" />
+
+// ES2019
+/// <reference lib="es2019.array" />
+/// <reference lib="es2019.object" />
+/// <reference lib="es2019.string" />
+/// <reference lib="es2019.symbol" />
+/// <reference lib="es2019.intl" />
+
+// ES2020
+/// <reference lib="es2020.bigint" />
+/// <reference lib="es2020.promise" />
+/// <reference lib="es2020.sharedmemory" />
+/// <reference lib="es2020.string" />
+/// <reference lib="es2020.symbol.wellknown" />
+/// <reference lib="es2020.intl" />
+/// <reference lib="es2020.number" />
+
+// ES2021
+/// <reference lib="es2021.promise" />
+/// <reference lib="es2021.string" />
+/// <reference lib="es2021.weakref" />
+/// <reference lib="es2021.intl" />
+
+// ES2022
+/// <reference lib="es2022.array" />
+/// <reference lib="es2022.error" />
+/// <reference lib="es2022.object" />
+/// <reference lib="es2022.string" />
+/// <reference lib="es2022.regexp" />
+/// <reference lib="es2022.intl" />
+
+// TODO(need-discussion): Intentionally omitting ES2023 array-by-copy methods here.
+// - findLast / findLastIndex (feature: array-findlast) are Baseline "high",
+//   but they co-reside in `src/lib/es2023.array.d.ts` with array-by-copy
+//   methods (toReversed/toSorted/toSpliced/with) which are Baseline "low".
+//   Referencing the whole file would incorrectly allow low features.
+// - Follow-up: consider splitting `es2023.array.d.ts` into separate fragments
+//   (e.g. `es2023.array.findlast` and `es2023.array.by-copy`) so `baseline`
+//   can safely include only the high part.

--- a/src/lib/libs.json
+++ b/src/lib/libs.json
@@ -104,7 +104,8 @@
         "es2022.full",
         "es2023.full",
         "es2024.full",
-        "esnext.full"
+        "esnext.full",
+        "baseline"
     ],
     "paths": {
         "dom.generated": "lib.dom.d.ts",
@@ -114,6 +115,7 @@
         "webworker.iterable.generated": "lib.webworker.iterable.d.ts",
         "webworker.asynciterable.generated": "lib.webworker.asynciterable.d.ts",
         "es5.full": "lib.d.ts",
-        "es2015.full": "lib.es6.d.ts"
+        "es2015.full": "lib.es6.d.ts",
+        "baseline": "lib.baseline.d.ts"
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #62536

## Overview
- This PoC adds a new `lib` value, `baseline`, to TypeScript.
- When users set `compilerOptions.lib: ["baseline"]` in tsconfig.json, the compiler only exposes types for JavaScript built‑ins that have reached Baseline Widely Available ("high"). Any built‑ins that are not yet in Baseline (`low`/`false`) are left undeclared and thus surface as ordinary type errors when referenced.
- Language syntax (operators/statements/grammar/classes) is out of scope for this PR.

## Scope (In/Out)
- In: ECMAScript (JS) built‑in APIs only.
- Data source: Features under `javascript.builtins.*` in web‑features whose `status.baseline == "high"` (Widely Available).
- Out: Language syntax (operators/statements/grammar/classes), DOM/Web API/Worker/ScriptHost (host environment APIs). (TODO)

## Spec
- `baseline`.
  - Concretely, we introduce `src/lib/baseline.d.ts`, and reference only those existing `src/lib/es20xx.*.d.ts` fragments that correspond to Baseline Widely features via `/// <reference lib="...">`.
  - Built‑ins that haven't reached Baseline remain undeclared, so referencing them produces normal type errors.


<details>
<summary>Data Source and Verification (jq)</summary>

- Data: `web-features` `data.json`
  - Path: `/Users/ru/Documents/eslint-plugin/eslint-plugin-baseline-js/node_modules/web-features/data.json`
- We extract feature IDs where `status.baseline == "high"` and any `compat_features` entry starts with `javascript.builtins.`. We verified both the count and the list.

Set a variable:

```sh
DATA_PATH="/Users/ru/Documents/eslint-plugin/eslint-plugin-baseline-js/node_modules/web-features/data.json"
```

Count (unique feature IDs):

```sh
jq -r '.features | to_entries[] \
  | select(.value.status?.baseline=="high") \
  | select(any(.value.compat_features[]?; startswith("javascript.builtins."))) \
  | .key' "$DATA_PATH" | sort -u | wc -l
```

List (unique feature IDs):

```sh
jq -r '.features | to_entries[] \
  | select(.value.status?.baseline=="high") \
  | select(any(.value.compat_features[]?; startswith("javascript.builtins."))) \
  | .key' "$DATA_PATH" | sort -u
```

- At the time of writing, we extract 65 JS built‑in features as Baseline Widely.

</details>

## TODO

- [ ] Scope and variants
  - Should we offer a `baseline.full` variant similar to `es2015.full` that also includes host libs like `dom`? (Note: this would mean JS is Baseline‑gated, but DOM is not.)

- [ ] Defining `baseline.d.ts`
  - Should we keep the allowlist references in the TS repo manually, or provide a mapper/tooling on the WebDX CG side? Either way, this repo needs the final mapping.
  - Known mismatch example between web‑features granularity and TS lib fragment granularity:
    - `src/lib/es2023.array.d.ts` currently contains both:
      - `findLast`/`findLastIndex` (web‑features: `array-findlast`, Baseline = high), and
      - `toReversed`/`toSorted`/`toSpliced`/`with` (web‑features: `array-by-copy`, Baseline = low)
    - We should decide whether to split this into separate fragments (e.g. `es2023.array.findlast` vs `es2023.array.by-copy`) so `baseline` can safely include only the Baseline‑high set.

- [ ] Sustainable data maintenance


