### PR TITLE
Support @deprecated on namespace aliases (ImportEqualsDeclaration)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42740,6 +42740,22 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     );
                 }
             }
+            // Also check if the type reference is an alias that is deprecated (e.g., ImportEqualsDeclaration with @deprecated)
+            if (node.kind !== SyntaxKind.ImportType) {
+                const name = getTypeReferenceName(node as TypeReferenceType);
+                if (name) {
+                    const aliasSymbol = resolveEntityName(name, SymbolFlags.Type, /*ignoreErrors*/ true, /*dontResolveAlias*/ true);
+                    if (aliasSymbol && aliasSymbol !== unknownSymbol && aliasSymbol !== symbol && aliasSymbol.flags & SymbolFlags.Alias) {
+                        if (isDeprecatedSymbol(aliasSymbol) && aliasSymbol.declarations) {
+                            addDeprecatedSuggestion(
+                                getDeprecatedSuggestionNode(node),
+                                aliasSymbol.declarations,
+                                aliasSymbol.escapedName as string,
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/tests/cases/fourslash/jsdocDeprecated_namespaceAlias.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_namespaceAlias.ts
@@ -1,0 +1,46 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /example.ts
+//// export type Bar = string | number;
+//// /** @deprecated */
+//// export type Baz = string | number;
+
+// @Filename: /foo.ts
+//// import * as example from './example';
+////
+//// export namespace JSX {
+////     /** @deprecated */
+////     export type Foo = string | number;
+////
+////     /** @deprecated */
+////     export import Bar = example.Bar;
+////
+////     export import Baz = example.Baz;
+//// }
+////
+//// export type X = JSX.[|Foo|];   // Should be deprecated (Foo itself is deprecated)
+//// export type Y = JSX.[|Bar|];   // Should be deprecated (Bar alias is deprecated)
+//// export type Z = JSX.[|Baz|];   // Should be deprecated (example.Baz is deprecated)
+
+goTo.file('/foo.ts');
+const ranges = test.ranges();
+verify.getSuggestionDiagnostics([
+    {
+        "message": "'Foo' is deprecated.",
+        "code": 6385,
+        "range": ranges[0],
+        "reportsDeprecated": true,
+    },
+    {
+        "message": "'Bar' is deprecated.",
+        "code": 6385,
+        "range": ranges[1],
+        "reportsDeprecated": true,
+    },
+    {
+        "message": "'Baz' is deprecated.",
+        "code": 6385,
+        "range": ranges[2],
+        "reportsDeprecated": true,
+    },
+]);


### PR DESCRIPTION
Fixes #62340

## Problem

When using `@deprecated` on a namespace alias like:

```typescript
export namespace JSX {
    /** @deprecated */
    export import Bar = example.Bar;
}
```

Accessing `JSX.Bar` as a type did not show a deprecation warning, even though the alias itself is marked as deprecated.

## Root Cause

In `checkTypeReferenceOrImport`, the `resolvedSymbol` is the resolved target of the alias (e.g., `example.Bar`), not the alias symbol itself. Since the alias (the `ImportEqualsDeclaration`) was not being checked, its `@deprecated` JSDoc was ignored.

## Fix

Added code to also resolve the entity name without resolving aliases (`dontResolveAlias: true`) and check if the alias symbol itself is deprecated using `isDeprecatedSymbol()`.

## Test

Added `tests/cases/fourslash/jsdocDeprecated_namespaceAlias.ts` covering:
1. Direct type alias with `@deprecated` (already worked)
2. `ImportEqualsDeclaration` with `@deprecated` (the bug being fixed)
3. `ImportEqualsDeclaration` aliasing a deprecated type (already worked)