### PR TITLE
Disallow `[await] using` statements under case/default clauses

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -503,6 +503,7 @@ import {
     isCallLikeOrFunctionLikeExpression,
     isCallOrNewExpression,
     isCallSignatureDeclaration,
+    isCaseOrDefaultClause,
     isCatchClause,
     isCatchClauseVariableDeclaration,
     isCatchClauseVariableDeclarationOrBindingElement,
@@ -53079,6 +53080,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     blockScopeFlags === NodeFlags.Using ?
                         Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration :
                         Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration,
+                );
+            }
+            else if (isVariableStatement(declarationList.parent) && isCaseOrDefaultClause(declarationList.parent.parent)) {
+                return grammarErrorOnNode(
+                    declarationList,
+                    blockScopeFlags === NodeFlags.Using ?
+                        Diagnostics.using_declarations_are_not_allowed_in_case_or_default_clauses_unless_contained_within_a_block :
+                        Diagnostics.await_using_declarations_are_not_allowed_in_case_or_default_clauses_unless_contained_within_a_block,
                 );
             }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1849,6 +1849,14 @@
         "category": "Error",
         "code": 1546
     },
+    "'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.": {
+        "category": "Error",
+        "code": 1547
+    },
+    "'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.": {
+        "category": "Error",
+        "code": 1548
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).errors.txt
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).errors.txt
@@ -1,21 +1,23 @@
 awaitUsingDeclarations.1.ts(1,1): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(36,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(41,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(45,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(52,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(57,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(60,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(63,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(67,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(70,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(46,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(51,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(58,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(63,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(68,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(71,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(74,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(79,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(78,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(81,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(85,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(90,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(96,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(101,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(105,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 
 
-==== awaitUsingDeclarations.1.ts (15 errors) ====
+==== awaitUsingDeclarations.1.ts (17 errors) ====
     await using d1 = { async [Symbol.asyncDispose]() {} };
     ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
@@ -59,64 +61,79 @@ awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' stateme
     }
     
     switch (Math.random()) {
-        case 0:
+        case 0: {
             await using d20 = { async [Symbol.asyncDispose]() {} };
             ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
             break;
+        }
     
-        case 1:
+        case 1: {
             await using d21 = { async [Symbol.asyncDispose]() {} };
             ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
             break;
+        }
+    
+        default: {
+            await using d22 = { async [Symbol.asyncDispose]() {} };
+            ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+        }
     }
     
     if (true)
         switch (0) {
-            case 0:
-                await using d22 = { async [Symbol.asyncDispose]() {} };
+            case 0: {
+                await using d23 = { async [Symbol.asyncDispose]() {} };
                 ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
                 break;
+            }
+    
+            default: {
+                await using d24 = { async [Symbol.asyncDispose]() {} };
+                ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+            }
         }
     
     try {
-        await using d23 = { async [Symbol.asyncDispose]() {} };
-        ~~~~~
-!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-    }
-    catch {
-        await using d24 = { async [Symbol.asyncDispose]() {} };
-        ~~~~~
-!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-    }
-    finally {
         await using d25 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
-    
-    if (true) {
+    catch {
         await using d26 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
-    else {
+    finally {
         await using d27 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
     
-    while (true) {
+    if (true) {
         await using d28 = { async [Symbol.asyncDispose]() {} };
+        ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    }
+    else {
+        await using d29 = { async [Symbol.asyncDispose]() {} };
+        ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    }
+    
+    while (true) {
+        await using d30 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
     }
     
     do {
-        await using d29 = { async [Symbol.asyncDispose]() {} };
+        await using d31 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
@@ -124,20 +141,20 @@ awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' stateme
     while (true);
     
     for (;;) {
-        await using d30 = { async [Symbol.asyncDispose]() {} };
+        await using d32 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
     }
     
     for (const x in {}) {
-        await using d31 = { async [Symbol.asyncDispose]() {} };
+        await using d33 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
     
     for (const x of []) {
-        await using d32 = { async [Symbol.asyncDispose]() {} };
+        await using d34 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).js
@@ -40,61 +40,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};
@@ -176,247 +187,244 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function af() {
     return __awaiter(this, void 0, void 0, function* () {
-        const env_15 = { stack: [], error: void 0, hasError: false };
+        const env_18 = { stack: [], error: void 0, hasError: false };
         try {
-            const d3 = __addDisposableResource(env_15, { [Symbol.asyncDispose]() {
+            const d3 = __addDisposableResource(env_18, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
             yield null;
         }
-        catch (e_15) {
-            env_15.error = e_15;
-            env_15.hasError = true;
+        catch (e_18) {
+            env_18.error = e_18;
+            env_18.hasError = true;
         }
         finally {
-            const result_15 = __disposeResources(env_15);
-            if (result_15)
-                yield result_15;
+            const result_18 = __disposeResources(env_18);
+            if (result_18)
+                yield result_18;
         }
     });
 }
 function ag() {
     return __asyncGenerator(this, arguments, function* ag_1() {
-        const env_16 = { stack: [], error: void 0, hasError: false };
+        const env_19 = { stack: [], error: void 0, hasError: false };
         try {
-            const d5 = __addDisposableResource(env_16, { [Symbol.asyncDispose]() {
+            const d5 = __addDisposableResource(env_19, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
             yield yield __await(void 0);
             yield __await(null);
         }
-        catch (e_16) {
-            env_16.error = e_16;
-            env_16.hasError = true;
+        catch (e_19) {
+            env_19.error = e_19;
+            env_19.hasError = true;
         }
         finally {
-            const result_16 = __disposeResources(env_16);
-            if (result_16)
-                yield __await(result_16);
+            const result_19 = __disposeResources(env_19);
+            if (result_19)
+                yield __await(result_19);
         }
     });
 }
-var d1, a, C1, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1;
+const env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, { [Symbol.asyncDispose]() {
+    d1 = __addDisposableResource(env_1, { [Symbol.asyncDispose]() {
             return __awaiter(this, void 0, void 0, function* () { });
         } }, true);
     a = () => __awaiter(void 0, void 0, void 0, function* () {
-        const env_17 = { stack: [], error: void 0, hasError: false };
+        const env_20 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_17, { [Symbol.asyncDispose]() {
+            const d6 = __addDisposableResource(env_20, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
         }
-        catch (e_17) {
-            env_17.error = e_17;
-            env_17.hasError = true;
+        catch (e_20) {
+            env_20.error = e_20;
+            env_20.hasError = true;
         }
         finally {
-            const result_17 = __disposeResources(env_17);
-            if (result_17)
-                yield result_17;
+            const result_20 = __disposeResources(env_20);
+            if (result_20)
+                yield result_20;
         }
     });
     C1 = class C1 {
         constructor() {
             this.a = () => __awaiter(this, void 0, void 0, function* () {
-                const env_18 = { stack: [], error: void 0, hasError: false };
+                const env_21 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d7 = __addDisposableResource(env_18, { [Symbol.asyncDispose]() {
+                    const d7 = __addDisposableResource(env_21, { [Symbol.asyncDispose]() {
                             return __awaiter(this, void 0, void 0, function* () { });
                         } }, true);
                 }
-                catch (e_18) {
-                    env_18.error = e_18;
-                    env_18.hasError = true;
+                catch (e_21) {
+                    env_21.error = e_21;
+                    env_21.hasError = true;
                 }
                 finally {
-                    const result_18 = __disposeResources(env_18);
-                    if (result_18)
-                        yield result_18;
+                    const result_21 = __disposeResources(env_21);
+                    if (result_21)
+                        yield result_21;
                 }
             });
         }
         am() {
             return __awaiter(this, void 0, void 0, function* () {
-                const env_19 = { stack: [], error: void 0, hasError: false };
+                const env_22 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d13 = __addDisposableResource(env_19, { [Symbol.asyncDispose]() {
+                    const d13 = __addDisposableResource(env_22, { [Symbol.asyncDispose]() {
                             return __awaiter(this, void 0, void 0, function* () { });
                         } }, true);
                     yield null;
                 }
-                catch (e_19) {
-                    env_19.error = e_19;
-                    env_19.hasError = true;
+                catch (e_22) {
+                    env_22.error = e_22;
+                    env_22.hasError = true;
                 }
                 finally {
-                    const result_19 = __disposeResources(env_19);
-                    if (result_19)
-                        yield result_19;
+                    const result_22 = __disposeResources(env_22);
+                    if (result_22)
+                        yield result_22;
                 }
             });
         }
         ag() {
             return __asyncGenerator(this, arguments, function* ag_2() {
-                const env_20 = { stack: [], error: void 0, hasError: false };
+                const env_23 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d15 = __addDisposableResource(env_20, { [Symbol.asyncDispose]() {
+                    const d15 = __addDisposableResource(env_23, { [Symbol.asyncDispose]() {
                             return __awaiter(this, void 0, void 0, function* () { });
                         } }, true);
                     yield yield __await(void 0);
                     yield __await(null);
                 }
-                catch (e_20) {
-                    env_20.error = e_20;
-                    env_20.hasError = true;
+                catch (e_23) {
+                    env_23.error = e_23;
+                    env_23.hasError = true;
                 }
                 finally {
-                    const result_20 = __disposeResources(env_20);
-                    if (result_20)
-                        yield __await(result_20);
+                    const result_23 = __disposeResources(env_23);
+                    if (result_23)
+                        yield __await(result_23);
                 }
             });
         }
     };
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { [Symbol.asyncDispose]() {
+            const d19 = __addDisposableResource(env_2, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            const result_1 = __disposeResources(env_3);
+            const result_1 = __disposeResources(env_2);
             if (result_1)
                 await result_1;
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { [Symbol.asyncDispose]() {
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { [Symbol.asyncDispose]() {
                         return __awaiter(this, void 0, void 0, function* () { });
                     } }, true);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { [Symbol.asyncDispose]() {
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                const result_2 = __disposeResources(env_3);
+                if (result_2)
+                    await result_2;
+            }
+        }
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { [Symbol.asyncDispose]() {
                         return __awaiter(this, void 0, void 0, function* () { });
                     } }, true);
                 break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                const result_3 = __disposeResources(env_4);
+                if (result_3)
+                    await result_3;
+            }
+        }
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { [Symbol.asyncDispose]() {
+                        return __awaiter(this, void 0, void 0, function* () { });
+                    } }, true);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                const result_4 = __disposeResources(env_5);
+                if (result_4)
+                    await result_4;
+            }
         }
     }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        const result_2 = __disposeResources(env_1);
-        if (result_2)
-            await result_2;
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { [Symbol.asyncDispose]() {
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { [Symbol.asyncDispose]() {
                             return __awaiter(this, void 0, void 0, function* () { });
                         } }, true);
                     break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    const result_5 = __disposeResources(env_6);
+                    if (result_5)
+                        await result_5;
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { [Symbol.asyncDispose]() {
+                            return __awaiter(this, void 0, void 0, function* () { });
+                        } }, true);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    const result_6 = __disposeResources(env_7);
+                    if (result_6)
+                        await result_6;
+                }
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
-        }
-        finally {
-            const result_3 = __disposeResources(env_4);
-            if (result_3)
-                await result_3;
-        }
-    }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { [Symbol.asyncDispose]() {
-                    return __awaiter(this, void 0, void 0, function* () { });
-                } }, true);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            const result_4 = __disposeResources(env_5);
-            if (result_4)
-                await result_4;
-        }
-    }
-    catch (_a) {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { [Symbol.asyncDispose]() {
-                    return __awaiter(this, void 0, void 0, function* () { });
-                } }, true);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            const result_5 = __disposeResources(env_6);
-            if (result_5)
-                await result_5;
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { [Symbol.asyncDispose]() {
-                    return __awaiter(this, void 0, void 0, function* () { });
-                } }, true);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            const result_6 = __disposeResources(env_7);
-            if (result_6)
-                await result_6;
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { [Symbol.asyncDispose]() {
+            const d25 = __addDisposableResource(env_8, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
         }
@@ -430,10 +438,10 @@ try {
                 await result_7;
         }
     }
-    else {
+    catch (_a) {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { [Symbol.asyncDispose]() {
+            const d26 = __addDisposableResource(env_9, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
         }
@@ -447,13 +455,12 @@ try {
                 await result_8;
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { [Symbol.asyncDispose]() {
+            const d27 = __addDisposableResource(env_10, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
-            break;
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -465,13 +472,12 @@ try {
                 await result_9;
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { [Symbol.asyncDispose]() {
+            const d28 = __addDisposableResource(env_11, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
-            break;
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -482,14 +488,13 @@ try {
             if (result_10)
                 await result_10;
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { [Symbol.asyncDispose]() {
+            const d29 = __addDisposableResource(env_12, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
-            break;
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -501,12 +506,13 @@ try {
                 await result_11;
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { [Symbol.asyncDispose]() {
+            const d30 = __addDisposableResource(env_13, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -518,12 +524,13 @@ try {
                 await result_12;
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { [Symbol.asyncDispose]() {
+            const d31 = __addDisposableResource(env_14, { [Symbol.asyncDispose]() {
                     return __awaiter(this, void 0, void 0, function* () { });
                 } }, true);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -534,15 +541,67 @@ try {
             if (result_13)
                 await result_13;
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { [Symbol.asyncDispose]() {
+                    return __awaiter(this, void 0, void 0, function* () { });
+                } }, true);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            const result_14 = __disposeResources(env_15);
+            if (result_14)
+                await result_14;
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { [Symbol.asyncDispose]() {
+                    return __awaiter(this, void 0, void 0, function* () { });
+                } }, true);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            const result_15 = __disposeResources(env_16);
+            if (result_15)
+                await result_15;
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { [Symbol.asyncDispose]() {
+                    return __awaiter(this, void 0, void 0, function* () { });
+                } }, true);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            const result_16 = __disposeResources(env_17);
+            if (result_16)
+                await result_16;
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    const result_14 = __disposeResources(env_2);
-    if (result_14)
-        await result_14;
+    const result_17 = __disposeResources(env_1);
+    if (result_17)
+        await result_17;
 }
 export {};

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2017).js
@@ -40,61 +40,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};
@@ -166,216 +177,215 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
 };
 async function af() {
-    const env_15 = { stack: [], error: void 0, hasError: false };
+    const env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        const d3 = __addDisposableResource(env_15, { async [Symbol.asyncDispose]() { } }, true);
+        const d3 = __addDisposableResource(env_18, { async [Symbol.asyncDispose]() { } }, true);
         await null;
     }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
+    catch (e_18) {
+        env_18.error = e_18;
+        env_18.hasError = true;
     }
     finally {
-        const result_15 = __disposeResources(env_15);
-        if (result_15)
-            await result_15;
+        const result_18 = __disposeResources(env_18);
+        if (result_18)
+            await result_18;
     }
 }
 function ag() {
     return __asyncGenerator(this, arguments, function* ag_1() {
-        const env_16 = { stack: [], error: void 0, hasError: false };
+        const env_19 = { stack: [], error: void 0, hasError: false };
         try {
-            const d5 = __addDisposableResource(env_16, { async [Symbol.asyncDispose]() { } }, true);
+            const d5 = __addDisposableResource(env_19, { async [Symbol.asyncDispose]() { } }, true);
             yield yield __await(void 0);
             yield __await(null);
         }
-        catch (e_16) {
-            env_16.error = e_16;
-            env_16.hasError = true;
+        catch (e_19) {
+            env_19.error = e_19;
+            env_19.hasError = true;
         }
         finally {
-            const result_16 = __disposeResources(env_16);
-            if (result_16)
-                yield __await(result_16);
+            const result_19 = __disposeResources(env_19);
+            if (result_19)
+                yield __await(result_19);
         }
     });
 }
-var d1, a, C1, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1;
+const env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, { async [Symbol.asyncDispose]() { } }, true);
+    d1 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
     a = async () => {
-        const env_17 = { stack: [], error: void 0, hasError: false };
+        const env_20 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_17, { async [Symbol.asyncDispose]() { } }, true);
+            const d6 = __addDisposableResource(env_20, { async [Symbol.asyncDispose]() { } }, true);
         }
-        catch (e_17) {
-            env_17.error = e_17;
-            env_17.hasError = true;
+        catch (e_20) {
+            env_20.error = e_20;
+            env_20.hasError = true;
         }
         finally {
-            const result_17 = __disposeResources(env_17);
-            if (result_17)
-                await result_17;
+            const result_20 = __disposeResources(env_20);
+            if (result_20)
+                await result_20;
         }
     };
     C1 = class C1 {
         constructor() {
             this.a = async () => {
-                const env_18 = { stack: [], error: void 0, hasError: false };
+                const env_21 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d7 = __addDisposableResource(env_18, { async [Symbol.asyncDispose]() { } }, true);
+                    const d7 = __addDisposableResource(env_21, { async [Symbol.asyncDispose]() { } }, true);
                 }
-                catch (e_18) {
-                    env_18.error = e_18;
-                    env_18.hasError = true;
+                catch (e_21) {
+                    env_21.error = e_21;
+                    env_21.hasError = true;
                 }
                 finally {
-                    const result_18 = __disposeResources(env_18);
-                    if (result_18)
-                        await result_18;
+                    const result_21 = __disposeResources(env_21);
+                    if (result_21)
+                        await result_21;
                 }
             };
         }
         async am() {
-            const env_19 = { stack: [], error: void 0, hasError: false };
+            const env_22 = { stack: [], error: void 0, hasError: false };
             try {
-                const d13 = __addDisposableResource(env_19, { async [Symbol.asyncDispose]() { } }, true);
+                const d13 = __addDisposableResource(env_22, { async [Symbol.asyncDispose]() { } }, true);
                 await null;
             }
-            catch (e_19) {
-                env_19.error = e_19;
-                env_19.hasError = true;
+            catch (e_22) {
+                env_22.error = e_22;
+                env_22.hasError = true;
             }
             finally {
-                const result_19 = __disposeResources(env_19);
-                if (result_19)
-                    await result_19;
+                const result_22 = __disposeResources(env_22);
+                if (result_22)
+                    await result_22;
             }
         }
         ag() {
             return __asyncGenerator(this, arguments, function* ag_2() {
-                const env_20 = { stack: [], error: void 0, hasError: false };
+                const env_23 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d15 = __addDisposableResource(env_20, { async [Symbol.asyncDispose]() { } }, true);
+                    const d15 = __addDisposableResource(env_23, { async [Symbol.asyncDispose]() { } }, true);
                     yield yield __await(void 0);
                     yield __await(null);
                 }
-                catch (e_20) {
-                    env_20.error = e_20;
-                    env_20.hasError = true;
+                catch (e_23) {
+                    env_23.error = e_23;
+                    env_23.hasError = true;
                 }
                 finally {
-                    const result_20 = __disposeResources(env_20);
-                    if (result_20)
-                        yield __await(result_20);
+                    const result_23 = __disposeResources(env_23);
+                    if (result_23)
+                        yield __await(result_23);
                 }
             });
         }
     };
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { async [Symbol.asyncDispose]() { } }, true);
+            const d19 = __addDisposableResource(env_2, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            const result_1 = __disposeResources(env_3);
+            const result_1 = __disposeResources(env_2);
             if (result_1)
                 await result_1;
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { async [Symbol.asyncDispose]() { } }, true);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        const result_2 = __disposeResources(env_1);
-        if (result_2)
-            await result_2;
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { async [Symbol.asyncDispose]() { } }, true);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                const result_2 = __disposeResources(env_3);
+                if (result_2)
+                    await result_2;
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { async [Symbol.asyncDispose]() { } }, true);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                const result_3 = __disposeResources(env_4);
+                if (result_3)
+                    await result_3;
+            }
         }
-        finally {
-            const result_3 = __disposeResources(env_4);
-            if (result_3)
-                await result_3;
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { async [Symbol.asyncDispose]() { } }, true);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                const result_4 = __disposeResources(env_5);
+                if (result_4)
+                    await result_4;
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { async [Symbol.asyncDispose]() { } }, true);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    const result_5 = __disposeResources(env_6);
+                    if (result_5)
+                        await result_5;
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { async [Symbol.asyncDispose]() { } }, true);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    const result_6 = __disposeResources(env_7);
+                    if (result_6)
+                        await result_6;
+                }
+            }
+        }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            const result_4 = __disposeResources(env_5);
-            if (result_4)
-                await result_4;
-        }
-    }
-    catch (_a) {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            const result_5 = __disposeResources(env_6);
-            if (result_5)
-                await result_5;
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            const result_6 = __disposeResources(env_7);
-            if (result_6)
-                await result_6;
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { async [Symbol.asyncDispose]() { } }, true);
+            const d25 = __addDisposableResource(env_8, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -387,10 +397,10 @@ try {
                 await result_7;
         }
     }
-    else {
+    catch (_a) {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { async [Symbol.asyncDispose]() { } }, true);
+            const d26 = __addDisposableResource(env_9, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -402,11 +412,10 @@ try {
                 await result_8;
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d27 = __addDisposableResource(env_10, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -418,11 +427,10 @@ try {
                 await result_9;
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d28 = __addDisposableResource(env_11, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -433,12 +441,11 @@ try {
             if (result_10)
                 await result_10;
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d29 = __addDisposableResource(env_12, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -450,10 +457,11 @@ try {
                 await result_11;
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { async [Symbol.asyncDispose]() { } }, true);
+            const d30 = __addDisposableResource(env_13, { async [Symbol.asyncDispose]() { } }, true);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -465,10 +473,11 @@ try {
                 await result_12;
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { async [Symbol.asyncDispose]() { } }, true);
+            const d31 = __addDisposableResource(env_14, { async [Symbol.asyncDispose]() { } }, true);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -479,15 +488,61 @@ try {
             if (result_13)
                 await result_13;
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { async [Symbol.asyncDispose]() { } }, true);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            const result_14 = __disposeResources(env_15);
+            if (result_14)
+                await result_14;
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { async [Symbol.asyncDispose]() { } }, true);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            const result_15 = __disposeResources(env_16);
+            if (result_15)
+                await result_15;
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { async [Symbol.asyncDispose]() { } }, true);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            const result_16 = __disposeResources(env_17);
+            if (result_16)
+                await result_16;
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    const result_14 = __disposeResources(env_2);
-    if (result_14)
-        await result_14;
+    const result_17 = __disposeResources(env_1);
+    if (result_17)
+        await result_17;
 }
 export {};

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2022).js
@@ -40,61 +40,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};
@@ -153,210 +164,209 @@ var __disposeResources = (this && this.__disposeResources) || (function (Suppres
     return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
 });
 async function af() {
-    const env_15 = { stack: [], error: void 0, hasError: false };
+    const env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        const d3 = __addDisposableResource(env_15, { async [Symbol.asyncDispose]() { } }, true);
+        const d3 = __addDisposableResource(env_18, { async [Symbol.asyncDispose]() { } }, true);
         await null;
     }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
+    catch (e_18) {
+        env_18.error = e_18;
+        env_18.hasError = true;
     }
     finally {
-        const result_15 = __disposeResources(env_15);
-        if (result_15)
-            await result_15;
+        const result_18 = __disposeResources(env_18);
+        if (result_18)
+            await result_18;
     }
 }
 async function* ag() {
-    const env_16 = { stack: [], error: void 0, hasError: false };
+    const env_19 = { stack: [], error: void 0, hasError: false };
     try {
-        const d5 = __addDisposableResource(env_16, { async [Symbol.asyncDispose]() { } }, true);
+        const d5 = __addDisposableResource(env_19, { async [Symbol.asyncDispose]() { } }, true);
         yield;
         await null;
     }
-    catch (e_16) {
-        env_16.error = e_16;
-        env_16.hasError = true;
+    catch (e_19) {
+        env_19.error = e_19;
+        env_19.hasError = true;
     }
     finally {
-        const result_16 = __disposeResources(env_16);
-        if (result_16)
-            await result_16;
+        const result_19 = __disposeResources(env_19);
+        if (result_19)
+            await result_19;
     }
 }
-var d1, a, C1, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1;
+const env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, { async [Symbol.asyncDispose]() { } }, true);
+    d1 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
     a = async () => {
-        const env_17 = { stack: [], error: void 0, hasError: false };
+        const env_20 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_17, { async [Symbol.asyncDispose]() { } }, true);
+            const d6 = __addDisposableResource(env_20, { async [Symbol.asyncDispose]() { } }, true);
         }
-        catch (e_17) {
-            env_17.error = e_17;
-            env_17.hasError = true;
+        catch (e_20) {
+            env_20.error = e_20;
+            env_20.hasError = true;
         }
         finally {
-            const result_17 = __disposeResources(env_17);
-            if (result_17)
-                await result_17;
+            const result_20 = __disposeResources(env_20);
+            if (result_20)
+                await result_20;
         }
     };
     C1 = class C1 {
         a = async () => {
-            const env_18 = { stack: [], error: void 0, hasError: false };
+            const env_21 = { stack: [], error: void 0, hasError: false };
             try {
-                const d7 = __addDisposableResource(env_18, { async [Symbol.asyncDispose]() { } }, true);
+                const d7 = __addDisposableResource(env_21, { async [Symbol.asyncDispose]() { } }, true);
             }
-            catch (e_18) {
-                env_18.error = e_18;
-                env_18.hasError = true;
+            catch (e_21) {
+                env_21.error = e_21;
+                env_21.hasError = true;
             }
             finally {
-                const result_18 = __disposeResources(env_18);
-                if (result_18)
-                    await result_18;
+                const result_21 = __disposeResources(env_21);
+                if (result_21)
+                    await result_21;
             }
         };
         async am() {
-            const env_19 = { stack: [], error: void 0, hasError: false };
+            const env_22 = { stack: [], error: void 0, hasError: false };
             try {
-                const d13 = __addDisposableResource(env_19, { async [Symbol.asyncDispose]() { } }, true);
+                const d13 = __addDisposableResource(env_22, { async [Symbol.asyncDispose]() { } }, true);
                 await null;
             }
-            catch (e_19) {
-                env_19.error = e_19;
-                env_19.hasError = true;
+            catch (e_22) {
+                env_22.error = e_22;
+                env_22.hasError = true;
             }
             finally {
-                const result_19 = __disposeResources(env_19);
-                if (result_19)
-                    await result_19;
+                const result_22 = __disposeResources(env_22);
+                if (result_22)
+                    await result_22;
             }
         }
         async *ag() {
-            const env_20 = { stack: [], error: void 0, hasError: false };
+            const env_23 = { stack: [], error: void 0, hasError: false };
             try {
-                const d15 = __addDisposableResource(env_20, { async [Symbol.asyncDispose]() { } }, true);
+                const d15 = __addDisposableResource(env_23, { async [Symbol.asyncDispose]() { } }, true);
                 yield;
                 await null;
             }
-            catch (e_20) {
-                env_20.error = e_20;
-                env_20.hasError = true;
+            catch (e_23) {
+                env_23.error = e_23;
+                env_23.hasError = true;
             }
             finally {
-                const result_20 = __disposeResources(env_20);
-                if (result_20)
-                    await result_20;
+                const result_23 = __disposeResources(env_23);
+                if (result_23)
+                    await result_23;
             }
         }
     };
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { async [Symbol.asyncDispose]() { } }, true);
+            const d19 = __addDisposableResource(env_2, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            const result_1 = __disposeResources(env_3);
+            const result_1 = __disposeResources(env_2);
             if (result_1)
                 await result_1;
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { async [Symbol.asyncDispose]() { } }, true);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { async [Symbol.asyncDispose]() { } }, true);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        const result_2 = __disposeResources(env_1);
-        if (result_2)
-            await result_2;
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { async [Symbol.asyncDispose]() { } }, true);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                const result_2 = __disposeResources(env_3);
+                if (result_2)
+                    await result_2;
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { async [Symbol.asyncDispose]() { } }, true);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                const result_3 = __disposeResources(env_4);
+                if (result_3)
+                    await result_3;
+            }
         }
-        finally {
-            const result_3 = __disposeResources(env_4);
-            if (result_3)
-                await result_3;
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { async [Symbol.asyncDispose]() { } }, true);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                const result_4 = __disposeResources(env_5);
+                if (result_4)
+                    await result_4;
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { async [Symbol.asyncDispose]() { } }, true);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    const result_5 = __disposeResources(env_6);
+                    if (result_5)
+                        await result_5;
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { async [Symbol.asyncDispose]() { } }, true);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    const result_6 = __disposeResources(env_7);
+                    if (result_6)
+                        await result_6;
+                }
+            }
+        }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            const result_4 = __disposeResources(env_5);
-            if (result_4)
-                await result_4;
-        }
-    }
-    catch {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            const result_5 = __disposeResources(env_6);
-            if (result_5)
-                await result_5;
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { async [Symbol.asyncDispose]() { } }, true);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            const result_6 = __disposeResources(env_7);
-            if (result_6)
-                await result_6;
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { async [Symbol.asyncDispose]() { } }, true);
+            const d25 = __addDisposableResource(env_8, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -368,10 +378,10 @@ try {
                 await result_7;
         }
     }
-    else {
+    catch {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { async [Symbol.asyncDispose]() { } }, true);
+            const d26 = __addDisposableResource(env_9, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -383,11 +393,10 @@ try {
                 await result_8;
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d27 = __addDisposableResource(env_10, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -399,11 +408,10 @@ try {
                 await result_9;
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d28 = __addDisposableResource(env_11, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -414,12 +422,11 @@ try {
             if (result_10)
                 await result_10;
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { async [Symbol.asyncDispose]() { } }, true);
-            break;
+            const d29 = __addDisposableResource(env_12, { async [Symbol.asyncDispose]() { } }, true);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -431,10 +438,11 @@ try {
                 await result_11;
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { async [Symbol.asyncDispose]() { } }, true);
+            const d30 = __addDisposableResource(env_13, { async [Symbol.asyncDispose]() { } }, true);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -446,10 +454,11 @@ try {
                 await result_12;
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { async [Symbol.asyncDispose]() { } }, true);
+            const d31 = __addDisposableResource(env_14, { async [Symbol.asyncDispose]() { } }, true);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -460,15 +469,61 @@ try {
             if (result_13)
                 await result_13;
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { async [Symbol.asyncDispose]() { } }, true);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            const result_14 = __disposeResources(env_15);
+            if (result_14)
+                await result_14;
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { async [Symbol.asyncDispose]() { } }, true);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            const result_15 = __disposeResources(env_16);
+            if (result_15)
+                await result_15;
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { async [Symbol.asyncDispose]() { } }, true);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            const result_16 = __disposeResources(env_17);
+            if (result_16)
+                await result_16;
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    const result_14 = __disposeResources(env_2);
-    if (result_14)
-        await result_14;
+    const result_17 = __disposeResources(env_1);
+    if (result_17)
+        await result_17;
 }
 export {};

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).errors.txt
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).errors.txt
@@ -1,21 +1,23 @@
 awaitUsingDeclarations.1.ts(1,1): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(36,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(41,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(45,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(52,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(57,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(60,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(63,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(67,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(70,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(46,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(51,9): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(58,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(63,13): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(68,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(71,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(74,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(79,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(78,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(81,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(85,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 awaitUsingDeclarations.1.ts(90,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(96,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(101,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+awaitUsingDeclarations.1.ts(105,5): error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 
 
-==== awaitUsingDeclarations.1.ts (15 errors) ====
+==== awaitUsingDeclarations.1.ts (17 errors) ====
     await using d1 = { async [Symbol.asyncDispose]() {} };
     ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
@@ -59,64 +61,79 @@ awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' stateme
     }
     
     switch (Math.random()) {
-        case 0:
+        case 0: {
             await using d20 = { async [Symbol.asyncDispose]() {} };
             ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
             break;
+        }
     
-        case 1:
+        case 1: {
             await using d21 = { async [Symbol.asyncDispose]() {} };
             ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
             break;
+        }
+    
+        default: {
+            await using d22 = { async [Symbol.asyncDispose]() {} };
+            ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+        }
     }
     
     if (true)
         switch (0) {
-            case 0:
-                await using d22 = { async [Symbol.asyncDispose]() {} };
+            case 0: {
+                await using d23 = { async [Symbol.asyncDispose]() {} };
                 ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
                 break;
+            }
+    
+            default: {
+                await using d24 = { async [Symbol.asyncDispose]() {} };
+                ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+            }
         }
     
     try {
-        await using d23 = { async [Symbol.asyncDispose]() {} };
-        ~~~~~
-!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-    }
-    catch {
-        await using d24 = { async [Symbol.asyncDispose]() {} };
-        ~~~~~
-!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-    }
-    finally {
         await using d25 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
-    
-    if (true) {
+    catch {
         await using d26 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
-    else {
+    finally {
         await using d27 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
     
-    while (true) {
+    if (true) {
         await using d28 = { async [Symbol.asyncDispose]() {} };
+        ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    }
+    else {
+        await using d29 = { async [Symbol.asyncDispose]() {} };
+        ~~~~~
+!!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    }
+    
+    while (true) {
+        await using d30 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
     }
     
     do {
-        await using d29 = { async [Symbol.asyncDispose]() {} };
+        await using d31 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
@@ -124,20 +141,20 @@ awaitUsingDeclarations.1.ts(94,5): error TS2854: Top-level 'await using' stateme
     while (true);
     
     for (;;) {
-        await using d30 = { async [Symbol.asyncDispose]() {} };
+        await using d32 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
         break;
     }
     
     for (const x in {}) {
-        await using d31 = { async [Symbol.asyncDispose]() {} };
+        await using d33 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }
     
     for (const x of []) {
-        await using d32 = { async [Symbol.asyncDispose]() {} };
+        await using d34 = { async [Symbol.asyncDispose]() {} };
         ~~~~~
 !!! error TS2854: Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).js
@@ -40,61 +40,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};
@@ -201,19 +212,19 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function reject(value) { resume("throw", value); }
     function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
 };
-var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
 function af() {
     return __awaiter(this, void 0, void 0, function () {
-        var env_15, d3, e_15, result_15;
+        var env_18, d3, e_18, result_18;
         var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    env_15 = { stack: [], error: void 0, hasError: false };
+                    env_18 = { stack: [], error: void 0, hasError: false };
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 3, 4, 7]);
-                    d3 = __addDisposableResource(env_15, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                    d3 = __addDisposableResource(env_18, (_a = {}, _a[Symbol.asyncDispose] = function () {
                         return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                             return [2 /*return*/];
                         }); });
@@ -223,14 +234,14 @@ function af() {
                     _b.sent();
                     return [3 /*break*/, 7];
                 case 3:
-                    e_15 = _b.sent();
-                    env_15.error = e_15;
-                    env_15.hasError = true;
+                    e_18 = _b.sent();
+                    env_18.error = e_18;
+                    env_18.hasError = true;
                     return [3 /*break*/, 7];
                 case 4:
-                    result_15 = __disposeResources(env_15);
-                    if (!result_15) return [3 /*break*/, 6];
-                    return [4 /*yield*/, result_15];
+                    result_18 = __disposeResources(env_18);
+                    if (!result_18) return [3 /*break*/, 6];
+                    return [4 /*yield*/, result_18];
                 case 5:
                     _b.sent();
                     _b.label = 6;
@@ -242,16 +253,16 @@ function af() {
 }
 function ag() {
     return __asyncGenerator(this, arguments, function ag_1() {
-        var env_16, d5, e_16, result_16;
+        var env_19, d5, e_19, result_19;
         var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    env_16 = { stack: [], error: void 0, hasError: false };
+                    env_19 = { stack: [], error: void 0, hasError: false };
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 5, 6, 9]);
-                    d5 = __addDisposableResource(env_16, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                    d5 = __addDisposableResource(env_19, (_a = {}, _a[Symbol.asyncDispose] = function () {
                         return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                             return [2 /*return*/];
                         }); });
@@ -265,14 +276,14 @@ function ag() {
                     _b.sent();
                     return [3 /*break*/, 9];
                 case 5:
-                    e_16 = _b.sent();
-                    env_16.error = e_16;
-                    env_16.hasError = true;
+                    e_19 = _b.sent();
+                    env_19.error = e_19;
+                    env_19.hasError = true;
                     return [3 /*break*/, 9];
                 case 6:
-                    result_16 = __disposeResources(env_16);
-                    if (!result_16) return [3 /*break*/, 8];
-                    return [4 /*yield*/, __await(result_16)];
+                    result_19 = __disposeResources(env_19);
+                    if (!result_19) return [3 /*break*/, 8];
+                    return [4 /*yield*/, __await(result_19)];
                 case 7:
                     _b.sent();
                     _b.label = 8;
@@ -282,39 +293,39 @@ function ag() {
         });
     });
 }
-var d1, a, C1, env_1;
-var env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1;
+var env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, (_a = {}, _a[Symbol.asyncDispose] = function () {
+    d1 = __addDisposableResource(env_1, (_a = {}, _a[Symbol.asyncDispose] = function () {
         return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
             return [2 /*return*/];
         }); });
     }, _a), true);
     a = function () { return __awaiter(void 0, void 0, void 0, function () {
-        var env_17, d6, e_17, result_17;
+        var env_20, d6, e_20, result_20;
         var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    env_17 = { stack: [], error: void 0, hasError: false };
+                    env_20 = { stack: [], error: void 0, hasError: false };
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 2, 3, 6]);
-                    d6 = __addDisposableResource(env_17, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                    d6 = __addDisposableResource(env_20, (_a = {}, _a[Symbol.asyncDispose] = function () {
                         return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                             return [2 /*return*/];
                         }); });
                     }, _a), true);
                     return [3 /*break*/, 6];
                 case 2:
-                    e_17 = _b.sent();
-                    env_17.error = e_17;
-                    env_17.hasError = true;
+                    e_20 = _b.sent();
+                    env_20.error = e_20;
+                    env_20.hasError = true;
                     return [3 /*break*/, 6];
                 case 3:
-                    result_17 = __disposeResources(env_17);
-                    if (!result_17) return [3 /*break*/, 5];
-                    return [4 /*yield*/, result_17];
+                    result_20 = __disposeResources(env_20);
+                    if (!result_20) return [3 /*break*/, 5];
+                    return [4 /*yield*/, result_20];
                 case 4:
                     _b.sent();
                     _b.label = 5;
@@ -327,30 +338,30 @@ try {
         function C1() {
             var _this = this;
             this.a = function () { return __awaiter(_this, void 0, void 0, function () {
-                var env_18, d7, e_18, result_18;
+                var env_21, d7, e_21, result_21;
                 var _a;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            env_18 = { stack: [], error: void 0, hasError: false };
+                            env_21 = { stack: [], error: void 0, hasError: false };
                             _b.label = 1;
                         case 1:
                             _b.trys.push([1, 2, 3, 6]);
-                            d7 = __addDisposableResource(env_18, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                            d7 = __addDisposableResource(env_21, (_a = {}, _a[Symbol.asyncDispose] = function () {
                                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                                     return [2 /*return*/];
                                 }); });
                             }, _a), true);
                             return [3 /*break*/, 6];
                         case 2:
-                            e_18 = _b.sent();
-                            env_18.error = e_18;
-                            env_18.hasError = true;
+                            e_21 = _b.sent();
+                            env_21.error = e_21;
+                            env_21.hasError = true;
                             return [3 /*break*/, 6];
                         case 3:
-                            result_18 = __disposeResources(env_18);
-                            if (!result_18) return [3 /*break*/, 5];
-                            return [4 /*yield*/, result_18];
+                            result_21 = __disposeResources(env_21);
+                            if (!result_21) return [3 /*break*/, 5];
+                            return [4 /*yield*/, result_21];
                         case 4:
                             _b.sent();
                             _b.label = 5;
@@ -362,16 +373,16 @@ try {
         }
         C1.prototype.am = function () {
             return __awaiter(this, void 0, void 0, function () {
-                var env_19, d13, e_19, result_19;
+                var env_22, d13, e_22, result_22;
                 var _a;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            env_19 = { stack: [], error: void 0, hasError: false };
+                            env_22 = { stack: [], error: void 0, hasError: false };
                             _b.label = 1;
                         case 1:
                             _b.trys.push([1, 3, 4, 7]);
-                            d13 = __addDisposableResource(env_19, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                            d13 = __addDisposableResource(env_22, (_a = {}, _a[Symbol.asyncDispose] = function () {
                                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                                     return [2 /*return*/];
                                 }); });
@@ -381,14 +392,14 @@ try {
                             _b.sent();
                             return [3 /*break*/, 7];
                         case 3:
-                            e_19 = _b.sent();
-                            env_19.error = e_19;
-                            env_19.hasError = true;
+                            e_22 = _b.sent();
+                            env_22.error = e_22;
+                            env_22.hasError = true;
                             return [3 /*break*/, 7];
                         case 4:
-                            result_19 = __disposeResources(env_19);
-                            if (!result_19) return [3 /*break*/, 6];
-                            return [4 /*yield*/, result_19];
+                            result_22 = __disposeResources(env_22);
+                            if (!result_22) return [3 /*break*/, 6];
+                            return [4 /*yield*/, result_22];
                         case 5:
                             _b.sent();
                             _b.label = 6;
@@ -400,16 +411,16 @@ try {
         };
         C1.prototype.ag = function () {
             return __asyncGenerator(this, arguments, function ag_2() {
-                var env_20, d15, e_20, result_20;
+                var env_23, d15, e_23, result_23;
                 var _a;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            env_20 = { stack: [], error: void 0, hasError: false };
+                            env_23 = { stack: [], error: void 0, hasError: false };
                             _b.label = 1;
                         case 1:
                             _b.trys.push([1, 5, 6, 9]);
-                            d15 = __addDisposableResource(env_20, (_a = {}, _a[Symbol.asyncDispose] = function () {
+                            d15 = __addDisposableResource(env_23, (_a = {}, _a[Symbol.asyncDispose] = function () {
                                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                                     return [2 /*return*/];
                                 }); });
@@ -423,14 +434,14 @@ try {
                             _b.sent();
                             return [3 /*break*/, 9];
                         case 5:
-                            e_20 = _b.sent();
-                            env_20.error = e_20;
-                            env_20.hasError = true;
+                            e_23 = _b.sent();
+                            env_23.error = e_23;
+                            env_23.hasError = true;
                             return [3 /*break*/, 9];
                         case 6:
-                            result_20 = __disposeResources(env_20);
-                            if (!result_20) return [3 /*break*/, 8];
-                            return [4 /*yield*/, __await(result_20)];
+                            result_23 = __disposeResources(env_23);
+                            if (!result_23) return [3 /*break*/, 8];
+                            return [4 /*yield*/, __await(result_23)];
                         case 7:
                             _b.sent();
                             _b.label = 8;
@@ -443,140 +454,135 @@ try {
         return C1;
     }());
     {
-        var env_3 = { stack: [], error: void 0, hasError: false };
+        var env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            var d19 = __addDisposableResource(env_3, (_b = {}, _b[Symbol.asyncDispose] = function () {
+            var d19 = __addDisposableResource(env_2, (_b = {}, _b[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
             }, _b), true);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            var result_1 = __disposeResources(env_3);
+            var result_1 = __disposeResources(env_2);
             if (result_1)
                 await result_1;
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                var d20 = __addDisposableResource(env_1, (_c = {}, _c[Symbol.asyncDispose] = function () {
+    switch (Math.random()) {
+        case 0: {
+            var env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d20 = __addDisposableResource(env_3, (_c = {}, _c[Symbol.asyncDispose] = function () {
                     return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                         return [2 /*return*/];
                     }); });
                 }, _c), true);
                 break;
-            case 1:
-                var d21 = __addDisposableResource(env_1, (_d = {}, _d[Symbol.asyncDispose] = function () {
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                var result_2 = __disposeResources(env_3);
+                if (result_2)
+                    await result_2;
+            }
+        }
+        case 1: {
+            var env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d21 = __addDisposableResource(env_4, (_d = {}, _d[Symbol.asyncDispose] = function () {
                     return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                         return [2 /*return*/];
                     }); });
                 }, _d), true);
                 break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                var result_3 = __disposeResources(env_4);
+                if (result_3)
+                    await result_3;
+            }
+        }
+        default: {
+            var env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d22 = __addDisposableResource(env_5, (_e = {}, _e[Symbol.asyncDispose] = function () {
+                    return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                        return [2 /*return*/];
+                    }); });
+                }, _e), true);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                var result_4 = __disposeResources(env_5);
+                if (result_4)
+                    await result_4;
+            }
         }
     }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        var result_2 = __disposeResources(env_1);
-        if (result_2)
-            await result_2;
-    }
-    if (true) {
-        var env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    var d22 = __addDisposableResource(env_4, (_e = {}, _e[Symbol.asyncDispose] = function () {
+    if (true)
+        switch (0) {
+            case 0: {
+                var env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d23 = __addDisposableResource(env_6, (_f = {}, _f[Symbol.asyncDispose] = function () {
                         return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                             return [2 /*return*/];
                         }); });
-                    }, _e), true);
+                    }, _f), true);
                     break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    var result_5 = __disposeResources(env_6);
+                    if (result_5)
+                        await result_5;
+                }
+            }
+            default: {
+                var env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d24 = __addDisposableResource(env_7, (_g = {}, _g[Symbol.asyncDispose] = function () {
+                        return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                            return [2 /*return*/];
+                        }); });
+                    }, _g), true);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    var result_6 = __disposeResources(env_7);
+                    if (result_6)
+                        await result_6;
+                }
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
-        }
-        finally {
-            var result_3 = __disposeResources(env_4);
-            if (result_3)
-                await result_3;
-        }
-    }
     try {
-        var env_5 = { stack: [], error: void 0, hasError: false };
+        var env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            var d23 = __addDisposableResource(env_5, (_f = {}, _f[Symbol.asyncDispose] = function () {
-                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
-                    return [2 /*return*/];
-                }); });
-            }, _f), true);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            var result_4 = __disposeResources(env_5);
-            if (result_4)
-                await result_4;
-        }
-    }
-    catch (_r) {
-        var env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d24 = __addDisposableResource(env_6, (_g = {}, _g[Symbol.asyncDispose] = function () {
-                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
-                    return [2 /*return*/];
-                }); });
-            }, _g), true);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            var result_5 = __disposeResources(env_6);
-            if (result_5)
-                await result_5;
-        }
-    }
-    finally {
-        var env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d25 = __addDisposableResource(env_7, (_h = {}, _h[Symbol.asyncDispose] = function () {
+            var d25 = __addDisposableResource(env_8, (_h = {}, _h[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
             }, _h), true);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            var result_6 = __disposeResources(env_7);
-            if (result_6)
-                await result_6;
-        }
-    }
-    if (true) {
-        var env_8 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d26 = __addDisposableResource(env_8, (_j = {}, _j[Symbol.asyncDispose] = function () {
-                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
-                    return [2 /*return*/];
-                }); });
-            }, _j), true);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -588,14 +594,14 @@ try {
                 await result_7;
         }
     }
-    else {
+    catch (_t) {
         var env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            var d27 = __addDisposableResource(env_9, (_k = {}, _k[Symbol.asyncDispose] = function () {
+            var d26 = __addDisposableResource(env_9, (_j = {}, _j[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _k), true);
+            }, _j), true);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -607,15 +613,14 @@ try {
                 await result_8;
         }
     }
-    while (true) {
+    finally {
         var env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            var d28 = __addDisposableResource(env_10, (_l = {}, _l[Symbol.asyncDispose] = function () {
+            var d27 = __addDisposableResource(env_10, (_k = {}, _k[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _l), true);
-            break;
+            }, _k), true);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -627,15 +632,14 @@ try {
                 await result_9;
         }
     }
-    do {
+    if (true) {
         var env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            var d29 = __addDisposableResource(env_11, (_m = {}, _m[Symbol.asyncDispose] = function () {
+            var d28 = __addDisposableResource(env_11, (_l = {}, _l[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _m), true);
-            break;
+            }, _l), true);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -646,16 +650,15 @@ try {
             if (result_10)
                 await result_10;
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         var env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            var d30 = __addDisposableResource(env_12, (_o = {}, _o[Symbol.asyncDispose] = function () {
+            var d29 = __addDisposableResource(env_12, (_m = {}, _m[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _o), true);
-            break;
+            }, _m), true);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -667,14 +670,15 @@ try {
                 await result_11;
         }
     }
-    for (var x in {}) {
+    while (true) {
         var env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            var d31 = __addDisposableResource(env_13, (_p = {}, _p[Symbol.asyncDispose] = function () {
+            var d30 = __addDisposableResource(env_13, (_o = {}, _o[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _p), true);
+            }, _o), true);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -686,15 +690,15 @@ try {
                 await result_12;
         }
     }
-    for (var _i = 0, _s = []; _i < _s.length; _i++) {
-        var x = _s[_i];
+    do {
         var env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            var d32 = __addDisposableResource(env_14, (_q = {}, _q[Symbol.asyncDispose] = function () {
+            var d31 = __addDisposableResource(env_14, (_p = {}, _p[Symbol.asyncDispose] = function () {
                 return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
                     return [2 /*return*/];
                 }); });
-            }, _q), true);
+            }, _p), true);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -705,15 +709,74 @@ try {
             if (result_13)
                 await result_13;
         }
+    } while (true);
+    for (;;) {
+        var env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d32 = __addDisposableResource(env_15, (_q = {}, _q[Symbol.asyncDispose] = function () {
+                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                    return [2 /*return*/];
+                }); });
+            }, _q), true);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            var result_14 = __disposeResources(env_15);
+            if (result_14)
+                await result_14;
+        }
+    }
+    for (var x in {}) {
+        var env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d33 = __addDisposableResource(env_16, (_r = {}, _r[Symbol.asyncDispose] = function () {
+                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                    return [2 /*return*/];
+                }); });
+            }, _r), true);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            var result_15 = __disposeResources(env_16);
+            if (result_15)
+                await result_15;
+        }
+    }
+    for (var _i = 0, _u = []; _i < _u.length; _i++) {
+        var x = _u[_i];
+        var env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d34 = __addDisposableResource(env_17, (_s = {}, _s[Symbol.asyncDispose] = function () {
+                return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+                    return [2 /*return*/];
+                }); });
+            }, _s), true);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            var result_16 = __disposeResources(env_17);
+            if (result_16)
+                await result_16;
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    var result_14 = __disposeResources(env_2);
-    if (result_14)
-        await result_14;
+    var result_17 = __disposeResources(env_1);
+    if (result_17)
+        await result_17;
 }
 export {};

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=esnext).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=esnext).js
@@ -40,61 +40,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};
@@ -131,50 +142,59 @@ class C1 {
     await using d19 = { async [Symbol.asyncDispose]() { } };
 }
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() { } };
         break;
-    case 1:
+    }
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() { } };
         break;
+    }
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() { } };
+    }
 }
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() { } };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() { } };
             break;
+        }
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() { } };
+        }
     }
 try {
-    await using d23 = { async [Symbol.asyncDispose]() { } };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() { } };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() { } };
 }
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() { } };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() { } };
 }
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() { } };
-    break;
 }
-do {
+else {
     await using d29 = { async [Symbol.asyncDispose]() { } };
-    break;
-} while (true);
-for (;;) {
+}
+while (true) {
     await using d30 = { async [Symbol.asyncDispose]() { } };
     break;
 }
-for (const x in {}) {
+do {
     await using d31 = { async [Symbol.asyncDispose]() { } };
+    break;
+} while (true);
+for (;;) {
+    await using d32 = { async [Symbol.asyncDispose]() { } };
+    break;
+}
+for (const x in {}) {
+    await using d33 = { async [Symbol.asyncDispose]() { } };
 }
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() { } };
+    await using d34 = { async [Symbol.asyncDispose]() { } };
 }
 export {};

--- a/tests/baselines/reference/awaitUsingDeclarations.17.errors.txt
+++ b/tests/baselines/reference/awaitUsingDeclarations.17.errors.txt
@@ -1,0 +1,43 @@
+awaitUsingDeclarations.17.ts(3,9): error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+awaitUsingDeclarations.17.ts(7,9): error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+awaitUsingDeclarations.17.ts(11,9): error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+awaitUsingDeclarations.17.ts(17,13): error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+awaitUsingDeclarations.17.ts(21,13): error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+
+
+==== awaitUsingDeclarations.17.ts (5 errors) ====
+    switch (Math.random()) {
+        case 0:
+            await using d20 = { async [Symbol.asyncDispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+            break;
+    
+        case 1:
+            await using d21 = { async [Symbol.asyncDispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+            break;
+    
+        default:
+            await using d22 = { async [Symbol.asyncDispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+    }
+    
+    if (true)
+        switch (0) {
+            case 0:
+                await using d23 = { async [Symbol.asyncDispose]() {} };
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+                break;
+    
+            default:
+                await using d24 = { async [Symbol.asyncDispose]() {} };
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1548: 'await using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+        }
+    
+    export {};
+    

--- a/tests/baselines/reference/awaitUsingDeclarations.17.js
+++ b/tests/baselines/reference/awaitUsingDeclarations.17.js
@@ -1,0 +1,49 @@
+//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts] ////
+
+//// [awaitUsingDeclarations.17.ts]
+switch (Math.random()) {
+    case 0:
+        await using d20 = { async [Symbol.asyncDispose]() {} };
+        break;
+
+    case 1:
+        await using d21 = { async [Symbol.asyncDispose]() {} };
+        break;
+
+    default:
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+}
+
+if (true)
+    switch (0) {
+        case 0:
+            await using d23 = { async [Symbol.asyncDispose]() {} };
+            break;
+
+        default:
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+    }
+
+export {};
+
+
+//// [awaitUsingDeclarations.17.js]
+switch (Math.random()) {
+    case 0:
+        await using d20 = { async [Symbol.asyncDispose]() { } };
+        break;
+    case 1:
+        await using d21 = { async [Symbol.asyncDispose]() { } };
+        break;
+    default:
+        await using d22 = { async [Symbol.asyncDispose]() { } };
+}
+if (true)
+    switch (0) {
+        case 0:
+            await using d23 = { async [Symbol.asyncDispose]() { } };
+            break;
+        default:
+            await using d24 = { async [Symbol.asyncDispose]() { } };
+    }
+export {};

--- a/tests/baselines/reference/usingDeclarations.1(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2015).js
@@ -94,61 +94,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};
@@ -230,73 +241,24 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 var _a;
 function f() {
-    const env_15 = { stack: [], error: void 0, hasError: false };
+    const env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        const d2 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
+        const d2 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
     }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
+    catch (e_18) {
+        env_18.error = e_18;
+        env_18.hasError = true;
     }
     finally {
-        __disposeResources(env_15);
+        __disposeResources(env_18);
     }
 }
 function af() {
     return __awaiter(this, void 0, void 0, function* () {
-        const env_16 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d3 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
-            yield null;
-        }
-        catch (e_16) {
-            env_16.error = e_16;
-            env_16.hasError = true;
-        }
-        finally {
-            __disposeResources(env_16);
-        }
-    });
-}
-function* g() {
-    const env_17 = { stack: [], error: void 0, hasError: false };
-    try {
-        const d4 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
-        yield;
-    }
-    catch (e_17) {
-        env_17.error = e_17;
-        env_17.hasError = true;
-    }
-    finally {
-        __disposeResources(env_17);
-    }
-}
-function ag() {
-    return __asyncGenerator(this, arguments, function* ag_1() {
-        const env_18 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d5 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
-            yield yield __await(void 0);
-            yield __await(null);
-        }
-        catch (e_18) {
-            env_18.error = e_18;
-            env_18.hasError = true;
-        }
-        finally {
-            __disposeResources(env_18);
-        }
-    });
-}
-var d1, a, C1, C2, C3, N, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
-try {
-    d1 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
-    a = () => {
         const env_19 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
+            const d3 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
+            yield null;
         }
         catch (e_19) {
             env_19.error = e_19;
@@ -305,52 +267,74 @@ try {
         finally {
             __disposeResources(env_19);
         }
+    });
+}
+function* g() {
+    const env_20 = { stack: [], error: void 0, hasError: false };
+    try {
+        const d4 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
+        yield;
+    }
+    catch (e_20) {
+        env_20.error = e_20;
+        env_20.hasError = true;
+    }
+    finally {
+        __disposeResources(env_20);
+    }
+}
+function ag() {
+    return __asyncGenerator(this, arguments, function* ag_1() {
+        const env_21 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d5 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
+            yield yield __await(void 0);
+            yield __await(null);
+        }
+        catch (e_21) {
+            env_21.error = e_21;
+            env_21.hasError = true;
+        }
+        finally {
+            __disposeResources(env_21);
+        }
+    });
+}
+var d1, a, C1, C2, C3, N;
+const env_1 = { stack: [], error: void 0, hasError: false };
+try {
+    d1 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
+    a = () => {
+        const env_22 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d6 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_22) {
+            env_22.error = e_22;
+            env_22.hasError = true;
+        }
+        finally {
+            __disposeResources(env_22);
+        }
     };
     C1 = (_a = class C1 {
             constructor() {
                 this.a = () => {
-                    const env_21 = { stack: [], error: void 0, hasError: false };
+                    const env_24 = { stack: [], error: void 0, hasError: false };
                     try {
-                        const d7 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
+                        const d7 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
                     }
-                    catch (e_21) {
-                        env_21.error = e_21;
-                        env_21.hasError = true;
+                    catch (e_24) {
+                        env_24.error = e_24;
+                        env_24.hasError = true;
                     }
                     finally {
-                        __disposeResources(env_21);
+                        __disposeResources(env_24);
                     }
                 };
-                const env_20 = { stack: [], error: void 0, hasError: false };
-                try {
-                    const d8 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
-                }
-                catch (e_20) {
-                    env_20.error = e_20;
-                    env_20.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_20);
-                }
-            }
-            m() {
-                const env_22 = { stack: [], error: void 0, hasError: false };
-                try {
-                    const d10 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
-                }
-                catch (e_22) {
-                    env_22.error = e_22;
-                    env_22.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_22);
-                }
-            }
-            get x() {
                 const env_23 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d11 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
-                    return 0;
+                    const d8 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
                 }
                 catch (e_23) {
                     env_23.error = e_23;
@@ -360,40 +344,24 @@ try {
                     __disposeResources(env_23);
                 }
             }
-            set x(v) {
-                const env_24 = { stack: [], error: void 0, hasError: false };
+            m() {
+                const env_25 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d12 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
+                    const d10 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
                 }
-                catch (e_24) {
-                    env_24.error = e_24;
-                    env_24.hasError = true;
+                catch (e_25) {
+                    env_25.error = e_25;
+                    env_25.hasError = true;
                 }
                 finally {
-                    __disposeResources(env_24);
+                    __disposeResources(env_25);
                 }
             }
-            am() {
-                return __awaiter(this, void 0, void 0, function* () {
-                    const env_25 = { stack: [], error: void 0, hasError: false };
-                    try {
-                        const d13 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
-                        yield null;
-                    }
-                    catch (e_25) {
-                        env_25.error = e_25;
-                        env_25.hasError = true;
-                    }
-                    finally {
-                        __disposeResources(env_25);
-                    }
-                });
-            }
-            *g() {
+            get x() {
                 const env_26 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d14 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
-                    yield;
+                    const d11 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
+                    return 0;
                 }
                 catch (e_26) {
                     env_26.error = e_26;
@@ -403,175 +371,217 @@ try {
                     __disposeResources(env_26);
                 }
             }
+            set x(v) {
+                const env_27 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d12 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
+                }
+                catch (e_27) {
+                    env_27.error = e_27;
+                    env_27.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_27);
+                }
+            }
+            am() {
+                return __awaiter(this, void 0, void 0, function* () {
+                    const env_28 = { stack: [], error: void 0, hasError: false };
+                    try {
+                        const d13 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
+                        yield null;
+                    }
+                    catch (e_28) {
+                        env_28.error = e_28;
+                        env_28.hasError = true;
+                    }
+                    finally {
+                        __disposeResources(env_28);
+                    }
+                });
+            }
+            *g() {
+                const env_29 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d14 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
+                    yield;
+                }
+                catch (e_29) {
+                    env_29.error = e_29;
+                    env_29.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_29);
+                }
+            }
             ag() {
                 return __asyncGenerator(this, arguments, function* ag_2() {
-                    const env_27 = { stack: [], error: void 0, hasError: false };
+                    const env_30 = { stack: [], error: void 0, hasError: false };
                     try {
-                        const d15 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
+                        const d15 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
                         yield yield __await(void 0);
                         yield __await(null);
                     }
-                    catch (e_27) {
-                        env_27.error = e_27;
-                        env_27.hasError = true;
+                    catch (e_30) {
+                        env_30.error = e_30;
+                        env_30.hasError = true;
                     }
                     finally {
-                        __disposeResources(env_27);
+                        __disposeResources(env_30);
                     }
                 });
             }
         },
         (() => {
-            const env_28 = { stack: [], error: void 0, hasError: false };
+            const env_31 = { stack: [], error: void 0, hasError: false };
             try {
-                const d9 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
+                const d9 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
             }
-            catch (e_28) {
-                env_28.error = e_28;
-                env_28.hasError = true;
+            catch (e_31) {
+                env_31.error = e_31;
+                env_31.hasError = true;
             }
             finally {
-                __disposeResources(env_28);
+                __disposeResources(env_31);
             }
         })(),
         _a);
     C2 = class C2 extends C1 {
         constructor() {
-            const env_29 = { stack: [], error: void 0, hasError: false };
+            const env_32 = { stack: [], error: void 0, hasError: false };
             try {
-                const d16 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
+                const d16 = __addDisposableResource(env_32, { [Symbol.dispose]() { } }, false);
                 super();
             }
-            catch (e_29) {
-                env_29.error = e_29;
-                env_29.hasError = true;
+            catch (e_32) {
+                env_32.error = e_32;
+                env_32.hasError = true;
             }
             finally {
-                __disposeResources(env_29);
+                __disposeResources(env_32);
             }
         }
     };
     C3 = class C3 extends C1 {
         constructor() {
-            const env_30 = { stack: [], error: void 0, hasError: false };
+            const env_33 = { stack: [], error: void 0, hasError: false };
             try {
-                const d17 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
+                const d17 = __addDisposableResource(env_33, { [Symbol.dispose]() { } }, false);
                 super();
                 this.y = 1;
             }
-            catch (e_30) {
-                env_30.error = e_30;
-                env_30.hasError = true;
+            catch (e_33) {
+                env_33.error = e_33;
+                env_33.hasError = true;
             }
             finally {
-                __disposeResources(env_30);
+                __disposeResources(env_33);
             }
         }
     };
     (function (N) {
-        const env_31 = { stack: [], error: void 0, hasError: false };
+        const env_34 = { stack: [], error: void 0, hasError: false };
         try {
-            const d18 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
+            const d18 = __addDisposableResource(env_34, { [Symbol.dispose]() { } }, false);
         }
-        catch (e_31) {
-            env_31.error = e_31;
-            env_31.hasError = true;
+        catch (e_34) {
+            env_34.error = e_34;
+            env_34.hasError = true;
         }
         finally {
-            __disposeResources(env_31);
+            __disposeResources(env_34);
         }
     })(N || (N = {}));
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
+            const d19 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            __disposeResources(env_3);
+            __disposeResources(env_2);
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        __disposeResources(env_1);
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                __disposeResources(env_3);
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                __disposeResources(env_4);
+            }
         }
-        finally {
-            __disposeResources(env_4);
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                __disposeResources(env_5);
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_6);
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_7);
+                }
+            }
+        }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            __disposeResources(env_5);
-        }
-    }
-    catch (_b) {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            __disposeResources(env_6);
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            __disposeResources(env_7);
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
+            const d25 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -581,10 +591,10 @@ try {
             __disposeResources(env_8);
         }
     }
-    else {
+    catch (_b) {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
+            const d26 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -594,11 +604,10 @@ try {
             __disposeResources(env_9);
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
-            break;
+            const d27 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -608,11 +617,10 @@ try {
             __disposeResources(env_10);
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
-            break;
+            const d28 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -621,12 +629,11 @@ try {
         finally {
             __disposeResources(env_11);
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
-            break;
+            const d29 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -636,10 +643,11 @@ try {
             __disposeResources(env_12);
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            const d30 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -649,10 +657,11 @@ try {
             __disposeResources(env_13);
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            const d31 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -661,13 +670,53 @@ try {
         finally {
             __disposeResources(env_14);
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            __disposeResources(env_15);
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            __disposeResources(env_16);
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            __disposeResources(env_17);
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    __disposeResources(env_2);
+    __disposeResources(env_1);
 }
 export {};

--- a/tests/baselines/reference/usingDeclarations.1(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2017).js
@@ -94,61 +94,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};
@@ -221,125 +232,98 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 var _a;
 function f() {
-    const env_15 = { stack: [], error: void 0, hasError: false };
+    const env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        const d2 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
+        const d2 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
     }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
+    catch (e_18) {
+        env_18.error = e_18;
+        env_18.hasError = true;
     }
     finally {
-        __disposeResources(env_15);
+        __disposeResources(env_18);
     }
 }
 async function af() {
-    const env_16 = { stack: [], error: void 0, hasError: false };
+    const env_19 = { stack: [], error: void 0, hasError: false };
     try {
-        const d3 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
+        const d3 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
         await null;
     }
-    catch (e_16) {
-        env_16.error = e_16;
-        env_16.hasError = true;
+    catch (e_19) {
+        env_19.error = e_19;
+        env_19.hasError = true;
     }
     finally {
-        __disposeResources(env_16);
+        __disposeResources(env_19);
     }
 }
 function* g() {
-    const env_17 = { stack: [], error: void 0, hasError: false };
+    const env_20 = { stack: [], error: void 0, hasError: false };
     try {
-        const d4 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
+        const d4 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
         yield;
     }
-    catch (e_17) {
-        env_17.error = e_17;
-        env_17.hasError = true;
+    catch (e_20) {
+        env_20.error = e_20;
+        env_20.hasError = true;
     }
     finally {
-        __disposeResources(env_17);
+        __disposeResources(env_20);
     }
 }
 function ag() {
     return __asyncGenerator(this, arguments, function* ag_1() {
-        const env_18 = { stack: [], error: void 0, hasError: false };
+        const env_21 = { stack: [], error: void 0, hasError: false };
         try {
-            const d5 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
+            const d5 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
             yield yield __await(void 0);
             yield __await(null);
         }
-        catch (e_18) {
-            env_18.error = e_18;
-            env_18.hasError = true;
+        catch (e_21) {
+            env_21.error = e_21;
+            env_21.hasError = true;
         }
         finally {
-            __disposeResources(env_18);
+            __disposeResources(env_21);
         }
     });
 }
-var d1, a, C1, C2, C3, N, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1, C2, C3, N;
+const env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
+    d1 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
     a = () => {
-        const env_19 = { stack: [], error: void 0, hasError: false };
+        const env_22 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
+            const d6 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
         }
-        catch (e_19) {
-            env_19.error = e_19;
-            env_19.hasError = true;
+        catch (e_22) {
+            env_22.error = e_22;
+            env_22.hasError = true;
         }
         finally {
-            __disposeResources(env_19);
+            __disposeResources(env_22);
         }
     };
     C1 = (_a = class C1 {
             constructor() {
                 this.a = () => {
-                    const env_21 = { stack: [], error: void 0, hasError: false };
+                    const env_24 = { stack: [], error: void 0, hasError: false };
                     try {
-                        const d7 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
+                        const d7 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
                     }
-                    catch (e_21) {
-                        env_21.error = e_21;
-                        env_21.hasError = true;
+                    catch (e_24) {
+                        env_24.error = e_24;
+                        env_24.hasError = true;
                     }
                     finally {
-                        __disposeResources(env_21);
+                        __disposeResources(env_24);
                     }
                 };
-                const env_20 = { stack: [], error: void 0, hasError: false };
-                try {
-                    const d8 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
-                }
-                catch (e_20) {
-                    env_20.error = e_20;
-                    env_20.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_20);
-                }
-            }
-            m() {
-                const env_22 = { stack: [], error: void 0, hasError: false };
-                try {
-                    const d10 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
-                }
-                catch (e_22) {
-                    env_22.error = e_22;
-                    env_22.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_22);
-                }
-            }
-            get x() {
                 const env_23 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d11 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
-                    return 0;
+                    const d8 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
                 }
                 catch (e_23) {
                     env_23.error = e_23;
@@ -349,24 +333,10 @@ try {
                     __disposeResources(env_23);
                 }
             }
-            set x(v) {
-                const env_24 = { stack: [], error: void 0, hasError: false };
-                try {
-                    const d12 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
-                }
-                catch (e_24) {
-                    env_24.error = e_24;
-                    env_24.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_24);
-                }
-            }
-            async am() {
+            m() {
                 const env_25 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d13 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
-                    await null;
+                    const d10 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
                 }
                 catch (e_25) {
                     env_25.error = e_25;
@@ -376,11 +346,11 @@ try {
                     __disposeResources(env_25);
                 }
             }
-            *g() {
+            get x() {
                 const env_26 = { stack: [], error: void 0, hasError: false };
                 try {
-                    const d14 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
-                    yield;
+                    const d11 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
+                    return 0;
                 }
                 catch (e_26) {
                     env_26.error = e_26;
@@ -390,175 +360,215 @@ try {
                     __disposeResources(env_26);
                 }
             }
+            set x(v) {
+                const env_27 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d12 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
+                }
+                catch (e_27) {
+                    env_27.error = e_27;
+                    env_27.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_27);
+                }
+            }
+            async am() {
+                const env_28 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d13 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
+                    await null;
+                }
+                catch (e_28) {
+                    env_28.error = e_28;
+                    env_28.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_28);
+                }
+            }
+            *g() {
+                const env_29 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d14 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
+                    yield;
+                }
+                catch (e_29) {
+                    env_29.error = e_29;
+                    env_29.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_29);
+                }
+            }
             ag() {
                 return __asyncGenerator(this, arguments, function* ag_2() {
-                    const env_27 = { stack: [], error: void 0, hasError: false };
+                    const env_30 = { stack: [], error: void 0, hasError: false };
                     try {
-                        const d15 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
+                        const d15 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
                         yield yield __await(void 0);
                         yield __await(null);
                     }
-                    catch (e_27) {
-                        env_27.error = e_27;
-                        env_27.hasError = true;
+                    catch (e_30) {
+                        env_30.error = e_30;
+                        env_30.hasError = true;
                     }
                     finally {
-                        __disposeResources(env_27);
+                        __disposeResources(env_30);
                     }
                 });
             }
         },
         (() => {
-            const env_28 = { stack: [], error: void 0, hasError: false };
+            const env_31 = { stack: [], error: void 0, hasError: false };
             try {
-                const d9 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
+                const d9 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
             }
-            catch (e_28) {
-                env_28.error = e_28;
-                env_28.hasError = true;
+            catch (e_31) {
+                env_31.error = e_31;
+                env_31.hasError = true;
             }
             finally {
-                __disposeResources(env_28);
+                __disposeResources(env_31);
             }
         })(),
         _a);
     C2 = class C2 extends C1 {
         constructor() {
-            const env_29 = { stack: [], error: void 0, hasError: false };
+            const env_32 = { stack: [], error: void 0, hasError: false };
             try {
-                const d16 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
+                const d16 = __addDisposableResource(env_32, { [Symbol.dispose]() { } }, false);
                 super();
             }
-            catch (e_29) {
-                env_29.error = e_29;
-                env_29.hasError = true;
+            catch (e_32) {
+                env_32.error = e_32;
+                env_32.hasError = true;
             }
             finally {
-                __disposeResources(env_29);
+                __disposeResources(env_32);
             }
         }
     };
     C3 = class C3 extends C1 {
         constructor() {
-            const env_30 = { stack: [], error: void 0, hasError: false };
+            const env_33 = { stack: [], error: void 0, hasError: false };
             try {
-                const d17 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
+                const d17 = __addDisposableResource(env_33, { [Symbol.dispose]() { } }, false);
                 super();
                 this.y = 1;
             }
-            catch (e_30) {
-                env_30.error = e_30;
-                env_30.hasError = true;
+            catch (e_33) {
+                env_33.error = e_33;
+                env_33.hasError = true;
             }
             finally {
-                __disposeResources(env_30);
+                __disposeResources(env_33);
             }
         }
     };
     (function (N) {
-        const env_31 = { stack: [], error: void 0, hasError: false };
+        const env_34 = { stack: [], error: void 0, hasError: false };
         try {
-            const d18 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
+            const d18 = __addDisposableResource(env_34, { [Symbol.dispose]() { } }, false);
         }
-        catch (e_31) {
-            env_31.error = e_31;
-            env_31.hasError = true;
+        catch (e_34) {
+            env_34.error = e_34;
+            env_34.hasError = true;
         }
         finally {
-            __disposeResources(env_31);
+            __disposeResources(env_34);
         }
     })(N || (N = {}));
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
+            const d19 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            __disposeResources(env_3);
+            __disposeResources(env_2);
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        __disposeResources(env_1);
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                __disposeResources(env_3);
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                __disposeResources(env_4);
+            }
         }
-        finally {
-            __disposeResources(env_4);
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                __disposeResources(env_5);
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_6);
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_7);
+                }
+            }
+        }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            __disposeResources(env_5);
-        }
-    }
-    catch (_b) {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            __disposeResources(env_6);
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            __disposeResources(env_7);
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
+            const d25 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -568,10 +578,10 @@ try {
             __disposeResources(env_8);
         }
     }
-    else {
+    catch (_b) {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
+            const d26 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -581,11 +591,10 @@ try {
             __disposeResources(env_9);
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
-            break;
+            const d27 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -595,11 +604,10 @@ try {
             __disposeResources(env_10);
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
-            break;
+            const d28 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -608,12 +616,11 @@ try {
         finally {
             __disposeResources(env_11);
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
-            break;
+            const d29 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -623,10 +630,11 @@ try {
             __disposeResources(env_12);
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            const d30 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -636,10 +644,11 @@ try {
             __disposeResources(env_13);
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            const d31 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -648,13 +657,53 @@ try {
         finally {
             __disposeResources(env_14);
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            __disposeResources(env_15);
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            __disposeResources(env_16);
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            __disposeResources(env_17);
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    __disposeResources(env_2);
+    __disposeResources(env_1);
 }
 export {};

--- a/tests/baselines/reference/usingDeclarations.1(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2022).js
@@ -94,61 +94,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};
@@ -207,52 +218,9 @@ var __disposeResources = (this && this.__disposeResources) || (function (Suppres
     return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
 });
 function f() {
-    const env_15 = { stack: [], error: void 0, hasError: false };
-    try {
-        const d2 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
-    }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
-    }
-    finally {
-        __disposeResources(env_15);
-    }
-}
-async function af() {
-    const env_16 = { stack: [], error: void 0, hasError: false };
-    try {
-        const d3 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
-        await null;
-    }
-    catch (e_16) {
-        env_16.error = e_16;
-        env_16.hasError = true;
-    }
-    finally {
-        __disposeResources(env_16);
-    }
-}
-function* g() {
-    const env_17 = { stack: [], error: void 0, hasError: false };
-    try {
-        const d4 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
-        yield;
-    }
-    catch (e_17) {
-        env_17.error = e_17;
-        env_17.hasError = true;
-    }
-    finally {
-        __disposeResources(env_17);
-    }
-}
-async function* ag() {
     const env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        const d5 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
-        yield;
-        await null;
+        const d2 = __addDisposableResource(env_18, { [Symbol.dispose]() { } }, false);
     }
     catch (e_18) {
         env_18.error = e_18;
@@ -262,67 +230,71 @@ async function* ag() {
         __disposeResources(env_18);
     }
 }
-var d1, a, C1, C2, C3, N, env_1;
-const env_2 = { stack: [], error: void 0, hasError: false };
+async function af() {
+    const env_19 = { stack: [], error: void 0, hasError: false };
+    try {
+        const d3 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
+        await null;
+    }
+    catch (e_19) {
+        env_19.error = e_19;
+        env_19.hasError = true;
+    }
+    finally {
+        __disposeResources(env_19);
+    }
+}
+function* g() {
+    const env_20 = { stack: [], error: void 0, hasError: false };
+    try {
+        const d4 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
+        yield;
+    }
+    catch (e_20) {
+        env_20.error = e_20;
+        env_20.hasError = true;
+    }
+    finally {
+        __disposeResources(env_20);
+    }
+}
+async function* ag() {
+    const env_21 = { stack: [], error: void 0, hasError: false };
+    try {
+        const d5 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
+        yield;
+        await null;
+    }
+    catch (e_21) {
+        env_21.error = e_21;
+        env_21.hasError = true;
+    }
+    finally {
+        __disposeResources(env_21);
+    }
+}
+var d1, a, C1, C2, C3, N;
+const env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
+    d1 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
     a = () => {
-        const env_19 = { stack: [], error: void 0, hasError: false };
+        const env_22 = { stack: [], error: void 0, hasError: false };
         try {
-            const d6 = __addDisposableResource(env_19, { [Symbol.dispose]() { } }, false);
+            const d6 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
         }
-        catch (e_19) {
-            env_19.error = e_19;
-            env_19.hasError = true;
+        catch (e_22) {
+            env_22.error = e_22;
+            env_22.hasError = true;
         }
         finally {
-            __disposeResources(env_19);
+            __disposeResources(env_22);
         }
     };
     C1 = class C1 {
         a = () => {
-            const env_20 = { stack: [], error: void 0, hasError: false };
-            try {
-                const d7 = __addDisposableResource(env_20, { [Symbol.dispose]() { } }, false);
-            }
-            catch (e_20) {
-                env_20.error = e_20;
-                env_20.hasError = true;
-            }
-            finally {
-                __disposeResources(env_20);
-            }
-        };
-        constructor() {
-            const env_21 = { stack: [], error: void 0, hasError: false };
-            try {
-                const d8 = __addDisposableResource(env_21, { [Symbol.dispose]() { } }, false);
-            }
-            catch (e_21) {
-                env_21.error = e_21;
-                env_21.hasError = true;
-            }
-            finally {
-                __disposeResources(env_21);
-            }
-        }
-        static {
-            const env_22 = { stack: [], error: void 0, hasError: false };
-            try {
-                const d9 = __addDisposableResource(env_22, { [Symbol.dispose]() { } }, false);
-            }
-            catch (e_22) {
-                env_22.error = e_22;
-                env_22.hasError = true;
-            }
-            finally {
-                __disposeResources(env_22);
-            }
-        }
-        m() {
             const env_23 = { stack: [], error: void 0, hasError: false };
             try {
-                const d10 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
+                const d7 = __addDisposableResource(env_23, { [Symbol.dispose]() { } }, false);
             }
             catch (e_23) {
                 env_23.error = e_23;
@@ -331,12 +303,11 @@ try {
             finally {
                 __disposeResources(env_23);
             }
-        }
-        get x() {
+        };
+        constructor() {
             const env_24 = { stack: [], error: void 0, hasError: false };
             try {
-                const d11 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
-                return 0;
+                const d8 = __addDisposableResource(env_24, { [Symbol.dispose]() { } }, false);
             }
             catch (e_24) {
                 env_24.error = e_24;
@@ -346,10 +317,10 @@ try {
                 __disposeResources(env_24);
             }
         }
-        set x(v) {
+        static {
             const env_25 = { stack: [], error: void 0, hasError: false };
             try {
-                const d12 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
+                const d9 = __addDisposableResource(env_25, { [Symbol.dispose]() { } }, false);
             }
             catch (e_25) {
                 env_25.error = e_25;
@@ -359,11 +330,10 @@ try {
                 __disposeResources(env_25);
             }
         }
-        async am() {
+        m() {
             const env_26 = { stack: [], error: void 0, hasError: false };
             try {
-                const d13 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
-                await null;
+                const d10 = __addDisposableResource(env_26, { [Symbol.dispose]() { } }, false);
             }
             catch (e_26) {
                 env_26.error = e_26;
@@ -373,11 +343,11 @@ try {
                 __disposeResources(env_26);
             }
         }
-        *g() {
+        get x() {
             const env_27 = { stack: [], error: void 0, hasError: false };
             try {
-                const d14 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
-                yield;
+                const d11 = __addDisposableResource(env_27, { [Symbol.dispose]() { } }, false);
+                return 0;
             }
             catch (e_27) {
                 env_27.error = e_27;
@@ -387,12 +357,10 @@ try {
                 __disposeResources(env_27);
             }
         }
-        async *ag() {
+        set x(v) {
             const env_28 = { stack: [], error: void 0, hasError: false };
             try {
-                const d15 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
-                yield;
-                await null;
+                const d12 = __addDisposableResource(env_28, { [Symbol.dispose]() { } }, false);
             }
             catch (e_28) {
                 env_28.error = e_28;
@@ -402,13 +370,11 @@ try {
                 __disposeResources(env_28);
             }
         }
-    };
-    C2 = class C2 extends C1 {
-        constructor() {
+        async am() {
             const env_29 = { stack: [], error: void 0, hasError: false };
             try {
-                const d16 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
-                super();
+                const d13 = __addDisposableResource(env_29, { [Symbol.dispose]() { } }, false);
+                await null;
             }
             catch (e_29) {
                 env_29.error = e_29;
@@ -418,14 +384,11 @@ try {
                 __disposeResources(env_29);
             }
         }
-    };
-    C3 = class C3 extends C1 {
-        y = 1;
-        constructor() {
+        *g() {
             const env_30 = { stack: [], error: void 0, hasError: false };
             try {
-                const d17 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
-                super();
+                const d14 = __addDisposableResource(env_30, { [Symbol.dispose]() { } }, false);
+                yield;
             }
             catch (e_30) {
                 env_30.error = e_30;
@@ -435,111 +398,158 @@ try {
                 __disposeResources(env_30);
             }
         }
+        async *ag() {
+            const env_31 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d15 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
+                yield;
+                await null;
+            }
+            catch (e_31) {
+                env_31.error = e_31;
+                env_31.hasError = true;
+            }
+            finally {
+                __disposeResources(env_31);
+            }
+        }
+    };
+    C2 = class C2 extends C1 {
+        constructor() {
+            const env_32 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d16 = __addDisposableResource(env_32, { [Symbol.dispose]() { } }, false);
+                super();
+            }
+            catch (e_32) {
+                env_32.error = e_32;
+                env_32.hasError = true;
+            }
+            finally {
+                __disposeResources(env_32);
+            }
+        }
+    };
+    C3 = class C3 extends C1 {
+        y = 1;
+        constructor() {
+            const env_33 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d17 = __addDisposableResource(env_33, { [Symbol.dispose]() { } }, false);
+                super();
+            }
+            catch (e_33) {
+                env_33.error = e_33;
+                env_33.hasError = true;
+            }
+            finally {
+                __disposeResources(env_33);
+            }
+        }
     };
     (function (N) {
-        const env_31 = { stack: [], error: void 0, hasError: false };
+        const env_34 = { stack: [], error: void 0, hasError: false };
         try {
-            const d18 = __addDisposableResource(env_31, { [Symbol.dispose]() { } }, false);
+            const d18 = __addDisposableResource(env_34, { [Symbol.dispose]() { } }, false);
         }
-        catch (e_31) {
-            env_31.error = e_31;
-            env_31.hasError = true;
+        catch (e_34) {
+            env_34.error = e_34;
+            env_34.hasError = true;
         }
         finally {
-            __disposeResources(env_31);
+            __disposeResources(env_34);
         }
     })(N || (N = {}));
     {
-        const env_3 = { stack: [], error: void 0, hasError: false };
+        const env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            const d19 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
+            const d19 = __addDisposableResource(env_2, { [Symbol.dispose]() { } }, false);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            __disposeResources(env_3);
+            __disposeResources(env_2);
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                const d20 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
+    switch (Math.random()) {
+        case 0: {
+            const env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d20 = __addDisposableResource(env_3, { [Symbol.dispose]() { } }, false);
                 break;
-            case 1:
-                const d21 = __addDisposableResource(env_1, { [Symbol.dispose]() { } }, false);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        __disposeResources(env_1);
-    }
-    if (true) {
-        const env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    const d22 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                __disposeResources(env_3);
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            const env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d21 = __addDisposableResource(env_4, { [Symbol.dispose]() { } }, false);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                __disposeResources(env_4);
+            }
         }
-        finally {
-            __disposeResources(env_4);
+        default: {
+            const env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                const d22 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                __disposeResources(env_5);
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                const env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d23 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_6);
+                }
+            }
+            default: {
+                const env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    const d24 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_7);
+                }
+            }
+        }
     try {
-        const env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d23 = __addDisposableResource(env_5, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            __disposeResources(env_5);
-        }
-    }
-    catch {
-        const env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d24 = __addDisposableResource(env_6, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            __disposeResources(env_6);
-        }
-    }
-    finally {
-        const env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d25 = __addDisposableResource(env_7, { [Symbol.dispose]() { } }, false);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            __disposeResources(env_7);
-        }
-    }
-    if (true) {
         const env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            const d26 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
+            const d25 = __addDisposableResource(env_8, { [Symbol.dispose]() { } }, false);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -549,10 +559,10 @@ try {
             __disposeResources(env_8);
         }
     }
-    else {
+    catch {
         const env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            const d27 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
+            const d26 = __addDisposableResource(env_9, { [Symbol.dispose]() { } }, false);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -562,11 +572,10 @@ try {
             __disposeResources(env_9);
         }
     }
-    while (true) {
+    finally {
         const env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            const d28 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
-            break;
+            const d27 = __addDisposableResource(env_10, { [Symbol.dispose]() { } }, false);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -576,11 +585,10 @@ try {
             __disposeResources(env_10);
         }
     }
-    do {
+    if (true) {
         const env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            const d29 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
-            break;
+            const d28 = __addDisposableResource(env_11, { [Symbol.dispose]() { } }, false);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -589,12 +597,11 @@ try {
         finally {
             __disposeResources(env_11);
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         const env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            const d30 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
-            break;
+            const d29 = __addDisposableResource(env_12, { [Symbol.dispose]() { } }, false);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -604,10 +611,11 @@ try {
             __disposeResources(env_12);
         }
     }
-    for (const x in {}) {
+    while (true) {
         const env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            const d31 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            const d30 = __addDisposableResource(env_13, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -617,10 +625,11 @@ try {
             __disposeResources(env_13);
         }
     }
-    for (const x of []) {
+    do {
         const env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            const d32 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            const d31 = __addDisposableResource(env_14, { [Symbol.dispose]() { } }, false);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -629,13 +638,53 @@ try {
         finally {
             __disposeResources(env_14);
         }
+    } while (true);
+    for (;;) {
+        const env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d32 = __addDisposableResource(env_15, { [Symbol.dispose]() { } }, false);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            __disposeResources(env_15);
+        }
+    }
+    for (const x in {}) {
+        const env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d33 = __addDisposableResource(env_16, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            __disposeResources(env_16);
+        }
+    }
+    for (const x of []) {
+        const env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            const d34 = __addDisposableResource(env_17, { [Symbol.dispose]() { } }, false);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            __disposeResources(env_17);
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    __disposeResources(env_2);
+    __disposeResources(env_1);
 }
 export {};

--- a/tests/baselines/reference/usingDeclarations.1(target=es5).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es5).js
@@ -94,61 +94,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};
@@ -270,45 +281,45 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function reject(value) { resume("throw", value); }
     function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
 };
-var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
-var _r;
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
+var _t;
 function f() {
     var _a;
-    var env_15 = { stack: [], error: void 0, hasError: false };
+    var env_18 = { stack: [], error: void 0, hasError: false };
     try {
-        var d2 = __addDisposableResource(env_15, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+        var d2 = __addDisposableResource(env_18, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
     }
-    catch (e_15) {
-        env_15.error = e_15;
-        env_15.hasError = true;
+    catch (e_18) {
+        env_18.error = e_18;
+        env_18.hasError = true;
     }
     finally {
-        __disposeResources(env_15);
+        __disposeResources(env_18);
     }
 }
 function af() {
     return __awaiter(this, void 0, void 0, function () {
-        var env_16, d3, e_16;
+        var env_19, d3, e_19;
         var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    env_16 = { stack: [], error: void 0, hasError: false };
+                    env_19 = { stack: [], error: void 0, hasError: false };
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 3, 4, 5]);
-                    d3 = __addDisposableResource(env_16, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                    d3 = __addDisposableResource(env_19, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                     return [4 /*yield*/, null];
                 case 2:
                     _b.sent();
                     return [3 /*break*/, 5];
                 case 3:
-                    e_16 = _b.sent();
-                    env_16.error = e_16;
-                    env_16.hasError = true;
+                    e_19 = _b.sent();
+                    env_19.error = e_19;
+                    env_19.hasError = true;
                     return [3 /*break*/, 5];
                 case 4:
-                    __disposeResources(env_16);
+                    __disposeResources(env_19);
                     return [7 /*endfinally*/];
                 case 5: return [2 /*return*/];
             }
@@ -316,27 +327,27 @@ function af() {
     });
 }
 function g() {
-    var env_17, d4, e_17;
+    var env_20, d4, e_20;
     var _a;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:
-                env_17 = { stack: [], error: void 0, hasError: false };
+                env_20 = { stack: [], error: void 0, hasError: false };
                 _b.label = 1;
             case 1:
                 _b.trys.push([1, 3, 4, 5]);
-                d4 = __addDisposableResource(env_17, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                d4 = __addDisposableResource(env_20, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                 return [4 /*yield*/];
             case 2:
                 _b.sent();
                 return [3 /*break*/, 5];
             case 3:
-                e_17 = _b.sent();
-                env_17.error = e_17;
-                env_17.hasError = true;
+                e_20 = _b.sent();
+                env_20.error = e_20;
+                env_20.hasError = true;
                 return [3 /*break*/, 5];
             case 4:
-                __disposeResources(env_17);
+                __disposeResources(env_20);
                 return [7 /*endfinally*/];
             case 5: return [2 /*return*/];
         }
@@ -344,16 +355,16 @@ function g() {
 }
 function ag() {
     return __asyncGenerator(this, arguments, function ag_1() {
-        var env_18, d5, e_18;
+        var env_21, d5, e_21;
         var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    env_18 = { stack: [], error: void 0, hasError: false };
+                    env_21 = { stack: [], error: void 0, hasError: false };
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 5, 6, 7]);
-                    d5 = __addDisposableResource(env_18, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                    d5 = __addDisposableResource(env_21, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                     return [4 /*yield*/, __await(void 0)];
                 case 2: return [4 /*yield*/, _b.sent()];
                 case 3:
@@ -363,100 +374,44 @@ function ag() {
                     _b.sent();
                     return [3 /*break*/, 7];
                 case 5:
-                    e_18 = _b.sent();
-                    env_18.error = e_18;
-                    env_18.hasError = true;
+                    e_21 = _b.sent();
+                    env_21.error = e_21;
+                    env_21.hasError = true;
                     return [3 /*break*/, 7];
                 case 6:
-                    __disposeResources(env_18);
+                    __disposeResources(env_21);
                     return [7 /*endfinally*/];
                 case 7: return [2 /*return*/];
             }
         });
     });
 }
-var d1, a, C1, C2, C3, N, env_1;
-var env_2 = { stack: [], error: void 0, hasError: false };
+var d1, a, C1, C2, C3, N;
+var env_1 = { stack: [], error: void 0, hasError: false };
 try {
-    d1 = __addDisposableResource(env_2, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+    d1 = __addDisposableResource(env_1, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
     a = function () {
         var _a;
-        var env_19 = { stack: [], error: void 0, hasError: false };
+        var env_22 = { stack: [], error: void 0, hasError: false };
         try {
-            var d6 = __addDisposableResource(env_19, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+            var d6 = __addDisposableResource(env_22, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
         }
-        catch (e_19) {
-            env_19.error = e_19;
-            env_19.hasError = true;
+        catch (e_22) {
+            env_22.error = e_22;
+            env_22.hasError = true;
         }
         finally {
-            __disposeResources(env_19);
+            __disposeResources(env_22);
         }
     };
-    C1 = (_r = /** @class */ (function () {
+    C1 = (_t = /** @class */ (function () {
             function C1() {
                 var _a;
                 this.a = function () {
                     var _a;
-                    var env_21 = { stack: [], error: void 0, hasError: false };
-                    try {
-                        var d7 = __addDisposableResource(env_21, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
-                    }
-                    catch (e_21) {
-                        env_21.error = e_21;
-                        env_21.hasError = true;
-                    }
-                    finally {
-                        __disposeResources(env_21);
-                    }
-                };
-                var env_20 = { stack: [], error: void 0, hasError: false };
-                try {
-                    var d8 = __addDisposableResource(env_20, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
-                }
-                catch (e_20) {
-                    env_20.error = e_20;
-                    env_20.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_20);
-                }
-            }
-            C1.prototype.m = function () {
-                var _a;
-                var env_22 = { stack: [], error: void 0, hasError: false };
-                try {
-                    var d10 = __addDisposableResource(env_22, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
-                }
-                catch (e_22) {
-                    env_22.error = e_22;
-                    env_22.hasError = true;
-                }
-                finally {
-                    __disposeResources(env_22);
-                }
-            };
-            Object.defineProperty(C1.prototype, "x", {
-                get: function () {
-                    var _a;
-                    var env_23 = { stack: [], error: void 0, hasError: false };
-                    try {
-                        var d11 = __addDisposableResource(env_23, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
-                        return 0;
-                    }
-                    catch (e_23) {
-                        env_23.error = e_23;
-                        env_23.hasError = true;
-                    }
-                    finally {
-                        __disposeResources(env_23);
-                    }
-                },
-                set: function (v) {
-                    var _a;
                     var env_24 = { stack: [], error: void 0, hasError: false };
                     try {
-                        var d12 = __addDisposableResource(env_24, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                        var d7 = __addDisposableResource(env_24, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                     }
                     catch (e_24) {
                         env_24.error = e_24;
@@ -465,33 +420,89 @@ try {
                     finally {
                         __disposeResources(env_24);
                     }
+                };
+                var env_23 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d8 = __addDisposableResource(env_23, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                }
+                catch (e_23) {
+                    env_23.error = e_23;
+                    env_23.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_23);
+                }
+            }
+            C1.prototype.m = function () {
+                var _a;
+                var env_25 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d10 = __addDisposableResource(env_25, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                }
+                catch (e_25) {
+                    env_25.error = e_25;
+                    env_25.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_25);
+                }
+            };
+            Object.defineProperty(C1.prototype, "x", {
+                get: function () {
+                    var _a;
+                    var env_26 = { stack: [], error: void 0, hasError: false };
+                    try {
+                        var d11 = __addDisposableResource(env_26, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                        return 0;
+                    }
+                    catch (e_26) {
+                        env_26.error = e_26;
+                        env_26.hasError = true;
+                    }
+                    finally {
+                        __disposeResources(env_26);
+                    }
+                },
+                set: function (v) {
+                    var _a;
+                    var env_27 = { stack: [], error: void 0, hasError: false };
+                    try {
+                        var d12 = __addDisposableResource(env_27, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                    }
+                    catch (e_27) {
+                        env_27.error = e_27;
+                        env_27.hasError = true;
+                    }
+                    finally {
+                        __disposeResources(env_27);
+                    }
                 },
                 enumerable: false,
                 configurable: true
             });
             C1.prototype.am = function () {
                 return __awaiter(this, void 0, void 0, function () {
-                    var env_25, d13, e_25;
+                    var env_28, d13, e_28;
                     var _a;
                     return __generator(this, function (_b) {
                         switch (_b.label) {
                             case 0:
-                                env_25 = { stack: [], error: void 0, hasError: false };
+                                env_28 = { stack: [], error: void 0, hasError: false };
                                 _b.label = 1;
                             case 1:
                                 _b.trys.push([1, 3, 4, 5]);
-                                d13 = __addDisposableResource(env_25, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                                d13 = __addDisposableResource(env_28, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                                 return [4 /*yield*/, null];
                             case 2:
                                 _b.sent();
                                 return [3 /*break*/, 5];
                             case 3:
-                                e_25 = _b.sent();
-                                env_25.error = e_25;
-                                env_25.hasError = true;
+                                e_28 = _b.sent();
+                                env_28.error = e_28;
+                                env_28.hasError = true;
                                 return [3 /*break*/, 5];
                             case 4:
-                                __disposeResources(env_25);
+                                __disposeResources(env_28);
                                 return [7 /*endfinally*/];
                             case 5: return [2 /*return*/];
                         }
@@ -499,27 +510,27 @@ try {
                 });
             };
             C1.prototype.g = function () {
-                var env_26, d14, e_26;
+                var env_29, d14, e_29;
                 var _a;
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            env_26 = { stack: [], error: void 0, hasError: false };
+                            env_29 = { stack: [], error: void 0, hasError: false };
                             _b.label = 1;
                         case 1:
                             _b.trys.push([1, 3, 4, 5]);
-                            d14 = __addDisposableResource(env_26, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                            d14 = __addDisposableResource(env_29, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                             return [4 /*yield*/];
                         case 2:
                             _b.sent();
                             return [3 /*break*/, 5];
                         case 3:
-                            e_26 = _b.sent();
-                            env_26.error = e_26;
-                            env_26.hasError = true;
+                            e_29 = _b.sent();
+                            env_29.error = e_29;
+                            env_29.hasError = true;
                             return [3 /*break*/, 5];
                         case 4:
-                            __disposeResources(env_26);
+                            __disposeResources(env_29);
                             return [7 /*endfinally*/];
                         case 5: return [2 /*return*/];
                     }
@@ -527,16 +538,16 @@ try {
             };
             C1.prototype.ag = function () {
                 return __asyncGenerator(this, arguments, function ag_2() {
-                    var env_27, d15, e_27;
+                    var env_30, d15, e_30;
                     var _a;
                     return __generator(this, function (_b) {
                         switch (_b.label) {
                             case 0:
-                                env_27 = { stack: [], error: void 0, hasError: false };
+                                env_30 = { stack: [], error: void 0, hasError: false };
                                 _b.label = 1;
                             case 1:
                                 _b.trys.push([1, 5, 6, 7]);
-                                d15 = __addDisposableResource(env_27, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                                d15 = __addDisposableResource(env_30, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                                 return [4 /*yield*/, __await(void 0)];
                             case 2: return [4 /*yield*/, _b.sent()];
                             case 3:
@@ -546,12 +557,12 @@ try {
                                 _b.sent();
                                 return [3 /*break*/, 7];
                             case 5:
-                                e_27 = _b.sent();
-                                env_27.error = e_27;
-                                env_27.hasError = true;
+                                e_30 = _b.sent();
+                                env_30.error = e_30;
+                                env_30.hasError = true;
                                 return [3 /*break*/, 7];
                             case 6:
-                                __disposeResources(env_27);
+                                __disposeResources(env_30);
                                 return [7 /*endfinally*/];
                             case 7: return [2 /*return*/];
                         }
@@ -562,35 +573,35 @@ try {
         }()),
         (function () {
             var _a;
-            var env_28 = { stack: [], error: void 0, hasError: false };
+            var env_31 = { stack: [], error: void 0, hasError: false };
             try {
-                var d9 = __addDisposableResource(env_28, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                var d9 = __addDisposableResource(env_31, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
             }
-            catch (e_28) {
-                env_28.error = e_28;
-                env_28.hasError = true;
+            catch (e_31) {
+                env_31.error = e_31;
+                env_31.hasError = true;
             }
             finally {
-                __disposeResources(env_28);
+                __disposeResources(env_31);
             }
         })(),
-        _r);
+        _t);
     C2 = /** @class */ (function (_super) {
         __extends(C2, _super);
         function C2() {
             var _a;
             var _this = this;
-            var env_29 = { stack: [], error: void 0, hasError: false };
+            var env_32 = { stack: [], error: void 0, hasError: false };
             try {
-                var d16 = __addDisposableResource(env_29, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                var d16 = __addDisposableResource(env_32, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                 _this = _super.call(this) || this;
             }
-            catch (e_29) {
-                env_29.error = e_29;
-                env_29.hasError = true;
+            catch (e_32) {
+                env_32.error = e_32;
+                env_32.hasError = true;
             }
             finally {
-                __disposeResources(env_29);
+                __disposeResources(env_32);
             }
             return _this;
         }
@@ -601,18 +612,18 @@ try {
         function C3() {
             var _a;
             var _this = this;
-            var env_30 = { stack: [], error: void 0, hasError: false };
+            var env_33 = { stack: [], error: void 0, hasError: false };
             try {
-                var d17 = __addDisposableResource(env_30, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+                var d17 = __addDisposableResource(env_33, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
                 _this = _super.call(this) || this;
                 _this.y = 1;
             }
-            catch (e_30) {
-                env_30.error = e_30;
-                env_30.hasError = true;
+            catch (e_33) {
+                env_33.error = e_33;
+                env_33.hasError = true;
             }
             finally {
-                __disposeResources(env_30);
+                __disposeResources(env_33);
             }
             return _this;
         }
@@ -620,109 +631,108 @@ try {
     }(C1));
     (function (N) {
         var _a;
-        var env_31 = { stack: [], error: void 0, hasError: false };
+        var env_34 = { stack: [], error: void 0, hasError: false };
         try {
-            var d18 = __addDisposableResource(env_31, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
+            var d18 = __addDisposableResource(env_34, (_a = {}, _a[Symbol.dispose] = function () { }, _a), false);
         }
-        catch (e_31) {
-            env_31.error = e_31;
-            env_31.hasError = true;
+        catch (e_34) {
+            env_34.error = e_34;
+            env_34.hasError = true;
         }
         finally {
-            __disposeResources(env_31);
+            __disposeResources(env_34);
         }
     })(N || (N = {}));
     {
-        var env_3 = { stack: [], error: void 0, hasError: false };
+        var env_2 = { stack: [], error: void 0, hasError: false };
         try {
-            var d19 = __addDisposableResource(env_3, (_b = {}, _b[Symbol.dispose] = function () { }, _b), false);
+            var d19 = __addDisposableResource(env_2, (_b = {}, _b[Symbol.dispose] = function () { }, _b), false);
         }
         catch (e_1) {
-            env_3.error = e_1;
-            env_3.hasError = true;
+            env_2.error = e_1;
+            env_2.hasError = true;
         }
         finally {
-            __disposeResources(env_3);
+            __disposeResources(env_2);
         }
     }
-    env_1 = { stack: [], error: void 0, hasError: false };
-    try {
-        switch (Math.random()) {
-            case 0:
-                var d20 = __addDisposableResource(env_1, (_c = {}, _c[Symbol.dispose] = function () { }, _c), false);
+    switch (Math.random()) {
+        case 0: {
+            var env_3 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d20 = __addDisposableResource(env_3, (_c = {}, _c[Symbol.dispose] = function () { }, _c), false);
                 break;
-            case 1:
-                var d21 = __addDisposableResource(env_1, (_d = {}, _d[Symbol.dispose] = function () { }, _d), false);
-                break;
-        }
-    }
-    catch (e_2) {
-        env_1.error = e_2;
-        env_1.hasError = true;
-    }
-    finally {
-        __disposeResources(env_1);
-    }
-    if (true) {
-        var env_4 = { stack: [], error: void 0, hasError: false };
-        try {
-            switch (0) {
-                case 0:
-                    var d22 = __addDisposableResource(env_4, (_e = {}, _e[Symbol.dispose] = function () { }, _e), false);
-                    break;
+            }
+            catch (e_2) {
+                env_3.error = e_2;
+                env_3.hasError = true;
+            }
+            finally {
+                __disposeResources(env_3);
             }
         }
-        catch (e_3) {
-            env_4.error = e_3;
-            env_4.hasError = true;
+        case 1: {
+            var env_4 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d21 = __addDisposableResource(env_4, (_d = {}, _d[Symbol.dispose] = function () { }, _d), false);
+                break;
+            }
+            catch (e_3) {
+                env_4.error = e_3;
+                env_4.hasError = true;
+            }
+            finally {
+                __disposeResources(env_4);
+            }
         }
-        finally {
-            __disposeResources(env_4);
+        default: {
+            var env_5 = { stack: [], error: void 0, hasError: false };
+            try {
+                var d22 = __addDisposableResource(env_5, (_e = {}, _e[Symbol.dispose] = function () { }, _e), false);
+            }
+            catch (e_4) {
+                env_5.error = e_4;
+                env_5.hasError = true;
+            }
+            finally {
+                __disposeResources(env_5);
+            }
         }
     }
+    if (true)
+        switch (0) {
+            case 0: {
+                var env_6 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d23 = __addDisposableResource(env_6, (_f = {}, _f[Symbol.dispose] = function () { }, _f), false);
+                    break;
+                }
+                catch (e_5) {
+                    env_6.error = e_5;
+                    env_6.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_6);
+                }
+            }
+            default: {
+                var env_7 = { stack: [], error: void 0, hasError: false };
+                try {
+                    var d24 = __addDisposableResource(env_7, (_g = {}, _g[Symbol.dispose] = function () { }, _g), false);
+                }
+                catch (e_6) {
+                    env_7.error = e_6;
+                    env_7.hasError = true;
+                }
+                finally {
+                    __disposeResources(env_7);
+                }
+            }
+        }
     try {
-        var env_5 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d23 = __addDisposableResource(env_5, (_f = {}, _f[Symbol.dispose] = function () { }, _f), false);
-        }
-        catch (e_4) {
-            env_5.error = e_4;
-            env_5.hasError = true;
-        }
-        finally {
-            __disposeResources(env_5);
-        }
-    }
-    catch (_s) {
-        var env_6 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d24 = __addDisposableResource(env_6, (_g = {}, _g[Symbol.dispose] = function () { }, _g), false);
-        }
-        catch (e_5) {
-            env_6.error = e_5;
-            env_6.hasError = true;
-        }
-        finally {
-            __disposeResources(env_6);
-        }
-    }
-    finally {
-        var env_7 = { stack: [], error: void 0, hasError: false };
-        try {
-            var d25 = __addDisposableResource(env_7, (_h = {}, _h[Symbol.dispose] = function () { }, _h), false);
-        }
-        catch (e_6) {
-            env_7.error = e_6;
-            env_7.hasError = true;
-        }
-        finally {
-            __disposeResources(env_7);
-        }
-    }
-    if (true) {
         var env_8 = { stack: [], error: void 0, hasError: false };
         try {
-            var d26 = __addDisposableResource(env_8, (_j = {}, _j[Symbol.dispose] = function () { }, _j), false);
+            var d25 = __addDisposableResource(env_8, (_h = {}, _h[Symbol.dispose] = function () { }, _h), false);
         }
         catch (e_7) {
             env_8.error = e_7;
@@ -732,10 +742,10 @@ try {
             __disposeResources(env_8);
         }
     }
-    else {
+    catch (_u) {
         var env_9 = { stack: [], error: void 0, hasError: false };
         try {
-            var d27 = __addDisposableResource(env_9, (_k = {}, _k[Symbol.dispose] = function () { }, _k), false);
+            var d26 = __addDisposableResource(env_9, (_j = {}, _j[Symbol.dispose] = function () { }, _j), false);
         }
         catch (e_8) {
             env_9.error = e_8;
@@ -745,11 +755,10 @@ try {
             __disposeResources(env_9);
         }
     }
-    while (true) {
+    finally {
         var env_10 = { stack: [], error: void 0, hasError: false };
         try {
-            var d28 = __addDisposableResource(env_10, (_l = {}, _l[Symbol.dispose] = function () { }, _l), false);
-            break;
+            var d27 = __addDisposableResource(env_10, (_k = {}, _k[Symbol.dispose] = function () { }, _k), false);
         }
         catch (e_9) {
             env_10.error = e_9;
@@ -759,11 +768,10 @@ try {
             __disposeResources(env_10);
         }
     }
-    do {
+    if (true) {
         var env_11 = { stack: [], error: void 0, hasError: false };
         try {
-            var d29 = __addDisposableResource(env_11, (_m = {}, _m[Symbol.dispose] = function () { }, _m), false);
-            break;
+            var d28 = __addDisposableResource(env_11, (_l = {}, _l[Symbol.dispose] = function () { }, _l), false);
         }
         catch (e_10) {
             env_11.error = e_10;
@@ -772,12 +780,11 @@ try {
         finally {
             __disposeResources(env_11);
         }
-    } while (true);
-    for (;;) {
+    }
+    else {
         var env_12 = { stack: [], error: void 0, hasError: false };
         try {
-            var d30 = __addDisposableResource(env_12, (_o = {}, _o[Symbol.dispose] = function () { }, _o), false);
-            break;
+            var d29 = __addDisposableResource(env_12, (_m = {}, _m[Symbol.dispose] = function () { }, _m), false);
         }
         catch (e_11) {
             env_12.error = e_11;
@@ -787,10 +794,11 @@ try {
             __disposeResources(env_12);
         }
     }
-    for (var x in {}) {
+    while (true) {
         var env_13 = { stack: [], error: void 0, hasError: false };
         try {
-            var d31 = __addDisposableResource(env_13, (_p = {}, _p[Symbol.dispose] = function () { }, _p), false);
+            var d30 = __addDisposableResource(env_13, (_o = {}, _o[Symbol.dispose] = function () { }, _o), false);
+            break;
         }
         catch (e_12) {
             env_13.error = e_12;
@@ -800,11 +808,11 @@ try {
             __disposeResources(env_13);
         }
     }
-    for (var _i = 0, _t = []; _i < _t.length; _i++) {
-        var x = _t[_i];
+    do {
         var env_14 = { stack: [], error: void 0, hasError: false };
         try {
-            var d32 = __addDisposableResource(env_14, (_q = {}, _q[Symbol.dispose] = function () { }, _q), false);
+            var d31 = __addDisposableResource(env_14, (_p = {}, _p[Symbol.dispose] = function () { }, _p), false);
+            break;
         }
         catch (e_13) {
             env_14.error = e_13;
@@ -813,13 +821,54 @@ try {
         finally {
             __disposeResources(env_14);
         }
+    } while (true);
+    for (;;) {
+        var env_15 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d32 = __addDisposableResource(env_15, (_q = {}, _q[Symbol.dispose] = function () { }, _q), false);
+            break;
+        }
+        catch (e_14) {
+            env_15.error = e_14;
+            env_15.hasError = true;
+        }
+        finally {
+            __disposeResources(env_15);
+        }
+    }
+    for (var x in {}) {
+        var env_16 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d33 = __addDisposableResource(env_16, (_r = {}, _r[Symbol.dispose] = function () { }, _r), false);
+        }
+        catch (e_15) {
+            env_16.error = e_15;
+            env_16.hasError = true;
+        }
+        finally {
+            __disposeResources(env_16);
+        }
+    }
+    for (var _i = 0, _v = []; _i < _v.length; _i++) {
+        var x = _v[_i];
+        var env_17 = { stack: [], error: void 0, hasError: false };
+        try {
+            var d34 = __addDisposableResource(env_17, (_s = {}, _s[Symbol.dispose] = function () { }, _s), false);
+        }
+        catch (e_16) {
+            env_17.error = e_16;
+            env_17.hasError = true;
+        }
+        finally {
+            __disposeResources(env_17);
+        }
     }
 }
-catch (e_14) {
-    env_2.error = e_14;
-    env_2.hasError = true;
+catch (e_17) {
+    env_1.error = e_17;
+    env_1.hasError = true;
 }
 finally {
-    __disposeResources(env_2);
+    __disposeResources(env_1);
 }
 export {};

--- a/tests/baselines/reference/usingDeclarations.1(target=esnext).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=esnext).js
@@ -94,61 +94,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};
@@ -229,50 +240,59 @@ var N;
     using d19 = { [Symbol.dispose]() { } };
 }
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() { } };
         break;
-    case 1:
+    }
+    case 1: {
         using d21 = { [Symbol.dispose]() { } };
         break;
+    }
+    default: {
+        using d22 = { [Symbol.dispose]() { } };
+    }
 }
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() { } };
+        case 0: {
+            using d23 = { [Symbol.dispose]() { } };
             break;
+        }
+        default: {
+            using d24 = { [Symbol.dispose]() { } };
+        }
     }
 try {
-    using d23 = { [Symbol.dispose]() { } };
-}
-catch {
-    using d24 = { [Symbol.dispose]() { } };
-}
-finally {
     using d25 = { [Symbol.dispose]() { } };
 }
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() { } };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() { } };
 }
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() { } };
-    break;
 }
-do {
+else {
     using d29 = { [Symbol.dispose]() { } };
-    break;
-} while (true);
-for (;;) {
+}
+while (true) {
     using d30 = { [Symbol.dispose]() { } };
     break;
 }
-for (const x in {}) {
+do {
     using d31 = { [Symbol.dispose]() { } };
+    break;
+} while (true);
+for (;;) {
+    using d32 = { [Symbol.dispose]() { } };
+    break;
+}
+for (const x in {}) {
+    using d33 = { [Symbol.dispose]() { } };
 }
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() { } };
+    using d34 = { [Symbol.dispose]() { } };
 }
 export {};

--- a/tests/baselines/reference/usingDeclarations.17.errors.txt
+++ b/tests/baselines/reference/usingDeclarations.17.errors.txt
@@ -1,0 +1,43 @@
+usingDeclarations.17.ts(3,9): error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+usingDeclarations.17.ts(7,9): error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+usingDeclarations.17.ts(11,9): error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+usingDeclarations.17.ts(17,13): error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+usingDeclarations.17.ts(21,13): error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+
+
+==== usingDeclarations.17.ts (5 errors) ====
+    switch (Math.random()) {
+        case 0:
+            using d20 = { [Symbol.dispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+            break;
+    
+        case 1:
+            using d21 = { [Symbol.dispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+            break;
+    
+        default:
+            using d22 = { [Symbol.dispose]() {} };
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+    }
+    
+    if (true)
+        switch (0) {
+            case 0:
+                using d23 = { [Symbol.dispose]() {} };
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+                break;
+    
+            default:
+                using d24 = { [Symbol.dispose]() {} };
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1547: 'using' declarations are not allowed in 'case' or 'default' clauses unless contained within a block.
+        }
+    
+    export {};
+    

--- a/tests/baselines/reference/usingDeclarations.17.js
+++ b/tests/baselines/reference/usingDeclarations.17.js
@@ -1,0 +1,49 @@
+//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts] ////
+
+//// [usingDeclarations.17.ts]
+switch (Math.random()) {
+    case 0:
+        using d20 = { [Symbol.dispose]() {} };
+        break;
+
+    case 1:
+        using d21 = { [Symbol.dispose]() {} };
+        break;
+
+    default:
+        using d22 = { [Symbol.dispose]() {} };
+}
+
+if (true)
+    switch (0) {
+        case 0:
+            using d23 = { [Symbol.dispose]() {} };
+            break;
+
+        default:
+            using d24 = { [Symbol.dispose]() {} };
+    }
+
+export {};
+
+
+//// [usingDeclarations.17.js]
+switch (Math.random()) {
+    case 0:
+        using d20 = { [Symbol.dispose]() { } };
+        break;
+    case 1:
+        using d21 = { [Symbol.dispose]() { } };
+        break;
+    default:
+        using d22 = { [Symbol.dispose]() { } };
+}
+if (true)
+    switch (0) {
+        case 0:
+            using d23 = { [Symbol.dispose]() { } };
+            break;
+        default:
+            using d24 = { [Symbol.dispose]() { } };
+    }
+export {};

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
@@ -42,61 +42,72 @@ class C1 {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         await using d20 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         await using d21 = { async [Symbol.asyncDispose]() {} };
         break;
+    }
+
+    default: {
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            await using d22 = { async [Symbol.asyncDispose]() {} };
+        case 0: {
+            await using d23 = { async [Symbol.asyncDispose]() {} };
             break;
+        }
+
+        default: {
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+        }
     }
 
 try {
-    await using d23 = { async [Symbol.asyncDispose]() {} };
-}
-catch {
-    await using d24 = { async [Symbol.asyncDispose]() {} };
-}
-finally {
     await using d25 = { async [Symbol.asyncDispose]() {} };
 }
-
-if (true) {
+catch {
     await using d26 = { async [Symbol.asyncDispose]() {} };
 }
-else {
+finally {
     await using d27 = { async [Symbol.asyncDispose]() {} };
 }
 
-while (true) {
+if (true) {
     await using d28 = { async [Symbol.asyncDispose]() {} };
+}
+else {
+    await using d29 = { async [Symbol.asyncDispose]() {} };
+}
+
+while (true) {
+    await using d30 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 do {
-    await using d29 = { async [Symbol.asyncDispose]() {} };
+    await using d31 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    await using d30 = { async [Symbol.asyncDispose]() {} };
+    await using d32 = { async [Symbol.asyncDispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    await using d31 = { async [Symbol.asyncDispose]() {} };
+    await using d33 = { async [Symbol.asyncDispose]() {} };
 }
 
 for (const x of []) {
-    await using d32 = { async [Symbol.asyncDispose]() {} };
+    await using d34 = { async [Symbol.asyncDispose]() {} };
 }
 
 export {};

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts
@@ -1,0 +1,29 @@
+// @target: esnext
+// @module: esnext
+// @lib: esnext
+// @noTypesAndSymbols: true
+
+switch (Math.random()) {
+    case 0:
+        await using d20 = { async [Symbol.asyncDispose]() {} };
+        break;
+
+    case 1:
+        await using d21 = { async [Symbol.asyncDispose]() {} };
+        break;
+
+    default:
+        await using d22 = { async [Symbol.asyncDispose]() {} };
+}
+
+if (true)
+    switch (0) {
+        case 0:
+            await using d23 = { async [Symbol.asyncDispose]() {} };
+            break;
+
+        default:
+            await using d24 = { async [Symbol.asyncDispose]() {} };
+    }
+
+export {};

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
@@ -96,61 +96,72 @@ namespace N {
 }
 
 switch (Math.random()) {
-    case 0:
+    case 0: {
         using d20 = { [Symbol.dispose]() {} };
         break;
+    }
 
-    case 1:
+    case 1: {
         using d21 = { [Symbol.dispose]() {} };
         break;
+    }
+
+    default: {
+        using d22 = { [Symbol.dispose]() {} };
+    }
 }
 
 if (true)
     switch (0) {
-        case 0:
-            using d22 = { [Symbol.dispose]() {} };
+        case 0: {
+            using d23 = { [Symbol.dispose]() {} };
             break;
+        }
+
+        default: {
+            using d24 = { [Symbol.dispose]() {} };
+        }
     }
 
 try {
-    using d23 = { [Symbol.dispose]() {} };
-}
-catch {
-    using d24 = { [Symbol.dispose]() {} };
-}
-finally {
     using d25 = { [Symbol.dispose]() {} };
 }
-
-if (true) {
+catch {
     using d26 = { [Symbol.dispose]() {} };
 }
-else {
+finally {
     using d27 = { [Symbol.dispose]() {} };
 }
 
-while (true) {
+if (true) {
     using d28 = { [Symbol.dispose]() {} };
+}
+else {
+    using d29 = { [Symbol.dispose]() {} };
+}
+
+while (true) {
+    using d30 = { [Symbol.dispose]() {} };
     break;
 }
 
 do {
-    using d29 = { [Symbol.dispose]() {} };
+    using d31 = { [Symbol.dispose]() {} };
     break;
 }
 while (true);
 
 for (;;) {
-    using d30 = { [Symbol.dispose]() {} };
+    using d32 = { [Symbol.dispose]() {} };
     break;
 }
 
 for (const x in {}) {
-    using d31 = { [Symbol.dispose]() {} };
+    using d33 = { [Symbol.dispose]() {} };
 }
 
 for (const x of []) {
-    using d32 = { [Symbol.dispose]() {} };
+    using d34 = { [Symbol.dispose]() {} };
 }
 
 export {};

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts
@@ -1,0 +1,29 @@
+// @target: esnext
+// @module: esnext
+// @lib: esnext
+// @noTypesAndSymbols: true
+
+switch (Math.random()) {
+    case 0:
+        using d20 = { [Symbol.dispose]() {} };
+        break;
+
+    case 1:
+        using d21 = { [Symbol.dispose]() {} };
+        break;
+
+    default:
+        using d22 = { [Symbol.dispose]() {} };
+}
+
+if (true)
+    switch (0) {
+        case 0:
+            using d23 = { [Symbol.dispose]() {} };
+            break;
+
+        default:
+            using d24 = { [Symbol.dispose]() {} };
+    }
+
+export {};


### PR DESCRIPTION
As per tc39/ecma262@8e5d501ff76c17aaa79307157ae66cff240699b3, `[await] using` VariableStatements cannot be immediate children of case/default clauses; they must be contained within a block.

Resolves #62708.