### PR TITLE
Enhance isJS check in getNewImportFixes function

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -1277,7 +1277,7 @@ function getNewImportFixes(
                 return undefined;
             }
             if (!importedSymbolHasValueMeaning && usagePosition !== undefined) {
-                const scriptKind = 'scriptKind' in sourceFile
+                const scriptKind = isFullSourceFile(sourceFile)
                     ? sourceFile.scriptKind
                     : host.getScriptKind?.(sourceFile.fileName);
                 const isJs = scriptKind !== undefined


### PR DESCRIPTION
Fixes https://github.com/vuejs/language-tools/issues/4582

In `getNewImportFixes`, prioritize checking scriptKind over file extension for `isJs`. This ensures consistent `JsdocTypeImport` behavior for file types added via LS plugins.