### PR TITLE
Fix duplicate JSDoc @typedef and @callback comments in declaration emit

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5992,15 +5992,25 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         }
     }
 
-    function shouldWriteComment(text: string, pos: number) {
+    function shouldWriteComment(text: string, pos: number, end?: number) {
         if (printerOptions.onlyPrintJsDocStyle) {
-            return (isJSDocLikeText(text, pos) || isPinnedComment(text, pos));
+            if (!isJSDocLikeText(text, pos) && !isPinnedComment(text, pos)) {
+                return false;
+            }
+            // Skip @typedef and @callback comments - they're converted to type declarations
+            if (end !== undefined) {
+                const commentText = text.slice(pos, end);
+                if (commentText.includes("@typedef") || commentText.includes("@callback")) {
+                    return false;
+                }
+            }
+            return true;
         }
         return true;
     }
 
     function emitLeadingComment(commentPos: number, commentEnd: number, kind: SyntaxKind, hasTrailingNewLine: boolean, rangePos: number) {
-        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
+        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos, commentEnd)) return;
         if (!hasWrittenComment) {
             emitNewLineBeforeLeadingCommentOfPosition(getCurrentLineMap(), writer, rangePos, commentPos);
             hasWrittenComment = true;
@@ -6032,7 +6042,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     }
 
     function emitTrailingComment(commentPos: number, commentEnd: number, _kind: SyntaxKind, hasTrailingNewLine: boolean) {
-        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
+        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos, commentEnd)) return;
         // trailing comments are emitted at space/*trailing comment1 */space/*trailing comment2*/
         if (!writer.isAtStartOfLine()) {
             writer.writeSpace(" ");
@@ -6135,7 +6145,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     }
 
     function emitComment(text: string, lineMap: readonly number[], writer: EmitTextWriter, commentPos: number, commentEnd: number, newLine: string) {
-        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
+        if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos, commentEnd)) return;
         emitPos(commentPos);
         writeCommentRange(text, lineMap, writer, commentPos, commentEnd, newLine);
         emitPos(commentEnd);

--- a/tests/baselines/reference/callbackTagNestedParameter.js
+++ b/tests/baselines/reference/callbackTagNestedParameter.js
@@ -23,13 +23,6 @@ function eachPerson(callback) {
 
 //// [cb_nested.d.ts]
 /**
- * @callback WorksWithPeopleCallback
- * @param {Object} person
- * @param {string} person.name
- * @param {number} [person.age]
- * @returns {void}
- */
-/**
  * For each person, calls your callback.
  * @param {WorksWithPeopleCallback} callback
  * @returns {void}

--- a/tests/baselines/reference/callbackTagVariadicType.js
+++ b/tests/baselines/reference/callbackTagVariadicType.js
@@ -28,11 +28,6 @@ var res = (0, exports.x)('a', 'b');
 
 
 //// [callbackTagVariadicType.d.ts]
-/**
- * @callback Foo
- * @param {...string} args
- * @returns {number}
- */
 /** @type {Foo} */
 export const x: Foo;
 export type Foo = (...args: string[]) => number;

--- a/tests/baselines/reference/checkJsdocSatisfiesTag15.js
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag15.js
@@ -96,7 +96,6 @@ function fn7(uuid) { }
 /** @satisfies {(uuid: string) => void} */
 export function fn7(uuid: any): void;
 export function fn1(uuid: string): void;
-/** @typedef {Parameters<typeof fn1>} Foo */
 /** @type Foo */
 export const v1: Foo;
 /** @type Foo */

--- a/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.js
+++ b/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.js
@@ -48,10 +48,6 @@ export default X;
 export type Options = {
     test?: typeof import("./Test.js").default | undefined;
 };
-/**
- * @typedef {Object} Options
- * @property {typeof import("./Test.js").default} [test]
- */
 declare class X extends Test {
     /**
      * @param {Options} options

--- a/tests/baselines/reference/jsDeclarationsFunctionClassesCjsExportAssignment.js
+++ b/tests/baselines/reference/jsDeclarationsFunctionClassesCjsExportAssignment.js
@@ -154,27 +154,6 @@ declare class Timer {
 //// [context.d.ts]
 export = Context;
 /**
- * Imports
- *
- * @typedef {import("./timer")} Timer
- * @typedef {import("./hook")} Hook
- * @typedef {import("./hook").HookHandler} HookHandler
- */
-/**
- * Input type definition
- *
- * @typedef {Object} Input
- * @prop {Timer} timer
- * @prop {Hook} hook
- */
-/**
- * State type definition
- *
- * @typedef {Object} State
- * @prop {Timer} timer
- * @prop {Hook} hook
- */
-/**
  * New `Context`
  *
  * @class
@@ -182,27 +161,6 @@ export = Context;
  */
 declare function Context(input: Input): Context;
 declare class Context {
-    /**
-     * Imports
-     *
-     * @typedef {import("./timer")} Timer
-     * @typedef {import("./hook")} Hook
-     * @typedef {import("./hook").HookHandler} HookHandler
-     */
-    /**
-     * Input type definition
-     *
-     * @typedef {Object} Input
-     * @prop {Timer} timer
-     * @prop {Hook} hook
-     */
-    /**
-     * State type definition
-     *
-     * @typedef {Object} State
-     * @prop {Timer} timer
-     * @prop {Hook} hook
-     */
     /**
      * New `Context`
      *
@@ -250,16 +208,10 @@ type State = {
 //// [hook.d.ts]
 export = Hook;
 /**
- * @typedef {(arg: import("./context")) => void} HookHandler
- */
-/**
  * @param {HookHandler} handle
  */
 declare function Hook(handle: HookHandler): void;
 declare class Hook {
-    /**
-     * @typedef {(arg: import("./context")) => void} HookHandler
-     */
     /**
      * @param {HookHandler} handle
      */

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
@@ -80,7 +80,6 @@ export const myTypes: {
 export namespace testFnTypes {
     type input = boolean | myTypes.typeC;
 }
-/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
 /**
  * @function testFn
  * @description A test function.

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
@@ -77,7 +77,6 @@ export namespace myTypes {
     type typeC = myTypes.typeB | Function;
 }
 //// [file2.d.ts]
-/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
 /**
  * @function testFn
  * @description A test function.

--- a/tests/baselines/reference/jsDeclarationsImportNamespacedType.js
+++ b/tests/baselines/reference/jsDeclarationsImportNamespacedType.js
@@ -13,7 +13,6 @@ export var dummy = 1
 
 
 //// [mod1.d.ts]
-/** @typedef {number} Dotted.Name */
 export const dummy: number;
 export namespace Dotted {
     type Name = number;

--- a/tests/baselines/reference/jsDeclarationsImportTypeBundled.js
+++ b/tests/baselines/reference/jsDeclarationsImportTypeBundled.js
@@ -32,9 +32,6 @@ module.exports = items;
 declare module "folder/mod1" {
     export = x;
     /**
-     * @typedef {{x: number}} Item
-     */
-    /**
      * @type {Item};
      */
     const x: Item;

--- a/tests/baselines/reference/jsDeclarationsInheritedTypes.js
+++ b/tests/baselines/reference/jsDeclarationsInheritedTypes.js
@@ -36,14 +36,6 @@ class C3 extends C1 {
 
 
 //// [a.d.ts]
-/**
- * @typedef A
- * @property {string} a
- */
-/**
- * @typedef B
- * @property {number} b
- */
 declare class C1 {
     /**
      * @type {A}

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.js
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.js
@@ -74,11 +74,6 @@ type couldntThinkOfAny = {
         new (): {};
     };
 };
-/** @typedef {import('./base')} BaseFactory */
-/**
- * @callback BaseFactoryFactory
- * @param {import('./base')} factory
- */
 /** @enum {import('./base')} */
 declare const couldntThinkOfAny: {};
 /**

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.js
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.js
@@ -56,7 +56,6 @@ declare namespace BaseFactory {
 declare class Base {
 }
 //// [file.d.ts]
-/** @typedef {typeof import('./base')} BaseFactory */
 /**
  *
  * @param {InstanceType<BaseFactory["Base"]>} base

--- a/tests/baselines/reference/jsDeclarationsTypeAliases.js
+++ b/tests/baselines/reference/jsDeclarationsTypeAliases.js
@@ -123,9 +123,6 @@ export type SomeType = {
     x: string;
 } | number | LocalThing | ExportedThing;
 /**
- * @typedef {{x: string} | number | LocalThing | ExportedThing} SomeType
- */
-/**
  * @param {number} x
  * @returns {SomeType}
  */

--- a/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.js
+++ b/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.js
@@ -68,9 +68,6 @@ module.exports = {
 
 //// [conn.d.ts]
 export = Conn;
-/**
- * @typedef {string | number} Whatever
- */
 declare class Conn {
     item: number;
     method(): void;
@@ -81,9 +78,6 @@ declare namespace Conn {
 type Whatever = string | number;
 //// [usage.d.ts]
 export type Conn = import("./conn");
-/**
- * @typedef {import("./conn")} Conn
- */
 export class Wrap {
     /**
      * @param {Conn} c

--- a/tests/baselines/reference/jsDeclarationsTypedefFunction.js
+++ b/tests/baselines/reference/jsDeclarationsTypedefFunction.js
@@ -34,11 +34,6 @@ const send = handlers => new Promise((resolve, reject) => {
 
 
 //// [foo.d.ts]
-/**
- * @typedef {{
- *   [id: string]: [Function, Function];
- * }} ResolveRejectMap
- */
 declare let id: number;
 /**
  * @param {ResolveRejectMap} handlers

--- a/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.js
+++ b/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.js
@@ -110,13 +110,6 @@ export type TaskGroup = {
     label: string;
     traceEventNames: string[];
 };
-/** @typedef {'parseHTML'|'styleLayout'} TaskGroupIds */
-/**
- * @typedef TaskGroup
- * @property {TaskGroupIds} id
- * @property {string} label
- * @property {string[]} traceEventNames
- */
 /**
  * @type {{[P in TaskGroupIds]: {id: P, label: string}}}
  */
@@ -130,14 +123,6 @@ export const taskNameToGroup: {
 };
 //// [index.d.ts]
 export = MainThreadTasks;
-/** @typedef {import('./module.js').TaskGroup} TaskGroup */
-/**
- * @typedef TaskNode
- * @prop {TaskNode[]} children
- * @prop {TaskNode|undefined} parent
- * @prop {TaskGroup} group
- */
-/** @typedef {{timers: Map<string, TaskNode>}} PriorTaskData */
 declare class MainThreadTasks {
     /**
      * @param {TaskGroup} x

--- a/tests/baselines/reference/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.js
+++ b/tests/baselines/reference/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.js
@@ -47,9 +47,6 @@ NewAjax.prototype.case6_unexpectedlyResolvesPathToNodeModules;
 
 
 //// [index.d.ts]
-/**
- * @typedef {import('@lion/ajax').LionRequestInit} LionRequestInit
- */
 export class NewAjax {
     /**
      * @param {LionRequestInit} [init]

--- a/tests/baselines/reference/jsdocTemplateTagDefault.js
+++ b/tests/baselines/reference/jsdocTemplateTagDefault.js
@@ -131,29 +131,6 @@ function f3(a, b) { }
 /**
  * @template T
  * @template [U=T] - ok: default can reference earlier type parameter
- * @typedef {[T, U]} B
- */
-/**
- * @template {string | number} [T] - error: default requires an `=type`
- * @typedef {[T]} C
- */
-/**
- * @template {string | number} [T=] - error: default requires a `type`
- * @typedef {[T]} D
- */
-/**
- * @template {string | number} [T=string]
- * @template U - error: Required type parameters cannot follow optional type parameters
- * @typedef {[T, U]} E
- */
-/**
- * @template [T=U] - error: Type parameter defaults can only reference previously declared type parameters.
- * @template [U=T]
- * @typedef {[T, U]} G
- */
-/**
- * @template T
- * @template [U=T] - ok: default can reference earlier type parameter
  * @param {T} a
  * @param {U} b
  */
@@ -172,10 +149,6 @@ declare function f2<T extends string | number = string, U>(a: T, b: U): void;
  * @param {U} b
  */
 declare function f3<T = U, U = T>(a: T, b: U): void;
-/**
- * @template {string | number} [T=string] - ok: defaults are permitted
- * @typedef {[T]} A
- */
 /** @type {A} */ declare const aDefault1: A;
 /** @type {A} */ declare const aDefault2: A;
 /** @type {A<string>} */ declare const aString: A<string>;

--- a/tests/baselines/reference/linkTagEmit1.js
+++ b/tests/baselines/reference/linkTagEmit1.js
@@ -47,13 +47,6 @@ var see3 = true;
 
 
 //// [linkTagEmit1.d.ts]
-/** @typedef {number} N */
-/**
- * @typedef {Object} D1
- * @property {1} e Just link to {@link NS.R} this time
- * @property {1} m Wyatt Earp loved {@link N integers} I bet.
- */
-/** @typedef {number} Z @see N {@link N} */
 /**
  * @param {number} integer {@link Z}
  */

--- a/tests/baselines/reference/recursiveTypeReferences2.js
+++ b/tests/baselines/reference/recursiveTypeReferences2.js
@@ -55,27 +55,6 @@ var p = {};
 
 
 //// [bug39372.d.ts]
-/** @typedef {ReadonlyArray<Json>} JsonArray */
-/** @typedef {{ readonly [key: string]: Json }} JsonRecord */
-/** @typedef {boolean | number | string | null | JsonRecord | JsonArray | readonly []} Json */
-/**
- * @template T
- * @typedef {{
-  $A: {
-    [K in keyof T]?: XMLObject<T[K]>[]
-  },
-  $O: {
-    [K in keyof T]?: {
-      $$?: Record<string, string>
-    } & (T[K] extends string ? {$:string} : XMLObject<T[K]>)
-  },
-  $$?: Record<string, string>,
-  } & {
-  [K in keyof T]?: (
-    T[K] extends string ? string
-      : XMLObject<T[K]>
-  )
-}} XMLObject<T> */
 /** @type {XMLObject<{foo:string}>} */
 declare const p: XMLObject<{
     foo: string;

--- a/tests/baselines/reference/templateInsideCallback.js
+++ b/tests/baselines/reference/templateInsideCallback.js
@@ -131,18 +131,6 @@ declare function flatMap<U>(): any;
  */
 declare function flatMap(): any;
 /**
- * @typedef Oops
- * @template T
- * @property {T} a
- * @property {T} b
- */
-/**
- * @callback Call
- * @template T
- * @param {T} x
- * @returns {T}
- */
-/**
  * @template T
  * @type {Call<T>}
  */

--- a/tests/baselines/reference/typeTagNoErasure.js
+++ b/tests/baselines/reference/typeTagNoErasure.js
@@ -19,7 +19,6 @@ test('hi'); // error, T=number
 
 
 //// [typeTagNoErasure.d.ts]
-/** @template T @typedef {<T1 extends T>(data: T1) => T1} Test */
 /** @type {Test<number>} */
 declare const test: Test<number>;
 type Test<T> = <T1 extends T>(data: T1) => T1;


### PR DESCRIPTION
Fixes #62453.

When emitting declaration files from JavaScript with JSDoc `@typedef` and `@callback` tags, the comments were being emitted twice: once as converted TypeScript type declarations (correct) and once as raw JSDoc comments (duplicate).

The fix skips emitting `@typedef` and `@callback` comments during declaration emit since they are already represented as type declarations.