### PR TITLE
Add support for importing JSON modules "as const"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12515,6 +12515,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!declaration.statements.length) {
                 return emptyObjectType;
             }
+            if (compilerOptions.importJsonAsConst) {
+                return checkExpression(declaration.statements[0].expression);
+            }
             return getWidenedType(getWidenedLiteralType(checkExpression(declaration.statements[0].expression)));
         }
         if (isAccessor(declaration)) {
@@ -41395,6 +41398,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isConstContext(node: Expression): boolean {
         const parent = node.parent;
+        if (compilerOptions.importJsonAsConst && parent.kind === SyntaxKind.ExpressionStatement && isSourceFile(parent.parent) && isJsonSourceFile(parent.parent)) {
+            return true;
+        }
         return isAssertionExpression(parent) && isConstTypeReference(parent.type) ||
             isJSDocTypeAssertion(parent) && isConstTypeReference(getJSDocTypeAssertionType(parent)) ||
             isValidConstAssertionArgument(node) && isConstTypeVariable(getContextualType(node, ContextFlags.None)) ||

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1344,6 +1344,15 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         defaultValueDescription: false,
     },
     {
+        name: "importJsonAsConst",
+        type: "boolean",
+        affectsSemanticDiagnostics: true,
+        affectsBuildInfo: true,
+        category: Diagnostics.Language_and_Environment,
+        description: Diagnostics.Import_JSON_files_as_const_assertions,
+        defaultValueDescription: false,
+    },
+    {
         name: "allowArbitraryExtensions",
         type: "boolean",
         affectsProgramStructure: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6719,6 +6719,10 @@
         "category": "Message",
         "code": 6932
     },
+    "Import JSON files as const assertions.": {
+        "category": "Message",
+        "code": 6933
+    },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7442,6 +7442,7 @@ export interface CompilerOptions {
     /** @internal */ help?: boolean;
     ignoreDeprecations?: string;
     importHelpers?: boolean;
+    importJsonAsConst?: boolean;
     /** @deprecated */
     importsNotUsedAsValues?: ImportsNotUsedAsValues;
     /** @internal */ init?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7039,6 +7039,7 @@ declare namespace ts {
         forceConsistentCasingInFileNames?: boolean;
         ignoreDeprecations?: string;
         importHelpers?: boolean;
+        importJsonAsConst?: boolean;
         /** @deprecated */
         importsNotUsedAsValues?: ImportsNotUsedAsValues;
         inlineSourceMap?: boolean;

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/importJsonAsConst/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/importJsonAsConst/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "importJsonAsConst": true
+    }
+}

--- a/tests/baselines/reference/jsonLiteralTypes.js
+++ b/tests/baselines/reference/jsonLiteralTypes.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/jsonLiteralTypes.ts] ////
+
+//// [data.json]
+{
+    "s": "string literal",
+    "n": 123,
+    "b": true,
+    "arr": ["a", "b"]
+}
+
+//// [main.ts]
+import data from "./data.json";
+
+const s: "string literal" = data.s;
+const n: 123 = data.n;
+const b: true = data.b;
+const arr: readonly ["a", "b"] = data.arr;
+
+
+//// [main.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const data_json_1 = __importDefault(require("./data.json"));
+const s = data_json_1.default.s;
+const n = data_json_1.default.n;
+const b = data_json_1.default.b;
+const arr = data_json_1.default.arr;

--- a/tests/baselines/reference/jsonLiteralTypes.symbols
+++ b/tests/baselines/reference/jsonLiteralTypes.symbols
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/jsonLiteralTypes.ts] ////
+
+=== data.json ===
+{
+    "s": "string literal",
+>"s" : Symbol("s", Decl(data.json, 0, 1))
+
+    "n": 123,
+>"n" : Symbol("n", Decl(data.json, 1, 26))
+
+    "b": true,
+>"b" : Symbol("b", Decl(data.json, 2, 13))
+
+    "arr": ["a", "b"]
+>"arr" : Symbol("arr", Decl(data.json, 3, 14))
+}
+
+=== main.ts ===
+import data from "./data.json";
+>data : Symbol(data, Decl(main.ts, 0, 6))
+
+const s: "string literal" = data.s;
+>s : Symbol(s, Decl(main.ts, 2, 5))
+>data.s : Symbol("s", Decl(data.json, 0, 1))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>s : Symbol("s", Decl(data.json, 0, 1))
+
+const n: 123 = data.n;
+>n : Symbol(n, Decl(main.ts, 3, 5))
+>data.n : Symbol("n", Decl(data.json, 1, 26))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>n : Symbol("n", Decl(data.json, 1, 26))
+
+const b: true = data.b;
+>b : Symbol(b, Decl(main.ts, 4, 5))
+>data.b : Symbol("b", Decl(data.json, 2, 13))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>b : Symbol("b", Decl(data.json, 2, 13))
+
+const arr: readonly ["a", "b"] = data.arr;
+>arr : Symbol(arr, Decl(main.ts, 5, 5))
+>data.arr : Symbol("arr", Decl(data.json, 3, 14))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>arr : Symbol("arr", Decl(data.json, 3, 14))
+

--- a/tests/baselines/reference/jsonLiteralTypes.types
+++ b/tests/baselines/reference/jsonLiteralTypes.types
@@ -1,0 +1,83 @@
+//// [tests/cases/compiler/jsonLiteralTypes.ts] ////
+
+=== data.json ===
+{
+>{    "s": "string literal",    "n": 123,    "b": true,    "arr": ["a", "b"]} : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>                                                                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    "s": "string literal",
+>"s" : "string literal"
+>    : ^^^^^^^^^^^^^^^^
+>"string literal" : "string literal"
+>                 : ^^^^^^^^^^^^^^^^
+
+    "n": 123,
+>"n" : 123
+>    : ^^^
+>123 : 123
+>    : ^^^
+
+    "b": true,
+>"b" : true
+>    : ^^^^
+>true : true
+>     : ^^^^
+
+    "arr": ["a", "b"]
+>"arr" : readonly ["a", "b"]
+>      : ^^^^^^^^^^^^^^^^^^^
+>["a", "b"] : readonly ["a", "b"]
+>           : ^^^^^^^^^^^^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+}
+
+=== main.ts ===
+import data from "./data.json";
+>data : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+const s: "string literal" = data.s;
+>s : "string literal"
+>  : ^^^^^^^^^^^^^^^^
+>data.s : "string literal"
+>       : ^^^^^^^^^^^^^^^^
+>data : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>s : "string literal"
+>  : ^^^^^^^^^^^^^^^^
+
+const n: 123 = data.n;
+>n : 123
+>  : ^^^
+>data.n : 123
+>       : ^^^
+>data : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>n : 123
+>  : ^^^
+
+const b: true = data.b;
+>b : true
+>  : ^^^^
+>true : true
+>     : ^^^^
+>data.b : true
+>       : ^^^^
+>data : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : true
+>  : ^^^^
+
+const arr: readonly ["a", "b"] = data.arr;
+>arr : readonly ["a", "b"]
+>    : ^^^^^^^^^^^^^^^^^^^
+>data.arr : readonly ["a", "b"]
+>         : ^^^^^^^^^^^^^^^^^^^
+>data : { readonly s: "string literal"; readonly n: 123; readonly b: true; readonly arr: readonly ["a", "b"]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>arr : readonly ["a", "b"]
+>    : ^^^^^^^^^^^^^^^^^^^
+

--- a/tests/baselines/reference/jsonLiteralTypesDefault.errors.txt
+++ b/tests/baselines/reference/jsonLiteralTypesDefault.errors.txt
@@ -1,0 +1,43 @@
+main.ts(14,7): error TS2322: Type 'string' is not assignable to type '"string literal"'.
+main.ts(15,7): error TS2322: Type 'number' is not assignable to type '123'.
+main.ts(16,7): error TS2322: Type 'boolean' is not assignable to type 'true'.
+main.ts(17,7): error TS2322: Type 'string[]' is not assignable to type 'readonly ["a", "b"]'.
+  Target requires 2 element(s) but source may have fewer.
+
+
+==== data.json (0 errors) ====
+    {
+        "s": "string literal",
+        "n": 123,
+        "b": true,
+        "arr": ["a", "b"]
+    }
+    
+==== main.ts (4 errors) ====
+    import data from "./data.json";
+    
+    // Should be wide types
+    const s: string = data.s;
+    const n: number = data.n;
+    const b: boolean = data.b;
+    const arr: string[] = data.arr;
+    
+    // Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+    // Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+    // But here data.s IS string.
+    // Let's verify by assigning to literals which should fail if it is string.
+    
+    const literalS: "string literal" = data.s; // Error expected: string not assignable to "string literal"
+          ~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type '"string literal"'.
+    const literalN: 123 = data.n; // Error expected
+          ~~~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type '123'.
+    const literalB: true = data.b; // Error expected
+          ~~~~~~~~
+!!! error TS2322: Type 'boolean' is not assignable to type 'true'.
+    const literalArr: readonly ["a", "b"] = data.arr; // Error expected
+          ~~~~~~~~~~
+!!! error TS2322: Type 'string[]' is not assignable to type 'readonly ["a", "b"]'.
+!!! error TS2322:   Target requires 2 element(s) but source may have fewer.
+    

--- a/tests/baselines/reference/jsonLiteralTypesDefault.js
+++ b/tests/baselines/reference/jsonLiteralTypesDefault.js
@@ -1,0 +1,50 @@
+//// [tests/cases/compiler/jsonLiteralTypesDefault.ts] ////
+
+//// [data.json]
+{
+    "s": "string literal",
+    "n": 123,
+    "b": true,
+    "arr": ["a", "b"]
+}
+
+//// [main.ts]
+import data from "./data.json";
+
+// Should be wide types
+const s: string = data.s;
+const n: number = data.n;
+const b: boolean = data.b;
+const arr: string[] = data.arr;
+
+// Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+// Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+// But here data.s IS string.
+// Let's verify by assigning to literals which should fail if it is string.
+
+const literalS: "string literal" = data.s; // Error expected: string not assignable to "string literal"
+const literalN: 123 = data.n; // Error expected
+const literalB: true = data.b; // Error expected
+const literalArr: readonly ["a", "b"] = data.arr; // Error expected
+
+
+//// [main.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const data_json_1 = __importDefault(require("./data.json"));
+// Should be wide types
+const s = data_json_1.default.s;
+const n = data_json_1.default.n;
+const b = data_json_1.default.b;
+const arr = data_json_1.default.arr;
+// Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+// Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+// But here data.s IS string.
+// Let's verify by assigning to literals which should fail if it is string.
+const literalS = data_json_1.default.s; // Error expected: string not assignable to "string literal"
+const literalN = data_json_1.default.n; // Error expected
+const literalB = data_json_1.default.b; // Error expected
+const literalArr = data_json_1.default.arr; // Error expected

--- a/tests/baselines/reference/jsonLiteralTypesDefault.symbols
+++ b/tests/baselines/reference/jsonLiteralTypesDefault.symbols
@@ -1,0 +1,75 @@
+//// [tests/cases/compiler/jsonLiteralTypesDefault.ts] ////
+
+=== data.json ===
+{
+    "s": "string literal",
+>"s" : Symbol("s", Decl(data.json, 0, 1))
+
+    "n": 123,
+>"n" : Symbol("n", Decl(data.json, 1, 26))
+
+    "b": true,
+>"b" : Symbol("b", Decl(data.json, 2, 13))
+
+    "arr": ["a", "b"]
+>"arr" : Symbol("arr", Decl(data.json, 3, 14))
+}
+
+=== main.ts ===
+import data from "./data.json";
+>data : Symbol(data, Decl(main.ts, 0, 6))
+
+// Should be wide types
+const s: string = data.s;
+>s : Symbol(s, Decl(main.ts, 3, 5))
+>data.s : Symbol("s", Decl(data.json, 0, 1))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>s : Symbol("s", Decl(data.json, 0, 1))
+
+const n: number = data.n;
+>n : Symbol(n, Decl(main.ts, 4, 5))
+>data.n : Symbol("n", Decl(data.json, 1, 26))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>n : Symbol("n", Decl(data.json, 1, 26))
+
+const b: boolean = data.b;
+>b : Symbol(b, Decl(main.ts, 5, 5))
+>data.b : Symbol("b", Decl(data.json, 2, 13))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>b : Symbol("b", Decl(data.json, 2, 13))
+
+const arr: string[] = data.arr;
+>arr : Symbol(arr, Decl(main.ts, 6, 5))
+>data.arr : Symbol("arr", Decl(data.json, 3, 14))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>arr : Symbol("arr", Decl(data.json, 3, 14))
+
+// Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+// Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+// But here data.s IS string.
+// Let's verify by assigning to literals which should fail if it is string.
+
+const literalS: "string literal" = data.s; // Error expected: string not assignable to "string literal"
+>literalS : Symbol(literalS, Decl(main.ts, 13, 5))
+>data.s : Symbol("s", Decl(data.json, 0, 1))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>s : Symbol("s", Decl(data.json, 0, 1))
+
+const literalN: 123 = data.n; // Error expected
+>literalN : Symbol(literalN, Decl(main.ts, 14, 5))
+>data.n : Symbol("n", Decl(data.json, 1, 26))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>n : Symbol("n", Decl(data.json, 1, 26))
+
+const literalB: true = data.b; // Error expected
+>literalB : Symbol(literalB, Decl(main.ts, 15, 5))
+>data.b : Symbol("b", Decl(data.json, 2, 13))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>b : Symbol("b", Decl(data.json, 2, 13))
+
+const literalArr: readonly ["a", "b"] = data.arr; // Error expected
+>literalArr : Symbol(literalArr, Decl(main.ts, 16, 5))
+>data.arr : Symbol("arr", Decl(data.json, 3, 14))
+>data : Symbol(data, Decl(main.ts, 0, 6))
+>arr : Symbol("arr", Decl(data.json, 3, 14))
+

--- a/tests/baselines/reference/jsonLiteralTypesDefault.types
+++ b/tests/baselines/reference/jsonLiteralTypesDefault.types
@@ -1,0 +1,129 @@
+//// [tests/cases/compiler/jsonLiteralTypesDefault.ts] ////
+
+=== data.json ===
+{
+>{    "s": "string literal",    "n": 123,    "b": true,    "arr": ["a", "b"]} : { s: string; n: number; b: boolean; arr: string[]; }
+>                                                                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    "s": "string literal",
+>"s" : string
+>    : ^^^^^^
+>"string literal" : "string literal"
+>                 : ^^^^^^^^^^^^^^^^
+
+    "n": 123,
+>"n" : number
+>    : ^^^^^^
+>123 : 123
+>    : ^^^
+
+    "b": true,
+>"b" : boolean
+>    : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    "arr": ["a", "b"]
+>"arr" : string[]
+>      : ^^^^^^^^
+>["a", "b"] : string[]
+>           : ^^^^^^^^
+>"a" : "a"
+>    : ^^^
+>"b" : "b"
+>    : ^^^
+}
+
+=== main.ts ===
+import data from "./data.json";
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+// Should be wide types
+const s: string = data.s;
+>s : string
+>  : ^^^^^^
+>data.s : string
+>       : ^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>s : string
+>  : ^^^^^^
+
+const n: number = data.n;
+>n : number
+>  : ^^^^^^
+>data.n : number
+>       : ^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>n : number
+>  : ^^^^^^
+
+const b: boolean = data.b;
+>b : boolean
+>  : ^^^^^^^
+>data.b : boolean
+>       : ^^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : boolean
+>  : ^^^^^^^
+
+const arr: string[] = data.arr;
+>arr : string[]
+>    : ^^^^^^^^
+>data.arr : string[]
+>         : ^^^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>arr : string[]
+>    : ^^^^^^^^
+
+// Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+// Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+// But here data.s IS string.
+// Let's verify by assigning to literals which should fail if it is string.
+
+const literalS: "string literal" = data.s; // Error expected: string not assignable to "string literal"
+>literalS : "string literal"
+>         : ^^^^^^^^^^^^^^^^
+>data.s : string
+>       : ^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>s : string
+>  : ^^^^^^
+
+const literalN: 123 = data.n; // Error expected
+>literalN : 123
+>         : ^^^
+>data.n : number
+>       : ^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>n : number
+>  : ^^^^^^
+
+const literalB: true = data.b; // Error expected
+>literalB : true
+>         : ^^^^
+>true : true
+>     : ^^^^
+>data.b : boolean
+>       : ^^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>b : boolean
+>  : ^^^^^^^
+
+const literalArr: readonly ["a", "b"] = data.arr; // Error expected
+>literalArr : readonly ["a", "b"]
+>           : ^^^^^^^^^^^^^^^^^^^
+>data.arr : string[]
+>         : ^^^^^^^^
+>data : { s: string; n: number; b: boolean; arr: string[]; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>arr : string[]
+>    : ^^^^^^^^
+

--- a/tests/baselines/reference/tsc/commandLine/help-all.js
+++ b/tests/baselines/reference/tsc/commandLine/help-all.js
@@ -555,6 +555,11 @@ Enable experimental support for legacy experimental decorators.
 type: boolean
 default: false
 
+[94m--importJsonAsConst[39m
+Import JSON files as const assertions.
+type: boolean
+default: false
+
 [94m--jsx[39m
 Specify what JSX code is generated.
 one of: preserve, react, react-native, react-jsx, react-jsxdev

--- a/tests/cases/compiler/jsonLiteralTypes.ts
+++ b/tests/cases/compiler/jsonLiteralTypes.ts
@@ -1,0 +1,22 @@
+// @resolveJsonModule: true
+// @esModuleInterop: true
+// @module: commonjs
+// @target: esnext
+// @strict: true
+// @importJsonAsConst: true
+
+// @Filename: data.json
+{
+    "s": "string literal",
+    "n": 123,
+    "b": true,
+    "arr": ["a", "b"]
+}
+
+// @Filename: main.ts
+import data from "./data.json";
+
+const s: "string literal" = data.s;
+const n: 123 = data.n;
+const b: true = data.b;
+const arr: readonly ["a", "b"] = data.arr;

--- a/tests/cases/compiler/jsonLiteralTypesDefault.ts
+++ b/tests/cases/compiler/jsonLiteralTypesDefault.ts
@@ -1,0 +1,32 @@
+// @resolveJsonModule: true
+// @esModuleInterop: true
+// @module: commonjs
+// @target: esnext
+// @strict: true
+
+// @Filename: data.json
+{
+    "s": "string literal",
+    "n": 123,
+    "b": true,
+    "arr": ["a", "b"]
+}
+
+// @Filename: main.ts
+import data from "./data.json";
+
+// Should be wide types
+const s: string = data.s;
+const n: number = data.n;
+const b: boolean = data.b;
+const arr: string[] = data.arr;
+
+// Should NOT be literal types (these assignments should fail if they were literals, but since we are assigning TO them, we check what they ARE)
+// Actually, data.s is string. So `const x: "literal" = data.s` would fail if data.s is string.
+// But here data.s IS string.
+// Let's verify by assigning to literals which should fail if it is string.
+
+const literalS: "string literal" = data.s; // Error expected: string not assignable to "string literal"
+const literalN: 123 = data.n; // Error expected
+const literalB: true = data.b; // Error expected
+const literalArr: readonly ["a", "b"] = data.arr; // Error expected


### PR DESCRIPTION
This is the same feature as https://github.com/microsoft/typescript-go/pull/2539, implemented for the "legacy" compiler (i.e. the one written in TS). I'm aware of the current status of feature PRs:

> Development in this codebase [is winding down](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/#typescript-6.0-is-the-last-javascript-based-release) and PRs will only be merged if they fix critical 6.0 issues

I feel that this is a relatively small feature and that the feature parity between v6 and v7 would be really helpful, especially consider the *clear* demand for it (1313 thumbs up on the issue at the time of writing)

This PR implements importing JSON modules with const context, which has the same effect as an `as const` assertion.

This was discussed in and fixes #32063. The issue suggests using a `const` import attribute, however this PR uses a compiler option which is much simpler and should be more maintainable.

This feature is opt-in so existing code will not be broken. It can be enabled by setting `compilerOptions.importJsonAsConst` to `true` in tsconfig.

I've already tested a patch on some of my own code and it works great. I also added some new tests for completeness.