### PR TITLE
Fix incorrectly reported 2689 error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3445,8 +3445,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.PropertyAccessExpression:
                 return node.parent ? getEntityNameForExtendingInterface(node.parent) : undefined;
             case SyntaxKind.ExpressionWithTypeArguments:
-                if (isEntityNameExpression((node as ExpressionWithTypeArguments).expression)) {
-                    return (node as ExpressionWithTypeArguments).expression as EntityNameExpression;
+                if (isExpressionWithTypeArgumentsInClassExtendsClause(node) && isEntityNameExpression(node.expression)) {
+                    return node.expression;
                 }
                 // falls through
             default:

--- a/tests/baselines/reference/typeUsedAsValueError3.errors.txt
+++ b/tests/baselines/reference/typeUsedAsValueError3.errors.txt
@@ -1,0 +1,13 @@
+typeUsedAsValueError3.ts(6,14): error TS2693: 'foo' only refers to a type, but is being used as a value here.
+
+
+==== typeUsedAsValueError3.ts (1 errors) ====
+    class baz<B> {}
+    interface foo<A> {
+      new (): typeof baz
+    }
+    
+    const bar = (foo<string>)<number>
+                 ~~~
+!!! error TS2693: 'foo' only refers to a type, but is being used as a value here.
+    

--- a/tests/baselines/reference/typeUsedAsValueError3.symbols
+++ b/tests/baselines/reference/typeUsedAsValueError3.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/typeUsedAsValueError3.ts] ////
+
+=== typeUsedAsValueError3.ts ===
+class baz<B> {}
+>baz : Symbol(baz, Decl(typeUsedAsValueError3.ts, 0, 0))
+>B : Symbol(B, Decl(typeUsedAsValueError3.ts, 0, 10))
+
+interface foo<A> {
+>foo : Symbol(foo, Decl(typeUsedAsValueError3.ts, 0, 15))
+>A : Symbol(A, Decl(typeUsedAsValueError3.ts, 1, 14))
+
+  new (): typeof baz
+>baz : Symbol(baz, Decl(typeUsedAsValueError3.ts, 0, 0))
+}
+
+const bar = (foo<string>)<number>
+>bar : Symbol(bar, Decl(typeUsedAsValueError3.ts, 5, 5))
+

--- a/tests/baselines/reference/typeUsedAsValueError3.types
+++ b/tests/baselines/reference/typeUsedAsValueError3.types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/typeUsedAsValueError3.ts] ////
+
+=== typeUsedAsValueError3.ts ===
+class baz<B> {}
+>baz : baz<B>
+>    : ^^^^^^
+
+interface foo<A> {
+  new (): typeof baz
+>baz : typeof baz
+>    : ^^^^^^^^^^
+}
+
+const bar = (foo<string>)<number>
+>bar : any
+>    : ^^^
+>(foo<string>)<number> : any
+>                      : ^^^
+>(foo<string>) : any
+>              : ^^^
+>foo<string> : any
+>            : ^^^
+>foo : any
+>    : ^^^
+

--- a/tests/cases/compiler/typeUsedAsValueError3.ts
+++ b/tests/cases/compiler/typeUsedAsValueError3.ts
@@ -1,0 +1,9 @@
+// @strict: true
+// @noEmit: true
+
+class baz<B> {}
+interface foo<A> {
+  new (): typeof baz
+}
+
+const bar = (foo<string>)<number>


### PR DESCRIPTION
spotted by @LukeAbby

current confusing error:
```ts
    class baz<B> {}
    interface foo<A> {
      new (): typeof baz
    }

    const bar = (foo<string>)<number>
                 ~~~
!!! error TS2689: Cannot extend an interface 'foo'. Did you mean 'implements'?
```