### PR TITLE
Consistently resolve to the `errorType` on `arguments` with error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30975,7 +30975,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         checkIdentifierCalculateNodeCheckFlags(node, symbol);
 
         if (symbol === argumentsSymbol) {
-            if (isInPropertyInitializerOrClassStaticBlock(node)) {
+            if (isInPropertyInitializerOrClassStaticBlock(node, /*ignoreArrowFunctions*/ true)) {
                 return errorType;
             }
             return getTypeOfSymbol(symbol);

--- a/tests/baselines/reference/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.types
+++ b/tests/baselines/reference/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.types
@@ -116,12 +116,12 @@ function D() {
 >  : ^^^^^^^^
 
      a = () => arguments  // should error
->a : () => IArguments
->  : ^^^^^^^^^^^^^^^^
->() => arguments : () => IArguments
->                : ^^^^^^^^^^^^^^^^
->arguments : IArguments
->          : ^^^^^^^^^^
+>a : () => any
+>  : ^^^^^^^^^
+>() => arguments : () => any
+>                : ^^^^^^^^^
+>arguments : any
+>          : ^^^
   }
 }
 
@@ -142,18 +142,18 @@ function D1() {
 >                                                                                                                                                                                          : ^^^^^^^^^^
 
       arguments;    // should error
->arguments : IArguments
->          : ^^^^^^^^^^
+>arguments : any
+>          : ^^^
 
       const b = () => {
->b : () => IArguments
->  : ^^^^^^^^^^^^^^^^
->() => {        return arguments;     // should error      } : () => IArguments
->                                                            : ^^^^^^^^^^^^^^^^
+>b : () => any
+>  : ^^^^^^^^^
+>() => {        return arguments;     // should error      } : () => any
+>                                                            : ^^^^^^^^^
 
         return arguments;     // should error
->arguments : IArguments
->          : ^^^^^^^^^^
+>arguments : any
+>          : ^^^
       }
 
       function f() {
@@ -286,16 +286,16 @@ function D5() {
 >  : ^^^^^^^^
 
      a = (() => { return arguments; })()  // should error
->a : IArguments
->  : ^^^^^^^^^^
->(() => { return arguments; })() : IArguments
->                                : ^^^^^^^^^^
->(() => { return arguments; }) : () => IArguments
->                              : ^^^^^^^^^^^^^^^^
->() => { return arguments; } : () => IArguments
->                            : ^^^^^^^^^^^^^^^^
->arguments : IArguments
->          : ^^^^^^^^^^
+>a : any
+>  : ^^^
+>(() => { return arguments; })() : any
+>                                : ^^^
+>(() => { return arguments; }) : () => any
+>                              : ^^^^^^^^^
+>() => { return arguments; } : () => any
+>                            : ^^^^^^^^^
+>arguments : any
+>          : ^^^
   }
 }
 
@@ -310,14 +310,14 @@ function D6() {
 >  : ^^^^^^^^
 
      a = (x = arguments) => {}    // should error
->a : (x?: IArguments) => void
->  : ^ ^^^^^^^^^^^^^^^^^^^^^^
->(x = arguments) => {} : (x?: IArguments) => void
->                      : ^ ^^^^^^^^^^^^^^^^^^^^^^
->x : IArguments
->  : ^^^^^^^^^^
->arguments : IArguments
->          : ^^^^^^^^^^
+>a : (x?: any) => void
+>  : ^ ^^^^^^^^^^^^^^^
+>(x = arguments) => {} : (x?: any) => void
+>                      : ^ ^^^^^^^^^^^^^^^
+>x : any
+>  : ^^^
+>arguments : any
+>          : ^^^
   }
 }
 


### PR DESCRIPTION
This PR fixes this inconsistency:
```ts
function Cls() {
  return class T {
     a = () => arguments // 'arguments' cannot be referenced in property initializers or class static initialization blocks.(2815)
     //        ^? (local var) arguments: IArguments

     static {
      arguments // 'arguments' cannot be referenced in property initializers or class static initialization blocks.(2815)
      // ^? (local var) arguments: any
     }
  }
}
```

It feels like https://github.com/microsoft/TypeScript/pull/48172 forgot to update this one `isInPropertyInitializerOrClassStaticBlock` call. 
