### PR TITLE
More test suite strictness fixups

### DIFF
--- a/tests/cases/compiler/blockScopedBindingCaptureThisInFunction.ts
+++ b/tests/cases/compiler/blockScopedBindingCaptureThisInFunction.ts
@@ -1,3 +1,4 @@
+// @strict: false
 // https://github.com/Microsoft/TypeScript/issues/11038
 () => function () {
     for (let someKey in {}) {

--- a/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 namespace a {
     export var b = 10;
 }

--- a/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 declare class _this { // no error - as no code generation
 }
 var f = () => this;

--- a/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 declare var _this: number; // no error as no code gen
 var f = () => this;
 _this = 10; // Error

--- a/tests/cases/compiler/collisionThisExpressionAndClassInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndClassInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 class _this {
 }
 var f = () => this;

--- a/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 enum _this { // Error
     _thisVal1,
     _thisVal2,

--- a/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 function _this() { //Error
     return 10;
 }

--- a/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
@@ -1,3 +1,4 @@
+// @strict: false
 namespace _this { //Error
     class c {
     }

--- a/tests/cases/compiler/collisionThisExpressionAndVarInGlobal.ts
+++ b/tests/cases/compiler/collisionThisExpressionAndVarInGlobal.ts
@@ -1,2 +1,3 @@
+// @strict: false
 var _this = 1;
 var f = () => this;

--- a/tests/cases/compiler/declarationEmitPromise.ts
+++ b/tests/cases/compiler/declarationEmitPromise.ts
@@ -1,4 +1,5 @@
 // @declaration: true
+// @noImplicitThis: false
 // @module: commonjs
 // @target: es6
 

--- a/tests/cases/compiler/lambdaPropSelf.ts
+++ b/tests/cases/compiler/lambdaPropSelf.ts
@@ -1,3 +1,4 @@
+// @strict: false
 declare var ko: any;
 
 class Person {

--- a/tests/cases/compiler/noParameterReassignmentJSIIFE.ts
+++ b/tests/cases/compiler/noParameterReassignmentJSIIFE.ts
@@ -1,6 +1,7 @@
 // @allowJs: true
 // @checkJs: true
 // @noEmit: true
+// @noImplicitThis: false
 // @filename: index.js
 self.importScripts = (function (importScripts) {
     return function () {

--- a/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
+++ b/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
@@ -1,4 +1,5 @@
 // @strictNullChecks: true
+// @strictPropertyInitialization: false
 
 type T1 = { a: number };
 type T2 = T1 & { b: number };

--- a/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
+++ b/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
@@ -1,3 +1,4 @@
+// @strict: false
 export function foo() {
    export var x = this;
 }

--- a/tests/cases/fourslash/fixExactOptionalUnassignableProperties11.ts
+++ b/tests/cases/fourslash/fixExactOptionalUnassignableProperties11.ts
@@ -11,7 +11,7 @@
 //// declare var j: J
 //// class C {
 ////     ic: IC
-////     m() { this.ic/**/ = j }
+////     constructor() { this.ic/**/ = j }
 //// }
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Add_undefined_to_optional_property_type.message }
@@ -30,7 +30,7 @@ interface J {
 declare var j: J
 class C {
     ic: IC
-    m() { this.ic = j }
+    constructor() { this.ic = j }
 }`,
 });
 

--- a/tests/cases/fourslash/fixExactOptionalUnassignableProperties12.ts
+++ b/tests/cases/fourslash/fixExactOptionalUnassignableProperties12.ts
@@ -9,10 +9,10 @@
 ////     a?: number | undefined
 //// }
 //// declare var j: J
-//// class C {
+//// interface C {
 ////     ic2: IC2
 //// }
-//// var c = new C()
+//// declare var c: C
 //// c.ic2/**/ = j
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Add_undefined_to_optional_property_type.message }
@@ -29,10 +29,10 @@ interface J {
     a?: number | undefined
 }
 declare var j: J
-class C {
+interface C {
     ic2: IC2
 }
-var c = new C()
+declare var c: C
 c.ic2 = j`,
 });
 


### PR DESCRIPTION
This is a small set of fixes for what's mainly `noImplicitThis` and `strictPropertyInitialization`. I didn't change everything - I think we should actually just deal with most of the `noImplicitThis` errors.

Part of #62333.