### PR TITLE
Add TypeScript declaration file for messageformat module

### DIFF
--- a/src/types/messageformat.d.ts
+++ b/src/types/messageformat.d.ts
@@ -1,0 +1,10 @@
+declare module "messageformat" {
+  type Msg = (data: object) => string;
+
+  interface MessageFormat {
+    constructor(locale: string);
+    compile(message: string): Msg;
+  }
+
+  export default MessageFormat;
+}


### PR DESCRIPTION
This PR adds a custom TypeScript declaration file for the messageformat JavaScript library, which does not provide its own type definitions. By declaring the module "messageformat" with proper types, this change allows TypeScript projects to import and use the library without compilation errors. It defines the Msg type for compiled messages and the MessageFormat interface with a constructor and compile method, and provides a default export for convenient usage. This change ensures compatibility with TypeScript 2.8+ and can be placed under src/types/messageformat/index.d.ts for custom type resolution. Resolves #23185.