### PR TITLE
Reenable fail-fast in merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   test:
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         config:
           # Main builds


### PR DESCRIPTION
If a job fails in a merge queue, it's either a platform flake, or a runtime merge conflict. Don't bother running all jobs and let it quit out as early as possible.