### PR TITLE
Add failing test for variance measurement with nested generic type aliases

### DIFF
--- a/tests/cases/compiler/varianceNestedGenericTypeAlias.ts
+++ b/tests/cases/compiler/varianceNestedGenericTypeAlias.ts
@@ -1,0 +1,52 @@
+// @strict: true
+
+// Repro from #60453
+// Variance measurement fails for type aliases with deeply nested anonymous object types
+// containing Arrays, incorrectly computing variance as Independent instead of Covariant.
+
+type TypeA = number;
+type TypeB = boolean;
+
+// Two levels of nesting - should be covariant in T
+type DataTypeTwo<T extends TypeA | TypeB> = {
+  one: Array<{ two: Array<T> }>;
+};
+
+// Three levels of nesting - should be covariant in T
+type DataTypeThree<T extends TypeA | TypeB> = {
+  one: Array<{ two: Array<{ three: Array<T> }> }>;
+};
+
+// Inline literal assignments correctly error
+let testingThreeErr: DataTypeThree<TypeA> = {
+  one: [{ two: [{ three: [true] }] }]  // Error expected
+};
+
+let testingTwoErr: DataTypeTwo<TypeA> = {
+  one: [{ two: [false] }]  // Error expected
+};
+
+// Variable assignments should also error but currently don't due to
+// variance being incorrectly computed as Independent
+let testingThree: DataTypeThree<TypeA> = {
+  one: [{ two: [{ three: [5] }] }]
+};
+
+let t3a: DataTypeThree<TypeB> = testingThree;  // Error expected: number not assignable to boolean
+
+let testingTwo: DataTypeTwo<TypeA> = {
+  one: [{ two: [5] }]
+};
+
+let t2a: DataTypeTwo<TypeB> = testingTwo;  // Error expected: number not assignable to boolean
+
+// Workaround: explicit variance annotation fixes the issue
+type DataTypeThreeFixed<out T extends TypeA | TypeB> = {
+  one: Array<{ two: Array<{ three: Array<T> }> }>;
+};
+
+let testingThreeFixed: DataTypeThreeFixed<TypeA> = {
+  one: [{ two: [{ three: [5] }] }]
+};
+
+let t3aFixed: DataTypeThreeFixed<TypeB> = testingThreeFixed;  // Error expected and works correctly


### PR DESCRIPTION
## Summary

This PR adds a failing test case for issue #60453.

**Bug**: Variance is incorrectly computed as `Independent` (instead of `Covariant`) for type aliases with deeply nested anonymous object types containing Arrays. This causes type-unsafe assignments to be silently allowed.

## Investigation Findings

### Reproduction

```typescript
type DataTypeThree<T extends number | boolean> = {
  one: Array<{ two: Array<{ three: Array<T> }> }>;
};

let a: DataTypeThree<number> = { one: [{ two: [{ three: [5] }] }] };
let b: DataTypeThree<boolean> = a;  // No error! Should error.
```

### Root Cause Analysis

1. **Variance Computation**: In `getVariancesWorker` (checker.ts:24958), variance is computed by comparing `Type<markerSubType>` vs `Type<markerSuperType>` using `isTypeAssignableTo`.

2. **The Problem**: For deeply nested types, both comparisons incorrectly return `true`:
   - `isTypeAssignableTo(Sub, Super)` = `true` (correct → Covariant)
   - `isTypeAssignableTo(Super, Sub)` = `true` (INCORRECT → adds Contravariant)
   
   This results in `Bivariant` variance, which then becomes `Independent` after the subsequent check.

3. **Cache Evidence**: After comparison, the relation cache shows:
   - Without "warmup": `SuperToSub = 1 (Succeeded)` — wrong!
   - With "warmup": `SuperToSub = 2 (Failed)` — correct

4. **Order Dependency**: The bug manifests only when the complex type is used first. If a simpler generic type with object structure (e.g., `type Y<T> = { x: Array<T> }`) is used before the complex type, the bug disappears.

5. **Potential Cause**: `checkTypeRelatedTo` returns `result !== Ternary.False` (line 22404). This means `Ternary.Unknown` (value 1) is treated as `true`. When structural comparison encounters edge cases during first use, `Unknown` may be incorrectly interpreted as success.

### Workaround

Explicit variance annotation fixes the issue:
```typescript
type DataTypeThreeFixed<out T extends number | boolean> = {
  one: Array<{ two: Array<{ three: Array<T> }> }>;
};
```

## Test Plan

- [x] Add failing test case `varianceNestedGenericTypeAlias.ts`
- [ ] Fix the variance computation (future PR)
- [ ] Update baselines

Fixes #60453