### PR TITLE
Improve satisfies semantics: return never when target type is never

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38168,6 +38168,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const errorNode = findAncestor(target.parent, n => n.kind === SyntaxKind.SatisfiesExpression || n.kind === SyntaxKind.JSDocSatisfiesTag);
         checkTypeAssignableToAndOptionallyElaborate(exprType, targetType, errorNode, expression, Diagnostics.Type_0_does_not_satisfy_the_expected_type_1);
+        // If the target type is the intrinsic `never` type, treat the whole satisfies-expression
+        // as having type `never`. This makes patterns like `foo satisfies never` usable with
+        // exhaustiveness checks such as `assertNever(foo satisfies never)`.
+        if (targetType === neverType) {
+            return targetType;
+        }
         return exprType;
     }
 


### PR DESCRIPTION
PR: Make `satisfies` Narrow to `never` When Target Type Is `never`

Issue---> #62807 — "Switch doesn't narrow type when type isn't a discriminated union"

This PR updates the TypeScript compiler so that a `satisfies` expression produces the type `never` when its target type is exactly the intrinsic `never` type. This allows patterns like:
assertNever(foo satisfies never);
