### PR TITLE
Revert "ES2020: fix String.prototype.matchAll type and description"

### DIFF
--- a/src/lib/es2020.string.d.ts
+++ b/src/lib/es2020.string.d.ts
@@ -6,7 +6,7 @@ interface String {
     /**
      * Matches a string with a regular expression, and returns an iterable of matches
      * containing the results of that search.
-     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     * @param regexp A regular expression
      */
     matchAll(regexp: RegExp): RegExpStringIterator<RegExpExecArray>;
 

--- a/src/lib/es2020.string.d.ts
+++ b/src/lib/es2020.string.d.ts
@@ -4,11 +4,11 @@
 
 interface String {
     /**
-     * Matches a string with a regular expression or string, and returns an iterable of matches
+     * Matches a string with a regular expression, and returns an iterable of matches
      * containing the results of that search.
-     * @param regexp A regular expression or string literal with which to search the string
+     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
      */
-    matchAll(regexp: RegExp | string): RegExpStringIterator<RegExpExecArray>;
+    matchAll(regexp: RegExp): RegExpStringIterator<RegExpExecArray>;
 
     /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
     toLocaleLowerCase(locales?: Intl.LocalesArgument): string;

--- a/tests/baselines/reference/stringMatchAll.types
+++ b/tests/baselines/reference/stringMatchAll.types
@@ -6,12 +6,12 @@ const matches = "matchAll".matchAll(/\w/g);
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"matchAll".matchAll(/\w/g) : RegExpStringIterator<RegExpExecArray>
 >                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->"matchAll".matchAll : (regexp: RegExp | string) => RegExpStringIterator<RegExpExecArray>
->                    : ^      ^^               ^^^^^                                     
+>"matchAll".matchAll : (regexp: RegExp) => RegExpStringIterator<RegExpExecArray>
+>                    : ^      ^^      ^^^^^                                     
 >"matchAll" : "matchAll"
 >           : ^^^^^^^^^^
->matchAll : (regexp: RegExp | string) => RegExpStringIterator<RegExpExecArray>
->         : ^      ^^               ^^^^^                                     
+>matchAll : (regexp: RegExp) => RegExpStringIterator<RegExpExecArray>
+>         : ^      ^^      ^^^^^                                     
 >/\w/g : RegExp
 >      : ^^^^^^
 


### PR DESCRIPTION
Reverts microsoft/TypeScript#62873

It did not fix the linked issue, but instead actually "fixed" #47310, which is marked as working-as-intended for the same reason as why we ban other params for strictness' sake.