### PR TITLE
ES2020: fix String.prototype.matchAll type and description

### DIFF
--- a/src/lib/es2020.string.d.ts
+++ b/src/lib/es2020.string.d.ts
@@ -4,11 +4,11 @@
 
 interface String {
     /**
-     * Matches a string with a regular expression, and returns an iterable of matches
+     * Matches a string with a regular expression or string, and returns an iterable of matches
      * containing the results of that search.
-     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     * @param regexp A regular expression or string literal with which to search the string
      */
-    matchAll(regexp: RegExp): RegExpStringIterator<RegExpExecArray>;
+    matchAll(regexp: RegExp | string): RegExpStringIterator<RegExpExecArray>;
 
     /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
     toLocaleLowerCase(locales?: Intl.LocalesArgument): string;

--- a/tests/baselines/reference/stringMatchAll.types
+++ b/tests/baselines/reference/stringMatchAll.types
@@ -6,12 +6,12 @@ const matches = "matchAll".matchAll(/\w/g);
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"matchAll".matchAll(/\w/g) : RegExpStringIterator<RegExpExecArray>
 >                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->"matchAll".matchAll : (regexp: RegExp) => RegExpStringIterator<RegExpExecArray>
->                    : ^      ^^      ^^^^^                                     
+>"matchAll".matchAll : (regexp: RegExp | string) => RegExpStringIterator<RegExpExecArray>
+>                    : ^      ^^               ^^^^^                                     
 >"matchAll" : "matchAll"
 >           : ^^^^^^^^^^
->matchAll : (regexp: RegExp) => RegExpStringIterator<RegExpExecArray>
->         : ^      ^^      ^^^^^                                     
+>matchAll : (regexp: RegExp | string) => RegExpStringIterator<RegExpExecArray>
+>         : ^      ^^               ^^^^^                                     
 >/\w/g : RegExp
 >      : ^^^^^^
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55843

(it would be very ideal to get this bugfix into v5, assuming v6 is the go implementation)