### PR TITLE
Remove unnecessary type assertions

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2618,7 +2618,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         if (inStrictMode && isLeftHandSideExpression(node.left) && isAssignmentOperator(node.operatorToken.kind)) {
             // ECMA 262 (Annex C) The identifier eval or arguments may not appear as the LeftHandSideExpression of an
             // Assignment operator(11.13) or of a PostfixExpression(11.3)
-            checkStrictModeEvalOrArguments(node, node.left as Identifier);
+            checkStrictModeEvalOrArguments(node, node.left);
         }
     }
 
@@ -2713,7 +2713,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         // Assignment operator(11.13) or of a PostfixExpression(11.3) or as the UnaryExpression
         // operated upon by a Prefix Increment(11.4.4) or a Prefix Decrement(11.4.5) operator.
         if (inStrictMode) {
-            checkStrictModeEvalOrArguments(node, node.operand as Identifier);
+            checkStrictModeEvalOrArguments(node, node.operand);
         }
     }
 
@@ -2721,7 +2721,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         // Grammar checking
         if (inStrictMode) {
             if (node.operator === SyntaxKind.PlusPlusToken || node.operator === SyntaxKind.MinusMinusToken) {
-                checkStrictModeEvalOrArguments(node, node.operand as Identifier);
+                checkStrictModeEvalOrArguments(node, node.operand);
             }
         }
     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1871,7 +1871,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getSuggestedSymbolForNonexistentModule,
         getSuggestedSymbolForNonexistentClassMember,
         getBaseConstraintOfType,
-        getDefaultFromTypeParameter: type => type && type.flags & TypeFlags.TypeParameter ? getDefaultFromTypeParameter(type as TypeParameter) : undefined,
+        getDefaultFromTypeParameter: type => type && type.flags & TypeFlags.TypeParameter ? getDefaultFromTypeParameter(type) : undefined,
         resolveName(name, location, meaning, excludeGlobals) {
             return resolveName(location, escapeLeadingUnderscores(name), meaning, /*nameNotFoundMessage*/ undefined, /*isUse*/ false, excludeGlobals);
         },
@@ -2113,7 +2113,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var templateConstraintType = getUnionType([stringType, numberType, booleanType, bigintType, nullType, undefinedType]) as UnionType;
     var numericStringType = getTemplateLiteralType(["", ""], [numberType]); // The `${number}` type
 
-    var restrictiveMapper: TypeMapper = makeFunctionTypeMapper(t => t.flags & TypeFlags.TypeParameter ? getRestrictiveTypeParameter(t as TypeParameter) : t, () => "(restrictive mapper)");
+    var restrictiveMapper: TypeMapper = makeFunctionTypeMapper(t => t.flags & TypeFlags.TypeParameter ? getRestrictiveTypeParameter(t) : t, () => "(restrictive mapper)");
     var permissiveMapper: TypeMapper = makeFunctionTypeMapper(t => t.flags & TypeFlags.TypeParameter ? wildcardType : t, () => "(permissive mapper)");
     var uniqueLiteralType = createIntrinsicType(TypeFlags.Never, "never", /*objectFlags*/ undefined, "unique literal"); // `uniqueLiteralType` is a special `never` flagged by union reduction to behave as a literal
     var uniqueLiteralMapper: TypeMapper = makeFunctionTypeMapper(t => t.flags & TypeFlags.TypeParameter ? uniqueLiteralType : t, () => "(unique literal mapper)"); // replace all type parameters with the unique literal type (disregarding constraints)
@@ -3387,7 +3387,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function diagnosticName(nameArg: __String | Identifier | PrivateIdentifier) {
-        return isString(nameArg) ? unescapeLeadingUnderscores(nameArg as __String) : declarationNameToString(nameArg as Identifier);
+        return isString(nameArg) ? unescapeLeadingUnderscores(nameArg) : declarationNameToString(nameArg as Identifier);
     }
 
     function checkAndReportErrorForMissingPrefix(errorLocation: Node, name: __String, nameArg: __String | Identifier): boolean {
@@ -6874,19 +6874,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (type.flags & TypeFlags.TypeParameter && contains(context.inferTypeParameters, type)) {
                     context.approximateLength += symbolName(type.symbol).length + 6;
                     let constraintNode: TypeNode | undefined;
-                    const constraint = getConstraintOfTypeParameter(type as TypeParameter);
+                    const constraint = getConstraintOfTypeParameter(type);
                     if (constraint) {
                         // If the infer type has a constraint that is not the same as the constraint
                         // we would have normally inferred based on context, we emit the constraint
                         // using `infer T extends ?`. We omit inferred constraints from type references
                         // as they may be elided.
-                        const inferredConstraint = getInferredTypeParameterConstraint(type as TypeParameter, /*omitTypeReferences*/ true);
+                        const inferredConstraint = getInferredTypeParameterConstraint(type, /*omitTypeReferences*/ true);
                         if (!(inferredConstraint && isTypeIdenticalTo(constraint, inferredConstraint))) {
                             context.approximateLength += 9;
                             constraintNode = constraint && typeToTypeNodeHelper(constraint, context);
                         }
                     }
-                    return factory.createInferTypeNode(typeParameterToDeclarationWithConstraint(type as TypeParameter, context, constraintNode));
+                    return factory.createInferTypeNode(typeParameterToDeclarationWithConstraint(type, context, constraintNode));
                 }
                 if (
                     context.flags & NodeBuilderFlags.GenerateNamesForShadowedTypeParams &&
@@ -7096,7 +7096,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // homomorphic mapped type with a non-homomorphic naive inlining
                     // wrap it with a conditional like `SomeModifiersType extends infer U ? {..the mapped type...} : never` to ensure the resulting
                     // type stays homomorphic
-                    const originalConstraint = instantiateType(getConstraintOfTypeParameter(getTypeFromTypeNode(context, (type.declaration.typeParameter.constraint! as TypeOperatorNode).type) as TypeParameter) || unknownType, type.mapper);
+                    const originalConstraint = instantiateType(getConstraintOfTypeParameter(getTypeFromTypeNode(context, (type.declaration.typeParameter.constraint! as TypeOperatorNode).type)) || unknownType, type.mapper);
                     return factory.createConditionalTypeNode(
                         typeToTypeNodeHelper(getModifiersTypeFromMappedType(type), context),
                         factory.createInferTypeNode(factory.createTypeParameterDeclaration(/*modifiers*/ undefined, factory.cloneNode(newTypeVariable!.typeName) as Identifier, originalConstraint.flags & TypeFlags.Unknown ? undefined : typeToTypeNodeHelper(originalConstraint, context))),
@@ -8663,7 +8663,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const lastId = isIdentifier(nonRootParts) ? nonRootParts : nonRootParts.right;
                         setIdentifierTypeArguments(lastId, /*typeArguments*/ undefined);
                     }
-                    return factory.createImportTypeNode(lit, attributes, nonRootParts as EntityName, typeParameterNodes as readonly TypeNode[], isTypeOf);
+                    return factory.createImportTypeNode(lit, attributes, nonRootParts, typeParameterNodes as readonly TypeNode[], isTypeOf);
                 }
                 else {
                     const splitNode = getTopmostIndexedAccessType(nonRootParts);
@@ -11128,7 +11128,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             flags |= t.flags;
             if (!(t.flags & TypeFlags.Nullable)) {
                 if (t.flags & (TypeFlags.BooleanLiteral) || !expandingEnum && (t.flags | TypeFlags.EnumLike)) {
-                    const baseType = t.flags & TypeFlags.BooleanLiteral ? booleanType : getBaseTypeOfEnumLikeType(t as LiteralType);
+                    const baseType = t.flags & TypeFlags.BooleanLiteral ? booleanType : getBaseTypeOfEnumLikeType(t);
                     if (baseType.flags & TypeFlags.Union) {
                         const count = (baseType as UnionType).types.length;
                         if (i + count <= types.length && getRegularTypeOfLiteralType(types[i + count - 1]) === getRegularTypeOfLiteralType((baseType as UnionType).types[count - 1])) {
@@ -13195,7 +13195,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const implementsType = getTypeFromTypeNode(node);
                     if (!isErrorType(implementsType)) {
                         if (resolvedImplementsTypes === emptyArray) {
-                            resolvedImplementsTypes = [implementsType as ObjectType];
+                            resolvedImplementsTypes = [implementsType];
                         }
                         else {
                             resolvedImplementsTypes.push(implementsType);
@@ -13343,7 +13343,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             if (isValidBaseType(baseType)) {
                                 if (type !== baseType && !hasBaseType(baseType, type)) {
                                     if (type.resolvedBaseTypes === emptyArray) {
-                                        type.resolvedBaseTypes = [baseType as ObjectType];
+                                        type.resolvedBaseTypes = [baseType];
                                     }
                                     else {
                                         type.resolvedBaseTypes.push(baseType);
@@ -14708,7 +14708,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return type;
         }
         if (type.flags & TypeFlags.Union) {
-            return mapType(type as UnionType, getLowerBoundOfKeyType, /*noReductions*/ true);
+            return mapType(type, getLowerBoundOfKeyType, /*noReductions*/ true);
         }
         if (type.flags & TypeFlags.Intersection) {
             // Similarly to getTypeFromIntersectionTypeNode, we preserve the special string & {}, number & {},
@@ -14891,7 +14891,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // the modifiers type is T. Otherwise, the modifiers type is unknown.
                 const declaredType = getTypeFromMappedTypeNode(type.declaration) as MappedType;
                 const constraint = getConstraintTypeFromMappedType(declaredType);
-                const extendedConstraint = constraint && constraint.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(constraint as TypeParameter) : constraint;
+                const extendedConstraint = constraint && constraint.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(constraint) : constraint;
                 type.modifiersType = extendedConstraint && extendedConstraint.flags & TypeFlags.Index ? instantiateType((extendedConstraint as IndexType).type, type.mapper) : unknownType;
             }
         }
@@ -14967,7 +14967,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     resolveReverseMappedTypeMembers(type as ReverseMappedType);
                 }
                 else if ((type as ObjectType).objectFlags & ObjectFlags.Anonymous) {
-                    resolveAnonymousTypeMembers(type as AnonymousType);
+                    resolveAnonymousTypeMembers(type);
                 }
                 else if ((type as MappedType).objectFlags & ObjectFlags.Mapped) {
                     resolveMappedTypeMembers(type as MappedType);
@@ -15081,7 +15081,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getConstraintOfType(type: InstantiableType | UnionOrIntersectionType): Type | undefined {
-        return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type as TypeParameter) :
+        return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type) :
             type.flags & TypeFlags.IndexedAccess ? getConstraintOfIndexedAccess(type as IndexedAccessType) :
             type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
             getBaseConstraintOfType(type);
@@ -15231,7 +15231,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getBaseConstraintOfType(type: Type): Type | undefined {
         if (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) || isGenericTupleType(type)) {
-            const constraint = getResolvedBaseConstraint(type as InstantiableType | UnionOrIntersectionType);
+            const constraint = getResolvedBaseConstraint(type);
             return constraint !== noConstraintType && constraint !== circularConstraintType ? constraint : undefined;
         }
         return type.flags & TypeFlags.Index ? stringNumberSymbolType : undefined;
@@ -15281,7 +15281,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (!popTypeResolution()) {
                     if (t.flags & TypeFlags.TypeParameter) {
-                        const errorNode = getConstraintDeclaration(t as TypeParameter);
+                        const errorNode = getConstraintDeclaration(t);
                         if (errorNode) {
                             const diagnostic = error(errorNode, Diagnostics.Type_parameter_0_has_a_circular_constraint, typeToString(t));
                             if (currentNode && !isNodeDescendantOf(errorNode, currentNode) && !isNodeDescendantOf(currentNode, errorNode)) {
@@ -15303,7 +15303,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function computeBaseConstraint(t: Type): Type | undefined {
             if (t.flags & TypeFlags.TypeParameter) {
-                const constraint = getConstraintFromTypeParameter(t as TypeParameter);
+                const constraint = getConstraintFromTypeParameter(t);
                 return (t as TypeParameter).isThisType || !constraint ?
                     constraint :
                     getBaseConstraint(constraint);
@@ -17567,7 +17567,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getGlobalTypeOrUndefined(name: __String, arity = 0): ObjectType | undefined {
         const symbol = getGlobalSymbol(name, SymbolFlags.Type, /*diagnostic*/ undefined);
-        return symbol && getTypeOfGlobalSymbol(symbol, arity) as GenericType;
+        return symbol && getTypeOfGlobalSymbol(symbol, arity);
     }
 
     function getGlobalExtractSymbol(): Symbol | undefined {
@@ -17838,8 +17838,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         type.outerTypeParameters = undefined;
         type.localTypeParameters = typeParameters;
         type.instantiations = new Map<string, TypeReference>();
-        type.instantiations.set(getTypeListId(type.typeParameters), type as GenericType);
-        type.target = type as GenericType;
+        type.instantiations.set(getTypeListId(type.typeParameters), type);
+        type.target = type;
         type.resolvedTypeArguments = type.typeParameters;
         type.thisType = createTypeParameter();
         type.thisType.isThisType = true;
@@ -18932,7 +18932,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getIndexType(type: Type, indexFlags = IndexFlags.None): Type {
         type = getReducedType(type);
         return isNoInferType(type) ? getNoInferType(getIndexType((type as SubstitutionType).baseType, indexFlags)) :
-            shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type as InstantiableType | UnionOrIntersectionType, indexFlags) :
+            shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type, indexFlags) :
             type.flags & TypeFlags.Union ? getIntersectionType(map((type as UnionType).types, t => getIndexType(t, indexFlags))) :
             type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
             getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
@@ -19187,7 +19187,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (prop) {
                 if (accessFlags & AccessFlags.ReportDeprecated && accessNode && prop.declarations && isDeprecatedSymbol(prop) && isUncalledFunctionReference(accessNode, prop)) {
                     const deprecatedNode = accessExpression?.argumentExpression ?? (isIndexedAccessTypeNode(accessNode) ? accessNode.indexType : accessNode);
-                    addDeprecatedSuggestion(deprecatedNode, prop.declarations, propName as string);
+                    addDeprecatedSuggestion(deprecatedNode, prop.declarations, propName);
                 }
                 if (accessExpression) {
                     markPropertyAsReferenced(prop, accessExpression, isSelfTypeAccess(accessExpression.expression, objectType.symbol));
@@ -19294,16 +19294,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 else if (noImplicitAny && !(accessFlags & AccessFlags.SuppressNoImplicitAnyError)) {
                     if (propName !== undefined && typeHasStaticProperty(propName, objectType)) {
                         const typeName = typeToString(objectType);
-                        error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead, propName as string, typeName, typeName + "[" + getTextOfNode(accessExpression.argumentExpression) + "]");
+                        error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead, propName, typeName, typeName + "[" + getTextOfNode(accessExpression.argumentExpression) + "]");
                     }
                     else if (getIndexTypeOfType(objectType, numberType)) {
                         error(accessExpression.argumentExpression, Diagnostics.Element_implicitly_has_an_any_type_because_index_expression_is_not_of_type_number);
                     }
                     else {
                         let suggestion: string | undefined;
-                        if (propName !== undefined && (suggestion = getSuggestionForNonexistentProperty(propName as string, objectType))) {
+                        if (propName !== undefined && (suggestion = getSuggestionForNonexistentProperty(propName, objectType))) {
                             if (suggestion !== undefined) {
-                                error(accessExpression.argumentExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName as string, typeToString(objectType), suggestion);
+                                error(accessExpression.argumentExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName, typeToString(objectType), suggestion);
                             }
                         }
                         else {
@@ -19884,8 +19884,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isDistributionDependent(root: ConditionalRoot) {
         return root.isDistributive && (
-            isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.trueType) ||
-            isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.falseType)
+            isTypeParameterPossiblyReferenced(root.checkType, root.node.trueType) ||
+            isTypeParameterPossiblyReferenced(root.checkType, root.node.falseType)
         );
     }
 
@@ -22868,8 +22868,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return;
             }
             reportRelationError(headMessage, source, target);
-            if (source.flags & TypeFlags.TypeParameter && source.symbol?.declarations?.[0] && !getConstraintOfType(source as TypeVariable)) {
-                const syntheticParam = cloneTypeParameter(source as TypeParameter);
+            if (source.flags & TypeFlags.TypeParameter && source.symbol?.declarations?.[0] && !getConstraintOfType(source)) {
+                const syntheticParam = cloneTypeParameter(source);
                 syntheticParam.constraint = instantiateType(target, makeUnaryTypeMapper(source, syntheticParam));
                 if (hasNonCircularBaseConstraint(syntheticParam)) {
                     const targetConstraintString = typeToString(target, source.symbol.declarations[0]);
@@ -22931,7 +22931,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let reducedTarget = target;
             let checkTypes: Type[] | undefined;
             if (target.flags & TypeFlags.Union) {
-                reducedTarget = findMatchingDiscriminantType(source, target as UnionType, isRelatedTo) || filterPrimitivesIfContainsNonPrimitive(target as UnionType);
+                reducedTarget = findMatchingDiscriminantType(source, target, isRelatedTo) || filterPrimitivesIfContainsNonPrimitive(target as UnionType);
                 checkTypes = reducedTarget.flags & TypeFlags.Union ? (reducedTarget as UnionType).types : [reducedTarget];
             }
             for (const prop of getPropertiesOfType(source)) {
@@ -23097,7 +23097,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         undefined;
                     return primitive && containsType(targetTypes, primitive) || alternateForm && containsType(targetTypes, alternateForm) ? Ternary.True : Ternary.False;
                 }
-                const match = getMatchingUnionConstituentForType(target as UnionType, source);
+                const match = getMatchingUnionConstituentForType(target, source);
                 if (match) {
                     const related = isRelatedTo(source, match, RecursionFlags.Target, /*reportErrors*/ false, /*headMessage*/ undefined, intersectionState);
                     if (related) {
@@ -23164,7 +23164,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const sourceTypes = source.types;
             // We strip `undefined` from the target if the `source` trivially doesn't contain it for our correspondence-checking fastpath
             // since `undefined` is frequently added by optionality and would otherwise spoil a potentially useful correspondence
-            const undefinedStrippedTarget = getUndefinedStrippedTargetIfNeeded(source, target as UnionType);
+            const undefinedStrippedTarget = getUndefinedStrippedTargetIfNeeded(source, target);
             for (let i = 0; i < sourceTypes.length; i++) {
                 const sourceType = sourceTypes[i];
                 if (undefinedStrippedTarget.flags & TypeFlags.Union && sourceTypes.length >= (undefinedStrippedTarget as UnionType).types.length && sourceTypes.length % (undefinedStrippedTarget as UnionType).types.length === 0) {
@@ -23835,7 +23835,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (sourceFlags & TypeFlags.TypeVariable) {
                 // IndexedAccess comparisons are handled above in the `targetFlags & TypeFlage.IndexedAccess` branch
                 if (!(sourceFlags & TypeFlags.IndexedAccess && targetFlags & TypeFlags.IndexedAccess)) {
-                    const constraint = getConstraintOfType(source as TypeVariable) || unknownType;
+                    const constraint = getConstraintOfType(source) || unknownType;
                     // hi-speed no-this-instantiation check (less accurate, but avoids costly `this`-instantiation when the constraint will suffice), see #28231 for report on why this is needed
                     if (result = isRelatedTo(constraint, target, RecursionFlags.Source, /*reportErrors*/ false, /*headMessage*/ undefined, intersectionState)) {
                         return result;
@@ -25046,7 +25046,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isUnconstrainedTypeParameter(type: Type) {
-        return type.flags & TypeFlags.TypeParameter && !getConstraintOfTypeParameter(type as TypeParameter);
+        return type.flags & TypeFlags.TypeParameter && !getConstraintOfTypeParameter(type);
     }
 
     function isNonDeferredTypeReference(type: Type): type is TypeReference {
@@ -25569,7 +25569,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getBaseTypeOfLiteralType(type: Type): Type {
-        return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type as LiteralType) :
+        return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type) :
             type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
             type.flags & TypeFlags.NumberLiteral ? numberType :
             type.flags & TypeFlags.BigIntLiteral ? bigintType :
@@ -25595,18 +25595,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getWidenedLiteralType(type: Type): Type {
-        return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type as LiteralType) :
+        return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type) :
             type.flags & TypeFlags.StringLiteral && isFreshLiteralType(type) ? stringType :
             type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
             type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
             type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
-            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
+            type.flags & TypeFlags.Union ? mapType(type, getWidenedLiteralType) :
             type;
     }
 
     function getWidenedUniqueESSymbolType(type: Type): Type {
         return type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
-            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedUniqueESSymbolType) :
+            type.flags & TypeFlags.Union ? mapType(type, getWidenedUniqueESSymbolType) :
             type;
     }
 
@@ -26848,7 +26848,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 clearCachedInferences(inferences);
                             }
                         }
-                        if (!(priority & InferencePriority.ReturnType) && target.flags & TypeFlags.TypeParameter && inference.topLevel && !isTypeParameterAtTopLevel(originalTarget, target as TypeParameter)) {
+                        if (!(priority & InferencePriority.ReturnType) && target.flags & TypeFlags.TypeParameter && inference.topLevel && !isTypeParameterAtTopLevel(originalTarget, target)) {
                             inference.topLevel = false;
                             clearCachedInferences(inferences);
                         }
@@ -28127,7 +28127,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return 0;
             }
 
-            return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType) ?
+            return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type) ?
                 strictNullChecks ? TypeFacts.EmptyObjectStrictFacts : TypeFacts.EmptyObjectFacts :
                 isFunctionObjectType(type as ObjectType) ?
                 strictNullChecks ? TypeFacts.FunctionStrictFacts : TypeFacts.FunctionFacts :
@@ -28421,7 +28421,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             return true;
         }
-        if (source.flags & TypeFlags.EnumLike && getBaseTypeOfEnumLikeType(source as LiteralType) === target) {
+        if (source.flags & TypeFlags.EnumLike && getBaseTypeOfEnumLikeType(source) === target) {
             return true;
         }
         return containsType(target.types, source);
@@ -34512,7 +34512,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (containingType.flags & TypeFlags.TypeParameter) {
             // get the original type -- represented as the type constraint of the 'this' type
-            containingType = (containingType as TypeParameter).isThisType ? getConstraintOfTypeParameter(containingType as TypeParameter)! : getBaseConstraintOfType(containingType as TypeParameter)!; // TODO: GH#18217 Use a different variable that's allowed to be undefined
+            containingType = (containingType as TypeParameter).isThisType ? getConstraintOfTypeParameter(containingType)! : getBaseConstraintOfType(containingType)!; // TODO: GH#18217 Use a different variable that's allowed to be undefined
         }
         if (!containingType || !hasBaseType(containingType, enclosingClass)) {
             if (errorNode) {
@@ -34531,7 +34531,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (thisType) {
             // 2. The constraint of a type parameter used for an explicit 'this' parameter
             if (thisType.flags & TypeFlags.TypeParameter) {
-                thisType = getConstraintOfTypeParameter(thisType as TypeParameter);
+                thisType = getConstraintOfTypeParameter(thisType);
             }
         }
         else {
@@ -41927,7 +41927,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (node.name && isIdentifier(node.name) && (node.name.escapedText === "this" || node.name.escapedText === "new")) {
             if (func.parameters.indexOf(node) !== 0) {
-                error(node, Diagnostics.A_0_parameter_must_be_the_first_parameter, node.name.escapedText as string);
+                error(node, Diagnostics.A_0_parameter_must_be_the_first_parameter, node.name.escapedText);
             }
             if (func.kind === SyntaxKind.Constructor || func.kind === SyntaxKind.ConstructSignature || func.kind === SyntaxKind.ConstructorType) {
                 error(node, Diagnostics.A_constructor_cannot_have_a_this_parameter);
@@ -42053,7 +42053,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             checkGrammarFunctionLikeDeclaration(node as FunctionLikeDeclaration);
         }
 
-        const functionFlags = getFunctionFlags(node as FunctionLikeDeclaration);
+        const functionFlags = getFunctionFlags(node);
         if (!(functionFlags & FunctionFlags.Invalid)) {
             // Async generators prior to ES2018 require the __await and __asyncGenerator helpers
             if ((functionFlags & FunctionFlags.AsyncGenerator) === FunctionFlags.AsyncGenerator && languageVersion < LanguageFeatureMinimumTarget.AsyncGenerators) {
@@ -42113,7 +42113,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (returnTypeNode && returnTypeErrorLocation) {
-                const functionFlags = getFunctionFlags(node as FunctionDeclaration);
+                const functionFlags = getFunctionFlags(node);
                 if ((functionFlags & (FunctionFlags.Invalid | FunctionFlags.Generator)) === FunctionFlags.Generator) {
                     const returnType = getTypeFromTypeNode(returnTypeNode);
                     if (returnType === voidType) {
@@ -46756,7 +46756,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case "void":
             case "object":
             case "undefined":
-                error(name, message, name.escapedText as string);
+                error(name, message, name.escapedText);
         }
     }
 
@@ -51732,7 +51732,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 else if (legacyDecorators && (node.kind === SyntaxKind.GetAccessor || node.kind === SyntaxKind.SetAccessor)) {
-                    const accessors = getAllAccessorDeclarationsForDeclaration(node as AccessorDeclaration);
+                    const accessors = getAllAccessorDeclarationsForDeclaration(node);
                     if (hasDecorators(accessors.firstAccessor) && node === accessors.secondAccessor) {
                         return grammarErrorOnFirstToken(node, Diagnostics.Decorators_cannot_be_applied_to_multiple_get_Slashset_accessors_of_the_same_name);
                     }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -62,7 +62,6 @@ import {
     DeleteExpression,
     directorySeparator,
     DoStatement,
-    DotToken,
     ElementAccessExpression,
     emitDetachedComments,
     EmitFileNames,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2620,7 +2620,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
     function emitPropertyAccessExpression(node: PropertyAccessExpression) {
         emitExpression(node.expression, parenthesizer.parenthesizeLeftSideOfAccess);
-        const token = node.questionDotToken || setTextRangePosEnd(factory.createToken(SyntaxKind.DotToken) as DotToken, node.expression.end, node.name.pos);
+        const token = node.questionDotToken || setTextRangePosEnd(factory.createToken(SyntaxKind.DotToken), node.expression.end, node.name.pos);
         const linesBeforeDot = getLinesBetweenNodes(node, node.expression, token);
         const linesAfterDot = getLinesBetweenNodes(node, token, node.name);
 
@@ -4433,13 +4433,13 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (modifiers?.length) {
             if (every(modifiers, isModifier)) {
                 // if all modifier-likes are `Modifier`, simply emit the array as modifiers.
-                return emitModifierList(node, modifiers as NodeArray<Modifier>);
+                return emitModifierList(node, modifiers);
             }
 
             if (every(modifiers, isDecorator)) {
                 if (allowDecorators) {
                     // if all modifier-likes are `Decorator`, simply emit the array as decorators.
-                    return emitDecoratorList(node, modifiers as NodeArray<Decorator>);
+                    return emitDecoratorList(node, modifiers);
                 }
                 return node.pos;
             }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -10109,7 +10109,7 @@ namespace IncrementalParser {
                 Debug.assert(text === newText.substring(node.pos, node.end));
             }
 
-            forEachChild(node, visitNode as (node: Node) => void, visitArray as (nodes: NodeArray<Node>) => void);
+            forEachChild(node, visitNode, visitArray);
             if (hasJSDocNodes(node)) {
                 for (const jsDocComment of node.jsDoc!) {
                     visitNode(jsDocComment);
@@ -10262,7 +10262,7 @@ namespace IncrementalParser {
 
                 // Adjust the pos or end (or both) of the intersecting element accordingly.
                 adjustIntersectingElement(child, changeStart, changeRangeOldEnd, changeRangeNewEnd, delta);
-                forEachChild(child, visitNode as (node: Node) => void, visitArray as (nodes: NodeArray<Node>) => void);
+                forEachChild(child, visitNode, visitArray);
                 if (hasJSDocNodes(child)) {
                     for (const jsDocComment of child.jsDoc!) {
                         visitNode(jsDocComment);

--- a/src/compiler/symbolWalker.ts
+++ b/src/compiler/symbolWalker.ts
@@ -101,7 +101,7 @@ export function createGetSymbolWalker(
                 }
             }
             if (type.flags & TypeFlags.TypeParameter) {
-                visitTypeParameter(type as TypeParameter);
+                visitTypeParameter(type);
             }
             if (type.flags & TypeFlags.UnionOrIntersection) {
                 visitUnionOrIntersectionType(type as UnionOrIntersectionType);

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -1373,7 +1373,7 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
         // Disable substitution in the generated super accessor itself.
         else if (enabledSubstitutions && substitutedSuperAccessors[getNodeId(node)]) {
             const savedEnclosingSuperContainerFlags = enclosingSuperContainerFlags;
-            enclosingSuperContainerFlags = 0 as NodeCheckFlags;
+            enclosingSuperContainerFlags = 0;
             previousOnEmitNode(hint, node, emitCallback);
             enclosingSuperContainerFlags = savedEnclosingSuperContainerFlags;
             return;

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2243,7 +2243,7 @@ export function transformTypeScript(context: TransformationContext): Transformer
     function getInnerMostModuleDeclarationFromDottedModule(moduleDeclaration: ModuleDeclaration): ModuleDeclaration | undefined {
         if (moduleDeclaration.body!.kind === SyntaxKind.ModuleDeclaration) {
             const recursiveInnerModule = getInnerMostModuleDeclarationFromDottedModule(moduleDeclaration.body as ModuleDeclaration);
-            return recursiveInnerModule || moduleDeclaration.body as ModuleDeclaration;
+            return recursiveInnerModule || moduleDeclaration.body;
         }
     }
 

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -432,7 +432,7 @@ function createSolutionBuilderState<T extends BuilderProgram>(watch: boolean, ho
 
     // State of the solution
     const baseCompilerOptions = getCompilerOptionsOfBuildOptions(options);
-    const compilerHost = createCompilerHostFromProgramHost(host, () => state.projectCompilerOptions) as CompilerHost & ReadBuildProgramHost;
+    const compilerHost = createCompilerHostFromProgramHost(host, () => state.projectCompilerOptions);
     setGetSourceFileAsHashVersioned(compilerHost);
     compilerHost.getParsedCommandLine = fileName => parseConfigFile(state, fileName as ResolvedConfigFileName, toResolvedConfigFilePath(state, fileName as ResolvedConfigFileName));
     compilerHost.resolveModuleNameLiterals = maybeBind(host, host.resolveModuleNameLiterals);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -12269,7 +12269,7 @@ export function getSynthesizedDeepCloneWithReplacements<T extends Node>(
         setOriginalNode(clone, node);
     }
     else {
-        clone = getSynthesizedDeepCloneWorker(node as NonNullable<T>, replaceNode);
+        clone = getSynthesizedDeepCloneWorker(node, replaceNode);
     }
 
     if (clone && !includeTrivia) suppressLeadingAndTrailingTrivia(clone);

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -927,7 +927,7 @@ function getDeclarationIdentifier(node: Declaration | Expression): Identifier | 
 
 /** @internal */
 export function nodeHasName(statement: Node, name: Identifier): boolean {
-    if (isNamedDeclaration(statement) && isIdentifier(statement.name) && idText(statement.name as Identifier) === idText(name)) {
+    if (isNamedDeclaration(statement) && isIdentifier(statement.name) && idText(statement.name) === idText(name)) {
         return true;
     }
     if (isVariableStatement(statement) && some(statement.declarationList.declarations, d => nodeHasName(d, name))) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2063,7 +2063,7 @@ export class ProjectService {
             if (this.openFiles.has(fileOrDirectoryPath)) {
                 const info = Debug.checkDefined(this.getScriptInfoForPath(fileOrDirectoryPath));
                 if (info.isAttached(project)) {
-                    const loadLevelToSet = Math.max(updateLevel, project.openFileWatchTriggered.get(fileOrDirectoryPath) || ProgramUpdateLevel.Update) as ProgramUpdateLevel;
+                    const loadLevelToSet = Math.max(updateLevel, project.openFileWatchTriggered.get(fileOrDirectoryPath) || ProgramUpdateLevel.Update);
                     project.openFileWatchTriggered.set(fileOrDirectoryPath, loadLevelToSet);
                 }
                 else {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1753,7 +1753,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             this.moduleSpecifierCache.clear();
         }
 
-        const oldExternalFiles = this.externalFiles || emptyArray as SortedReadonlyArray<string>;
+        const oldExternalFiles = this.externalFiles || emptyArray;
         this.externalFiles = this.getExternalFiles();
         enumerateInsertsAndDeletes<string, string>(
             this.externalFiles,

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -829,7 +829,7 @@ function getPerProjectReferences<TResult>(
                     symlinkedProjectsMap.forEach((symlinkedProjects, symlinkedPath) => {
                         for (const symlinkedProject of symlinkedProjects) {
                             if (!symlinkedProject.isOrphan() && !resultsMap.has(symlinkedProject)) { // Optimization: don't enqueue if will be discarded
-                                queue.enqueue({ project: symlinkedProject, location: { fileName: symlinkedPath as string, pos: originalLocation.pos } });
+                                queue.enqueue({ project: symlinkedProject, location: { fileName: symlinkedPath, pos: originalLocation.pos } });
                             }
                         }
                     });

--- a/src/server/utilitiesPublic.ts
+++ b/src/server/utilitiesPublic.ts
@@ -44,7 +44,7 @@ export enum Msg {
 export function createInstallTypingsRequest(project: Project, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>, cachePath?: string): DiscoverTypings {
     return {
         projectName: project.getProjectName(),
-        fileNames: project.getFileNames(/*excludeFilesFromExternalLibraries*/ true, /*excludeConfigFiles*/ true).concat(project.getExcludedFiles() as NormalizedPath[]),
+        fileNames: project.getFileNames(/*excludeFilesFromExternalLibraries*/ true, /*excludeConfigFiles*/ true).concat(project.getExcludedFiles()),
         compilerOptions: project.getCompilationSettings(),
         typeAcquisition,
         unresolvedImports,

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -344,7 +344,7 @@ function convertClassificationsToResult(classifications: Classifications, text: 
     for (let i = 0; i < dense.length; i += 3) {
         const start = dense[i];
         const length = dense[i + 1];
-        const type = dense[i + 2] as ClassificationType;
+        const type = dense[i + 2];
 
         // Make a whitespace entry between the last item and this one.
         if (lastEnd >= 0) {

--- a/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
+++ b/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
@@ -17,7 +17,6 @@ import {
     isImportClause,
     isImportEqualsDeclaration,
     isImportSpecifier,
-    Node,
     or,
     Program,
     refactor,

--- a/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
+++ b/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
@@ -57,7 +57,7 @@ function getImportDeclaration(sourceFile: SourceFile, program: Program, start: n
 
     const checker = program.getTypeChecker();
     const symbol = checker.getSymbolAtLocation(identifier);
-    return find(symbol?.declarations || emptyArray, or(isImportClause, isImportSpecifier, isImportEqualsDeclaration) as (n: Node) => n is ImportClause | ImportSpecifier | ImportEqualsDeclaration);
+    return find(symbol?.declarations || emptyArray, or(isImportClause, isImportSpecifier, isImportEqualsDeclaration));
 }
 
 // Converts the import declaration of the offending import to a type-only import,

--- a/src/services/codefixes/generateAccessors.ts
+++ b/src/services/codefixes/generateAccessors.ts
@@ -197,7 +197,7 @@ export function getAccessorConvertiblePropertyAtPosition(file: SourceFile, progr
         isReadonly: hasEffectiveReadonlyModifier(declaration),
         type: getDeclarationType(declaration, program),
         container: declaration.kind === SyntaxKind.Parameter ? declaration.parent.parent : declaration.parent,
-        originalName: (declaration.name as AcceptedNameType).text,
+        originalName: declaration.name.text,
         declaration,
         fieldName,
         accessorName,

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5714,7 +5714,7 @@ function tryGetObjectTypeDeclarationCompletionContainer(sourceFile: SourceFile, 
         // class C { blah \n constructor/**/ }
         || (isIdentifier(contextToken) && isPropertyDeclaration(contextToken.parent) && isClassLike(location))
     ) {
-        return findAncestor(contextToken, isClassLike) as ObjectTypeDeclaration;
+        return findAncestor(contextToken, isClassLike);
     }
 
     switch (contextToken.kind) {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -447,7 +447,7 @@ export function getContextNode(node: NamedDeclaration | BinaryExpression | ForIn
         case SyntaxKind.ShorthandPropertyAssignment:
             return isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent) ?
                 getContextNode(
-                    findAncestor(node.parent, node => isBinaryExpression(node) || isForInOrOfStatement(node)) as BinaryExpression | ForInOrOfStatement,
+                    findAncestor(node.parent, node => isBinaryExpression(node) || isForInOrOfStatement(node)),
                 ) :
                 node;
         case SyntaxKind.SwitchStatement:

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -207,7 +207,7 @@ function updateImports(
             const toImport = oldFromNew !== undefined
                 // If we're at the new location (file was already renamed), need to redo module resolution starting from the old location.
                 // TODO:GH#18217
-                ? getSourceFileToImportFromResolved(importLiteral, resolveModuleName(importLiteral.text, oldImportFromPath, program.getCompilerOptions(), host as ModuleResolutionHost), oldToNew, allFiles)
+                ? getSourceFileToImportFromResolved(importLiteral, resolveModuleName(importLiteral.text, oldImportFromPath, program.getCompilerOptions(), host), oldToNew, allFiles)
                 : getSourceFileToImport(importedModuleSymbol, importLiteral, sourceFile, program, host, oldToNew);
 
             // Need an update if the imported file moved, or the importing file moved and was using a relative path.

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -31,7 +31,6 @@ import {
     LanguageServiceHost,
     last,
     mapDefined,
-    ModuleResolutionHost,
     moduleSpecifiers,
     normalizePath,
     pathIsRelative,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2631,7 +2631,7 @@ export function createLanguageService(
         [SyntaxKind.OpenBracketToken]: SyntaxKind.CloseBracketToken,
         [SyntaxKind.GreaterThanToken]: SyntaxKind.LessThanToken,
     }));
-    braceMatching.forEach((value, key) => braceMatching.set(value.toString(), Number(key) as SyntaxKind));
+    braceMatching.forEach((value, key) => braceMatching.set(value.toString(), Number(key)));
 
     function getBraceMatchingAtPosition(fileName: string, position: number): TextSpan[] {
         const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -810,7 +810,7 @@ function getCompletionEntriesForDirectoryFragment(
         // check for a version redirect
         const packageJsonPath = findPackageJson(baseDirectory, host);
         if (packageJsonPath) {
-            const packageJson = readJson(packageJsonPath, host as { readFile: (filename: string) => string | undefined; });
+            const packageJson = readJson(packageJsonPath, host);
             const typesVersions = (packageJson as any).typesVersions;
             if (typeof typesVersions === "object") {
                 const versionPaths = getPackageJsonTypesVersionsPaths(typesVersions)?.paths;
@@ -1385,7 +1385,7 @@ function enumerateNodeModulesVisibleToScript(host: LanguageServiceHost, scriptPa
 
     const result: string[] = [];
     for (const packageJson of findPackageJsons(scriptPath, host)) {
-        const contents = readJson(packageJson, host as { readFile: (filename: string) => string | undefined; }); // Cast to assert that readFile is defined
+        const contents = readJson(packageJson, host); // Cast to assert that readFile is defined
         // Provide completions for all non @types dependencies
         for (const key of nodeModulesDependencyKeys) {
             const dependencies: object | undefined = (contents as any)[key];

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -699,7 +699,7 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(
                     if (type.symbol && type.symbol.flags & SymbolFlags.TypeParameter && symbolKind !== ScriptElementKind.indexSignatureElement) {
                         const typeParameterParts = mapToDisplayParts(writer => {
                             const param = typeChecker.typeParameterToDeclaration(
-                                type as TypeParameter,
+                                type,
                                 enclosingDeclaration,
                                 symbolDisplayNodeBuilderFlags,
                                 /*internalFlags*/ undefined,

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -105,7 +105,6 @@ import {
     Type,
     TypeChecker,
     TypeFormatFlags,
-    TypeParameter,
     typeToDisplayParts,
     VariableDeclaration,
     WriterContextOut,

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -282,7 +282,7 @@ class ProjectTestCase {
                     }
 
                     const content = Utils.removeTestPathPrefixes(output.text, /*retainTrailingDirectorySeparator*/ true);
-                    Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + diskRelativeName, content as string | null); // eslint-disable-line no-restricted-syntax
+                    Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + diskRelativeName, content);
                 }
                 catch (e) {
                     errs.push(e);

--- a/src/testRunner/unittests/tsserver/inlayHints.ts
+++ b/src/testRunner/unittests/tsserver/inlayHints.ts
@@ -38,7 +38,7 @@ describe("unittests:: tsserver:: inlayHints::", () => {
             arguments: {
                 preferences: {
                     includeInlayParameterNameHints: "all",
-                } as ts.UserPreferences,
+                },
             },
         });
         verifyInlayHintResponse(session);

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -927,20 +927,20 @@ describe("unittests:: tsserver:: projects::", () => {
             arguments: {
                 file: f1.path,
             },
-        } as ts.server.protocol.OpenRequest);
+        });
         session.executeCommandSeq({
             command: ts.server.protocol.CommandTypes.Close,
             arguments: {
                 file: f1.path,
             },
-        } as ts.server.protocol.CloseRequest);
+        });
         session.executeCommandSeq({
             command: ts.server.protocol.CommandTypes.Geterr,
             arguments: {
                 delay: 0,
                 files: [f1.path],
             },
-        } as ts.server.protocol.GeterrRequest);
+        });
         baselineTsserverLogs("projects", "getting errors from closed script info does not throw exception because of getting project from orphan script info", session);
     });
 

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -193,7 +193,7 @@ describe("unittests:: tsserver:: Session:: General functionality", () => {
                     newLine: ts.NewLineKind.LineFeed,
                     moduleResolution: ts.ModuleResolutionKind.Node10,
                     allowNonTsExtensions: true, // injected by tsserver
-                } as ts.CompilerOptions,
+                },
             );
         });
 


### PR DESCRIPTION
While testing my changes to the @typescript-eslint/no-unnecessary-type-assertion lint rule on this repo, I found these unnecessary type assertions that can be removed without impacting runtime behaviour or triggering TS errors.

https://github.com/typescript-eslint/typescript-eslint/pull/11789