### PR TITLE
Add explicit type variance specifiers to Promise, Map, Set

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -1,4 +1,4 @@
-interface Map<K, V> {
+interface Map<out K, out V> {
     clear(): void;
     /**
      * @returns true if an element in the Map existed and has been removed, or false if the element does not exist.
@@ -34,14 +34,14 @@ interface MapConstructor {
 }
 declare var Map: MapConstructor;
 
-interface ReadonlyMap<K, V> {
+interface ReadonlyMap<out K, out V> {
     forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
     get(key: K): V | undefined;
     has(key: K): boolean;
     readonly size: number;
 }
 
-interface WeakMap<K extends WeakKey, V> {
+interface WeakMap<out K extends WeakKey, out V> {
     /**
      * Removes the specified element from the WeakMap.
      * @returns true if the element was successfully removed, or false if it was not present.
@@ -68,7 +68,7 @@ interface WeakMapConstructor {
 }
 declare var WeakMap: WeakMapConstructor;
 
-interface Set<T> {
+interface Set<out T> {
     /**
      * Appends a new element with a specified value to the end of the Set.
      */
@@ -100,13 +100,13 @@ interface SetConstructor {
 }
 declare var Set: SetConstructor;
 
-interface ReadonlySet<T> {
+interface ReadonlySet<out T> {
     forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
     has(value: T): boolean;
     readonly size: number;
 }
 
-interface WeakSet<T extends WeakKey> {
+interface WeakSet<out T extends WeakKey> {
     /**
      * Appends a new value to the end of the WeakSet.
      */

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -116,11 +116,11 @@ interface IArguments {
     [Symbol.iterator](): ArrayIterator<any>;
 }
 
-interface MapIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+interface MapIterator<out T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
     [Symbol.iterator](): MapIterator<T>;
 }
 
-interface Map<K, V> {
+interface Map<out K, out V> {
     /** Returns an iterable of entries in the map. */
     [Symbol.iterator](): MapIterator<[K, V]>;
 
@@ -140,7 +140,7 @@ interface Map<K, V> {
     values(): MapIterator<V>;
 }
 
-interface ReadonlyMap<K, V> {
+interface ReadonlyMap<out K, out V> {
     /** Returns an iterable of entries in the map. */
     [Symbol.iterator](): MapIterator<[K, V]>;
 
@@ -165,17 +165,17 @@ interface MapConstructor {
     new <K, V>(iterable?: Iterable<readonly [K, V]> | null): Map<K, V>;
 }
 
-interface WeakMap<K extends WeakKey, V> {}
+interface WeakMap<out K extends WeakKey, out V> {}
 
 interface WeakMapConstructor {
     new <K extends WeakKey, V>(iterable: Iterable<readonly [K, V]>): WeakMap<K, V>;
 }
 
-interface SetIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+interface SetIterator<out T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
     [Symbol.iterator](): SetIterator<T>;
 }
 
-interface Set<T> {
+interface Set<out T> {
     /** Iterates over values in the set. */
     [Symbol.iterator](): SetIterator<T>;
 
@@ -195,7 +195,7 @@ interface Set<T> {
     values(): SetIterator<T>;
 }
 
-interface ReadonlySet<T> {
+interface ReadonlySet<out T> {
     /** Iterates over values in the set. */
     [Symbol.iterator](): SetIterator<T>;
 
@@ -219,7 +219,7 @@ interface SetConstructor {
     new <T>(iterable?: Iterable<T> | null): Set<T>;
 }
 
-interface WeakSet<T extends WeakKey> {}
+interface WeakSet<out T extends WeakKey> {}
 
 interface WeakSetConstructor {
     new <T extends WeakKey = WeakKey>(iterable: Iterable<T>): WeakSet<T>;
@@ -245,7 +245,7 @@ interface PromiseConstructor {
     race<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>;
 }
 
-interface StringIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+interface StringIterator<out T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
     [Symbol.iterator](): StringIterator<T>;
 }
 

--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -115,19 +115,19 @@ interface Date {
     [Symbol.toPrimitive](hint: string): string | number;
 }
 
-interface Map<K, V> {
+interface Map<out K, out V> {
     readonly [Symbol.toStringTag]: string;
 }
 
-interface WeakMap<K extends WeakKey, V> {
+interface WeakMap<out K extends WeakKey, out V> {
     readonly [Symbol.toStringTag]: string;
 }
 
-interface Set<T> {
+interface Set<out T> {
     readonly [Symbol.toStringTag]: string;
 }
 
-interface WeakSet<T extends WeakKey> {
+interface WeakSet<out T extends WeakKey> {
     readonly [Symbol.toStringTag]: string;
 }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1516,7 +1516,7 @@ interface TypedPropertyDescriptor<T> {
 
 declare type PromiseConstructorLike = new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>;
 
-interface PromiseLike<T> {
+interface PromiseLike<out T> {
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -1529,7 +1529,7 @@ interface PromiseLike<T> {
 /**
  * Represents the completion of an asynchronous operation
  */
-interface Promise<T> {
+interface Promise<out T> {
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.

--- a/src/lib/esnext.collection.d.ts
+++ b/src/lib/esnext.collection.d.ts
@@ -1,6 +1,6 @@
 /// <reference lib="es2024.collection" />
 
-interface ReadonlySetLike<T> {
+interface ReadonlySetLike<out T> {
     /**
      * Despite its name, returns an iterator of the values in the set-like.
      */
@@ -15,7 +15,7 @@ interface ReadonlySetLike<T> {
     readonly size: number;
 }
 
-interface Set<T> {
+interface Set<out T> {
     /**
      * @returns a new Set containing all the elements in this Set and also all the elements in the argument.
      */
@@ -46,7 +46,7 @@ interface Set<T> {
     isDisjointFrom(other: ReadonlySetLike<unknown>): boolean;
 }
 
-interface ReadonlySet<T> {
+interface ReadonlySet<out T> {
     /**
      * @returns a new Set containing all the elements in this Set and also all the elements in the argument.
      */

--- a/tests/baselines/reference/completionsCommitCharactersGlobal.baseline
+++ b/tests/baselines/reference/completionsCommitCharactersGlobal.baseline
@@ -2693,9 +2693,9 @@
 // | type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never
 // | type Partial<T> = { [P in keyof T]?: T[P]; }
 // | type Pick<T, K extends keyof T> = { [P in K]: T[P]; }
-// | interface Promise<T>
+// | interface Promise<out T>
 // | type PromiseConstructorLike = new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>
-// | interface PromiseLike<T>
+// | interface PromiseLike<out T>
 // | type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void
 // | interface PropertyDescriptor
 // | interface PropertyDescriptorMap
@@ -2873,9 +2873,9 @@
 // | type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never
 // | type Partial<T> = { [P in keyof T]?: T[P]; }
 // | type Pick<T, K extends keyof T> = { [P in K]: T[P]; }
-// | interface Promise<T>
+// | interface Promise<out T>
 // | type PromiseConstructorLike = new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>
-// | interface PromiseLike<T>
+// | interface PromiseLike<out T>
 // | type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void
 // | interface PropertyDescriptor
 // | interface PropertyDescriptorMap
@@ -80791,6 +80791,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "out",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
               "text": "T",
               "kind": "typeParameterName"
             },
@@ -81096,6 +81104,14 @@
             {
               "text": "<",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
             },
             {
               "text": "T",
@@ -90262,6 +90278,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "out",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
               "text": "T",
               "kind": "typeParameterName"
             },
@@ -90567,6 +90591,14 @@
             {
               "text": "<",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
             },
             {
               "text": "T",

--- a/tests/baselines/reference/esNextWeakRefs_IterableWeakMap.types
+++ b/tests/baselines/reference/esNextWeakRefs_IterableWeakMap.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === esNextWeakRefs_IterableWeakMap.ts ===
 /** `static #cleanup` */
 const IterableWeakMap_cleanup = ({ ref, set }: {

--- a/tests/baselines/reference/goToTypeDefinitionModifiers.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinitionModifiers.baseline.jsonc
@@ -192,7 +192,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -245,7 +245,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -352,7 +352,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -404,7 +404,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -456,7 +456,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -508,7 +508,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|Promise|]<T> {
+// <|interface [|Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.

--- a/tests/baselines/reference/goToTypeDefinition_promiseType.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_promiseType.baseline.jsonc
@@ -12,7 +12,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|{| defId: 1 |}Promise|]<T> {
+// <|interface [|{| defId: 1 |}Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.
@@ -73,7 +73,7 @@
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
-// <|interface [|{| defId: 1 |}Promise|]<T> {
+// <|interface [|{| defId: 1 |}Promise|]<out T> {
 //     /**
 //      * Attaches callbacks for the resolution and/or rejection of the Promise.
 //      * @param onfulfilled The callback to execute when the Promise is resolved.

--- a/tests/baselines/reference/importTag24.types
+++ b/tests/baselines/reference/importTag24.types
@@ -1,9 +1,5 @@
 //// [tests/cases/conformance/jsdoc/importTag24.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === types.d.ts ===
 export type Foo = string;
 >Foo : string

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
@@ -1,8 +1,5 @@
 //// [tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-
 === inferFromGenericFunctionReturnTypes3.ts ===
 // Repros from #5487
 

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -1,9 +1,5 @@
 //// [tests/cases/conformance/types/conditional/inferTypes1.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 1,000
-
 === inferTypes1.ts ===
 type Unpacked<T> =
 >Unpacked : Unpacked<T>

--- a/tests/baselines/reference/mapGroupBy.types
+++ b/tests/baselines/reference/mapGroupBy.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/mapGroupBy.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === mapGroupBy.ts ===
 const basic = Map.groupBy([0, 2, 8], x => x < 5 ? 'small' : 'large');
 >basic : Map<"small" | "large", number[]>

--- a/tests/baselines/reference/narrowingPastLastAssignment.types
+++ b/tests/baselines/reference/narrowingPastLastAssignment.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/narrowingPastLastAssignment.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === narrowingPastLastAssignment.ts ===
 function action(f: Function) {}
 >action : (f: Function) => void

--- a/tests/baselines/reference/objectGroupBy.types
+++ b/tests/baselines/reference/objectGroupBy.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/objectGroupBy.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === objectGroupBy.ts ===
 const basic = Object.groupBy([0, 2, 8], x => x < 5 ? 'small' : 'large');
 >basic : Partial<Record<"small" | "large", number[]>>

--- a/tests/baselines/reference/parenthesizedJSDocCastAtReturnStatement.types
+++ b/tests/baselines/reference/parenthesizedJSDocCastAtReturnStatement.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/parenthesizedJSDocCastAtReturnStatement.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === index.js ===
 /** @type {Map<string, string | Set<string>>} */
 const cache = new Map()

--- a/tests/baselines/reference/quickinfoVerbosityLibType.baseline
+++ b/tests/baselines/reference/quickinfoVerbosityLibType.baseline
@@ -38,7 +38,7 @@
 // type Foo<T> = Promise<T>;
 //               ^^^^^^^
 // | ----------------------------------------------------------------------
-// | interface Promise<T>
+// | interface Promise<out T>
 // | Represents the completion of an asynchronous operation
 // | (verbosity level: 0)
 // | ----------------------------------------------------------------------
@@ -489,6 +489,14 @@
         {
           "text": "<",
           "kind": "punctuation"
+        },
+        {
+          "text": "out",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
         },
         {
           "text": "T",

--- a/tests/baselines/reference/returnConditionalExpressionJSDocCast.types
+++ b/tests/baselines/reference/returnConditionalExpressionJSDocCast.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/returnConditionalExpressionJSDocCast.ts] ////
 
-=== Performance Stats ===
-Type Count: 1,000
-Instantiation count: 2,500
-
 === file.js ===
 // Don't peek into conditional return expression if it's wrapped in a cast
 /** @type {Map<string, string>} */

--- a/tests/baselines/reference/substitutionTypePassedToExtends.types
+++ b/tests/baselines/reference/substitutionTypePassedToExtends.types
@@ -1,9 +1,5 @@
 //// [tests/cases/compiler/substitutionTypePassedToExtends.ts] ////
 
-=== Performance Stats ===
-Type Count: 500 -> 1,000
-Instantiation count: 100 -> 2,500
-
 === substitutionTypePassedToExtends.ts ===
 type Foo1<A,B> = [A, B] extends unknown[][] ? Bar1<[A, B]> : 'else'
 >Foo1 : Foo1<A, B>

--- a/tests/baselines/reference/typeParameterConstModifiersReturnsAndYields.types
+++ b/tests/baselines/reference/typeParameterConstModifiersReturnsAndYields.types
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReturnsAndYields.ts] ////
 
 === Performance Stats ===
-Type Count: 2,500
+Type Count: 1,000
 Instantiation count: 2,500
 
 === typeParameterConstModifiersReturnsAndYields.ts ===


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #62954

In theory this could improve the performance of type checking in certain scenarios by avoiding a call to `getVariancesWorker` as measured in the perfetto profiles.

I've opted to only include some of the most commonly used types, so the added parsing time doesn't outweigh the benefits

I wasn't sure if the explicit specifier needs to be on every expansion of an interface or only the first one, so I've added it to all of them from es5 to esnext, but depending on how the compiler handles it, it could be applied only to the first occurrence of the interface
