### PR TITLE
Don't error on `this` in arrows referencing explicit `typeof globalThis` annotation in parent this container

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31383,7 +31383,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const type = tryGetThisTypeAt(node, /*includeGlobalThis*/ true, container);
         if (noImplicitThis) {
             const globalThisType = getTypeOfSymbol(globalThisSymbol);
-            if (type === globalThisType && capturedByArrowFunction) {
+            if (type === globalThisType && capturedByArrowFunction && isSourceFile(container)) {
                 error(node, Diagnostics.The_containing_arrow_function_captures_the_global_value_of_this);
             }
             else if (!type) {

--- a/tests/baselines/reference/noImplicitThisFunctions2.errors.txt
+++ b/tests/baselines/reference/noImplicitThisFunctions2.errors.txt
@@ -1,0 +1,44 @@
+noImplicitThisFunctions2.ts(4,16): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+noImplicitThisFunctions2.ts(11,18): error TS7041: The containing arrow function captures the global value of 'this'.
+noImplicitThisFunctions2.ts(27,14): error TS7041: The containing arrow function captures the global value of 'this'.
+
+
+==== noImplicitThisFunctions2.ts (3 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/63001
+    
+    function f1() {
+      return () => this;
+                   ~~~~
+!!! error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+    }
+    
+    function f2(this: typeof globalThis) {
+      return () => this;
+    }
+    
+    const f3 = () => this;
+                     ~~~~
+!!! error TS7041: The containing arrow function captures the global value of 'this'.
+    
+    function f4(this: typeof globalThis) {
+      const inner = () => {
+        return () => this;
+      };
+      return inner;
+    }
+    
+    class C1 {
+      static method(this: typeof globalThis) {
+        return () => this;
+      }
+    }
+    
+    const obj1 = {
+      arr: () => this,
+                 ~~~~
+!!! error TS7041: The containing arrow function captures the global value of 'this'.
+      method(this: typeof globalThis) {
+        return () => this;
+      },
+    };
+    

--- a/tests/baselines/reference/noImplicitThisFunctions2.symbols
+++ b/tests/baselines/reference/noImplicitThisFunctions2.symbols
@@ -1,0 +1,71 @@
+//// [tests/cases/compiler/noImplicitThisFunctions2.ts] ////
+
+=== noImplicitThisFunctions2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63001
+
+function f1() {
+>f1 : Symbol(f1, Decl(noImplicitThisFunctions2.ts, 0, 0))
+
+  return () => this;
+}
+
+function f2(this: typeof globalThis) {
+>f2 : Symbol(f2, Decl(noImplicitThisFunctions2.ts, 4, 1))
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 6, 12))
+>globalThis : Symbol(globalThis)
+
+  return () => this;
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 6, 12))
+}
+
+const f3 = () => this;
+>f3 : Symbol(f3, Decl(noImplicitThisFunctions2.ts, 10, 5))
+>this : Symbol(globalThis)
+
+function f4(this: typeof globalThis) {
+>f4 : Symbol(f4, Decl(noImplicitThisFunctions2.ts, 10, 22))
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 12, 12))
+>globalThis : Symbol(globalThis)
+
+  const inner = () => {
+>inner : Symbol(inner, Decl(noImplicitThisFunctions2.ts, 13, 7))
+
+    return () => this;
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 12, 12))
+
+  };
+  return inner;
+>inner : Symbol(inner, Decl(noImplicitThisFunctions2.ts, 13, 7))
+}
+
+class C1 {
+>C1 : Symbol(C1, Decl(noImplicitThisFunctions2.ts, 17, 1))
+
+  static method(this: typeof globalThis) {
+>method : Symbol(C1.method, Decl(noImplicitThisFunctions2.ts, 19, 10))
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 20, 16))
+>globalThis : Symbol(globalThis)
+
+    return () => this;
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 20, 16))
+  }
+}
+
+const obj1 = {
+>obj1 : Symbol(obj1, Decl(noImplicitThisFunctions2.ts, 25, 5))
+
+  arr: () => this,
+>arr : Symbol(arr, Decl(noImplicitThisFunctions2.ts, 25, 14))
+>this : Symbol(globalThis)
+
+  method(this: typeof globalThis) {
+>method : Symbol(method, Decl(noImplicitThisFunctions2.ts, 26, 18))
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 27, 9))
+>globalThis : Symbol(globalThis)
+
+    return () => this;
+>this : Symbol(this, Decl(noImplicitThisFunctions2.ts, 27, 9))
+
+  },
+};
+

--- a/tests/baselines/reference/noImplicitThisFunctions2.types
+++ b/tests/baselines/reference/noImplicitThisFunctions2.types
@@ -1,0 +1,116 @@
+//// [tests/cases/compiler/noImplicitThisFunctions2.ts] ////
+
+=== noImplicitThisFunctions2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63001
+
+function f1() {
+>f1 : () => () => any
+>   : ^^^^^^^^^^^^^^^
+
+  return () => this;
+>() => this : () => any
+>           : ^^^^^^^^^
+>this : any
+>     : ^^^
+}
+
+function f2(this: typeof globalThis) {
+>f2 : (this: typeof globalThis) => () => typeof globalThis
+>   : ^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+>globalThis : typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^
+
+  return () => this;
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+}
+
+const f3 = () => this;
+>f3 : () => typeof globalThis
+>   : ^^^^^^^^^^^^^^^^^^^^^^^
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+
+function f4(this: typeof globalThis) {
+>f4 : (this: typeof globalThis) => () => () => typeof globalThis
+>   : ^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+>globalThis : typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^
+
+  const inner = () => {
+>inner : () => () => typeof globalThis
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>() => {    return () => this;  } : () => () => typeof globalThis
+>                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    return () => this;
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+
+  };
+  return inner;
+>inner : () => () => typeof globalThis
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+
+class C1 {
+>C1 : C1
+>   : ^^
+
+  static method(this: typeof globalThis) {
+>method : (this: typeof globalThis) => () => typeof globalThis
+>       : ^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+>globalThis : typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^
+
+    return () => this;
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+  }
+}
+
+const obj1 = {
+>obj1 : { arr: () => typeof globalThis; method(this: typeof globalThis): () => typeof globalThis; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{  arr: () => this,  method(this: typeof globalThis) {    return () => this;  },} : { arr: () => typeof globalThis; method(this: typeof globalThis): () => typeof globalThis; }
+>                                                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  arr: () => this,
+>arr : () => typeof globalThis
+>    : ^^^^^^^^^^^^^^^^^^^^^^^
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+
+  method(this: typeof globalThis) {
+>method : (this: typeof globalThis) => () => typeof globalThis
+>       : ^    ^^                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+>globalThis : typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^
+
+    return () => this;
+>() => this : () => typeof globalThis
+>           : ^^^^^^^^^^^^^^^^^^^^^^^
+>this : typeof globalThis
+>     : ^^^^^^^^^^^^^^^^^
+
+  },
+};
+

--- a/tests/cases/compiler/noImplicitThisFunctions2.ts
+++ b/tests/cases/compiler/noImplicitThisFunctions2.ts
@@ -1,0 +1,34 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/63001
+
+function f1() {
+  return () => this;
+}
+
+function f2(this: typeof globalThis) {
+  return () => this;
+}
+
+const f3 = () => this;
+
+function f4(this: typeof globalThis) {
+  const inner = () => {
+    return () => this;
+  };
+  return inner;
+}
+
+class C1 {
+  static method(this: typeof globalThis) {
+    return () => this;
+  }
+}
+
+const obj1 = {
+  arr: () => this,
+  method(this: typeof globalThis) {
+    return () => this;
+  },
+};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/63001