### PR TITLE
Add failing test for reverse mapped `this` leak (#62779)

### DIFF
--- a/tests/baselines/reference/reverseMappedThisLeak.errors.txt
+++ b/tests/baselines/reference/reverseMappedThisLeak.errors.txt
@@ -1,0 +1,24 @@
+reverseMappedThisLeak.ts(16,5): error TS2349: This expression is not callable.
+  Type 'unknown' has no call signatures.
+
+
+==== reverseMappedThisLeak.ts (1 errors) ====
+    declare function test<T extends Record<string, unknown>>(obj:{
+      [K in keyof T]: () => T[K];
+    }): T;
+    
+    const obj = test({
+      a() {
+        return 1;
+      },
+      b() {
+        return this.a();
+        // Expected: number
+        // Actual: T[string] (bug)
+      }
+    });
+    
+    obj.b(); // should be `number`, but currently inferred as `T[string]`
+        ~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type 'unknown' has no call signatures.

--- a/tests/baselines/reference/reverseMappedThisLeak.js
+++ b/tests/baselines/reference/reverseMappedThisLeak.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/reverseMappedThisLeak.ts] ////
+
+//// [reverseMappedThisLeak.ts]
+declare function test<T extends Record<string, unknown>>(obj:{
+  [K in keyof T]: () => T[K];
+}): T;
+
+const obj = test({
+  a() {
+    return 1;
+  },
+  b() {
+    return this.a();
+    // Expected: number
+    // Actual: T[string] (bug)
+  }
+});
+
+obj.b(); // should be `number`, but currently inferred as `T[string]`
+
+//// [reverseMappedThisLeak.js]
+"use strict";
+var obj = test({
+    a: function () {
+        return 1;
+    },
+    b: function () {
+        return this.a();
+        // Expected: number
+        // Actual: T[string] (bug)
+    }
+});
+obj.b(); // should be `number`, but currently inferred as `T[string]`

--- a/tests/baselines/reference/reverseMappedThisLeak.symbols
+++ b/tests/baselines/reference/reverseMappedThisLeak.symbols
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/reverseMappedThisLeak.ts] ////
+
+=== reverseMappedThisLeak.ts ===
+declare function test<T extends Record<string, unknown>>(obj:{
+>test : Symbol(test, Decl(reverseMappedThisLeak.ts, 0, 0))
+>T : Symbol(T, Decl(reverseMappedThisLeak.ts, 0, 22))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>obj : Symbol(obj, Decl(reverseMappedThisLeak.ts, 0, 57))
+
+  [K in keyof T]: () => T[K];
+>K : Symbol(K, Decl(reverseMappedThisLeak.ts, 1, 3))
+>T : Symbol(T, Decl(reverseMappedThisLeak.ts, 0, 22))
+>T : Symbol(T, Decl(reverseMappedThisLeak.ts, 0, 22))
+>K : Symbol(K, Decl(reverseMappedThisLeak.ts, 1, 3))
+
+}): T;
+>T : Symbol(T, Decl(reverseMappedThisLeak.ts, 0, 22))
+
+const obj = test({
+>obj : Symbol(obj, Decl(reverseMappedThisLeak.ts, 4, 5))
+>test : Symbol(test, Decl(reverseMappedThisLeak.ts, 0, 0))
+
+  a() {
+>a : Symbol(a, Decl(reverseMappedThisLeak.ts, 4, 18))
+
+    return 1;
+  },
+  b() {
+>b : Symbol(b, Decl(reverseMappedThisLeak.ts, 7, 4))
+
+    return this.a();
+>this.a : Symbol(a, Decl(reverseMappedThisLeak.ts, 4, 18))
+>this : Symbol(__type, Decl(reverseMappedThisLeak.ts, 0, 61))
+>a : Symbol(a, Decl(reverseMappedThisLeak.ts, 4, 18))
+
+    // Expected: number
+    // Actual: T[string] (bug)
+  }
+});
+
+obj.b(); // should be `number`, but currently inferred as `T[string]`
+>obj.b : Symbol(b, Decl(reverseMappedThisLeak.ts, 7, 4))
+>obj : Symbol(obj, Decl(reverseMappedThisLeak.ts, 4, 5))
+>b : Symbol(b, Decl(reverseMappedThisLeak.ts, 7, 4))
+

--- a/tests/baselines/reference/reverseMappedThisLeak.types
+++ b/tests/baselines/reference/reverseMappedThisLeak.types
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/reverseMappedThisLeak.ts] ////
+
+=== reverseMappedThisLeak.ts ===
+declare function test<T extends Record<string, unknown>>(obj:{
+>test : <T extends Record<string, unknown>>(obj: { [K in keyof T]: () => T[K]; }) => T
+>     : ^ ^^^^^^^^^                       ^^   ^^                               ^^^^^ 
+>obj : { [K in keyof T]: () => T[K]; }
+>    : ^^^ ^^^^^^^^^^^^^^^^^^^^    ^^^
+
+  [K in keyof T]: () => T[K];
+}): T;
+
+const obj = test({
+>obj : { a: number; b: T[string]; }
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>test({  a() {    return 1;  },  b() {    return this.a();    // Expected: number    // Actual: T[string] (bug)  }}) : { a: number; b: T[string]; }
+>                                                                                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>test : <T extends Record<string, unknown>>(obj: { [K in keyof T]: () => T[K]; }) => T
+>     : ^ ^^^^^^^^^                       ^^   ^^                               ^^^^^ 
+>{  a() {    return 1;  },  b() {    return this.a();    // Expected: number    // Actual: T[string] (bug)  }} : { a(): number; b(): T[string]; }
+>                                                                                                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  a() {
+>a : () => number
+>  : ^^^^^^^^^^^^
+
+    return 1;
+>1 : 1
+>  : ^
+
+  },
+  b() {
+>b : () => T[string]
+>  : ^^^^^^^^^^^^^^^
+
+    return this.a();
+>this.a() : number
+>         : ^^^^^^
+>this.a : () => number
+>       : ^^^^^^^^^^^^
+>this : { a: () => number; b: () => T[string]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>a : () => number
+>  : ^^^^^^^^^^^^
+
+    // Expected: number
+    // Actual: T[string] (bug)
+  }
+});
+
+obj.b(); // should be `number`, but currently inferred as `T[string]`
+>obj.b() : any
+>        : ^^^
+>obj.b : T[string]
+>      : ^^^^^^^^^
+>obj : { a: number; b: T[string]; }
+>    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : T[string]
+>  : ^^^^^^^^^
+

--- a/tests/cases/compiler/reverseMappedThisLeak.ts
+++ b/tests/cases/compiler/reverseMappedThisLeak.ts
@@ -1,0 +1,18 @@
+// @strict: true
+
+declare function test<T extends Record<string, unknown>>(obj:{
+  [K in keyof T]: () => T[K];
+}): T;
+
+const obj = test({
+  a() {
+    return 1;
+  },
+  b() {
+    return this.a();
+    // Expected: number
+    // Actual: T[string] (bug)
+  }
+});
+
+obj.b(); // should be `number`, but currently inferred as `T[string]`


### PR DESCRIPTION
Related to #62779
This PR adds a failing compiler test for issue #62779.

**Summary**
The test demonstrates that `this` inside a reverse-mapped type leaks a generic key type and causes incorrect inference (`T[string]`) instead of the concrete property return type.

**Files added**
- tests/cases/compiler/reverseMappedThisLeak.ts
- tests/baselines/reference/reverseMappedThisLeak.errors.txt
- tests/baselines/reference/reverseMappedThisLeak.js
- tests/baselines/reference/reverseMappedThisLeak.types
- tests/baselines/reference/reverseMappedThisLeak.symbols

**Reproduction**
The test is the minimal reproduction from the issue and is runnable with the existing test harness.

**Notes**
- This PR **does not** include a compiler fix — only a failing test + baselines to help maintainers reproduce and track the bug.
- To reproduce locally:
  - `npm test -- tests/cases/compiler/reverseMappedThisLeak.ts` (should pass once baselines are in `reference/`)
  - `npm test -- --generateBaseline` was used earlier to create these baselines.


(Please let me know if maintainers want a smaller repro or further variations.)

