### PR TITLE
Fix global plugin search paths, fixes #62618

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2106,8 +2106,9 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         // Search any globally-specified probe paths, then our peer node_modules
         return [
             ...this.projectService.pluginProbeLocations,
-            // ../../.. to walk from X/node_modules/typescript/lib/tsserver.js to X/node_modules/
-            combinePaths(this.projectService.getExecutingFilePath(), "../../.."),
+            // ../../.. to walk from X/node_modules/typescript/lib/tsserver.js to X/
+            // later we will append node_modules back on to resolve the plugin location
+            combinePaths(this.projectService.getExecutingFilePath(), "../../../.."),
         ];
     }
 
@@ -3204,3 +3205,4 @@ export function isBackgroundProject(project: Project): project is AutoImportProv
 export function isProjectDeferredClose(project: Project): project is ConfiguredProject {
     return isConfiguredProject(project) && !!project.deferredClose;
 }
+


### PR DESCRIPTION
The global plugin search path was resolving to "X/node_modules/node_modules" due to incorrect number of updirs in the initial path.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
