### PR TITLE
Turn `// @strict` off in all failing fourslash tests which do not contain baseline calls

### DIFF
--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc1.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @Filename: test123.ts
 /////** @type {number} */
 ////var [|x|];

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc10.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc10.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @param {?} x
 //// * @returns {number}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc11.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc11.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @param {?} x
 //// * @returns {number}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc12.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc12.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////class C {
 ////    /**
 ////     * @return {...*}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc17.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc17.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 ////class C {
 ////    /**
 ////     * @param {number} x - the first parameter

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc18.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc18.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 ////class C {
 ////    /** @param {number} value */
 ////    set c(value) { return value }

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 /////**
 //// * @param {number} x - the first parameter
 //// * @param {{ a: string, b: Date }} y - the most complex parameter

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc6.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc6.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////declare class C {
 ////    /** @type {number | null} */
 ////    p;

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc7.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc7.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @param {number} x
 //// * @returns {number}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @param {number} x
 //// * @returns {number}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc9.5.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc9.5.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @template T
 //// * @param {T} x

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc9.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc9.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 /////**
 //// * @param {?} x
 //// * @returns {number}

--- a/tests/cases/fourslash/cloduleAsBaseClass.ts
+++ b/tests/cases/fourslash/cloduleAsBaseClass.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////class A {
 ////    constructor(x: number) { }
 ////    foo() { }

--- a/tests/cases/fourslash/cloduleAsBaseClass2.ts
+++ b/tests/cases/fourslash/cloduleAsBaseClass2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @Filename: cloduleAsBaseClass2_0.ts
 ////class A {
 ////    constructor(x: number) { }

--- a/tests/cases/fourslash/cloduleTypeOf1.ts
+++ b/tests/cases/fourslash/cloduleTypeOf1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////class C<T> {
 ////    static foo(x: number) { }
 ////    x: T;

--- a/tests/cases/fourslash/codeFixAddMissingAsync2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingAsync2.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @strict: false
 ////interface Stuff {
 ////    b: () => Promise<string>;
 ////}

--- a/tests/cases/fourslash/codeFixAddMissingDeclareProperty.ts
+++ b/tests/cases/fourslash/codeFixAddMissingDeclareProperty.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @useDefineForClassFields: true
 
 ////class B {

--- a/tests/cases/fourslash/codeFixAddMissingEnumMember12.ts
+++ b/tests/cases/fourslash/codeFixAddMissingEnumMember12.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////const x; // this is x
 ////
 ////// this is E

--- a/tests/cases/fourslash/codeFixAddMissingProperties1.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface Foo {
 ////    a: number;
 ////    b: string;

--- a/tests/cases/fourslash/codeFixAddMissingProperties33.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties33.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////interface Foo {
 ////    a: number;
 ////    b: string;

--- a/tests/cases/fourslash/codeFixAddMissingProperties37.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties37.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface I {
 ////    x: number;
 ////    y: number;

--- a/tests/cases/fourslash/codeFixAddMissingProperties43.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties43.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface Foo {
 ////    a: number;
 ////    b: string;

--- a/tests/cases/fourslash/codeFixAddMissingProperties44.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties44.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @lib: es2020
 // @target: es2020
 

--- a/tests/cases/fourslash/codeFixAddMissingProperties6.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties6.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface I {
 ////    x: number;
 ////    y: number;

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////const f = promise => {
 ////    await promise;
 ////}

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////const f = (promise) => {
 ////    await promise;
 ////}

--- a/tests/cases/fourslash/codeFixCannotFindModule_suggestion.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_suggestion.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @moduleResolution: bundler
 // @Filename: /node_modules/abs/subModule.js
 ////export const x = 0;

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax15.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax15.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 //// var f = <[|function(number?): number|]>(x => x);
 
 verify.codeFix({

--- a/tests/cases/fourslash/codeFixClassExtendAbstractSomePropertiesPresent.ts
+++ b/tests/cases/fourslash/codeFixClassExtendAbstractSomePropertiesPresent.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitOverride: true
 //// abstract class A {
 ////    abstract x: number;

--- a/tests/cases/fourslash/codeFixClassImplementClassMemberAnonymousClass.ts
+++ b/tests/cases/fourslash/codeFixClassImplementClassMemberAnonymousClass.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class A {
 ////     foo() {
 ////         return class { x: number; }

--- a/tests/cases/fourslash/codeFixClassImplementClassPropertyModifiers.ts
+++ b/tests/cases/fourslash/codeFixClassImplementClassPropertyModifiers.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////abstract class A {
 ////    abstract x: number;
 ////    private y: number;

--- a/tests/cases/fourslash/codeFixClassImplementClassPropertyTypeQuery.ts
+++ b/tests/cases/fourslash/codeFixClassImplementClassPropertyTypeQuery.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////class A {
 ////    A: typeof A;
 ////}

--- a/tests/cases/fourslash/codeFixClassImplementDeepInheritance.ts
+++ b/tests/cases/fourslash/codeFixClassImplementDeepInheritance.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////// Referenced throughout the inheritance chain.
 ////interface I0 { a: number }
 ////

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @lib: es2017
 
 ////interface I<Species> {

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceDuplicateMember2.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceDuplicateMember2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// interface I1 {
 ////     x: number;
 //// }

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceHeritageClauseAlreadyHaveMember.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceHeritageClauseAlreadyHaveMember.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class Base {
 ////     foo: number;
 //// }

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplements1.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplements1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// interface I1 {
 ////     x: number;
 //// }

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplements2.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplements2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// interface I1 {
 ////     x: number;
 //// }

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplementsIntersection2.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleImplementsIntersection2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// interface I1 {
 ////     x: number;
 //// }

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceOptionalProperty.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceOptionalProperty.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface IPerson {
 ////    name: string;
 ////    birthday?: string;

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceSomePropertiesPresent.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceSomePropertiesPresent.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////
 //// interface I {
 ////     x: number;

--- a/tests/cases/fourslash/codeFixCorrectReturnValue10.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue10.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// const a: ((() => number) | (() => undefined)) = () => { 1 }
 
 verify.codeFixAvailable([

--- a/tests/cases/fourslash/codeFixCorrectReturnValue18.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue18.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //@Filename: file.tsx
 //// declare namespace JSX {
 ////     interface Element { }

--- a/tests/cases/fourslash/codeFixCorrectReturnValue19.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue19.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //@Filename: file.tsx
 //// declare namespace JSX {
 ////     interface Element { }

--- a/tests/cases/fourslash/codeFixCorrectReturnValue20.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue20.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //@Filename: file.tsx
 //// declare namespace JSX {
 ////     interface Element { }

--- a/tests/cases/fourslash/codeFixCorrectReturnValue8.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue8.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// function Foo (a: (() => number) | (() => undefined) ) { a() }
 //// Foo(() => { 1 })
 

--- a/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile6.ts
+++ b/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile6.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowjs: true
 // @noEmit: true
 // @checkJs: true

--- a/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile7.ts
+++ b/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile7.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowjs: true
 // @noEmit: true
 // @checkJs: true

--- a/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile8.ts
+++ b/tests/cases/fourslash/codeFixDisableJsDiagnosticsInFile8.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowjs: true
 // @noEmit: true
 // @checkJs: true

--- a/tests/cases/fourslash/codeFixForgottenThisPropertyAccess01.ts
+++ b/tests/cases/fourslash/codeFixForgottenThisPropertyAccess01.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @Filename: /a.ts
 ////export const foo = 0;
 

--- a/tests/cases/fourslash/codeFixForgottenThisPropertyAccess02.ts
+++ b/tests/cases/fourslash/codeFixForgottenThisPropertyAccess02.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////class C {
 ////    constructor(public foo) {
 ////    }

--- a/tests/cases/fourslash/codeFixForgottenThisPropertyAccess03.ts
+++ b/tests/cases/fourslash/codeFixForgottenThisPropertyAccess03.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////class C {
 ////    foo: number;
 ////    constructor() {[|

--- a/tests/cases/fourslash/codeFixInferFromUsageConstructor.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageConstructor.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @strictNullChecks: true
 
 ////class TokenType {

--- a/tests/cases/fourslash/codeFixInferFromUsageConstructorFunctionJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageConstructorFunctionJS.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @noImplicitAny: true

--- a/tests/cases/fourslash/codeFixInferFromUsageGetter2.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageGetter2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////class C {
 ////    [|get x() |]{

--- a/tests/cases/fourslash/codeFixInferFromUsageInaccessibleTypes.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageInaccessibleTypes.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////function f1(a) { a; }
 ////function h1() {

--- a/tests/cases/fourslash/codeFixInferFromUsageOptionalParam.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageOptionalParam.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////function f([|a? |]){
 ////    a;

--- a/tests/cases/fourslash/codeFixInferFromUsageOptionalParamJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageOptionalParamJS.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @noImplicitAny: true

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParam.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParam.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////function f(a: number, [|...rest |]){
 ////    a; rest;

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParam2.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParam2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////function f(a: number, [|...rest |]){
 ////    a; rest;

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParam2JS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParam2JS.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @noImplicitAny: true

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParamJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParamJS.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @noImplicitAny: true

--- a/tests/cases/fourslash/codeFixInferFromUsageString.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageString.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 //// function foo([|p, a, b |]) {
 ////     var x

--- a/tests/cases/fourslash/codeFixInitializePrivatePropertyJS.ts
+++ b/tests/cases/fourslash/codeFixInitializePrivatePropertyJS.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowjs: true
 // @checkJs: true
 

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports28-long-types.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports28-long-types.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @isolatedDeclarations: true
 // @declaration: true
 // fileName: code.ts

--- a/tests/cases/fourslash/codeFixOverrideModifier10.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier10.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitOverride: true
 
 //// class B {

--- a/tests/cases/fourslash/codeFixOverrideModifier9.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier9.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitOverride: true
 
 //// class B {

--- a/tests/cases/fourslash/codeFixOverrideModifier_js1.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier_js1.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @noEmit: true

--- a/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS1.ts
+++ b/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @filename: /a.js

--- a/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS2.ts
+++ b/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @filename: /a.js

--- a/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS3.ts
+++ b/tests/cases/fourslash/codeFixRenameUnmatchedParameterJS3.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 // @filename: /a.js

--- a/tests/cases/fourslash/codeFixSpellingVsMissingMember.ts
+++ b/tests/cases/fourslash/codeFixSpellingVsMissingMember.ts
@@ -2,6 +2,7 @@
 
 // Tests that the spelling fix is returned first.
 
+// @strict: false
 ////class C {
 ////    foof: number;
 ////    method() {

--- a/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts' />
+// @strict: false
 // @allowJs: true
 // @checkJs: true
 

--- a/tests/cases/fourslash/codeFixUndeclaredClassInstance.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredClassInstance.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class A {
 ////     a: number;
 ////     b: string;

--- a/tests/cases/fourslash/codeFixUndeclaredClassInstanceWithTypeParams.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredClassInstanceWithTypeParams.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class A<T> {
 ////     a: number;
 ////     b: string;

--- a/tests/cases/fourslash/codeFixUndeclaredPropertyFunctionEmptyClass.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredPropertyFunctionEmptyClass.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// [|class A {
 ////     constructor() {
 ////         this.x = function(x: number, y?: A){

--- a/tests/cases/fourslash/codeFixUndeclaredPropertyFunctionNonEmptyClass.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredPropertyFunctionNonEmptyClass.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// [|class A {
 ////     y: number;
 ////     constructor(public a: number) {

--- a/tests/cases/fourslash/codeFixUndeclaredPropertyObjectLiteral.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredPropertyObjectLiteral.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// [|class A {
 ////     constructor() {
 ////         let e: any = 10;

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_deleteWrite2.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_deleteWrite2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noLib: true
 // @noUnusedLocals: true
 

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_prefix.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_prefix.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 // @noUnusedParameters: true
 

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_suggestion.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_suggestion.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////function f([|p|]) {
 ////    const [|x|] = 0;
 ////}

--- a/tests/cases/fourslash/codefixInferFromUsageNullish.ts
+++ b/tests/cases/fourslash/codefixInferFromUsageNullish.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noImplicitAny: true
 ////declare const a: string
 ////function wat([|b |]) {

--- a/tests/cases/fourslash/completionCloneQuestionToken.ts
+++ b/tests/cases/fourslash/completionCloneQuestionToken.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @Filename: /file2.ts
 //// type TCallback<T = any> = (options: T) => any;
 //// type InKeyOf<E> = { [K in keyof E]?: TCallback<E[K]>; };

--- a/tests/cases/fourslash/completionListsThroughTransitiveBaseClasses.ts
+++ b/tests/cases/fourslash/completionListsThroughTransitiveBaseClasses.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////declare class A {
 ////    static foo;
 ////}

--- a/tests/cases/fourslash/completionListsThroughTransitiveBaseClasses2.ts
+++ b/tests/cases/fourslash/completionListsThroughTransitiveBaseClasses2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////declare class A {
 ////    foo;
 ////}

--- a/tests/cases/fourslash/completionsOverridingMethod9.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod9.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 // @Filename: a.ts
 // @newline: LF
 

--- a/tests/cases/fourslash/consistentContextualTypeErrorsAfterEdits.ts
+++ b/tests/cases/fourslash/consistentContextualTypeErrorsAfterEdits.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 //// class A {
 ////     foo: string;
 //// }

--- a/tests/cases/fourslash/constEnumsEmitOutputInMultipleFiles.ts
+++ b/tests/cases/fourslash/constEnumsEmitOutputInMultipleFiles.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @Filename: a.ts
 // @newLine: lf
 ////const enum TestEnum {

--- a/tests/cases/fourslash/contextualTypingOfArrayLiterals.ts
+++ b/tests/cases/fourslash/contextualTypingOfArrayLiterals.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////class C {
 ////    name: string;
 ////    age: number;

--- a/tests/cases/fourslash/defaultParamsAndContextualTypes.ts
+++ b/tests/cases/fourslash/defaultParamsAndContextualTypes.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+// @strict: false
 ////interface FooOptions {
 ////    text?: string;
 ////}

--- a/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts
+++ b/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts
@@ -1,3 +1,4 @@
+// @strict: false
 
 //// interface PartialObserver<T> {}
 //// interface Subscription {}

--- a/tests/cases/fourslash/derivedTypeIndexerWithGenericConstraints.ts
+++ b/tests/cases/fourslash/derivedTypeIndexerWithGenericConstraints.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////class CollectionItem {
 ////    x: number;
 ////}

--- a/tests/cases/fourslash/diagnosticsJsFileCompilationDuplicateFunctionImplementation.ts
+++ b/tests/cases/fourslash/diagnosticsJsFileCompilationDuplicateFunctionImplementation.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 // @declaration: true
 // @newLine: lf
 // @outFile: out.js

--- a/tests/cases/fourslash/emptyArrayInference.ts
+++ b/tests/cases/fourslash/emptyArrayInference.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////var x/*1*/x = true ? [1] : [undefined]; 
 ////var y/*2*/y = true ? [1] : [];
 

--- a/tests/cases/fourslash/exportEqualTypes.ts
+++ b/tests/cases/fourslash/exportEqualTypes.ts
@@ -1,5 +1,6 @@
 /// <reference path='./fourslash.ts'/>
 
+// @strict: false
 // @Filename: exportEqualTypes_file0.ts
 ////interface x {
 ////    (): Date;

--- a/tests/cases/fourslash/extendArrayInterfaceMember.ts
+++ b/tests/cases/fourslash/extendArrayInterfaceMember.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+// @strict: false
 ////var x = [1, 2, 3];
 ////var /*y*/y = x.pop(/*1*/5/*2*/);
 ////

--- a/tests/cases/fourslash/extendInterfaceOverloadedMethod.ts
+++ b/tests/cases/fourslash/extendInterfaceOverloadedMethod.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////interface A<T> {
 ////    foo(a: T): B<T>;
 ////    foo(): void ;

--- a/tests/cases/fourslash/extendsTArray.ts
+++ b/tests/cases/fourslash/extendsTArray.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////interface I1<T> {
 ////    (a: T): T;
 ////}

--- a/tests/cases/fourslash/extractFunctionContainingThis3.ts
+++ b/tests/cases/fourslash/extractFunctionContainingThis3.ts
@@ -1,6 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 
+// @strict: false
 ////const foo = {
 ////    bar: "1",
 ////    baz() {

--- a/tests/cases/fourslash/fixingTypeParametersQuickInfo.ts
+++ b/tests/cases/fourslash/fixingTypeParametersQuickInfo.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////declare function f<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
 ////var /*1*/result = /*2*/f(0, /*3*/x => null, /*4*/x => x.blahblah);
 

--- a/tests/cases/fourslash/functionTypes.ts
+++ b/tests/cases/fourslash/functionTypes.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////var f: Function;
 ////function g() { }
 ////

--- a/tests/cases/fourslash/genericInterfacePropertyInference1.ts
+++ b/tests/cases/fourslash/genericInterfacePropertyInference1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////interface I {
 ////    x: number;
 ////}

--- a/tests/cases/fourslash/genericInterfacePropertyInference2.ts
+++ b/tests/cases/fourslash/genericInterfacePropertyInference2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////interface I {
 ////    x: number;
 ////}

--- a/tests/cases/fourslash/genericMapTyping1.ts
+++ b/tests/cases/fourslash/genericMapTyping1.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////interface Iterator_<T, U> {
 ////    (value: T, index: any, list: any): U;
 ////}

--- a/tests/cases/fourslash/genericObjectBaseType.ts
+++ b/tests/cases/fourslash/genericObjectBaseType.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class C<T> {
 ////     constructor(){}
 ////     foo(a: T) {

--- a/tests/cases/fourslash/genericRespecialization1.ts
+++ b/tests/cases/fourslash/genericRespecialization1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class Food {
 ////     private amount: number;
 ////     constructor(public name: string) {

--- a/tests/cases/fourslash/getDeclarationDiagnostics.ts
+++ b/tests/cases/fourslash/getDeclarationDiagnostics.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 // @declaration: true
 // @outFile: true
 

--- a/tests/cases/fourslash/getSemanticDiagnosticForDeclaration.ts
+++ b/tests/cases/fourslash/getSemanticDiagnosticForDeclaration.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 // @module: CommonJS
 // @declaration: true
 //// export function /*1*/foo/*2*/() {

--- a/tests/cases/fourslash/incompatibleOverride.ts
+++ b/tests/cases/fourslash/incompatibleOverride.ts
@@ -2,6 +2,7 @@
 
 // Squiggle for implementing a derived class with an incompatible override is too large
 
+// @strict: false
 //// class Foo { xyz: string; }
 //// class Bar extends Foo { /*1*/xyz/*2*/: number = 1; }
 //// class Baz extends Foo { public /*3*/xyz/*4*/: number = 2; }

--- a/tests/cases/fourslash/inheritedModuleMembersForClodule2.ts
+++ b/tests/cases/fourslash/inheritedModuleMembersForClodule2.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////namespace M {
 ////    export namespace A {
 ////        var o;

--- a/tests/cases/fourslash/invertedCloduleAfterQuickInfo.ts
+++ b/tests/cases/fourslash/invertedCloduleAfterQuickInfo.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////namespace M {
 ////    namespace A {
 ////        var o;

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionAfterTypeArgs.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionAfterTypeArgs.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @strict: false
 //@Filename: file.tsx
 
 ////declare const React: any;

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @strict: false
 //@Filename: file.tsx
 ////interface NestedInterface {
 ////    Foo: NestedInterface;

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionUnclosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionUnclosed.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @strict: false
 //@Filename: file.tsx
 ////interface NestedInterface {
 ////    Foo: NestedInterface;

--- a/tests/cases/fourslash/multiModuleFundule.ts
+++ b/tests/cases/fourslash/multiModuleFundule.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////function C(x: number) { }
 ////
 ////namespace C {

--- a/tests/cases/fourslash/noSuggestionDiagnosticsOnParseError.ts
+++ b/tests/cases/fourslash/noSuggestionDiagnosticsOnParseError.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @Filename: /a.ts
 ////export {};
 ////const a = 1 d;

--- a/tests/cases/fourslash/objectLiteralCallSignatures.ts
+++ b/tests/cases/fourslash/objectLiteralCallSignatures.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////var /*1*/x: {
 ////    func1(x: number): number;         // Method signature
 ////    func2: (x: number) => number;     // Function type literal

--- a/tests/cases/fourslash/parenthesisFatArrows.ts
+++ b/tests/cases/fourslash/parenthesisFatArrows.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+// @strict: false
 ////x => x;
 ////(y) => y;
 /////**/

--- a/tests/cases/fourslash/pasteLambdaOverModule.ts
+++ b/tests/cases/fourslash/pasteLambdaOverModule.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 //// /**/
 
 goTo.marker();

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression2.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression2.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////function tempTag2(templateStrs: TemplateStringsArray, f: (x: number) => number, x: number): number;
 ////function tempTag2(templateStrs: TemplateStringsArray, f: (x: string) => string, h: (y: string) => string, x: string): string;
 ////function tempTag2(...rest: any[]): any {

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////interface Recursive {
 ////    next?: Recursive;
 ////    value: any;

--- a/tests/cases/fourslash/quickInfoForShorthandProperty.ts
+++ b/tests/cases/fourslash/quickInfoForShorthandProperty.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// var name1 = undefined, id1 = undefined;
 //// var /*obj1*/obj1 = {/*name1*/name1, /*id1*/id1};
 //// var name2 = "Hello";

--- a/tests/cases/fourslash/quickInfoGenericTypeArgumentInference1.ts
+++ b/tests/cases/fourslash/quickInfoGenericTypeArgumentInference1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////namespace Underscore {
 ////    export interface Iterator<T, U> {
 ////        (value: T, index: any, list: any): U;

--- a/tests/cases/fourslash/quickInfoJsDocNonDiscriminatedUnionSharedProp.ts
+++ b/tests/cases/fourslash/quickInfoJsDocNonDiscriminatedUnionSharedProp.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 //// interface Entries {
 ////   /**
 ////    * Plugins info...

--- a/tests/cases/fourslash/quickInfoOnCatchVariable.ts
+++ b/tests/cases/fourslash/quickInfoOnCatchVariable.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 //// function f() {
 ////    try { } catch (/**/e) { }
 //// }

--- a/tests/cases/fourslash/quickInfoOnMergedInterfacesWithIncrementalEdits.ts
+++ b/tests/cases/fourslash/quickInfoOnMergedInterfacesWithIncrementalEdits.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////namespace MM {
 ////    interface B<T> {
 ////        foo: number;

--- a/tests/cases/fourslash/quickInfoOnMergedModule.ts
+++ b/tests/cases/fourslash/quickInfoOnMergedModule.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////namespace M2 {
 ////    export interface A {
 ////        foo: string;

--- a/tests/cases/fourslash/quickInfoOnNarrowedTypeInModule.ts
+++ b/tests/cases/fourslash/quickInfoOnNarrowedTypeInModule.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////var strOrNum: string | number;
 ////namespace m {
 ////    var nonExportedStrOrNum: string | number;

--- a/tests/cases/fourslash/quickInfoSignatureOptionalParameterFromUnion1.ts
+++ b/tests/cases/fourslash/quickInfoSignatureOptionalParameterFromUnion1.ts
@@ -2,6 +2,7 @@
 
 // https://github.com/microsoft/TypeScript/issues/55574
 
+// @strict: false
 //// declare const optionals:
 ////   | ((a?: { a: true }) => unknown)
 ////   | ((b?: { b: true }) => unknown);

--- a/tests/cases/fourslash/quickInfoSignatureRestParameterFromUnion2.ts
+++ b/tests/cases/fourslash/quickInfoSignatureRestParameterFromUnion2.ts
@@ -2,6 +2,7 @@
 
 // https://github.com/microsoft/TypeScript/issues/55574
 
+// @strict: false
 //// declare const rest:
 ////   | ((a?: { a: true }, ...rest: string[]) => unknown)
 ////   | ((b?: { b: true }) => unknown);

--- a/tests/cases/fourslash/quickInfoWidenedTypes.ts
+++ b/tests/cases/fourslash/quickInfoWidenedTypes.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////var /*1*/a = null;                   // var a: any
 ////var /*2*/b = undefined;              // var b: any
 ////var /*3*/c = { x: 0, y: null };	// var c: { x: number, y: any }

--- a/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess10.ts
+++ b/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess10.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 //// class A {
 ////     /*a*/public a?: string = "foo";/*b*/
 //// }

--- a/tests/cases/fourslash/signatureHelpCallExpressionJs.ts
+++ b/tests/cases/fourslash/signatureHelpCallExpressionJs.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @checkJs: true
 // @allowJs: true
 

--- a/tests/cases/fourslash/signatureHelpOptionalCall2.ts
+++ b/tests/cases/fourslash/signatureHelpOptionalCall2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////declare const fnTest: undefined | ((str: string, num: number) => void);
 ////fnTest?.(/*1*/);
 

--- a/tests/cases/fourslash/squiggleFunctionExpression.ts
+++ b/tests/cases/fourslash/squiggleFunctionExpression.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+// @strict: false
 ////function takesCallback(callback: (n) => any) { }
 ////takesCallback(function inner(n) { var /*1*/k/*2*/: string = 10; });
 

--- a/tests/cases/fourslash/squiggleIllegalSubclassOverride.ts
+++ b/tests/cases/fourslash/squiggleIllegalSubclassOverride.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+// @strict: false
 ////class Foo {
 ////    public x: number;
 ////}

--- a/tests/cases/fourslash/superInDerivedTypeOfGenericWithStatics.ts
+++ b/tests/cases/fourslash/superInDerivedTypeOfGenericWithStatics.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 ////namespace M {
 ////   export class C<T extends Date> {
 ////      static foo(): C<Date> {

--- a/tests/cases/fourslash/unclosedArrayErrorRecovery.ts
+++ b/tests/cases/fourslash/unclosedArrayErrorRecovery.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 ////var table: number[;
 /////**/table.push(1)
 

--- a/tests/cases/fourslash/underscoreTypings02.ts
+++ b/tests/cases/fourslash/underscoreTypings02.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+// @strict: false
 // @module: CommonJS
 
 //// interface Dictionary<T> {

--- a/tests/cases/fourslash/unusedClassInNamespace4.ts
+++ b/tests/cases/fourslash/unusedClassInNamespace4.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 // @noUnusedParameters:true
 //// [| namespace Validation {

--- a/tests/cases/fourslash/unusedParameterInFunction2.ts
+++ b/tests/cases/fourslash/unusedParameterInFunction2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedParameters: true
 ////function [|greeter(x,y)|] {
 ////    use(x);

--- a/tests/cases/fourslash/unusedParameterInLambda3.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda3.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 // @noUnusedParameters: true
 ////[|/*~a*/(/*~b*/x/*~c*/,/*~d*/y/*~e*/)/*~f*/ => /*~g*/x/*~h*/|]

--- a/tests/cases/fourslash/unusedTypeParametersInLambda3.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInLambda3.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 // @noUnusedParameters: true
 //// class A<Dummy> { public x: Dummy }

--- a/tests/cases/fourslash/unusedTypeParametersInLambda4.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInLambda4.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedParameters: true
 //// class A<T> {
 ////    public x: T;

--- a/tests/cases/fourslash/unusedVariableInClass1.ts
+++ b/tests/cases/fourslash/unusedVariableInClass1.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 ////class greeter {
 ////    [|private greeting: string;|]

--- a/tests/cases/fourslash/unusedVariableInClass2.ts
+++ b/tests/cases/fourslash/unusedVariableInClass2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: true
 ////class greeter {
 ////    [|public greeting1;

--- a/tests/cases/fourslash/unusedVariableInClass4.ts
+++ b/tests/cases/fourslash/unusedVariableInClass4.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 // @noUnusedLocals: false
 ////class greeter {
 ////    [|private greeting: string;|]


### PR DESCRIPTION
Part of #62333.

I did something similar to #62989, but looked for the first `//\s+@` comment line, falling back to the first `////` line. The script bails out if the word "baseline" appeared anywhere in the file.

Just like #62989, this doesn't get everything because `@strict` matches `@strictNullChecks`, so it's overly conservative. I'll have a follow-up PR for that.