### PR TITLE
Simplify `never` indexed by generic index types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19611,7 +19611,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 isGenericTupleType(objectType) && !indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target)) :
                 isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target))) || isGenericReducibleType(objectType))
         ) {
-            if (objectType.flags & TypeFlags.AnyOrUnknown) {
+            if (objectType.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Never)) {
                 return objectType;
             }
             // Defer the operation by creating an indexed access type.

--- a/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
@@ -695,3 +695,7 @@ keyofAndIndexedAccess.ts(318,5): error TS2322: Type 'T[K]' is not assignable to 
         t.cool;
     };
     
+    type IndexedNever<T> = never[keyof T];
+    type IndexedAny<T> = any[keyof T];
+    type IndexedUnknown<T> = unknown[keyof T];
+    

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -659,6 +659,10 @@ const cf2 = <T extends { [P in K | "cool"]: string; }, K extends keyof T>(t: T, 
     t.cool;
 };
 
+type IndexedNever<T> = never[keyof T];
+type IndexedAny<T> = any[keyof T];
+type IndexedUnknown<T> = unknown[keyof T];
+
 
 //// [keyofAndIndexedAccess.js]
 var __extends = (this && this.__extends) || (function () {
@@ -1435,3 +1439,6 @@ declare const cf1: <T extends { [P in K]: string; } & {
     cool: string;
 }, K extends keyof T>(t: T, k: K) => void;
 declare const cf2: <T extends { [P in K | "cool"]: string; }, K extends keyof T>(t: T, k: K) => void;
+type IndexedNever<T> = never[keyof T];
+type IndexedAny<T> = any[keyof T];
+type IndexedUnknown<T> = unknown[keyof T];

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -2345,3 +2345,18 @@ const cf2 = <T extends { [P in K | "cool"]: string; }, K extends keyof T>(t: T, 
 
 };
 
+type IndexedNever<T> = never[keyof T];
+>IndexedNever : Symbol(IndexedNever, Decl(keyofAndIndexedAccess.ts, 656, 2))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 658, 18))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 658, 18))
+
+type IndexedAny<T> = any[keyof T];
+>IndexedAny : Symbol(IndexedAny, Decl(keyofAndIndexedAccess.ts, 658, 38))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 659, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 659, 16))
+
+type IndexedUnknown<T> = unknown[keyof T];
+>IndexedUnknown : Symbol(IndexedUnknown, Decl(keyofAndIndexedAccess.ts, 659, 34))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 660, 20))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 660, 20))
+

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -3450,3 +3450,15 @@ const cf2 = <T extends { [P in K | "cool"]: string; }, K extends keyof T>(t: T, 
 
 };
 
+type IndexedNever<T> = never[keyof T];
+>IndexedNever : never
+>             : ^^^^^
+
+type IndexedAny<T> = any[keyof T];
+>IndexedAny : any
+>           : ^^^
+
+type IndexedUnknown<T> = unknown[keyof T];
+>IndexedUnknown : unknown
+>               : ^^^^^^^
+

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -658,3 +658,7 @@ const cf2 = <T extends { [P in K | "cool"]: string; }, K extends keyof T>(t: T, 
     const s: string = t[k];
     t.cool;
 };
+
+type IndexedNever<T> = never[keyof T];
+type IndexedAny<T> = any[keyof T];
+type IndexedUnknown<T> = unknown[keyof T];


### PR DESCRIPTION
As far as I can tell, there is no instantiation of `indexType` that could lead to indexed accesses like `never[keyof T]` to resolve to anything but `never`. So the compiler can avoid creating some extra types, just like it already does in the case of `any`