### PR TITLE
Update error for allowImportingTsExtensions to mention rewriteRelativeImportExtensions

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4669,7 +4669,7 @@
         "category": "Error",
         "code": 5095
     },
-    "Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.": {
+    "Option 'allowImportingTsExtensions' can only be used when one of 'noEmit', 'emitDeclarationOnly', or 'rewriteRelativeImportExtensions' is set.": {
         "category": "Error",
         "code": 5096
     },

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -4318,7 +4318,7 @@ export function createProgram(_rootNamesOrOptions: readonly string[] | CreatePro
         }
 
         if (options.allowImportingTsExtensions && !(options.noEmit || options.emitDeclarationOnly || options.rewriteRelativeImportExtensions)) {
-            createOptionValueDiagnostic("allowImportingTsExtensions", Diagnostics.Option_allowImportingTsExtensions_can_only_be_used_when_either_noEmit_or_emitDeclarationOnly_is_set);
+            createOptionValueDiagnostic("allowImportingTsExtensions", Diagnostics.Option_allowImportingTsExtensions_can_only_be_used_when_one_of_noEmit_emitDeclarationOnly_or_rewriteRelativeImportExtensions_is_set);
         }
 
         const moduleResolution = getEmitModuleResolutionKind(options);

--- a/tests/baselines/reference/bundlerImportTsExtensions(allowimportingtsextensions=true,noemit=false).errors.txt
+++ b/tests/baselines/reference/bundlerImportTsExtensions(allowimportingtsextensions=true,noemit=false).errors.txt
@@ -1,6 +1,6 @@
 error TS5056: Cannot write file 'out/b.js' because it would be overwritten by multiple input files.
 error TS5056: Cannot write file 'out/c.js' because it would be overwritten by multiple input files.
-error TS5096: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.
+error TS5096: Option 'allowImportingTsExtensions' can only be used when one of 'noEmit', 'emitDeclarationOnly', or 'rewriteRelativeImportExtensions' is set.
 error TS6054: File '/project/e.txt' has an unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts', '.js', '.jsx', '.cts', '.d.cts', '.cjs', '.mts', '.d.mts', '.mjs'.
   The file is in the program because:
     Root file specified for compilation
@@ -11,7 +11,7 @@ error TS6054: File '/project/e.txt' has an unsupported extension. The only suppo
 
 !!! error TS5056: Cannot write file 'out/b.js' because it would be overwritten by multiple input files.
 !!! error TS5056: Cannot write file 'out/c.js' because it would be overwritten by multiple input files.
-!!! error TS5096: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.
+!!! error TS5096: Option 'allowImportingTsExtensions' can only be used when one of 'noEmit', 'emitDeclarationOnly', or 'rewriteRelativeImportExtensions' is set.
 !!! error TS6054: File '/project/e.txt' has an unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts', '.js', '.jsx', '.cts', '.d.cts', '.cjs', '.mts', '.d.mts', '.mjs'.
 !!! error TS6054:   The file is in the program because:
 !!! error TS6054:     Root file specified for compilation


### PR DESCRIPTION
Fixes #60397.

error TS5096 currently says

> Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.

But in fact `rewriteRelativeImportExtensions` also works (as you can see from the line above the change in `src/compiler/program.ts` in this PR), and is often what I at least am reaching for. This PR updates it to read

> Option 'allowImportingTsExtensions' can only be used when one of 'noEmit', 'emitDeclarationOnly', or 'rewriteRelativeImportExtensions' is set.