### PR TITLE
Move knip args

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -601,7 +601,7 @@ export const knip = task({
     name: "knip",
     description: "Runs knip.",
     dependencies: [generateDiagnostics],
-    run: () => exec(process.execPath, ["node_modules/knip/bin/knip.js", "--tags=+internal,-knipignore", "--exclude=duplicates,enumMembers", ...(cmdLineOptions.fix ? ["--fix"] : [])]),
+    run: () => exec(process.execPath, ["node_modules/knip/bin/knip.js", ...(cmdLineOptions.fix ? ["--fix"] : [])]),
 });
 
 const { main: typingsInstaller, watch: watchTypingsInstaller } = entrypointBuildTask({

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,7 @@
 {
     "$schema": "https://unpkg.com/knip@5/schema.json",
+    "exclude": ["duplicates", "enumMembers"],
+    "tags": ["+internal", "-knipignore"],
     "includeEntryExports": true,
     "entry": [
         "Herebyfile.mjs",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -16,7 +16,6 @@
         "src/testRunner/_namespaces/Harness.ts",
 
         // The rest of the entry files, mostly to track used dependencies:
-        ".eslint-plugin-local.cjs",
         ".gulp.js",
         "scripts/eslint/{rules,tests}/*.cjs",
         "scripts/*.{cjs,mjs}"

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4792,7 +4792,7 @@ export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { par
     return typeParameters && find(typeParameters, p => p.name.escapedText === name);
 }
 
-/** @internal @knipignore */
+/** @internal */
 export function hasTypeArguments(node: Node): node is HasTypeArguments {
     return !!(node as HasTypeArguments).typeArguments;
 }


### PR DESCRIPTION
When running `knip` against the typescript codebase it's convenient to not have to add these flags on the CLI. Also good to have all config together in a single file.

Also removed an obsolete `knipignore` tag and an entry point that no longer exists.