### PR TITLE
Remove ES5 references, misc cleanup

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6774,7 +6774,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return parentName;
                     }
                     const memberName = symbolName(type.symbol);
-                    if (isIdentifierText(memberName, ScriptTarget.ES5)) {
+                    if (isIdentifierText(memberName, ScriptTarget.ESNext)) {
                         return appendReferenceToType(
                             parentName as TypeReferenceNode | ImportTypeNode,
                             factory.createTypeReferenceNode(memberName, /*typeArguments*/ undefined),

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46772,7 +46772,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function checkClassNameCollisionWithObject(name: Identifier): void {
         if (
-            languageVersion >= ScriptTarget.ES5 && name.escapedText === "Object"
+            name.escapedText === "Object"
             && host.getEmitModuleFormatOfFile(getSourceFileOfNode(name)) < ModuleKind.ES2015
         ) {
             error(name, Diagnostics.Class_name_cannot_be_Object_when_targeting_ES5_and_above_with_module_0, ModuleKind[moduleKind]); // https://github.com/Microsoft/TypeScript/issues/17494

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2625,7 +2625,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         }
 
         const preferNewLine = node.multiLine ? ListFormat.PreferNewLine : ListFormat.None;
-        const allowTrailingComma = currentSourceFile && currentSourceFile.languageVersion >= ScriptTarget.ES5 && !isJsonSourceFile(currentSourceFile) ? ListFormat.AllowTrailingComma : ListFormat.None;
+        const allowTrailingComma = currentSourceFile && !isJsonSourceFile(currentSourceFile) ? ListFormat.AllowTrailingComma : ListFormat.None;
         emitList(node, node.properties, ListFormat.ObjectLiteralExpressionProperties | allowTrailingComma | preferNewLine);
 
         if (indentedFlag) {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -879,7 +879,7 @@ export function transformTypeScript(context: TransformationContext): Transformer
 
     function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
         const facts = getClassFacts(node);
-        const promoteToIIFE = languageVersion <= ScriptTarget.ES5 &&
+        const promoteToIIFE = languageVersion < ScriptTarget.ES2015 &&
             !!(facts & ClassFacts.MayNeedImmediatelyInvokedFunctionExpression);
 
         if (

--- a/tests/baselines/reference/enumMemberNameNonIdentifier.js
+++ b/tests/baselines/reference/enumMemberNameNonIdentifier.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/enumMemberNameNonIdentifier.ts] ////
+
+//// [enumMemberNameNonIdentifier.ts]
+export const enum E {
+    regular = 0,
+    "hyphen-member" = 1,
+    "123startsWithNumber" = 2,
+    "has space" = 3,
+    // Greek Capital Yot (U+037F) - valid identifier in ES2015+ but NOT in ES5
+    Ϳ = 4,
+}
+
+export const a = E["hyphen-member"];
+export const b = E["123startsWithNumber"];
+export const c = E["has space"];
+export const d = E.regular;
+export const e = E.Ϳ;
+
+
+//// [enumMemberNameNonIdentifier.js]
+export const a = 1 /* E["hyphen-member"] */;
+export const b = 2 /* E["123startsWithNumber"] */;
+export const c = 3 /* E["has space"] */;
+export const d = 0 /* E.regular */;
+export const e = 4 /* E.Ϳ */;
+
+
+//// [enumMemberNameNonIdentifier.d.ts]
+export declare const enum E {
+    regular = 0,
+    "hyphen-member" = 1,
+    "123startsWithNumber" = 2,
+    "has space" = 3,
+    Ϳ = 4
+}
+export declare const a = E["hyphen-member"];
+export declare const b = E["123startsWithNumber"];
+export declare const c = E["has space"];
+export declare const d = E.regular;
+export declare const e = E.Ϳ;

--- a/tests/baselines/reference/enumMemberNameNonIdentifier.symbols
+++ b/tests/baselines/reference/enumMemberNameNonIdentifier.symbols
@@ -1,0 +1,50 @@
+//// [tests/cases/compiler/enumMemberNameNonIdentifier.ts] ////
+
+=== enumMemberNameNonIdentifier.ts ===
+export const enum E {
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+
+    regular = 0,
+>regular : Symbol(E.regular, Decl(enumMemberNameNonIdentifier.ts, 0, 21))
+
+    "hyphen-member" = 1,
+>"hyphen-member" : Symbol(E["hyphen-member"], Decl(enumMemberNameNonIdentifier.ts, 1, 16))
+
+    "123startsWithNumber" = 2,
+>"123startsWithNumber" : Symbol(E["123startsWithNumber"], Decl(enumMemberNameNonIdentifier.ts, 2, 24))
+
+    "has space" = 3,
+>"has space" : Symbol(E["has space"], Decl(enumMemberNameNonIdentifier.ts, 3, 30))
+
+    // Greek Capital Yot (U+037F) - valid identifier in ES2015+ but NOT in ES5
+    Ϳ = 4,
+>Ϳ : Symbol(E.Ϳ, Decl(enumMemberNameNonIdentifier.ts, 4, 20))
+}
+
+export const a = E["hyphen-member"];
+>a : Symbol(a, Decl(enumMemberNameNonIdentifier.ts, 9, 12))
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+>"hyphen-member" : Symbol(E["hyphen-member"], Decl(enumMemberNameNonIdentifier.ts, 1, 16))
+
+export const b = E["123startsWithNumber"];
+>b : Symbol(b, Decl(enumMemberNameNonIdentifier.ts, 10, 12))
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+>"123startsWithNumber" : Symbol(E["123startsWithNumber"], Decl(enumMemberNameNonIdentifier.ts, 2, 24))
+
+export const c = E["has space"];
+>c : Symbol(c, Decl(enumMemberNameNonIdentifier.ts, 11, 12))
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+>"has space" : Symbol(E["has space"], Decl(enumMemberNameNonIdentifier.ts, 3, 30))
+
+export const d = E.regular;
+>d : Symbol(d, Decl(enumMemberNameNonIdentifier.ts, 12, 12))
+>E.regular : Symbol(E.regular, Decl(enumMemberNameNonIdentifier.ts, 0, 21))
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+>regular : Symbol(E.regular, Decl(enumMemberNameNonIdentifier.ts, 0, 21))
+
+export const e = E.Ϳ;
+>e : Symbol(e, Decl(enumMemberNameNonIdentifier.ts, 13, 12))
+>E.Ϳ : Symbol(E.Ϳ, Decl(enumMemberNameNonIdentifier.ts, 4, 20))
+>E : Symbol(E, Decl(enumMemberNameNonIdentifier.ts, 0, 0))
+>Ϳ : Symbol(E.Ϳ, Decl(enumMemberNameNonIdentifier.ts, 4, 20))
+

--- a/tests/baselines/reference/enumMemberNameNonIdentifier.types
+++ b/tests/baselines/reference/enumMemberNameNonIdentifier.types
@@ -31,8 +31,8 @@ export const enum E {
 
     // Greek Capital Yot (U+037F) - valid identifier in ES2015+ but NOT in ES5
     Ϳ = 4,
->Ϳ : (typeof E)["\u037F"]
->  : ^^^^^^^^^^^^^^^^^^^^
+>Ϳ : E.Ϳ
+>  : ^^^
 >4 : 4
 >  : ^
 }
@@ -78,12 +78,12 @@ export const d = E.regular;
 >        : ^^^^^^^^^
 
 export const e = E.Ϳ;
->e : (typeof E)["\u037F"]
->  : ^^^^^^^^^^^^^^^^^^^^
->E.Ϳ : (typeof E)["\u037F"]
->    : ^^^^^^^^^^^^^^^^^^^^
+>e : E.Ϳ
+>  : ^^^
+>E.Ϳ : E.Ϳ
+>    : ^^^
 >E : typeof E
 >  : ^^^^^^^^
->Ϳ : (typeof E)["\u037F"]
->  : ^^^^^^^^^^^^^^^^^^^^
+>Ϳ : E.Ϳ
+>  : ^^^
 

--- a/tests/baselines/reference/enumMemberNameNonIdentifier.types
+++ b/tests/baselines/reference/enumMemberNameNonIdentifier.types
@@ -1,0 +1,89 @@
+//// [tests/cases/compiler/enumMemberNameNonIdentifier.ts] ////
+
+=== enumMemberNameNonIdentifier.ts ===
+export const enum E {
+>E : E
+>  : ^
+
+    regular = 0,
+>regular : E.regular
+>        : ^^^^^^^^^
+>0 : 0
+>  : ^
+
+    "hyphen-member" = 1,
+>"hyphen-member" : (typeof E)["hyphen-member"]
+>                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>1 : 1
+>  : ^
+
+    "123startsWithNumber" = 2,
+>"123startsWithNumber" : (typeof E)["123startsWithNumber"]
+>                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>2 : 2
+>  : ^
+
+    "has space" = 3,
+>"has space" : (typeof E)["has space"]
+>            : ^^^^^^^^^^^^^^^^^^^^^^^
+>3 : 3
+>  : ^
+
+    // Greek Capital Yot (U+037F) - valid identifier in ES2015+ but NOT in ES5
+    Ϳ = 4,
+>Ϳ : (typeof E)["\u037F"]
+>  : ^^^^^^^^^^^^^^^^^^^^
+>4 : 4
+>  : ^
+}
+
+export const a = E["hyphen-member"];
+>a : (typeof E)["hyphen-member"]
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>E["hyphen-member"] : (typeof E)["hyphen-member"]
+>                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"hyphen-member" : "hyphen-member"
+>                : ^^^^^^^^^^^^^^^
+
+export const b = E["123startsWithNumber"];
+>b : (typeof E)["123startsWithNumber"]
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>E["123startsWithNumber"] : (typeof E)["123startsWithNumber"]
+>                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"123startsWithNumber" : "123startsWithNumber"
+>                      : ^^^^^^^^^^^^^^^^^^^^^
+
+export const c = E["has space"];
+>c : (typeof E)["has space"]
+>  : ^^^^^^^^^^^^^^^^^^^^^^^
+>E["has space"] : (typeof E)["has space"]
+>               : ^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"has space" : "has space"
+>            : ^^^^^^^^^^^
+
+export const d = E.regular;
+>d : E.regular
+>  : ^^^^^^^^^
+>E.regular : E.regular
+>          : ^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>regular : E.regular
+>        : ^^^^^^^^^
+
+export const e = E.Ϳ;
+>e : (typeof E)["\u037F"]
+>  : ^^^^^^^^^^^^^^^^^^^^
+>E.Ϳ : (typeof E)["\u037F"]
+>    : ^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>Ϳ : (typeof E)["\u037F"]
+>  : ^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/cases/compiler/enumMemberNameNonIdentifier.ts
+++ b/tests/cases/compiler/enumMemberNameNonIdentifier.ts
@@ -1,0 +1,16 @@
+// @declaration: true
+
+export const enum E {
+    regular = 0,
+    "hyphen-member" = 1,
+    "123startsWithNumber" = 2,
+    "has space" = 3,
+    // Greek Capital Yot (U+037F) - valid identifier in ES2015+ but NOT in ES5
+    Ϳ = 4,
+}
+
+export const a = E["hyphen-member"];
+export const b = E["123startsWithNumber"];
+export const c = E["has space"];
+export const d = E.regular;
+export const e = E.Ϳ;


### PR DESCRIPTION
Some cleanup after #63067.

This removes all remaining non-test references to `ScriptTarget.ES5`. Most are just dead code or can be rephrased.

The one behavior difference is in the third commit. For enums, we were being conservative and printing identifiers that are only valid in ES2015+ as string literals. However, this does not practically matter because declaration emit just reuses the nodes, so everyone has been emitting these characters anyway. That and, we always parse declaration files with the latest options such that they're always cached (fairly certain; definitely true in Corsa), so it doesn't matter there. All that changes is the `types` baseline, which also implies that hover would change, which it does.

Strada before:

<img width="279" height="70" alt="image" src="https://github.com/user-attachments/assets/5bf237ce-55f0-4ca4-ac94-53e30d22e564" />

Corsa today (what this PR would do):

<img width="161" height="70" alt="image" src="https://github.com/user-attachments/assets/3cc6e9b7-82ea-4028-b8b5-5379571ca8ce" />

And of course, Corsa does not even have the code to do it the old way, lacking ES5 stuff or the plumbing to even pass that down.