### PR TITLE
Fix transform crash with destructured parameter property 

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1055,6 +1055,10 @@ export function transformTypeScript(context: TransformationContext): Transformer
 
         if (parametersWithPropertyAssignments) {
             for (const parameter of parametersWithPropertyAssignments) {
+                // Ignore parameter properties with destructured names; we will have errored on them earlier.
+                if (!isIdentifier(parameter.name)) {
+                    continue;
+                }
                 const parameterProperty = factory.createPropertyDeclaration(
                     /*modifiers*/ undefined,
                     parameter.name,

--- a/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.errors.txt
+++ b/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.errors.txt
@@ -1,0 +1,28 @@
+declarationEmitDestructuringParameterProperties2.ts(2,17): error TS1187: A parameter property may not be declared using a binding pattern.
+declarationEmitDestructuringParameterProperties2.ts(8,17): error TS1187: A parameter property may not be declared using a binding pattern.
+declarationEmitDestructuringParameterProperties2.ts(14,17): error TS1187: A parameter property may not be declared using a binding pattern.
+
+
+==== declarationEmitDestructuringParameterProperties2.ts (3 errors) ====
+    class C1 {
+        constructor(public [x, y, z]: string[]) {
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1187: A parameter property may not be declared using a binding pattern.
+        }
+    }
+    
+    type TupleType1 =[string, number, boolean];
+    class C2 {
+        constructor(public [x, y, z]: TupleType1) {
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1187: A parameter property may not be declared using a binding pattern.
+        }
+    }
+    
+    type ObjType1 = { x: number; y: string; z: boolean }
+    class C3 {
+        constructor(public { x, y, z }: ObjType1) {
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1187: A parameter property may not be declared using a binding pattern.
+        }
+    }

--- a/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.js
+++ b/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.js
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/declarationEmitDestructuringParameterProperties2.ts] ////
+
+//// [declarationEmitDestructuringParameterProperties2.ts]
+class C1 {
+    constructor(public [x, y, z]: string[]) {
+    }
+}
+
+type TupleType1 =[string, number, boolean];
+class C2 {
+    constructor(public [x, y, z]: TupleType1) {
+    }
+}
+
+type ObjType1 = { x: number; y: string; z: boolean }
+class C3 {
+    constructor(public { x, y, z }: ObjType1) {
+    }
+}
+
+//// [declarationEmitDestructuringParameterProperties2.js]
+class C1 {
+    constructor([x, y, z]) {
+    }
+}
+class C2 {
+    constructor([x, y, z]) {
+    }
+}
+class C3 {
+    constructor({ x, y, z }) {
+    }
+}
+
+
+//// [declarationEmitDestructuringParameterProperties2.d.ts]
+declare class C1 {
+    x: string;
+    y: string;
+    z: string;
+    constructor([x, y, z]: string[]);
+}
+type TupleType1 = [string, number, boolean];
+declare class C2 {
+    x: string;
+    y: number;
+    z: boolean;
+    constructor([x, y, z]: TupleType1);
+}
+type ObjType1 = {
+    x: number;
+    y: string;
+    z: boolean;
+};
+declare class C3 {
+    x: number;
+    y: string;
+    z: boolean;
+    constructor({ x, y, z }: ObjType1);
+}

--- a/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.symbols
+++ b/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.symbols
@@ -1,0 +1,43 @@
+//// [tests/cases/compiler/declarationEmitDestructuringParameterProperties2.ts] ////
+
+=== declarationEmitDestructuringParameterProperties2.ts ===
+class C1 {
+>C1 : Symbol(C1, Decl(declarationEmitDestructuringParameterProperties2.ts, 0, 0))
+
+    constructor(public [x, y, z]: string[]) {
+>x : Symbol(x, Decl(declarationEmitDestructuringParameterProperties2.ts, 1, 24))
+>y : Symbol(y, Decl(declarationEmitDestructuringParameterProperties2.ts, 1, 26))
+>z : Symbol(z, Decl(declarationEmitDestructuringParameterProperties2.ts, 1, 29))
+    }
+}
+
+type TupleType1 =[string, number, boolean];
+>TupleType1 : Symbol(TupleType1, Decl(declarationEmitDestructuringParameterProperties2.ts, 3, 1))
+
+class C2 {
+>C2 : Symbol(C2, Decl(declarationEmitDestructuringParameterProperties2.ts, 5, 43))
+
+    constructor(public [x, y, z]: TupleType1) {
+>x : Symbol(x, Decl(declarationEmitDestructuringParameterProperties2.ts, 7, 24))
+>y : Symbol(y, Decl(declarationEmitDestructuringParameterProperties2.ts, 7, 26))
+>z : Symbol(z, Decl(declarationEmitDestructuringParameterProperties2.ts, 7, 29))
+>TupleType1 : Symbol(TupleType1, Decl(declarationEmitDestructuringParameterProperties2.ts, 3, 1))
+    }
+}
+
+type ObjType1 = { x: number; y: string; z: boolean }
+>ObjType1 : Symbol(ObjType1, Decl(declarationEmitDestructuringParameterProperties2.ts, 9, 1))
+>x : Symbol(x, Decl(declarationEmitDestructuringParameterProperties2.ts, 11, 17))
+>y : Symbol(y, Decl(declarationEmitDestructuringParameterProperties2.ts, 11, 28))
+>z : Symbol(z, Decl(declarationEmitDestructuringParameterProperties2.ts, 11, 39))
+
+class C3 {
+>C3 : Symbol(C3, Decl(declarationEmitDestructuringParameterProperties2.ts, 11, 52))
+
+    constructor(public { x, y, z }: ObjType1) {
+>x : Symbol(x, Decl(declarationEmitDestructuringParameterProperties2.ts, 13, 24))
+>y : Symbol(y, Decl(declarationEmitDestructuringParameterProperties2.ts, 13, 27))
+>z : Symbol(z, Decl(declarationEmitDestructuringParameterProperties2.ts, 13, 30))
+>ObjType1 : Symbol(ObjType1, Decl(declarationEmitDestructuringParameterProperties2.ts, 9, 1))
+    }
+}

--- a/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.types
+++ b/tests/baselines/reference/declarationEmitDestructuringParameterProperties2.types
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/declarationEmitDestructuringParameterProperties2.ts] ////
+
+=== declarationEmitDestructuringParameterProperties2.ts ===
+class C1 {
+>C1 : C1
+>   : ^^
+
+    constructor(public [x, y, z]: string[]) {
+>x : string
+>  : ^^^^^^
+>y : string
+>  : ^^^^^^
+>z : string
+>  : ^^^^^^
+    }
+}
+
+type TupleType1 =[string, number, boolean];
+>TupleType1 : TupleType1
+>           : ^^^^^^^^^^
+
+class C2 {
+>C2 : C2
+>   : ^^
+
+    constructor(public [x, y, z]: TupleType1) {
+>x : string
+>  : ^^^^^^
+>y : number
+>  : ^^^^^^
+>z : boolean
+>  : ^^^^^^^
+    }
+}
+
+type ObjType1 = { x: number; y: string; z: boolean }
+>ObjType1 : ObjType1
+>         : ^^^^^^^^
+>x : number
+>  : ^^^^^^
+>y : string
+>  : ^^^^^^
+>z : boolean
+>  : ^^^^^^^
+
+class C3 {
+>C3 : C3
+>   : ^^
+
+    constructor(public { x, y, z }: ObjType1) {
+>x : number
+>  : ^^^^^^
+>y : string
+>  : ^^^^^^
+>z : boolean
+>  : ^^^^^^^
+    }
+}

--- a/tests/cases/compiler/declarationEmitDestructuringParameterProperties2.ts
+++ b/tests/cases/compiler/declarationEmitDestructuringParameterProperties2.ts
@@ -1,0 +1,19 @@
+﻿// @module: commonjs
+// @declaration: true
+// @target: es2024
+class C1 {
+    constructor(public [x, y, z]: string[]) {
+    }
+}
+
+type TupleType1 =[string, number, boolean];
+class C2 {
+    constructor(public [x, y, z]: TupleType1) {
+    }
+}
+
+type ObjType1 = { x: number; y: string; z: boolean }
+class C3 {
+    constructor(public { x, y, z }: ObjType1) {
+    }
+}


### PR DESCRIPTION
Found this while working on moving the target up to ES2024. This is illegal code, but we need to not attempt to transform it otherwise it'll break later.