### PR TITLE
fix(lib): allow 'default' in Intl.CollatorOptions.collation

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4404,7 +4404,7 @@ declare namespace Intl {
         numeric?: boolean | undefined;
         caseFirst?: "upper" | "lower" | "false" | undefined;
         sensitivity?: "base" | "accent" | "case" | "variant" | undefined;
-        collation?: "default"| "big5han" | "compat" | "dict" | "direct" | "ducet" | "emoji" | "eor" | "gb2312" | "phonebk" | "phonetic" | "pinyin" | "reformed" | "searchjl" | "stroke" | "trad" | "unihan" | "zhuyin" | undefined;
+        collation?: "default" | "big5han" | "compat" | "dict" | "direct" | "ducet" | "emoji" | "eor" | "gb2312" | "phonebk" | "phonetic" | "pinyin" | "reformed" | "searchjl" | "stroke" | "trad" | "unihan" | "zhuyin" | undefined;
         ignorePunctuation?: boolean | undefined;
     }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4404,7 +4404,7 @@ declare namespace Intl {
         numeric?: boolean | undefined;
         caseFirst?: "upper" | "lower" | "false" | undefined;
         sensitivity?: "base" | "accent" | "case" | "variant" | undefined;
-        collation?: "big5han" | "compat" | "dict" | "direct" | "ducet" | "emoji" | "eor" | "gb2312" | "phonebk" | "phonetic" | "pinyin" | "reformed" | "searchjl" | "stroke" | "trad" | "unihan" | "zhuyin" | undefined;
+        collation?: "default"| "big5han" | "compat" | "dict" | "direct" | "ducet" | "emoji" | "eor" | "gb2312" | "phonebk" | "phonetic" | "pinyin" | "reformed" | "searchjl" | "stroke" | "trad" | "unihan" | "zhuyin" | undefined;
         ignorePunctuation?: boolean | undefined;
     }
 

--- a/tests/cases/conformance/es2020/localesObjectArgument.ts
+++ b/tests/cases/conformance/es2020/localesObjectArgument.ts
@@ -50,6 +50,8 @@ new Intl.Collator([deDE, jaJP]);
 new Intl.Collator(readonlyLocales);
 Intl.Collator.supportedLocalesOf(enUS);
 Intl.Collator.supportedLocalesOf([deDE, jaJP]);
+new Intl.Collator(enUS, { collation: "default" });
+
 
 new Intl.DateTimeFormat(enUS);
 new Intl.DateTimeFormat([deDE, jaJP]);


### PR DESCRIPTION
Fixes #62971

Adds the missing 'default' literal to Intl.CollatorOptions.collation
to match runtime behavior.

