### PR TITLE
Update implied default for module based on target

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -9000,9 +9000,23 @@ const _computedOptions = createComputedCompilerOptions({
     module: {
         dependencies: ["target"],
         computeValue: (compilerOptions): ModuleKind => {
-            return typeof compilerOptions.module === "number" ?
-                compilerOptions.module :
-                _computedOptions.target.computeValue(compilerOptions) >= ScriptTarget.ES2015 ? ModuleKind.ES2015 : ModuleKind.CommonJS;
+            if (typeof compilerOptions.module === "number") {
+                return compilerOptions.module;
+            }
+            const target = _computedOptions.target.computeValue(compilerOptions);
+            if (target === ScriptTarget.ESNext) {
+                return ModuleKind.ESNext;
+            }
+            if (target >= ScriptTarget.ES2022) {
+                return ModuleKind.ES2022;
+            }
+            if (target >= ScriptTarget.ES2020) {
+                return ModuleKind.ES2020;
+            }
+            if (target >= ScriptTarget.ES2015) {
+                return ModuleKind.ES2015;
+            }
+            return ModuleKind.CommonJS;
         },
     },
     moduleResolution: {

--- a/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
@@ -12,11 +12,9 @@ awaitInNonAsyncFunction.ts(30,9): error TS1103: 'for await' loops are only allow
 awaitInNonAsyncFunction.ts(31,5): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
 awaitInNonAsyncFunction.ts(34,7): error TS1103: 'for await' loops are only allowed within async functions and at the top levels of modules.
 awaitInNonAsyncFunction.ts(35,5): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
-awaitInNonAsyncFunction.ts(39,5): error TS1432: Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
-awaitInNonAsyncFunction.ts(40,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 
 
-==== awaitInNonAsyncFunction.ts (16 errors) ====
+==== awaitInNonAsyncFunction.ts (14 errors) ====
     // https://github.com/Microsoft/TypeScript/issues/26586
     
     function normalFunc(p: Promise<number>) {
@@ -96,8 +94,4 @@ awaitInNonAsyncFunction.ts(40,1): error TS1378: Top-level 'await' expressions ar
     }
     
     for await (const _ of []);
-        ~~~~~
-!!! error TS1432: Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     await null;
-    ~~~~~
-!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.


### PR DESCRIPTION
If `module` is explicitly configured, we do what the config says (duh).

Otherwise, if target is ES5, then `module=commonjs`. If `target` is ES2015+, then `module=es2015`.

This PR changes the default module such that:

- If `target=esnext`, then `module=esnext`.
- If `target>=es2022`, then `module=es2022`.
- If `target>=es2020`, then `module=es2020`.
- If `target>=es2015`, then `module=es2015`.
- Otherwise, `module=commonjs`.

This leads to potentially less strange/misaligned behavior.

Only one test changes. I could find which features each module mode enables to verify these rules, if desired.