### PR TITLE
Handle more child types when generating navigation tree items for `export default`

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -59,6 +59,7 @@ import {
     isBindingPattern,
     isCallExpression,
     isClassDeclaration,
+    isClassExpression,
     isClassLike,
     isComputedPropertyName,
     isDeclaration,
@@ -104,6 +105,7 @@ import {
     removeFileExtension,
     setTextRange,
     ShorthandPropertyAssignment,
+    skipOuterExpressions,
     SourceFile,
     SpreadAssignment,
     SyntaxKind,
@@ -444,8 +446,8 @@ function addChildrenRecursively(node: Node | undefined): void {
             break;
 
         case SyntaxKind.ExportAssignment: {
-            const expression = (node as ExportAssignment).expression;
-            const child = isObjectLiteralExpression(expression) || isCallExpression(expression) ? expression :
+            const expression = skipOuterExpressions((node as ExportAssignment).expression);
+            const child = isObjectLiteralExpression(expression) || isCallExpression(expression) || isClassExpression(expression) ? expression :
                 isArrowFunction(expression) || isFunctionExpression(expression) ? expression.body : undefined;
             if (child) {
                 startNode(node);

--- a/tests/cases/fourslash/navigationBarExportAssignment1.ts
+++ b/tests/cases/fourslash/navigationBarExportAssignment1.ts
@@ -1,0 +1,110 @@
+/// <reference path="fourslash.ts"/>
+
+//// export const foo = {
+////   foo: {},
+//// };
+////
+//// export default {
+////   foo: {},
+//// };
+////
+//// export default {
+////   foo: {},
+//// };
+////
+//// type Type = typeof foo;
+////
+//// export default {
+////   foo: {},
+//// } as Type;
+////
+//// export default {
+////   foo: {},
+//// } satisfies Type;
+////
+//// export default (class {
+////   prop = 42;
+//// });
+
+verify.navigationTree({
+  text: '"navigationBarExportAssignment1"',
+  kind: "module",
+  childItems: [
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "<class>",
+          kind: "class",
+          childItems: [
+            {
+              text: "prop",
+              kind: "property",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      text: "foo",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "Type",
+      kind: "type",
+    },
+  ],
+});

--- a/tests/cases/fourslash/navigationItemsExportDefaultExpression2.ts
+++ b/tests/cases/fourslash/navigationItemsExportDefaultExpression2.ts
@@ -25,9 +25,13 @@
 //// export default (class {
 ////   prop = 42;
 //// });
+////
+//// export default (class Cls {
+////   prop = 42;
+//// });
 
 verify.navigationTree({
-  text: '"navigationBarExportAssignment1"',
+  text: '"navigationItemsExportDefaultExpression2"',
   kind: "module",
   childItems: [
     {
@@ -81,6 +85,23 @@ verify.navigationTree({
       childItems: [
         {
           text: "<class>",
+          kind: "class",
+          childItems: [
+            {
+              text: "prop",
+              kind: "property",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      text: "default",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "Cls",
           kind: "class",
           childItems: [
             {

--- a/tests/cases/fourslash/navigationItemsExportEqualsExpression.ts
+++ b/tests/cases/fourslash/navigationItemsExportEqualsExpression.ts
@@ -29,6 +29,9 @@
 ////         d: 1
 ////     }
 //// }
+////
+//// function foo(props: { x: number; y: number }) {}
+//// export = foo({ x: 1, y: 1 });
 
 verify.navigationTree({
   "text": '"navigationItemsExportEqualsExpression"',
@@ -85,7 +88,13 @@ verify.navigationTree({
     {
       "text": "export=",
       "kind": "class",
-      "kindModifiers": "export"
+      "kindModifiers": "export",
+      "childItems": [
+        {
+          "text": "AB",
+          "kind": "class"
+        }
+      ]
     },
     {
       "text": "export=",
@@ -113,6 +122,21 @@ verify.navigationTree({
       ]
     },
     {
+      "text": "export=",
+      "kind": "const",
+      "kindModifiers": "export",
+      "childItems": [
+        {
+          "text": "x",
+          "kind": "property"
+        },
+        {
+          "text": "y",
+          "kind": "property"
+        }
+      ]
+    },
+    {
       "text": "abc",
       "kind": "const"
     },
@@ -120,7 +144,10 @@ verify.navigationTree({
       "text": "export=",
       "kind": "const",
       "kindModifiers": "export"
+    },
+    {
+      "text": "foo",
+      "kind": "function"
     }
   ]
 });
-

--- a/tests/cases/fourslash/navigationItemsExportEqualsExpression2.ts
+++ b/tests/cases/fourslash/navigationItemsExportEqualsExpression2.ts
@@ -1,0 +1,131 @@
+/// <reference path="fourslash.ts"/>
+
+//// export const foo = {
+////   foo: {},
+//// };
+////
+//// export = {
+////   foo: {},
+//// };
+////
+//// export = {
+////   foo: {},
+//// };
+////
+//// type Type = typeof foo;
+////
+//// export = {
+////   foo: {},
+//// } as Type;
+////
+//// export = {
+////   foo: {},
+//// } satisfies Type;
+////
+//// export = (class {
+////   prop = 42;
+//// });
+////
+//// export = (class Cls {
+////   prop = 42;
+//// });
+
+verify.navigationTree({
+  text: '"navigationItemsExportEqualsExpression2"',
+  kind: "module",
+  childItems: [
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "<class>",
+          kind: "class",
+          childItems: [
+            {
+              text: "prop",
+              kind: "property",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      text: "export=",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "Cls",
+          kind: "class",
+          childItems: [
+            {
+              text: "prop",
+              kind: "property",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      text: "foo",
+      kind: "const",
+      kindModifiers: "export",
+      childItems: [
+        {
+          text: "foo",
+          kind: "property",
+        },
+      ],
+    },
+    {
+      text: "Type",
+      kind: "type",
+    },
+  ],
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/62609