### PR TITLE
Explicitly set `strict: false` for project tests, eval tests, and more programmatic fourslash tests

### DIFF
--- a/src/harness/evaluatorImpl.ts
+++ b/src/harness/evaluatorImpl.ts
@@ -39,6 +39,7 @@ export function evaluateTypeScript(source: string | { files: vfs.FileSet; rootFi
     const compilerOptions: ts.CompilerOptions = {
         target: ts.ScriptTarget.ES5,
         module: ts.ModuleKind.CommonJS,
+        strict: false,
         lib: ["lib.esnext.d.ts", "lib.dom.d.ts"],
         ...options,
     };

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderNoOutdir/amd/mapRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderNoOutdir/amd/mapRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderNoOutdir/node/mapRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderNoOutdir/node/mapRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleNoOutdir/amd/mapRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleNoOutdir/amd/mapRootAbsolutePathModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleNoOutdir/node/mapRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleNoOutdir/node/mapRootAbsolutePathModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory/node/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory/node/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/node/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/node/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderNoOutdir/amd/mapRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderNoOutdir/amd/mapRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderNoOutdir/node/mapRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderNoOutdir/node/mapRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
     "resolveMapRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderNoOutdir/amd/mapRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderNoOutdir/amd/mapRootRelativePathModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderNoOutdir/node/mapRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderNoOutdir/node/mapRootRelativePathModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory/amd/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory/amd/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory/node/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory/node/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleNoOutdir/amd/mapRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleNoOutdir/amd/mapRootRelativePathModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleNoOutdir/node/mapRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleNoOutdir/node/mapRootRelativePathModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory/amd/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory/amd/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory/node/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory/node/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/amd/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/amd/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/node/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/node/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderNoOutdir/amd/mapRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderNoOutdir/amd/mapRootRelativePathModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderNoOutdir/node/mapRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderNoOutdir/node/mapRootRelativePathModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory/amd/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory/amd/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory/node/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory/node/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/amd/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/amd/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/node/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/node/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "../mapFiles",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderNoOutdir/amd/maprootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderNoOutdir/amd/maprootUrlModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderNoOutdir/node/maprootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderNoOutdir/node/maprootUrlModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputDirectory/amd/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputDirectory/amd/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputDirectory/node/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputDirectory/node/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleNoOutdir/amd/maprootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleNoOutdir/amd/maprootUrlModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleNoOutdir/node/maprootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleNoOutdir/node/maprootUrlModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputDirectory/amd/maprootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputDirectory/amd/maprootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputDirectory/node/maprootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputDirectory/node/maprootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderNoOutdir/amd/maprootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderNoOutdir/amd/maprootUrlModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderNoOutdir/node/maprootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderNoOutdir/node/maprootUrlModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputDirectory/amd/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputDirectory/amd/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputDirectory/node/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputDirectory/node/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir/amd/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir/amd/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir/node/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir/node/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir/amd/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir/amd/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir/node/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir/node/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir/amd/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir/amd/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir/node/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir/node/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderNoOutdir/amd/outModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleMultifolderNoOutdir/amd/outModuleMultifolderNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderNoOutdir/node/outModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleMultifolderNoOutdir/node/outModuleMultifolderNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputDirectory/amd/outModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputDirectory/amd/outModuleMultifolderSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputDirectory/node/outModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputDirectory/node/outModuleMultifolderSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/outModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/outModuleMultifolderSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/outModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/outModuleMultifolderSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleNoOutdir/amd/outModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleSimpleNoOutdir/amd/outModuleSimpleNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleNoOutdir/node/outModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleSimpleNoOutdir/node/outModuleSimpleNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputDirectory/amd/outModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputDirectory/amd/outModuleSimpleSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputDirectory/node/outModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputDirectory/node/outModuleSimpleSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/amd/outModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/amd/outModuleSimpleSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/node/outModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/node/outModuleSimpleSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderNoOutdir/amd/outModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleSubfolderNoOutdir/amd/outModuleSubfolderNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderNoOutdir/node/outModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/outModuleSubfolderNoOutdir/node/outModuleSubfolderNoOutdir.json
@@ -6,6 +6,7 @@
     ],
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputDirectory/amd/outModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputDirectory/amd/outModuleSubfolderSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputDirectory/node/outModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputDirectory/node/outModuleSubfolderSpecifyOutputDirectory.json
@@ -7,6 +7,7 @@
     "outDir": "outdir/simple",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/amd/outModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/amd/outModuleSubfolderSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/node/outModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/node/outModuleSubfolderSpecifyOutputFile.json
@@ -7,6 +7,7 @@
     "outFile": "bin/test.js",
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/relativeNested/amd/relativeNested.json
+++ b/tests/baselines/reference/project/relativeNested/amd/relativeNested.json
@@ -5,6 +5,7 @@
         "app.ts"
     ],
     "runTest": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/relativeNested/node/relativeNested.json
+++ b/tests/baselines/reference/project/relativeNested/node/relativeNested.json
@@ -5,6 +5,7 @@
         "app.ts"
     ],
     "runTest": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderNoOutdir/amd/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderNoOutdir/amd/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderNoOutdir/node/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderNoOutdir/node/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleNoOutdir/amd/sourceRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleNoOutdir/amd/sourceRootAbsolutePathModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleNoOutdir/node/sourceRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleNoOutdir/node/sourceRootAbsolutePathModuleSimpleNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderNoOutdir/amd/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderNoOutdir/amd/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderNoOutdir/node/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderNoOutdir/node/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -9,6 +9,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -10,6 +10,7 @@
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
     "resolveSourceRoot": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderNoOutdir/amd/sourceRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderNoOutdir/amd/sourceRootRelativePathModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderNoOutdir/node/sourceRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderNoOutdir/node/sourceRootRelativePathModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory/node/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory/node/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleNoOutdir/amd/sourceRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleNoOutdir/amd/sourceRootRelativePathModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleNoOutdir/node/sourceRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleNoOutdir/node/sourceRootRelativePathModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory/amd/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory/amd/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory/node/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory/node/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/amd/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/amd/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/node/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/node/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderNoOutdir/amd/sourceRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderNoOutdir/amd/sourceRootRelativePathModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderNoOutdir/node/sourceRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderNoOutdir/node/sourceRootRelativePathModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory/node/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory/node/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/node/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/node/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "../src",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderNoOutdir/amd/sourcemapModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderNoOutdir/amd/sourcemapModuleMultifolderNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderNoOutdir/node/sourcemapModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderNoOutdir/node/sourcemapModuleMultifolderNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputDirectory/amd/sourcemapModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputDirectory/amd/sourcemapModuleMultifolderSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputDirectory/node/sourcemapModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputDirectory/node/sourcemapModuleMultifolderSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/sourcemapModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/sourcemapModuleMultifolderSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleNoOutdir/amd/sourcemapModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleNoOutdir/amd/sourcemapModuleSimpleNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleNoOutdir/node/sourcemapModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleNoOutdir/node/sourcemapModuleSimpleNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputDirectory/amd/sourcemapModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputDirectory/amd/sourcemapModuleSimpleSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputDirectory/node/sourcemapModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputDirectory/node/sourcemapModuleSimpleSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/amd/sourcemapModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/amd/sourcemapModuleSimpleSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/node/sourcemapModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/node/sourcemapModuleSimpleSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderNoOutdir/amd/sourcemapModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderNoOutdir/amd/sourcemapModuleSubfolderNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderNoOutdir/node/sourcemapModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderNoOutdir/node/sourcemapModuleSubfolderNoOutdir.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputDirectory/amd/sourcemapModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputDirectory/amd/sourcemapModuleSubfolderSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputDirectory/node/sourcemapModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputDirectory/node/sourcemapModuleSubfolderSpecifyOutputDirectory.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/amd/sourcemapModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/amd/sourcemapModuleSubfolderSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/node/sourcemapModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/node/sourcemapModuleSubfolderSpecifyOutputFile.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderNoOutdir/amd/sourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderNoOutdir/amd/sourcerootUrlModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderNoOutdir/node/sourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderNoOutdir/node/sourcerootUrlModuleMultifolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory/amd/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory/amd/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory/node/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory/node/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleNoOutdir/amd/sourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleNoOutdir/amd/sourcerootUrlModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleNoOutdir/node/sourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleNoOutdir/node/sourcerootUrlModuleSimpleNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory/amd/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory/amd/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory/node/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory/node/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/amd/sourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/amd/sourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/node/sourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/node/sourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderNoOutdir/amd/sourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderNoOutdir/amd/sourcerootUrlModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderNoOutdir/node/sourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderNoOutdir/node/sourcerootUrlModuleSubfolderNoOutdir.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory/amd/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory/amd/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory/node/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory/node/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/amd/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/amd/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/node/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/node/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules/amd/visibilityOfTypeUsedAcrossModules.json
+++ b/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules/amd/visibilityOfTypeUsedAcrossModules.json
@@ -5,6 +5,7 @@
         "commands.ts"
     ],
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules/node/visibilityOfTypeUsedAcrossModules.json
+++ b/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules/node/visibilityOfTypeUsedAcrossModules.json
@@ -5,6 +5,7 @@
         "commands.ts"
     ],
     "baselineCheck": true,
+    "strict": false,
     "resolvedInputFiles": [
         "lib.es5.d.ts",
         "lib.decorators.d.ts",

--- a/tests/cases/fourslash/findAllRefsReExportLocal.ts
+++ b/tests/cases/fourslash/findAllRefsReExportLocal.ts
@@ -1,6 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @noLib: true
+// @strict: false
 
 // @Filename: /a.ts
 ////[|var /*ax0*/[|{| "isDefinition": true, "contextRangeIndex": 0 |}x|];|]

--- a/tests/cases/fourslash/fixExactOptionalUnassignableProperties11.ts
+++ b/tests/cases/fourslash/fixExactOptionalUnassignableProperties11.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @strictNullChecks: true
 // @exactOptionalPropertyTypes: true
 //// interface IC {

--- a/tests/cases/fourslash/fixExactOptionalUnassignableProperties12.ts
+++ b/tests/cases/fourslash/fixExactOptionalUnassignableProperties12.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+// @strict: false
 // @strictNullChecks: true
 // @exactOptionalPropertyTypes: true
 //// interface IC2 {

--- a/tests/cases/fourslash/getEmitOutputTsxFile_React.ts
+++ b/tests/cases/fourslash/getEmitOutputTsxFile_React.ts
@@ -4,6 +4,7 @@
 // @declaration: true
 // @sourceMap: true
 // @jsx: react
+// @strict: false
 
 // @Filename: inputFile1.ts
 // @emitThisFile: true

--- a/tests/cases/fourslash/quickInfoUntypedModuleImport.ts
+++ b/tests/cases/fourslash/quickInfoUntypedModuleImport.ts
@@ -1,5 +1,7 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
+
 // @Filename: node_modules/foo/index.js
 //// /*index*/{}
 

--- a/tests/cases/fourslash/renameDestructuringAssignmentInFor.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInFor.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface I {
 ////    [|[|{| "contextRangeIndex": 0 |}property1|]: number;|]
 ////    property2: string;

--- a/tests/cases/fourslash/renameDestructuringAssignmentInForOf.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInForOf.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface I {
 ////    [|[|{| "contextRangeIndex": 0 |}property1|]: number;|]
 ////    property2: string;

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor2.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface MultiRobot {
 ////    name: string;
 ////    skills: {

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+// @strict: false
 ////interface MultiRobot {
 ////    name: string;
 ////    skills: {

--- a/tests/cases/fourslash/server/jsdocCallbackTag.ts
+++ b/tests/cases/fourslash/server/jsdocCallbackTag.ts
@@ -1,5 +1,6 @@
 /// <reference path="../fourslash.ts"/>
 
+// @strict: false
 // @allowNonTsExtensions: true
 // @Filename: jsdocCallbackTag.js
 //// /**

--- a/tests/cases/project/mapRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_multifolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSimpleNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_simple/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "tests/cases/projects/outputdir_module_subfolder/mapFiles",
-    "resolveMapRoot": true
+    "resolveMapRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/mapRootRelativePathModuleMultifolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/cases/project/mapRootRelativePathModuleSimpleNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/mapRootRelativePathModuleSubfolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/mapRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "../mapFiles"
+    "mapRoot": "../mapFiles",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/maprootUrlModuleMultifolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlModuleMultifolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSimpleNoOutdir.json
+++ b/tests/cases/project/maprootUrlModuleSimpleNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlModuleSimpleSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/maprootUrlModuleSubfolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlModuleSubfolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "mapRoot": "http://www.typescriptlang.org/"
+    "mapRoot": "http://www.typescriptlang.org/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "mapRoot": "http://www.typescriptlang.org/",
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/outModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/outModuleMultifolderNoOutdir.json
@@ -5,5 +5,6 @@
         "test.ts"
     ],
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/outModuleMultifolderSpecifyOutputDirectory.json
@@ -6,5 +6,6 @@
     ],
     "outDir": "outdir/simple",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/outModuleMultifolderSpecifyOutputFile.json
@@ -6,5 +6,6 @@
     ],
     "outFile": "bin/test.js",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSimpleNoOutdir.json
+++ b/tests/cases/project/outModuleSimpleNoOutdir.json
@@ -5,5 +5,6 @@
         "test.ts"
     ],
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/outModuleSimpleSpecifyOutputDirectory.json
@@ -6,5 +6,6 @@
     ],
     "outDir": "outdir/simple",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/outModuleSimpleSpecifyOutputFile.json
@@ -6,5 +6,6 @@
     ],
     "outFile": "bin/test.js",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/outModuleSubfolderNoOutdir.json
@@ -5,5 +5,6 @@
         "test.ts"
     ],
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/outModuleSubfolderSpecifyOutputDirectory.json
@@ -6,5 +6,6 @@
     ],
     "outDir": "outdir/simple",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/outModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/outModuleSubfolderSpecifyOutputFile.json
@@ -6,5 +6,6 @@
     ],
     "outFile": "bin/test.js",
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/relativeNested.json
+++ b/tests/cases/project/relativeNested.json
@@ -4,5 +4,6 @@
     "inputFiles": [
         "app.ts"
     ],
-    "runTest": true
+    "runTest": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleMultifolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_multifolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSimpleNoOutdir.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSimpleNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_simple/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSubfolderNoOutdir.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputDirectory.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "baselineCheck": true,
     "sourceRoot": "tests/cases/projects/outputdir_module_subfolder/src",
-    "resolveSourceRoot": true
+    "resolveSourceRoot": true,
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/sourceRootRelativePathModuleMultifolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootRelativePathModuleMultifolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSimpleNoOutdir.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSimpleNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSimpleSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSubfolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSubfolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "../src"
+    "sourceRoot": "../src",
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/sourcemapModuleMultifolderNoOutdir.json
@@ -6,5 +6,6 @@
     ],
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcemapModuleMultifolderSpecifyOutputDirectory.json
@@ -7,5 +7,6 @@
     "outDir": "outdir/simple",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourcemapModuleMultifolderSpecifyOutputFile.json
@@ -7,5 +7,6 @@
     "outFile": "bin/test.js",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSimpleNoOutdir.json
+++ b/tests/cases/project/sourcemapModuleSimpleNoOutdir.json
@@ -6,5 +6,6 @@
     ],
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcemapModuleSimpleSpecifyOutputDirectory.json
@@ -7,5 +7,6 @@
     "outDir": "outdir/simple",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/sourcemapModuleSimpleSpecifyOutputFile.json
@@ -7,5 +7,6 @@
     "outFile": "bin/test.js",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/sourcemapModuleSubfolderNoOutdir.json
@@ -6,5 +6,6 @@
     ],
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcemapModuleSubfolderSpecifyOutputDirectory.json
@@ -7,5 +7,6 @@
     "outDir": "outdir/simple",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcemapModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourcemapModuleSubfolderSpecifyOutputFile.json
@@ -7,5 +7,6 @@
     "outFile": "bin/test.js",
     "sourceMap": true,
     "declaration": true,
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleMultifolderNoOutdir.json
+++ b/tests/cases/project/sourcerootUrlModuleMultifolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcerootUrlModuleMultifolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourcerootUrlModuleMultifolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSimpleNoOutdir.json
+++ b/tests/cases/project/sourcerootUrlModuleSimpleNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcerootUrlModuleSimpleSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSimpleSpecifyOutputFile.json
+++ b/tests/cases/project/sourcerootUrlModuleSimpleSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSubfolderNoOutdir.json
+++ b/tests/cases/project/sourcerootUrlModuleSubfolderNoOutdir.json
@@ -7,5 +7,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
+++ b/tests/cases/project/sourcerootUrlModuleSubfolderSpecifyOutputDirectory.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
+++ b/tests/cases/project/sourcerootUrlModuleSubfolderSpecifyOutputFile.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "declaration": true,
     "baselineCheck": true,
-    "sourceRoot": "http://typescript.codeplex.com/"
+    "sourceRoot": "http://typescript.codeplex.com/",
+    "strict": false
 }

--- a/tests/cases/project/visibilityOfTypeUsedAcrossModules.json
+++ b/tests/cases/project/visibilityOfTypeUsedAcrossModules.json
@@ -4,5 +4,6 @@
     "inputFiles": [
         "commands.ts"
     ],
-    "baselineCheck": true
+    "baselineCheck": true,
+    "strict": false
 }


### PR DESCRIPTION
Part of #62333.

- Project tests manually needed an explicit `"strict": false` line added to each project file.
- All `evaluateTypeScript` tests assume `strict` is implicitly off.
- Fourslash tests from other PRs which I missed have an explicit `// @strict: false`

I think with this PR and #63023, we may be able to just flip the `strict` switch, accept baselines, and have tests pass.