### PR TITLE
Deprecate import assert in favor of import with

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -48552,6 +48552,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return grammarErrorOnFirstToken(node, Diagnostics.Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert);
             }
 
+            if (!isImportAttributes && compilerOptions.ignoreDeprecations !== "6.0") {
+                grammarErrorOnFirstToken(node, Diagnostics.Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert);
+            }
+
             if (declaration.moduleSpecifier && getEmitSyntaxForModuleSpecifierExpression(declaration.moduleSpecifier) === ModuleKind.CommonJS) {
                 return grammarErrorOnNode(
                     node,

--- a/tests/baselines/reference/getOccurrencesNonStringImportAssertion.baseline.jsonc
+++ b/tests/baselines/reference/getOccurrencesNonStringImportAssertion.baseline.jsonc
@@ -1,4 +1,4 @@
 // === documentHighlights ===
 // === /tests/cases/fourslash/getOccurrencesNonStringImportAssertion.ts ===
-// import * as react from "react" assert { cache: /*HIGHLIGHTS*/0 };
+// import * as react from "react" with { cache: /*HIGHLIGHTS*/0 };
 // react.Children;

--- a/tests/baselines/reference/importAssertion1(module=commonjs).errors.txt
+++ b/tests/baselines/reference/importAssertion1(module=commonjs).errors.txt
@@ -1,8 +1,8 @@
-1.ts(1,14): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(2,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(3,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(1,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(2,38): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(1,14): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(2,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(3,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(1,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(2,38): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 3.ts(2,25): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
 3.ts(3,25): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
 3.ts(4,25): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
@@ -11,7 +11,7 @@
 3.ts(8,11): message TS1450: Dynamic imports can only accept a module specifier and an optional set of attributes as arguments
 3.ts(9,25): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
 3.ts(10,25): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
-3.ts(10,52): error TS1009: Trailing comma not allowed.
+3.ts(10,50): error TS1009: Trailing comma not allowed.
 
 
 ==== 0.ts (0 errors) ====
@@ -19,27 +19,27 @@
     export const b = 2;
     
 ==== 1.ts (3 errors) ====
-    import './0' assert { type: "json" }
-                 ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import { a, b } from './0' assert { "type": "json" }
-                               ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import * as foo from './0' assert { type: "json" }
+    import './0' with { type: "json" }
+                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a, b } from './0' with { "type": "json" }
                                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import * as foo from './0' with { type: "json" }
+                               ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     a;
     b;
     foo.a;
     foo.b;
     
 ==== 2.ts (2 errors) ====
-    import { a, b } from './0' assert {}
-                               ~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a, b } from './0' with {}
+                               ~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     a;
     b;
     c;
@@ -47,14 +47,14 @@
     
 ==== 3.ts (9 errors) ====
     const a = import('./0')
-    const b = import('./0', { assert: { type: "json" } })
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const b = import('./0', { with: { type: "json" } })
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
-    const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const c = import('./0', { with: { type: "json", ttype: "typo" } })
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
-    const d = import('./0', { assert: {} })
-                            ~~~~~~~~~~~~~~
+    const d = import('./0', { with: {} })
+                            ~~~~~~~~~~~~
 !!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
     const dd = import('./0', {})
                              ~~
@@ -69,10 +69,10 @@
     const g = import('./0', {}, {})
                             ~~
 !!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
-    const h = import('./0', { assert: { type: "json" }},)
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const h = import('./0', { with: { type: "json" }},)
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
-                                                       ~
+                                                     ~
 !!! error TS1009: Trailing comma not allowed.
     
     

--- a/tests/baselines/reference/importAssertion1(module=commonjs).js
+++ b/tests/baselines/reference/importAssertion1(module=commonjs).js
@@ -5,17 +5,17 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
-import * as foo from './0' assert { type: "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
+import * as foo from './0' with { type: "json" }
 a;
 b;
 foo.a;
 foo.b;
 
 //// [2.ts]
-import { a, b } from './0' assert {}
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a, b } from './0' with {}
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 a;
 b;
 c;
@@ -23,15 +23,15 @@ d;
 
 //// [3.ts]
 const a = import('./0')
-const b = import('./0', { assert: { type: "json" } })
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-const d = import('./0', { assert: {} })
+const b = import('./0', { with: { type: "json" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
+const d = import('./0', { with: {} })
 const dd = import('./0', {})
 declare function foo(): any;
 const e = import('./0', foo())
 const f = import()
 const g = import('./0', {}, {})
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 
 
 

--- a/tests/baselines/reference/importAssertion1(module=commonjs).symbols
+++ b/tests/baselines/reference/importAssertion1(module=commonjs).symbols
@@ -8,12 +8,12 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : Symbol(foo, Decl(1.ts, 2, 6))
 
 a;
@@ -33,11 +33,11 @@ foo.b;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))
@@ -60,23 +60,23 @@ const a = import('./0')
 >a : Symbol(a, Decl(3.ts, 0, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Symbol(b, Decl(3.ts, 1, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 1, 25))
->type : Symbol(type, Decl(3.ts, 1, 35))
+>with : Symbol(with, Decl(3.ts, 1, 25))
+>type : Symbol(type, Decl(3.ts, 1, 33))
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Symbol(c, Decl(3.ts, 2, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 2, 25))
->type : Symbol(type, Decl(3.ts, 2, 35))
->ttype : Symbol(ttype, Decl(3.ts, 2, 49))
+>with : Symbol(with, Decl(3.ts, 2, 25))
+>type : Symbol(type, Decl(3.ts, 2, 33))
+>ttype : Symbol(ttype, Decl(3.ts, 2, 47))
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Symbol(d, Decl(3.ts, 3, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 3, 25))
+>with : Symbol(with, Decl(3.ts, 3, 25))
 
 const dd = import('./0', {})
 >dd : Symbol(dd, Decl(3.ts, 4, 5))
@@ -97,10 +97,10 @@ const g = import('./0', {}, {})
 >g : Symbol(g, Decl(3.ts, 8, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Symbol(h, Decl(3.ts, 9, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 9, 25))
->type : Symbol(type, Decl(3.ts, 9, 35))
+>with : Symbol(with, Decl(3.ts, 9, 25))
+>type : Symbol(type, Decl(3.ts, 9, 33))
 
 

--- a/tests/baselines/reference/importAssertion1(module=commonjs).types
+++ b/tests/baselines/reference/importAssertion1(module=commonjs).types
@@ -14,17 +14,17 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-import './0' assert { type: "json" }
+import './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-import { a, b } from './0' assert { "type": "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >type : any
@@ -55,13 +55,13 @@ foo.b;
 >  : ^
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1
@@ -102,17 +102,17 @@ const a = import('./0')
 >'./0' : "./0"
 >      : ^^^^^
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" } }) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" } }) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string
@@ -120,17 +120,17 @@ const b = import('./0', { assert: { type: "json" } })
 >"json" : "json"
 >       : ^^^^^^
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
->                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
+>                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json", ttype: "typo" } } : { assert: { type: string; ttype: string; }; }
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; ttype: string; }
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ with: { type: "json", ttype: "typo" } } : { with: { type: string; ttype: string; }; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; ttype: string; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ type: "json", ttype: "typo" } : { type: string; ttype: string; }
 >                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : string
@@ -142,17 +142,17 @@ const c = import('./0', { assert: { type: "json", ttype: "typo" } })
 >"typo" : "typo"
 >       : ^^^^^^
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: {} }) : Promise<typeof import("0")>
->                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: {} }) : Promise<typeof import("0")>
+>                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: {} } : { assert: {}; }
->               : ^^^^^^^^^^^^^^^
->assert : {}
->       : ^^
+>{ with: {} } : { with: {}; }
+>             : ^^^^^^^^^^^^^
+>with : {}
+>     : ^^
 >{} : {}
 >   : ^^
 
@@ -200,17 +200,17 @@ const g = import('./0', {}, {})
 >{} : {}
 >   : ^^
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" }},) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" }},) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" }} : { assert: { type: string; }; }
->                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" }} : { with: { type: string; }; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/importAssertion1(module=es2015).errors.txt
+++ b/tests/baselines/reference/importAssertion1(module=es2015).errors.txt
@@ -1,8 +1,8 @@
-1.ts(1,14): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(2,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(3,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(1,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(2,38): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(1,14): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(2,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(3,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(1,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(2,38): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 3.ts(1,11): error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
 3.ts(2,11): error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
 3.ts(3,11): error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
@@ -19,27 +19,27 @@
     export const b = 2;
     
 ==== 1.ts (3 errors) ====
-    import './0' assert { type: "json" }
-                 ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import { a, b } from './0' assert { "type": "json" }
-                               ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import * as foo from './0' assert { type: "json" }
+    import './0' with { type: "json" }
+                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a, b } from './0' with { "type": "json" }
                                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import * as foo from './0' with { type: "json" }
+                               ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     a;
     b;
     foo.a;
     foo.b;
     
 ==== 2.ts (2 errors) ====
-    import { a, b } from './0' assert {}
-                               ~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a, b } from './0' with {}
+                               ~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     a;
     b;
     c;
@@ -49,14 +49,14 @@
     const a = import('./0')
               ~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
-    const b = import('./0', { assert: { type: "json" } })
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const b = import('./0', { with: { type: "json" } })
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
-    const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const c = import('./0', { with: { type: "json", ttype: "typo" } })
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
-    const d = import('./0', { assert: {} })
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const d = import('./0', { with: {} })
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
     const dd = import('./0', {})
                ~~~~~~~~~~~~~~~~~
@@ -71,8 +71,8 @@
     const g = import('./0', {}, {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
-    const h = import('./0', { assert: { type: "json" }},)
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    const h = import('./0', { with: { type: "json" }},)
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', 'node20', or 'nodenext'.
     
     

--- a/tests/baselines/reference/importAssertion1(module=es2015).js
+++ b/tests/baselines/reference/importAssertion1(module=es2015).js
@@ -5,17 +5,17 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
-import * as foo from './0' assert { type: "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
+import * as foo from './0' with { type: "json" }
 a;
 b;
 foo.a;
 foo.b;
 
 //// [2.ts]
-import { a, b } from './0' assert {}
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a, b } from './0' with {}
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 a;
 b;
 c;
@@ -23,15 +23,15 @@ d;
 
 //// [3.ts]
 const a = import('./0')
-const b = import('./0', { assert: { type: "json" } })
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-const d = import('./0', { assert: {} })
+const b = import('./0', { with: { type: "json" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
+const d = import('./0', { with: {} })
 const dd = import('./0', {})
 declare function foo(): any;
 const e = import('./0', foo())
 const f = import()
 const g = import('./0', {}, {})
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 
 
 
@@ -39,30 +39,30 @@ const h = import('./0', { assert: { type: "json" }},)
 export const a = 1;
 export const b = 2;
 //// [1.js]
-import './0' assert { type: "json" };
-import { a, b } from './0' assert { "type": "json" };
-import * as foo from './0' assert { type: "json" };
+import './0' with { type: "json" };
+import { a, b } from './0' with { "type": "json" };
+import * as foo from './0' with { type: "json" };
 a;
 b;
 foo.a;
 foo.b;
 //// [2.js]
-import { a, b } from './0' assert {};
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" };
+import { a, b } from './0' with {};
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" };
 a;
 b;
 c;
 d;
 //// [3.js]
 const a = import('./0');
-const b = import('./0', { assert: { type: "json" } });
-const c = import('./0', { assert: { type: "json", ttype: "typo" } });
-const d = import('./0', { assert: {} });
+const b = import('./0', { with: { type: "json" } });
+const c = import('./0', { with: { type: "json", ttype: "typo" } });
+const d = import('./0', { with: {} });
 const dd = import('./0', {});
 const e = import('./0', foo());
 const f = import();
 const g = import('./0', {}, {});
-const h = import('./0', { assert: { type: "json" } });
+const h = import('./0', { with: { type: "json" } });
 
 
 //// [0.d.ts]

--- a/tests/baselines/reference/importAssertion1(module=es2015).symbols
+++ b/tests/baselines/reference/importAssertion1(module=es2015).symbols
@@ -8,12 +8,12 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : Symbol(foo, Decl(1.ts, 2, 6))
 
 a;
@@ -33,11 +33,11 @@ foo.b;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))
@@ -60,23 +60,23 @@ const a = import('./0')
 >a : Symbol(a, Decl(3.ts, 0, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Symbol(b, Decl(3.ts, 1, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 1, 25))
->type : Symbol(type, Decl(3.ts, 1, 35))
+>with : Symbol(with, Decl(3.ts, 1, 25))
+>type : Symbol(type, Decl(3.ts, 1, 33))
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Symbol(c, Decl(3.ts, 2, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 2, 25))
->type : Symbol(type, Decl(3.ts, 2, 35))
->ttype : Symbol(ttype, Decl(3.ts, 2, 49))
+>with : Symbol(with, Decl(3.ts, 2, 25))
+>type : Symbol(type, Decl(3.ts, 2, 33))
+>ttype : Symbol(ttype, Decl(3.ts, 2, 47))
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Symbol(d, Decl(3.ts, 3, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 3, 25))
+>with : Symbol(with, Decl(3.ts, 3, 25))
 
 const dd = import('./0', {})
 >dd : Symbol(dd, Decl(3.ts, 4, 5))
@@ -97,10 +97,10 @@ const g = import('./0', {}, {})
 >g : Symbol(g, Decl(3.ts, 8, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Symbol(h, Decl(3.ts, 9, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 9, 25))
->type : Symbol(type, Decl(3.ts, 9, 35))
+>with : Symbol(with, Decl(3.ts, 9, 25))
+>type : Symbol(type, Decl(3.ts, 9, 33))
 
 

--- a/tests/baselines/reference/importAssertion1(module=es2015).types
+++ b/tests/baselines/reference/importAssertion1(module=es2015).types
@@ -14,17 +14,17 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-import './0' assert { type: "json" }
+import './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-import { a, b } from './0' assert { "type": "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >type : any
@@ -55,13 +55,13 @@ foo.b;
 >  : ^
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1
@@ -102,17 +102,17 @@ const a = import('./0')
 >'./0' : "./0"
 >      : ^^^^^
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" } }) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" } }) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string
@@ -120,17 +120,17 @@ const b = import('./0', { assert: { type: "json" } })
 >"json" : "json"
 >       : ^^^^^^
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
->                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
+>                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json", ttype: "typo" } } : { assert: { type: string; ttype: string; }; }
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; ttype: string; }
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ with: { type: "json", ttype: "typo" } } : { with: { type: string; ttype: string; }; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; ttype: string; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ type: "json", ttype: "typo" } : { type: string; ttype: string; }
 >                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : string
@@ -142,17 +142,17 @@ const c = import('./0', { assert: { type: "json", ttype: "typo" } })
 >"typo" : "typo"
 >       : ^^^^^^
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: {} }) : Promise<typeof import("0")>
->                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: {} }) : Promise<typeof import("0")>
+>                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: {} } : { assert: {}; }
->               : ^^^^^^^^^^^^^^^
->assert : {}
->       : ^^
+>{ with: {} } : { with: {}; }
+>             : ^^^^^^^^^^^^^
+>with : {}
+>     : ^^
 >{} : {}
 >   : ^^
 
@@ -200,17 +200,17 @@ const g = import('./0', {}, {})
 >{} : {}
 >   : ^^
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" }},) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" }},) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" }} : { assert: { type: string; }; }
->                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" }} : { with: { type: string; }; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/importAssertion1(module=esnext).errors.txt
+++ b/tests/baselines/reference/importAssertion1(module=esnext).errors.txt
@@ -7,17 +7,17 @@
     export const b = 2;
     
 ==== 1.ts (0 errors) ====
-    import './0' assert { type: "json" }
-    import { a, b } from './0' assert { "type": "json" }
-    import * as foo from './0' assert { type: "json" }
+    import './0' with { type: "json" }
+    import { a, b } from './0' with { "type": "json" }
+    import * as foo from './0' with { type: "json" }
     a;
     b;
     foo.a;
     foo.b;
     
 ==== 2.ts (0 errors) ====
-    import { a, b } from './0' assert {}
-    import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+    import { a, b } from './0' with {}
+    import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
     a;
     b;
     c;
@@ -25,9 +25,9 @@
     
 ==== 3.ts (2 errors) ====
     const a = import('./0')
-    const b = import('./0', { assert: { type: "json" } })
-    const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-    const d = import('./0', { assert: {} })
+    const b = import('./0', { with: { type: "json" } })
+    const c = import('./0', { with: { type: "json", ttype: "typo" } })
+    const d = import('./0', { with: {} })
     const dd = import('./0', {})
     declare function foo(): any;
     const e = import('./0', foo())
@@ -37,6 +37,6 @@
     const g = import('./0', {}, {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! message TS1450: Dynamic imports can only accept a module specifier and an optional set of attributes as arguments
-    const h = import('./0', { assert: { type: "json" }},)
+    const h = import('./0', { with: { type: "json" }},)
     
     

--- a/tests/baselines/reference/importAssertion1(module=esnext).js
+++ b/tests/baselines/reference/importAssertion1(module=esnext).js
@@ -5,17 +5,17 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
-import * as foo from './0' assert { type: "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
+import * as foo from './0' with { type: "json" }
 a;
 b;
 foo.a;
 foo.b;
 
 //// [2.ts]
-import { a, b } from './0' assert {}
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a, b } from './0' with {}
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 a;
 b;
 c;
@@ -23,15 +23,15 @@ d;
 
 //// [3.ts]
 const a = import('./0')
-const b = import('./0', { assert: { type: "json" } })
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-const d = import('./0', { assert: {} })
+const b = import('./0', { with: { type: "json" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
+const d = import('./0', { with: {} })
 const dd = import('./0', {})
 declare function foo(): any;
 const e = import('./0', foo())
 const f = import()
 const g = import('./0', {}, {})
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 
 
 
@@ -39,30 +39,30 @@ const h = import('./0', { assert: { type: "json" }},)
 export const a = 1;
 export const b = 2;
 //// [1.js]
-import './0' assert { type: "json" };
-import { a, b } from './0' assert { "type": "json" };
-import * as foo from './0' assert { type: "json" };
+import './0' with { type: "json" };
+import { a, b } from './0' with { "type": "json" };
+import * as foo from './0' with { type: "json" };
 a;
 b;
 foo.a;
 foo.b;
 //// [2.js]
-import { a, b } from './0' assert {};
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" };
+import { a, b } from './0' with {};
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" };
 a;
 b;
 c;
 d;
 //// [3.js]
 const a = import('./0');
-const b = import('./0', { assert: { type: "json" } });
-const c = import('./0', { assert: { type: "json", ttype: "typo" } });
-const d = import('./0', { assert: {} });
+const b = import('./0', { with: { type: "json" } });
+const c = import('./0', { with: { type: "json", ttype: "typo" } });
+const d = import('./0', { with: {} });
 const dd = import('./0', {});
 const e = import('./0', foo());
 const f = import();
 const g = import('./0', {}, {});
-const h = import('./0', { assert: { type: "json" } });
+const h = import('./0', { with: { type: "json" } });
 
 
 //// [0.d.ts]

--- a/tests/baselines/reference/importAssertion1(module=esnext).symbols
+++ b/tests/baselines/reference/importAssertion1(module=esnext).symbols
@@ -8,12 +8,12 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : Symbol(foo, Decl(1.ts, 2, 6))
 
 a;
@@ -33,11 +33,11 @@ foo.b;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))
@@ -60,23 +60,23 @@ const a = import('./0')
 >a : Symbol(a, Decl(3.ts, 0, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Symbol(b, Decl(3.ts, 1, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 1, 25))
->type : Symbol(type, Decl(3.ts, 1, 35))
+>with : Symbol(with, Decl(3.ts, 1, 25))
+>type : Symbol(type, Decl(3.ts, 1, 33))
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Symbol(c, Decl(3.ts, 2, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 2, 25))
->type : Symbol(type, Decl(3.ts, 2, 35))
->ttype : Symbol(ttype, Decl(3.ts, 2, 49))
+>with : Symbol(with, Decl(3.ts, 2, 25))
+>type : Symbol(type, Decl(3.ts, 2, 33))
+>ttype : Symbol(ttype, Decl(3.ts, 2, 47))
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Symbol(d, Decl(3.ts, 3, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 3, 25))
+>with : Symbol(with, Decl(3.ts, 3, 25))
 
 const dd = import('./0', {})
 >dd : Symbol(dd, Decl(3.ts, 4, 5))
@@ -97,10 +97,10 @@ const g = import('./0', {}, {})
 >g : Symbol(g, Decl(3.ts, 8, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Symbol(h, Decl(3.ts, 9, 5))
 >'./0' : Symbol("0", Decl(0.ts, 0, 0))
->assert : Symbol(assert, Decl(3.ts, 9, 25))
->type : Symbol(type, Decl(3.ts, 9, 35))
+>with : Symbol(with, Decl(3.ts, 9, 25))
+>type : Symbol(type, Decl(3.ts, 9, 33))
 
 

--- a/tests/baselines/reference/importAssertion1(module=esnext).types
+++ b/tests/baselines/reference/importAssertion1(module=esnext).types
@@ -14,17 +14,17 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-import './0' assert { type: "json" }
+import './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-import { a, b } from './0' assert { "type": "json" }
+import { a, b } from './0' with { "type": "json" }
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import * as foo from './0' assert { type: "json" }
+import * as foo from './0' with { type: "json" }
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >type : any
@@ -55,13 +55,13 @@ foo.b;
 >  : ^
 
 === 2.ts ===
-import { a, b } from './0' assert {}
+import { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1
@@ -102,17 +102,17 @@ const a = import('./0')
 >'./0' : "./0"
 >      : ^^^^^
 
-const b = import('./0', { assert: { type: "json" } })
+const b = import('./0', { with: { type: "json" } })
 >b : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" } }) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" } }) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string
@@ -120,17 +120,17 @@ const b = import('./0', { assert: { type: "json" } })
 >"json" : "json"
 >       : ^^^^^^
 
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
 >c : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
->                                                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json", ttype: "typo" } }) : Promise<typeof import("0")>
+>                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json", ttype: "typo" } } : { assert: { type: string; ttype: string; }; }
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; ttype: string; }
->       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>{ with: { type: "json", ttype: "typo" } } : { with: { type: string; ttype: string; }; }
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; ttype: string; }
+>     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ type: "json", ttype: "typo" } : { type: string; ttype: string; }
 >                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : string
@@ -142,17 +142,17 @@ const c = import('./0', { assert: { type: "json", ttype: "typo" } })
 >"typo" : "typo"
 >       : ^^^^^^
 
-const d = import('./0', { assert: {} })
+const d = import('./0', { with: {} })
 >d : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: {} }) : Promise<typeof import("0")>
->                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: {} }) : Promise<typeof import("0")>
+>                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: {} } : { assert: {}; }
->               : ^^^^^^^^^^^^^^^
->assert : {}
->       : ^^
+>{ with: {} } : { with: {}; }
+>             : ^^^^^^^^^^^^^
+>with : {}
+>     : ^^
 >{} : {}
 >   : ^^
 
@@ -200,17 +200,17 @@ const g = import('./0', {}, {})
 >{} : {}
 >   : ^^
 
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 >h : Promise<typeof import("0")>
 >  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import('./0', { assert: { type: "json" }},) : Promise<typeof import("0")>
->                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import('./0', { with: { type: "json" }},) : Promise<typeof import("0")>
+>                                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'./0' : "./0"
 >      : ^^^^^
->{ assert: { type: "json" }} : { assert: { type: string; }; }
->                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" }} : { with: { type: string; }; }
+>                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/importAssertion2(module=commonjs).errors.txt
+++ b/tests/baselines/reference/importAssertion2(module=commonjs).errors.txt
@@ -1,9 +1,9 @@
-1.ts(1,22): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(2,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(3,21): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(4,27): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(1,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(2,38): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(1,22): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(2,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(3,21): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(4,27): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(1,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(2,38): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== 0.ts (0 errors) ====
@@ -11,24 +11,24 @@
     export const b = 2;
     
 ==== 1.ts (4 errors) ====
-    export {} from './0' assert { type: "json" }
-                         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export { a, b } from './0' assert { type: "json" }
-                               ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export * from './0' assert { type: "json" }
-                        ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export * as ns from './0' assert { type: "json" }
-                              ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export {} from './0' with { type: "json" }
+                         ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a, b } from './0' with { type: "json" }
+                               ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export * from './0' with { type: "json" }
+                        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export * as ns from './0' with { type: "json" }
+                              ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     
 ==== 2.ts (2 errors) ====
-    export { a, b } from './0' assert {}
-                               ~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a, b } from './0' with {}
+                               ~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     

--- a/tests/baselines/reference/importAssertion2(module=commonjs).js
+++ b/tests/baselines/reference/importAssertion2(module=commonjs).js
@@ -5,14 +5,14 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 
 //// [2.ts]
-export { a, b } from './0' assert {}
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a, b } from './0' with {}
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 
 
 //// [0.js]

--- a/tests/baselines/reference/importAssertion2(module=commonjs).symbols
+++ b/tests/baselines/reference/importAssertion2(module=commonjs).symbols
@@ -8,21 +8,21 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : Symbol(ns, Decl(1.ts, 3, 6))
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))

--- a/tests/baselines/reference/importAssertion2(module=commonjs).types
+++ b/tests/baselines/reference/importAssertion2(module=commonjs).types
@@ -14,11 +14,11 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export { a, b } from './0' assert { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : 1
 >  : ^
 >b : 2
@@ -26,24 +26,24 @@ export { a, b } from './0' assert { type: "json" }
 >type : any
 >     : ^^^
 
-export * from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export * as ns from './0' assert { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : typeof import("0")
 >   : ^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1

--- a/tests/baselines/reference/importAssertion2(module=es2015).errors.txt
+++ b/tests/baselines/reference/importAssertion2(module=es2015).errors.txt
@@ -1,9 +1,9 @@
-1.ts(1,22): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(2,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(3,21): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(4,27): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(1,28): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(2,38): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(1,22): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(2,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(3,21): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(4,27): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(1,28): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(2,38): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== 0.ts (0 errors) ====
@@ -11,24 +11,24 @@
     export const b = 2;
     
 ==== 1.ts (4 errors) ====
-    export {} from './0' assert { type: "json" }
-                         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export { a, b } from './0' assert { type: "json" }
-                               ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export * from './0' assert { type: "json" }
-                        ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export * as ns from './0' assert { type: "json" }
-                              ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export {} from './0' with { type: "json" }
+                         ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a, b } from './0' with { type: "json" }
+                               ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export * from './0' with { type: "json" }
+                        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export * as ns from './0' with { type: "json" }
+                              ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     
 ==== 2.ts (2 errors) ====
-    export { a, b } from './0' assert {}
-                               ~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a, b } from './0' with {}
+                               ~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     

--- a/tests/baselines/reference/importAssertion2(module=es2015).js
+++ b/tests/baselines/reference/importAssertion2(module=es2015).js
@@ -5,27 +5,27 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 
 //// [2.ts]
-export { a, b } from './0' assert {}
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a, b } from './0' with {}
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 
 
 //// [0.js]
 export const a = 1;
 export const b = 2;
 //// [1.js]
-export { a, b } from './0' assert { type: "json" };
-export * from './0' assert { type: "json" };
-import * as ns_1 from './0' assert { type: "json" };
+export { a, b } from './0' with { type: "json" };
+export * from './0' with { type: "json" };
+import * as ns_1 from './0' with { type: "json" };
 export { ns_1 as ns };
 //// [2.js]
-export { a, b } from './0' assert {};
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" };
+export { a, b } from './0' with {};
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" };
 
 
 //// [0.d.ts]

--- a/tests/baselines/reference/importAssertion2(module=es2015).symbols
+++ b/tests/baselines/reference/importAssertion2(module=es2015).symbols
@@ -8,21 +8,21 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : Symbol(ns, Decl(1.ts, 3, 6))
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))

--- a/tests/baselines/reference/importAssertion2(module=es2015).types
+++ b/tests/baselines/reference/importAssertion2(module=es2015).types
@@ -14,11 +14,11 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export { a, b } from './0' assert { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : 1
 >  : ^
 >b : 2
@@ -26,24 +26,24 @@ export { a, b } from './0' assert { type: "json" }
 >type : any
 >     : ^^^
 
-export * from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export * as ns from './0' assert { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : typeof import("0")
 >   : ^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1

--- a/tests/baselines/reference/importAssertion2(module=esnext).js
+++ b/tests/baselines/reference/importAssertion2(module=esnext).js
@@ -5,26 +5,26 @@ export const a = 1;
 export const b = 2;
 
 //// [1.ts]
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 
 //// [2.ts]
-export { a, b } from './0' assert {}
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a, b } from './0' with {}
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 
 
 //// [0.js]
 export const a = 1;
 export const b = 2;
 //// [1.js]
-export { a, b } from './0' assert { type: "json" };
-export * from './0' assert { type: "json" };
-export * as ns from './0' assert { type: "json" };
+export { a, b } from './0' with { type: "json" };
+export * from './0' with { type: "json" };
+export * as ns from './0' with { type: "json" };
 //// [2.js]
-export { a, b } from './0' assert {};
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" };
+export { a, b } from './0' with {};
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" };
 
 
 //// [0.d.ts]

--- a/tests/baselines/reference/importAssertion2(module=esnext).symbols
+++ b/tests/baselines/reference/importAssertion2(module=esnext).symbols
@@ -8,21 +8,21 @@ export const b = 2;
 >b : Symbol(b, Decl(0.ts, 1, 12))
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : Symbol(a, Decl(1.ts, 1, 8))
 >b : Symbol(b, Decl(1.ts, 1, 11))
 
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : Symbol(ns, Decl(1.ts, 3, 6))
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : Symbol(a, Decl(2.ts, 0, 8))
 >b : Symbol(b, Decl(2.ts, 0, 11))
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : Symbol(a, Decl(0.ts, 0, 12))
 >c : Symbol(c, Decl(2.ts, 1, 8))
 >b : Symbol(b, Decl(0.ts, 1, 12))

--- a/tests/baselines/reference/importAssertion2(module=esnext).types
+++ b/tests/baselines/reference/importAssertion2(module=esnext).types
@@ -14,32 +14,32 @@ export const b = 2;
 >  : ^
 
 === 1.ts ===
-export {} from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
 >type : error
 
-export { a, b } from './0' assert { type: "json" }
+export { a, b } from './0' with { type: "json" }
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 >type : error
 
-export * from './0' assert { type: "json" }
+export * from './0' with { type: "json" }
 >type : error
 
-export * as ns from './0' assert { type: "json" }
+export * as ns from './0' with { type: "json" }
 >ns : typeof import("0")
 >   : ^^^^^^^^^^^^^^^^^^
 >type : error
 
 === 2.ts ===
-export { a, b } from './0' assert {}
+export { a, b } from './0' with {}
 >a : 1
 >  : ^
 >b : 2
 >  : ^
 
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 >a : 1
 >  : ^
 >c : 1

--- a/tests/baselines/reference/importAssertion3(module=es2015).errors.txt
+++ b/tests/baselines/reference/importAssertion3(module=es2015).errors.txt
@@ -1,26 +1,26 @@
-1.ts(1,27): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-1.ts(2,30): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(1,31): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-2.ts(2,33): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(1,27): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+1.ts(2,30): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(1,31): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+2.ts(2,33): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== 0.ts (0 errors) ====
     export interface I { }
     
 ==== 1.ts (2 errors) ====
-    export type {} from './0' assert { type: "json" }
-                              ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    export type { I } from './0' assert { type: "json" }
-                                 ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export type {} from './0' with { type: "json" }
+                              ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    export type { I } from './0' with { type: "json" }
+                                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     
 ==== 2.ts (2 errors) ====
-    import type { I } from './0'  assert { type: "json" }
-                                  ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import type * as foo from './0' assert { type: "json" }
-                                    ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import type { I } from './0'  with { type: "json" }
+                                  ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import type * as foo from './0' with { type: "json" }
+                                    ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     
     

--- a/tests/baselines/reference/importAssertion3(module=es2015).js
+++ b/tests/baselines/reference/importAssertion3(module=es2015).js
@@ -4,12 +4,12 @@
 export interface I { }
 
 //// [1.ts]
-export type {} from './0' assert { type: "json" }
-export type { I } from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
+export type { I } from './0' with { type: "json" }
 
 //// [2.ts]
-import type { I } from './0'  assert { type: "json" }
-import type * as foo from './0' assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
+import type * as foo from './0' with { type: "json" }
 
 
 

--- a/tests/baselines/reference/importAssertion3(module=es2015).symbols
+++ b/tests/baselines/reference/importAssertion3(module=es2015).symbols
@@ -5,15 +5,15 @@ export interface I { }
 >I : Symbol(I, Decl(0.ts, 0, 0))
 
 === 1.ts ===
-export type {} from './0' assert { type: "json" }
-export type { I } from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
+export type { I } from './0' with { type: "json" }
 >I : Symbol(I, Decl(1.ts, 1, 13))
 
 === 2.ts ===
-import type { I } from './0'  assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
 >I : Symbol(I, Decl(2.ts, 0, 13))
 
-import type * as foo from './0' assert { type: "json" }
+import type * as foo from './0' with { type: "json" }
 >foo : Symbol(foo, Decl(2.ts, 1, 11))
 
 

--- a/tests/baselines/reference/importAssertion3(module=es2015).types
+++ b/tests/baselines/reference/importAssertion3(module=es2015).types
@@ -5,24 +5,24 @@
 export interface I { }
 
 === 1.ts ===
-export type {} from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export type { I } from './0' assert { type: "json" }
+export type { I } from './0' with { type: "json" }
 >I : import("0").I
 >  : ^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === 2.ts ===
-import type { I } from './0'  assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
 >I : I
 >  : ^
 >type : any
 >     : ^^^
 
-import type * as foo from './0' assert { type: "json" }
+import type * as foo from './0' with { type: "json" }
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >type : any

--- a/tests/baselines/reference/importAssertion3(module=esnext).errors.txt
+++ b/tests/baselines/reference/importAssertion3(module=esnext).errors.txt
@@ -1,26 +1,26 @@
-1.ts(1,27): error TS2822: Import assertions cannot be used with type-only imports or exports.
-1.ts(2,30): error TS2822: Import assertions cannot be used with type-only imports or exports.
-2.ts(1,31): error TS2822: Import assertions cannot be used with type-only imports or exports.
-2.ts(2,33): error TS2822: Import assertions cannot be used with type-only imports or exports.
+1.ts(1,27): error TS2857: Import attributes cannot be used with type-only imports or exports.
+1.ts(2,30): error TS2857: Import attributes cannot be used with type-only imports or exports.
+2.ts(1,31): error TS2857: Import attributes cannot be used with type-only imports or exports.
+2.ts(2,33): error TS2857: Import attributes cannot be used with type-only imports or exports.
 
 
 ==== 0.ts (0 errors) ====
     export interface I { }
     
 ==== 1.ts (2 errors) ====
-    export type {} from './0' assert { type: "json" }
-                              ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2822: Import assertions cannot be used with type-only imports or exports.
-    export type { I } from './0' assert { type: "json" }
-                                 ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2822: Import assertions cannot be used with type-only imports or exports.
+    export type {} from './0' with { type: "json" }
+                              ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2857: Import attributes cannot be used with type-only imports or exports.
+    export type { I } from './0' with { type: "json" }
+                                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2857: Import attributes cannot be used with type-only imports or exports.
     
 ==== 2.ts (2 errors) ====
-    import type { I } from './0'  assert { type: "json" }
-                                  ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2822: Import assertions cannot be used with type-only imports or exports.
-    import type * as foo from './0' assert { type: "json" }
-                                    ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2822: Import assertions cannot be used with type-only imports or exports.
+    import type { I } from './0'  with { type: "json" }
+                                  ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2857: Import attributes cannot be used with type-only imports or exports.
+    import type * as foo from './0' with { type: "json" }
+                                    ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2857: Import attributes cannot be used with type-only imports or exports.
     
     

--- a/tests/baselines/reference/importAssertion3(module=esnext).js
+++ b/tests/baselines/reference/importAssertion3(module=esnext).js
@@ -4,12 +4,12 @@
 export interface I { }
 
 //// [1.ts]
-export type {} from './0' assert { type: "json" }
-export type { I } from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
+export type { I } from './0' with { type: "json" }
 
 //// [2.ts]
-import type { I } from './0'  assert { type: "json" }
-import type * as foo from './0' assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
+import type * as foo from './0' with { type: "json" }
 
 
 

--- a/tests/baselines/reference/importAssertion3(module=esnext).symbols
+++ b/tests/baselines/reference/importAssertion3(module=esnext).symbols
@@ -5,15 +5,15 @@ export interface I { }
 >I : Symbol(I, Decl(0.ts, 0, 0))
 
 === 1.ts ===
-export type {} from './0' assert { type: "json" }
-export type { I } from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
+export type { I } from './0' with { type: "json" }
 >I : Symbol(I, Decl(1.ts, 1, 13))
 
 === 2.ts ===
-import type { I } from './0'  assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
 >I : Symbol(I, Decl(2.ts, 0, 13))
 
-import type * as foo from './0' assert { type: "json" }
+import type * as foo from './0' with { type: "json" }
 >foo : Symbol(foo, Decl(2.ts, 1, 11))
 
 

--- a/tests/baselines/reference/importAssertion3(module=esnext).types
+++ b/tests/baselines/reference/importAssertion3(module=esnext).types
@@ -5,24 +5,24 @@
 export interface I { }
 
 === 1.ts ===
-export type {} from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
 >type : any
 >     : ^^^
 
-export type { I } from './0' assert { type: "json" }
+export type { I } from './0' with { type: "json" }
 >I : import("0").I
 >  : ^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === 2.ts ===
-import type { I } from './0'  assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
 >I : I
 >  : ^
 >type : any
 >     : ^^^
 
-import type * as foo from './0' assert { type: "json" }
+import type * as foo from './0' with { type: "json" }
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >type : any

--- a/tests/baselines/reference/importAssertion4.errors.txt
+++ b/tests/baselines/reference/importAssertion4.errors.txt
@@ -3,7 +3,7 @@ importAssertion4.ts(2,1): error TS1005: '{' expected.
 
 
 ==== importAssertion4.ts (2 errors) ====
-    import * as f from "./first" assert
+    import * as f from "./first" with
                        ~~~~~~~~~
 !!! error TS2307: Cannot find module './first' or its corresponding type declarations.
     

--- a/tests/baselines/reference/importAssertion4.js
+++ b/tests/baselines/reference/importAssertion4.js
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/importAssertion/importAssertion4.ts] ////
 
 //// [importAssertion4.ts]
-import * as f from "./first" assert
+import * as f from "./first" with
 
 
 //// [importAssertion4.js]

--- a/tests/baselines/reference/importAssertion4.symbols
+++ b/tests/baselines/reference/importAssertion4.symbols
@@ -1,6 +1,6 @@
 //// [tests/cases/conformance/importAssertion/importAssertion4.ts] ////
 
 === importAssertion4.ts ===
-import * as f from "./first" assert
+import * as f from "./first" with
 >f : Symbol(f, Decl(importAssertion4.ts, 0, 6))
 

--- a/tests/baselines/reference/importAssertion4.types
+++ b/tests/baselines/reference/importAssertion4.types
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/importAssertion/importAssertion4.ts] ////
 
 === importAssertion4.ts ===
-import * as f from "./first" assert
+import * as f from "./first" with
 >f : any
 >  : ^^^
 

--- a/tests/baselines/reference/importAssertion5.errors.txt
+++ b/tests/baselines/reference/importAssertion5.errors.txt
@@ -3,10 +3,10 @@ importAssertion5.ts(2,1): error TS1005: '}' expected.
 
 
 ==== importAssertion5.ts (2 errors) ====
-    import * as f from "./first" assert {
+    import * as f from "./first" with {
                        ~~~~~~~~~
 !!! error TS2307: Cannot find module './first' or its corresponding type declarations.
     
     
 !!! error TS1005: '}' expected.
-!!! related TS1007 importAssertion5.ts:1:37: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 importAssertion5.ts:1:35: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/importAssertion5.js
+++ b/tests/baselines/reference/importAssertion5.js
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/importAssertion/importAssertion5.ts] ////
 
 //// [importAssertion5.ts]
-import * as f from "./first" assert {
+import * as f from "./first" with {
 
 
 //// [importAssertion5.js]

--- a/tests/baselines/reference/importAssertion5.symbols
+++ b/tests/baselines/reference/importAssertion5.symbols
@@ -1,6 +1,6 @@
 //// [tests/cases/conformance/importAssertion/importAssertion5.ts] ////
 
 === importAssertion5.ts ===
-import * as f from "./first" assert {
+import * as f from "./first" with {
 >f : Symbol(f, Decl(importAssertion5.ts, 0, 6))
 

--- a/tests/baselines/reference/importAssertion5.types
+++ b/tests/baselines/reference/importAssertion5.types
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/importAssertion/importAssertion5.ts] ////
 
 === importAssertion5.ts ===
-import * as f from "./first" assert {
+import * as f from "./first" with {
 >f : any
 >  : ^^^
 

--- a/tests/baselines/reference/importAssertionNonstring.errors.txt
+++ b/tests/baselines/reference/importAssertionNonstring.errors.txt
@@ -1,78 +1,60 @@
-mod.mts(1,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
 mod.mts(1,37): error TS2322: Type '{ field: 0; }' is not assignable to type 'ImportAttributes'.
   Property 'field' is incompatible with index signature.
     Type 'number' is not assignable to type 'string'.
-mod.mts(1,52): error TS2837: Import assertion values must be string literal expressions.
-mod.mts(3,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-mod.mts(3,52): error TS2837: Import assertion values must be string literal expressions.
-mod.mts(5,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+mod.mts(1,50): error TS2858: Import attribute values must be string literal expressions.
+mod.mts(3,50): error TS2858: Import attribute values must be string literal expressions.
 mod.mts(5,37): error TS2322: Type '{ field: RegExp; }' is not assignable to type 'ImportAttributes'.
   Property 'field' is incompatible with index signature.
     Type 'RegExp' is not assignable to type 'string'.
-mod.mts(5,52): error TS2837: Import assertion values must be string literal expressions.
-mod.mts(7,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+mod.mts(5,50): error TS2858: Import attribute values must be string literal expressions.
 mod.mts(7,37): error TS2322: Type '{ field: string[]; }' is not assignable to type 'ImportAttributes'.
   Property 'field' is incompatible with index signature.
     Type 'string[]' is not assignable to type 'string'.
-mod.mts(7,52): error TS2837: Import assertion values must be string literal expressions.
-mod.mts(9,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+mod.mts(7,50): error TS2858: Import attribute values must be string literal expressions.
 mod.mts(9,37): error TS2322: Type '{ field: { a: number; }; }' is not assignable to type 'ImportAttributes'.
   Property 'field' is incompatible with index signature.
     Type '{ a: number; }' is not assignable to type 'string'.
-mod.mts(9,52): error TS2837: Import assertion values must be string literal expressions.
-mod.mts(11,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-mod.mts(11,66): error TS2837: Import assertion values must be string literal expressions.
+mod.mts(9,50): error TS2858: Import attribute values must be string literal expressions.
+mod.mts(11,64): error TS2858: Import attribute values must be string literal expressions.
 
 
-==== mod.mts (16 errors) ====
-    import * as thing1 from "./mod.mjs" assert {field: 0};
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                        ~~~~~~~~~~~~~~~~~
+==== mod.mts (10 errors) ====
+    import * as thing1 from "./mod.mjs" with {field: 0};
+                                        ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ field: 0; }' is not assignable to type 'ImportAttributes'.
 !!! error TS2322:   Property 'field' is incompatible with index signature.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
-                                                       ~
-!!! error TS2837: Import assertion values must be string literal expressions.
+                                                     ~
+!!! error TS2858: Import attribute values must be string literal expressions.
     
-    import * as thing2 from "./mod.mjs" assert {field: `a`};
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                                       ~~~
-!!! error TS2837: Import assertion values must be string literal expressions.
+    import * as thing2 from "./mod.mjs" with {field: `a`};
+                                                     ~~~
+!!! error TS2858: Import attribute values must be string literal expressions.
     
-    import * as thing3 from "./mod.mjs" assert {field: /a/g};
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                        ~~~~~~~~~~~~~~~~~~~~
+    import * as thing3 from "./mod.mjs" with {field: /a/g};
+                                        ~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ field: RegExp; }' is not assignable to type 'ImportAttributes'.
 !!! error TS2322:   Property 'field' is incompatible with index signature.
 !!! error TS2322:     Type 'RegExp' is not assignable to type 'string'.
-                                                       ~~~~
-!!! error TS2837: Import assertion values must be string literal expressions.
+                                                     ~~~~
+!!! error TS2858: Import attribute values must be string literal expressions.
     
-    import * as thing4 from "./mod.mjs" assert {field: ["a"]};
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                        ~~~~~~~~~~~~~~~~~~~~~
+    import * as thing4 from "./mod.mjs" with {field: ["a"]};
+                                        ~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ field: string[]; }' is not assignable to type 'ImportAttributes'.
 !!! error TS2322:   Property 'field' is incompatible with index signature.
 !!! error TS2322:     Type 'string[]' is not assignable to type 'string'.
-                                                       ~~~~~
-!!! error TS2837: Import assertion values must be string literal expressions.
+                                                     ~~~~~
+!!! error TS2858: Import attribute values must be string literal expressions.
     
-    import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                        ~~~~~~~~~~~~~~~~~~~~~~~~
+    import * as thing5 from "./mod.mjs" with {field: { a: 0 }};
+                                        ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ field: { a: number; }; }' is not assignable to type 'ImportAttributes'.
 !!! error TS2322:   Property 'field' is incompatible with index signature.
 !!! error TS2322:     Type '{ a: number; }' is not assignable to type 'string'.
-                                                       ~~~~~~~~
-!!! error TS2837: Import assertion values must be string literal expressions.
+                                                     ~~~~~~~~
+!!! error TS2858: Import attribute values must be string literal expressions.
     
-    import * as thing6 from "./mod.mjs" assert {type: "json", field: 0..toString()}
-                                        ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                                                     ~~~~~~~~~~~~~
-!!! error TS2837: Import assertion values must be string literal expressions.
+    import * as thing6 from "./mod.mjs" with {type: "json", field: 0..toString()}
+                                                                   ~~~~~~~~~~~~~
+!!! error TS2858: Import attribute values must be string literal expressions.

--- a/tests/baselines/reference/importAssertionNonstring.js
+++ b/tests/baselines/reference/importAssertionNonstring.js
@@ -1,17 +1,17 @@
 //// [tests/cases/compiler/importAssertionNonstring.ts] ////
 
 //// [mod.mts]
-import * as thing1 from "./mod.mjs" assert {field: 0};
+import * as thing1 from "./mod.mjs" with {field: 0};
 
-import * as thing2 from "./mod.mjs" assert {field: `a`};
+import * as thing2 from "./mod.mjs" with {field: `a`};
 
-import * as thing3 from "./mod.mjs" assert {field: /a/g};
+import * as thing3 from "./mod.mjs" with {field: /a/g};
 
-import * as thing4 from "./mod.mjs" assert {field: ["a"]};
+import * as thing4 from "./mod.mjs" with {field: ["a"]};
 
-import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
+import * as thing5 from "./mod.mjs" with {field: { a: 0 }};
 
-import * as thing6 from "./mod.mjs" assert {type: "json", field: 0..toString()}
+import * as thing6 from "./mod.mjs" with {type: "json", field: 0..toString()}
 
 //// [mod.mjs]
 export {};

--- a/tests/baselines/reference/importAssertionNonstring.symbols
+++ b/tests/baselines/reference/importAssertionNonstring.symbols
@@ -1,23 +1,23 @@
 //// [tests/cases/compiler/importAssertionNonstring.ts] ////
 
 === mod.mts ===
-import * as thing1 from "./mod.mjs" assert {field: 0};
+import * as thing1 from "./mod.mjs" with {field: 0};
 >thing1 : Symbol(thing1, Decl(mod.mts, 0, 6))
 
-import * as thing2 from "./mod.mjs" assert {field: `a`};
+import * as thing2 from "./mod.mjs" with {field: `a`};
 >thing2 : Symbol(thing2, Decl(mod.mts, 2, 6))
 
-import * as thing3 from "./mod.mjs" assert {field: /a/g};
+import * as thing3 from "./mod.mjs" with {field: /a/g};
 >thing3 : Symbol(thing3, Decl(mod.mts, 4, 6))
 
-import * as thing4 from "./mod.mjs" assert {field: ["a"]};
+import * as thing4 from "./mod.mjs" with {field: ["a"]};
 >thing4 : Symbol(thing4, Decl(mod.mts, 6, 6))
 
-import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
+import * as thing5 from "./mod.mjs" with {field: { a: 0 }};
 >thing5 : Symbol(thing5, Decl(mod.mts, 8, 6))
->a : Symbol(a, Decl(mod.mts, 8, 52))
+>a : Symbol(a, Decl(mod.mts, 8, 50))
 
-import * as thing6 from "./mod.mjs" assert {type: "json", field: 0..toString()}
+import * as thing6 from "./mod.mjs" with {type: "json", field: 0..toString()}
 >thing6 : Symbol(thing6, Decl(mod.mts, 10, 6))
 >0..toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
 >toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))

--- a/tests/baselines/reference/importAssertionNonstring.types
+++ b/tests/baselines/reference/importAssertionNonstring.types
@@ -1,19 +1,19 @@
 //// [tests/cases/compiler/importAssertionNonstring.ts] ////
 
 === mod.mts ===
-import * as thing1 from "./mod.mjs" assert {field: 0};
+import * as thing1 from "./mod.mjs" with {field: 0};
 >thing1 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >field : any
 >      : ^^^
 
-import * as thing2 from "./mod.mjs" assert {field: `a`};
+import * as thing2 from "./mod.mjs" with {field: `a`};
 >thing2 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >field : any
 >      : ^^^
 
-import * as thing3 from "./mod.mjs" assert {field: /a/g};
+import * as thing3 from "./mod.mjs" with {field: /a/g};
 >thing3 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >field : any
@@ -21,7 +21,7 @@ import * as thing3 from "./mod.mjs" assert {field: /a/g};
 >/a/g : RegExp
 >     : ^^^^^^
 
-import * as thing4 from "./mod.mjs" assert {field: ["a"]};
+import * as thing4 from "./mod.mjs" with {field: ["a"]};
 >thing4 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >field : any
@@ -31,7 +31,7 @@ import * as thing4 from "./mod.mjs" assert {field: ["a"]};
 >"a" : "a"
 >    : ^^^
 
-import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
+import * as thing5 from "./mod.mjs" with {field: { a: 0 }};
 >thing5 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >field : any
@@ -43,7 +43,7 @@ import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
 >0 : 0
 >  : ^
 
-import * as thing6 from "./mod.mjs" assert {type: "json", field: 0..toString()}
+import * as thing6 from "./mod.mjs" with {type: "json", field: 0..toString()}
 >thing6 : typeof thing1
 >       : ^^^^^^^^^^^^^
 >type : any

--- a/tests/baselines/reference/importAssertionsDeprecated.errors.txt
+++ b/tests/baselines/reference/importAssertionsDeprecated.errors.txt
@@ -1,0 +1,29 @@
+/a.ts(1,35): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/b.ts(1,37): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/c.ts(1,51): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+
+
+==== /a.ts (1 errors) ====
+    import json from "./package.json" assert { type: "json" };
+                                      ~~~~~~
+!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+    
+==== /b.ts (1 errors) ====
+    import * as data from "./data.json" assert { type: "json" };
+                                        ~~~~~~
+!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+    
+==== /c.ts (1 errors) ====
+    export { default as config } from "./config.json" assert { type: "json" };
+                                                      ~~~~~~
+!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+    
+==== /package.json (0 errors) ====
+    {}
+    
+==== /data.json (0 errors) ====
+    {}
+    
+==== /config.json (0 errors) ====
+    {}
+    

--- a/tests/baselines/reference/importAssertionsDeprecated.js
+++ b/tests/baselines/reference/importAssertionsDeprecated.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/importAssertionsDeprecated.ts] ////
+
+//// [a.ts]
+import json from "./package.json" assert { type: "json" };
+
+//// [b.ts]
+import * as data from "./data.json" assert { type: "json" };
+
+//// [c.ts]
+export { default as config } from "./config.json" assert { type: "json" };
+
+//// [package.json]
+{}
+
+//// [data.json]
+{}
+
+//// [config.json]
+{}
+
+
+//// [a.js]
+export {};
+//// [b.js]
+export {};
+//// [c.js]
+export { default as config } from "./config.json" assert { type: "json" };

--- a/tests/baselines/reference/importAssertionsDeprecatedIgnored.js
+++ b/tests/baselines/reference/importAssertionsDeprecatedIgnored.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/importAssertionsDeprecatedIgnored.ts] ////
+
+//// [a.ts]
+// With ignoreDeprecations: "6.0", import assertions should not produce a deprecation error.
+import json from "./package.json" assert { type: "json" };
+
+//// [b.ts]
+import * as data from "./data.json" assert { type: "json" };
+
+//// [c.ts]
+export { default as config } from "./config.json" assert { type: "json" };
+
+//// [package.json]
+{}
+
+//// [data.json]
+{}
+
+//// [config.json]
+{}
+
+
+//// [a.js]
+export {};
+//// [b.js]
+export {};
+//// [c.js]
+export { default as config } from "./config.json" assert { type: "json" };

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node16).errors.txt
@@ -1,16 +1,16 @@
-index.ts(1,35): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-otherc.cts(1,35): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+index.ts(1,35): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+otherc.cts(1,35): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== index.ts (1 errors) ====
-    import json from "./package.json" assert { type: "json" };
-                                      ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import json from "./package.json" with { type: "json" };
+                                      ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 ==== otherc.cts (1 errors) ====
-    import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-                                      ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+    import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+                                      ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 ==== package.json (0 errors) ====
     {
         "name": "pkg",

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node16).js
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node16).js
@@ -1,10 +1,10 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 //// [index.ts]
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 //// [otherc.cts]
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 //// [package.json]
 {
     "name": "pkg",
@@ -17,4 +17,4 @@ export {};
 //// [otherc.cjs]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node16).symbols
@@ -1,18 +1,18 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : Symbol(json, Decl(index.ts, 0, 6))
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : Symbol(json, Decl(otherc.cts, 0, 6))
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Symbol(json2, Decl(otherc.cts, 1, 5))
 >"./package.json" : Symbol("package", Decl(package.json, 0, 0))
->assert : Symbol(assert, Decl(otherc.cts, 1, 40))
->type : Symbol(type, Decl(otherc.cts, 1, 50))
+>with : Symbol(with, Decl(otherc.cts, 1, 40))
+>type : Symbol(type, Decl(otherc.cts, 1, 48))
 
 === package.json ===
 {

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node16).types
@@ -1,30 +1,30 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Promise<{ default: { name: string; private: boolean; type: string; }; }>
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import("./package.json", { assert: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
->                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import("./package.json", { with: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"./package.json" : "./package.json"
 >                 : ^^^^^^^^^^^^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node18).errors.txt
@@ -1,13 +1,13 @@
-otherc.cts(1,35): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+otherc.cts(1,35): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== index.ts (0 errors) ====
-    import json from "./package.json" assert { type: "json" };
+    import json from "./package.json" with { type: "json" };
 ==== otherc.cts (1 errors) ====
-    import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-                                      ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
-    const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+    import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+                                      ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 ==== package.json (0 errors) ====
     {
         "name": "pkg",

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node18).js
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node18).js
@@ -1,10 +1,10 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 //// [index.ts]
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 //// [otherc.cts]
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 //// [package.json]
 {
     "name": "pkg",
@@ -17,4 +17,4 @@ export {};
 //// [otherc.cjs]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node18).symbols
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node18).symbols
@@ -1,18 +1,18 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : Symbol(json, Decl(index.ts, 0, 6))
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : Symbol(json, Decl(otherc.cts, 0, 6))
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Symbol(json2, Decl(otherc.cts, 1, 5))
 >"./package.json" : Symbol("package", Decl(package.json, 0, 0))
->assert : Symbol(assert, Decl(otherc.cts, 1, 40))
->type : Symbol(type, Decl(otherc.cts, 1, 50))
+>with : Symbol(with, Decl(otherc.cts, 1, 40))
+>type : Symbol(type, Decl(otherc.cts, 1, 48))
 
 === package.json ===
 {

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node18).types
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node18).types
@@ -1,30 +1,30 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Promise<{ default: { name: string; private: boolean; type: string; }; }>
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import("./package.json", { assert: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
->                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import("./package.json", { with: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"./package.json" : "./package.json"
 >                 : ^^^^^^^^^^^^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node20).errors.txt
@@ -1,16 +1,13 @@
-index.ts(1,35): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-otherc.cts(1,35): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+otherc.cts(1,35): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
-==== index.ts (1 errors) ====
-    import json from "./package.json" assert { type: "json" };
-                                      ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+==== index.ts (0 errors) ====
+    import json from "./package.json" with { type: "json" };
 ==== otherc.cts (1 errors) ====
-    import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-                                      ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+    import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+                                      ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 ==== package.json (0 errors) ====
     {
         "name": "pkg",

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node20).js
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node20).js
@@ -1,10 +1,10 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 //// [index.ts]
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 //// [otherc.cts]
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 //// [package.json]
 {
     "name": "pkg",
@@ -17,4 +17,4 @@ export {};
 //// [otherc.cjs]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node20).symbols
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node20).symbols
@@ -1,18 +1,18 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : Symbol(json, Decl(index.ts, 0, 6))
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : Symbol(json, Decl(otherc.cts, 0, 6))
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Symbol(json2, Decl(otherc.cts, 1, 5))
 >"./package.json" : Symbol("package", Decl(package.json, 0, 0))
->assert : Symbol(assert, Decl(otherc.cts, 1, 40))
->type : Symbol(type, Decl(otherc.cts, 1, 50))
+>with : Symbol(with, Decl(otherc.cts, 1, 40))
+>type : Symbol(type, Decl(otherc.cts, 1, 48))
 
 === package.json ===
 {

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node20).types
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node20).types
@@ -1,30 +1,30 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Promise<{ default: { name: string; private: boolean; type: string; }; }>
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import("./package.json", { assert: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
->                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import("./package.json", { with: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"./package.json" : "./package.json"
 >                 : ^^^^^^^^^^^^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).errors.txt
@@ -1,16 +1,13 @@
-index.ts(1,35): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-otherc.cts(1,35): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+otherc.cts(1,35): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
-==== index.ts (1 errors) ====
-    import json from "./package.json" assert { type: "json" };
-                                      ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+==== index.ts (0 errors) ====
+    import json from "./package.json" with { type: "json" };
 ==== otherc.cts (1 errors) ====
-    import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-                                      ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+    import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+                                      ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 ==== package.json (0 errors) ====
     {
         "name": "pkg",

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).js
@@ -1,10 +1,10 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 //// [index.ts]
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 //// [otherc.cts]
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 //// [package.json]
 {
     "name": "pkg",
@@ -17,4 +17,4 @@ export {};
 //// [otherc.cjs]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).symbols
@@ -1,18 +1,18 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : Symbol(json, Decl(index.ts, 0, 6))
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : Symbol(json, Decl(otherc.cts, 0, 6))
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Symbol(json2, Decl(otherc.cts, 1, 5))
 >"./package.json" : Symbol("package", Decl(package.json, 0, 0))
->assert : Symbol(assert, Decl(otherc.cts, 1, 40))
->type : Symbol(type, Decl(otherc.cts, 1, 50))
+>with : Symbol(with, Decl(otherc.cts, 1, 40))
+>type : Symbol(type, Decl(otherc.cts, 1, 48))
 
 === package.json ===
 {

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=nodenext).types
@@ -1,30 +1,30 @@
 //// [tests/cases/conformance/node/nodeModulesImportAssertions.ts] ////
 
 === index.ts ===
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
 === otherc.cts ===
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
 >json : { name: string; private: boolean; type: string; }
 >     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >type : any
 >     : ^^^
 
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 >json2 : Promise<{ default: { name: string; private: boolean; type: string; }; }>
 >      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->import("./package.json", { assert: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
->                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>import("./package.json", { with: { type: "json" } }) : Promise<{ default: { name: string; private: boolean; type: string; }; }>
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >"./package.json" : "./package.json"
 >                 : ^^^^^^^^^^^^^^^^
->{ assert: { type: "json" } } : { assert: { type: string; }; }
->                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->assert : { type: string; }
->       : ^^^^^^^^^^^^^^^^^
+>{ with: { type: "json" } } : { with: { type: string; }; }
+>                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>with : { type: string; }
+>     : ^^^^^^^^^^^^^^^^^
 >{ type: "json" } : { type: string; }
 >                 : ^^^^^^^^^^^^^^^^^
 >type : string

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).errors.txt
@@ -1,26 +1,26 @@
-/index.ts(6,50): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(6,50): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 /index.ts(7,14): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(7,49): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(7,49): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
                  ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).js
@@ -14,17 +14,17 @@ export interface ImportInterface {}
 //// [require.d.ts]
 export interface RequireInterface {}
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -33,13 +33,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node16).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).errors.txt
@@ -1,26 +1,26 @@
-/index.ts(6,50): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(6,50): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 /index.ts(7,14): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(7,49): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(7,49): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
                  ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).js
@@ -14,17 +14,17 @@ export interface ImportInterface {}
 //// [require.d.ts]
 export interface RequireInterface {}
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -33,13 +33,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node18).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).errors.txt
@@ -1,26 +1,26 @@
-/index.ts(6,50): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(6,50): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 /index.ts(7,14): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(7,49): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(7,49): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-                                                     ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
                  ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                                    ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).js
@@ -14,17 +14,17 @@ export interface ImportInterface {}
 //// [require.d.ts]
 export interface RequireInterface {}
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -33,13 +33,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=node20).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).errors.txt
@@ -1,26 +1,26 @@
-/index.ts(6,50): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(6,50): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 /index.ts(7,14): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(7,49): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(7,49): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-                                                     ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
                  ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                                    ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).js
@@ -14,17 +14,17 @@ export interface ImportInterface {}
 //// [require.d.ts]
 export interface RequireInterface {}
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -33,13 +33,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit1(module=nodenext).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).errors.txt
@@ -1,26 +1,26 @@
 /index.ts(6,14): error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-/index.ts(6,50): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-/index.ts(7,49): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(6,50): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(7,49): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
                  ~~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
-                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).js
@@ -19,17 +19,17 @@ export interface RequireInterface {}
     "type": "module"
 }
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -37,13 +37,13 @@ export {};
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node16).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).errors.txt
@@ -4,23 +4,23 @@
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
                  ~~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1454: `resolution-mode` can only be set for type-only imports.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
-                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1454: `resolution-mode` can only be set for type-only imports.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).js
@@ -19,17 +19,17 @@ export interface RequireInterface {}
     "type": "module"
 }
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -37,13 +37,13 @@ export {};
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node18).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).errors.txt
@@ -1,26 +1,26 @@
 /index.ts(6,14): error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-/index.ts(6,50): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(7,49): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(6,50): error TS1454: `resolution-mode` can only be set for type-only imports.
+/index.ts(7,49): error TS1454: `resolution-mode` can only be set for type-only imports.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
                  ~~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-                                                     ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
-                                                    ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1454: `resolution-mode` can only be set for type-only imports.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1454: `resolution-mode` can only be set for type-only imports.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).js
@@ -19,17 +19,17 @@ export interface RequireInterface {}
     "type": "module"
 }
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -37,13 +37,13 @@ export {};
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=node20).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).errors.txt
@@ -1,26 +1,26 @@
 /index.ts(6,14): error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-/index.ts(6,50): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(7,49): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(6,50): error TS1454: `resolution-mode` can only be set for type-only imports.
+/index.ts(7,49): error TS1454: `resolution-mode` can only be set for type-only imports.
 
 
 ==== /index.ts (3 errors) ====
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     
-    import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+    import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
                  ~~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'RequireInterface'.
-                                                     ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-    import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
-                                                    ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1454: `resolution-mode` can only be set for type-only imports.
+    import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1454: `resolution-mode` can only be set for type-only imports.
     export interface Loc extends Req, Imp {}
     
-    export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-    export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+    export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
     
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).js
@@ -19,17 +19,17 @@ export interface RequireInterface {}
     "type": "module"
 }
 //// [index.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 
 //// [index.js]
@@ -37,13 +37,13 @@ export {};
 
 
 //// [index.d.ts]
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }
-import { type RequireInterface as Req } from "pkg" assert { "resolution-mode": "require" };
-import { type ImportInterface as Imp } from "pkg" assert { "resolution-mode": "import" };
+import { type RequireInterface as Req } from "pkg" with { "resolution-mode": "require" };
+import { type ImportInterface as Imp } from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {
 }
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).symbols
@@ -1,33 +1,33 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 82))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 1, 80))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 0, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 1, 13))
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
 export interface Loc extends Req, Imp {}
->Loc : Symbol(Loc, Decl(index.ts, 6, 87))
+>Loc : Symbol(Loc, Decl(index.ts, 6, 85))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >Imp : Symbol(Imp, Decl(index.ts, 6, 8))
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 9, 13))
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 10, 13))
 
 === /node_modules/pkg/import.d.ts ===

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmit2(module=nodenext).types
@@ -1,23 +1,23 @@
 //// [tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts] ////
 
 === /index.ts ===
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any
 >    : ^^^
 
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 >Imp : any
@@ -25,11 +25,11 @@ import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "imp
 
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : ImportInterface
 >                : ^^^^^^^^^^^^^^^
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).errors.txt
@@ -1,27 +1,27 @@
-/index.ts(2,45): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-/index.ts(2,73): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,45): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(2,71): error TS1453: `resolution-mode` should be either `require` or `import`.
 /index.ts(4,10): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(4,39): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-/index.ts(6,76): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(4,39): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+/index.ts(6,76): error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
 
 
 ==== /index.ts (5 errors) ====
     // incorrect mode
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
-                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
-                                                                            ~~~~~~~~
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
+                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+                                                                          ~~~~~~~~
 !!! error TS1453: `resolution-mode` should be either `require` or `import`.
     // not type-only
-    import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
              ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     // not exclusively type-only
-    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
-                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
+                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2823: Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).js
@@ -15,11 +15,11 @@ export interface ImportInterface {}
 export interface RequireInterface {}
 //// [index.ts]
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
@@ -34,6 +34,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 import type { RequireInterface } from "pkg";
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).symbols
@@ -2,22 +2,22 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req2 : Symbol(Req2, Decl(index.ts, 5, 37))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 115))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 113))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node16).types
@@ -2,17 +2,17 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).errors.txt
@@ -1,27 +1,27 @@
-/index.ts(2,45): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
-/index.ts(2,73): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,45): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(2,71): error TS1453: `resolution-mode` should be either `require` or `import`.
 /index.ts(4,10): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(4,39): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
-/index.ts(6,76): error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(4,39): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(6,76): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (5 errors) ====
     // incorrect mode
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
-                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
-                                                                            ~~~~~~~~
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
+                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+                                                                          ~~~~~~~~
 !!! error TS1453: `resolution-mode` should be either `require` or `import`.
     // not type-only
-    import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
              ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     // not exclusively type-only
-    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
-                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2836: Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
+                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).js
@@ -15,11 +15,11 @@ export interface ImportInterface {}
 export interface RequireInterface {}
 //// [index.ts]
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
@@ -34,6 +34,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 import type { RequireInterface } from "pkg";
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).symbols
@@ -2,22 +2,22 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req2 : Symbol(Req2, Decl(index.ts, 5, 37))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 115))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 113))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node18).types
@@ -2,17 +2,17 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).errors.txt
@@ -1,27 +1,27 @@
-/index.ts(2,45): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(2,73): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,45): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(2,71): error TS1453: `resolution-mode` should be either `require` or `import`.
 /index.ts(4,10): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(4,39): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(6,76): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(4,39): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(6,76): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (5 errors) ====
     // incorrect mode
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
-                                                ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                                                            ~~~~~~~~
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
+                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+                                                                          ~~~~~~~~
 !!! error TS1453: `resolution-mode` should be either `require` or `import`.
     // not type-only
-    import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
              ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                          ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     // not exclusively type-only
-    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
-                                                                               ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
+                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).js
@@ -15,11 +15,11 @@ export interface ImportInterface {}
 export interface RequireInterface {}
 //// [index.ts]
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
@@ -34,6 +34,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 import type { RequireInterface } from "pkg";
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).symbols
@@ -2,22 +2,22 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req2 : Symbol(Req2, Decl(index.ts, 5, 37))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 115))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 113))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=node20).types
@@ -2,17 +2,17 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).errors.txt
@@ -1,27 +1,27 @@
-/index.ts(2,45): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(2,73): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,45): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(2,71): error TS1453: `resolution-mode` should be either `require` or `import`.
 /index.ts(4,10): error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-/index.ts(4,39): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-/index.ts(6,76): error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+/index.ts(4,39): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+/index.ts(6,76): error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
 
 
 ==== /index.ts (5 errors) ====
     // incorrect mode
-    import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
-                                                ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
-                                                                            ~~~~~~~~
+    import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
+                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+                                                                          ~~~~~~~~
 !!! error TS1453: `resolution-mode` should be either `require` or `import`.
     // not type-only
-    import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+    import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
              ~~~~~~~~~~~~~~~
 !!! error TS2305: Module '"pkg"' has no exported member 'ImportInterface'.
-                                          ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     // not exclusively type-only
-    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
-                                                                               ~~~~~~
-!!! error TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
+    import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
+                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2856: Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
     
     export interface LocalInterface extends RequireInterface, ImportInterface {}
     

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).js
@@ -15,11 +15,11 @@ export interface ImportInterface {}
 export interface RequireInterface {}
 //// [index.ts]
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
@@ -34,6 +34,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 import type { RequireInterface } from "pkg";
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 export interface LocalInterface extends RequireInterface, ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).symbols
@@ -2,22 +2,22 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req : Symbol(Req, Decl(index.ts, 5, 8))
 >RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
 >Req2 : Symbol(Req2, Decl(index.ts, 5, 37))
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
->LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 115))
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 5, 113))
 >RequireInterface : Symbol(RequireInterface, Decl(index.ts, 1, 13))
 >ImportInterface : Symbol(ImportInterface, Decl(index.ts, 3, 8))
 

--- a/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportModeDeclarationEmitErrors1(module=nodenext).types
@@ -2,17 +2,17 @@
 
 === /index.ts ===
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 >RequireInterface : RequireInterface
 >                 : ^^^^^^^^^^^^^^^^
 
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 >ImportInterface : any
 >                : ^^^
 
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 >RequireInterface : any
 >                 : ^^^
 >Req : any

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).js
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).js
@@ -20,15 +20,15 @@ export declare const x: "script";
 
 //// [app.ts]
 import type { x as Default } from "foo";
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 type _Default = typeof Default;
 type _Import = typeof Import;
 type _Require = typeof Require;
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 type _ImportRelative = typeof ImportRelative;
 type _RequireRelative = typeof RequireRelative;
 
@@ -50,13 +50,13 @@ export const x = "other";
 export declare const x = "other";
 //// [app.d.ts]
 import type { x as Default } from "foo";
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 type _Default = typeof Default;
 type _Import = typeof Import;
 type _Require = typeof Require;
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 type _ImportRelative = typeof ImportRelative;
 type _RequireRelative = typeof RequireRelative;
 export { _Default, _Import, _Require, _ImportRelative, _RequireRelative };

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).symbols
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).symbols
@@ -13,16 +13,16 @@ import type { x as Default } from "foo";
 >x : Symbol(Default, Decl(index.d.mts, 0, 20))
 >Default : Symbol(Default, Decl(app.ts, 0, 13))
 
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
 >x : Symbol(Default, Decl(index.d.mts, 0, 20))
 >Import : Symbol(Import, Decl(app.ts, 1, 13))
 
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 >x : Symbol(Require, Decl(index.d.cts, 0, 20))
 >Require : Symbol(Require, Decl(app.ts, 2, 13))
 
 type _Default = typeof Default;
->_Default : Symbol(_Default, Decl(app.ts, 2, 80))
+>_Default : Symbol(_Default, Decl(app.ts, 2, 78))
 >Default : Symbol(Default, Decl(app.ts, 0, 13))
 
 type _Import = typeof Import;
@@ -34,16 +34,16 @@ type _Require = typeof Require;
 >Require : Symbol(Require, Decl(app.ts, 2, 13))
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
 >x : Symbol(ImportRelative, Decl(other.ts, 0, 12))
 >ImportRelative : Symbol(ImportRelative, Decl(app.ts, 8, 13))
 
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 >x : Symbol(ImportRelative, Decl(other.ts, 0, 12))
 >RequireRelative : Symbol(RequireRelative, Decl(app.ts, 9, 13))
 
 type _ImportRelative = typeof ImportRelative;
->_ImportRelative : Symbol(_ImportRelative, Decl(app.ts, 9, 92))
+>_ImportRelative : Symbol(_ImportRelative, Decl(app.ts, 9, 90))
 >ImportRelative : Symbol(ImportRelative, Decl(app.ts, 8, 13))
 
 type _RequireRelative = typeof RequireRelative;

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).types
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=bundler).types
@@ -17,13 +17,13 @@ import type { x as Default } from "foo";
 >Default : any
 >        : ^^^
 
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
 >x : "module"
 >  : ^^^^^^^^
 >Import : any
 >       : ^^^
 
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 >x : "script"
 >  : ^^^^^^^^
 >Require : any
@@ -48,13 +48,13 @@ type _Require = typeof Require;
 >        : ^^^^^^^^
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
 >x : "other"
 >  : ^^^^^^^
 >ImportRelative : any
 >               : ^^^
 
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 >x : "other"
 >  : ^^^^^^^
 >RequireRelative : any

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).errors.txt
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).errors.txt
@@ -33,10 +33,10 @@ error TS5107: Option 'moduleResolution=classic' is deprecated and will stop func
     import type { x as Default } from "foo";
                                       ~~~~~
 !!! error TS2792: Cannot find module 'foo'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
-    import type { x as Import } from "foo" assert { "resolution-mode": "import" };
+    import type { x as Import } from "foo" with { "resolution-mode": "import" };
                                      ~~~~~
 !!! error TS2792: Cannot find module 'foo'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
-    import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+    import type { x as Require } from "foo" with { "resolution-mode": "require" };
                                       ~~~~~
 !!! error TS2792: Cannot find module 'foo'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
     type _Default = typeof Default;
@@ -44,8 +44,8 @@ error TS5107: Option 'moduleResolution=classic' is deprecated and will stop func
     type _Require = typeof Require;
     
     // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-    import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-    import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+    import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+    import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
     type _ImportRelative = typeof ImportRelative;
     type _RequireRelative = typeof RequireRelative;
     

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).js
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).js
@@ -20,15 +20,15 @@ export declare const x: "script";
 
 //// [app.ts]
 import type { x as Default } from "foo";
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 type _Default = typeof Default;
 type _Import = typeof Import;
 type _Require = typeof Require;
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 type _ImportRelative = typeof ImportRelative;
 type _RequireRelative = typeof RequireRelative;
 
@@ -50,13 +50,13 @@ export const x = "other";
 export declare const x = "other";
 //// [app.d.ts]
 import type { x as Default } from "foo";
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 type _Default = typeof Default;
 type _Import = typeof Import;
 type _Require = typeof Require;
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 type _ImportRelative = typeof ImportRelative;
 type _RequireRelative = typeof RequireRelative;
 export { _Default, _Import, _Require, _ImportRelative, _RequireRelative };

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).symbols
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).symbols
@@ -12,14 +12,14 @@ export declare const x: "script";
 import type { x as Default } from "foo";
 >Default : Symbol(Default, Decl(app.ts, 0, 13))
 
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
 >Import : Symbol(Import, Decl(app.ts, 1, 13))
 
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 >Require : Symbol(Require, Decl(app.ts, 2, 13))
 
 type _Default = typeof Default;
->_Default : Symbol(_Default, Decl(app.ts, 2, 80))
+>_Default : Symbol(_Default, Decl(app.ts, 2, 78))
 >Default : Symbol(Default, Decl(app.ts, 0, 13))
 
 type _Import = typeof Import;
@@ -31,16 +31,16 @@ type _Require = typeof Require;
 >Require : Symbol(Require, Decl(app.ts, 2, 13))
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
 >x : Symbol(ImportRelative, Decl(other.ts, 0, 12))
 >ImportRelative : Symbol(ImportRelative, Decl(app.ts, 8, 13))
 
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 >x : Symbol(ImportRelative, Decl(other.ts, 0, 12))
 >RequireRelative : Symbol(RequireRelative, Decl(app.ts, 9, 13))
 
 type _ImportRelative = typeof ImportRelative;
->_ImportRelative : Symbol(_ImportRelative, Decl(app.ts, 9, 92))
+>_ImportRelative : Symbol(_ImportRelative, Decl(app.ts, 9, 90))
 >ImportRelative : Symbol(ImportRelative, Decl(app.ts, 8, 13))
 
 type _RequireRelative = typeof RequireRelative;

--- a/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).types
+++ b/tests/baselines/reference/resolutionModeTypeOnlyImport1(moduleresolution=classic).types
@@ -17,13 +17,13 @@ import type { x as Default } from "foo";
 >Default : any
 >        : ^^^
 
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
 >x : any
 >  : ^^^
 >Import : any
 >       : ^^^
 
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 >x : any
 >  : ^^^
 >Require : any
@@ -48,13 +48,13 @@ type _Require = typeof Require;
 >        : ^^^
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
 >x : "other"
 >  : ^^^^^^^
 >ImportRelative : any
 >               : ^^^
 
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 >x : "other"
 >  : ^^^^^^^
 >RequireRelative : any

--- a/tests/cases/compiler/importAssertionNonstring.ts
+++ b/tests/cases/compiler/importAssertionNonstring.ts
@@ -1,14 +1,14 @@
 // @target: es2015
 // @module: nodenext
 // @filename: mod.mts
-import * as thing1 from "./mod.mjs" assert {field: 0};
+import * as thing1 from "./mod.mjs" with {field: 0};
 
-import * as thing2 from "./mod.mjs" assert {field: `a`};
+import * as thing2 from "./mod.mjs" with {field: `a`};
 
-import * as thing3 from "./mod.mjs" assert {field: /a/g};
+import * as thing3 from "./mod.mjs" with {field: /a/g};
 
-import * as thing4 from "./mod.mjs" assert {field: ["a"]};
+import * as thing4 from "./mod.mjs" with {field: ["a"]};
 
-import * as thing5 from "./mod.mjs" assert {field: { a: 0 }};
+import * as thing5 from "./mod.mjs" with {field: { a: 0 }};
 
-import * as thing6 from "./mod.mjs" assert {type: "json", field: 0..toString()}
+import * as thing6 from "./mod.mjs" with {type: "json", field: 0..toString()}

--- a/tests/cases/compiler/importAssertionsDeprecated.ts
+++ b/tests/cases/compiler/importAssertionsDeprecated.ts
@@ -1,0 +1,21 @@
+// @target: esnext
+// @module: esnext
+// @noTypesAndSymbols: true
+
+// @Filename: /a.ts
+import json from "./package.json" assert { type: "json" };
+
+// @Filename: /b.ts
+import * as data from "./data.json" assert { type: "json" };
+
+// @Filename: /c.ts
+export { default as config } from "./config.json" assert { type: "json" };
+
+// @Filename: /package.json
+{}
+
+// @Filename: /data.json
+{}
+
+// @Filename: /config.json
+{}

--- a/tests/cases/compiler/importAssertionsDeprecatedIgnored.ts
+++ b/tests/cases/compiler/importAssertionsDeprecatedIgnored.ts
@@ -1,0 +1,23 @@
+// @target: esnext
+// @module: esnext
+// @ignoreDeprecations: 6.0
+// @noTypesAndSymbols: true
+
+// @Filename: /a.ts
+// With ignoreDeprecations: "6.0", import assertions should not produce a deprecation error.
+import json from "./package.json" assert { type: "json" };
+
+// @Filename: /b.ts
+import * as data from "./data.json" assert { type: "json" };
+
+// @Filename: /c.ts
+export { default as config } from "./config.json" assert { type: "json" };
+
+// @Filename: /package.json
+{}
+
+// @Filename: /data.json
+{}
+
+// @Filename: /config.json
+{}

--- a/tests/cases/conformance/importAssertion/importAssertion1.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion1.ts
@@ -7,17 +7,17 @@ export const a = 1;
 export const b = 2;
 
 // @filename: 1.ts
-import './0' assert { type: "json" }
-import { a, b } from './0' assert { "type": "json" }
-import * as foo from './0' assert { type: "json" }
+import './0' with { type: "json" }
+import { a, b } from './0' with { "type": "json" }
+import * as foo from './0' with { type: "json" }
 a;
 b;
 foo.a;
 foo.b;
 
 // @filename: 2.ts
-import { a, b } from './0' assert {}
-import { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+import { a, b } from './0' with {}
+import { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }
 a;
 b;
 c;
@@ -25,13 +25,13 @@ d;
 
 // @filename: 3.ts
 const a = import('./0')
-const b = import('./0', { assert: { type: "json" } })
-const c = import('./0', { assert: { type: "json", ttype: "typo" } })
-const d = import('./0', { assert: {} })
+const b = import('./0', { with: { type: "json" } })
+const c = import('./0', { with: { type: "json", ttype: "typo" } })
+const d = import('./0', { with: {} })
 const dd = import('./0', {})
 declare function foo(): any;
 const e = import('./0', foo())
 const f = import()
 const g = import('./0', {}, {})
-const h = import('./0', { assert: { type: "json" }},)
+const h = import('./0', { with: { type: "json" }},)
 

--- a/tests/cases/conformance/importAssertion/importAssertion2.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion2.ts
@@ -7,11 +7,11 @@ export const a = 1;
 export const b = 2;
 
 // @filename: 1.ts
-export {} from './0' assert { type: "json" }
-export { a, b } from './0' assert { type: "json" }
-export * from './0' assert { type: "json" }
-export * as ns from './0' assert { type: "json" }
+export {} from './0' with { type: "json" }
+export { a, b } from './0' with { type: "json" }
+export * from './0' with { type: "json" }
+export * as ns from './0' with { type: "json" }
 
 // @filename: 2.ts
-export { a, b } from './0' assert {}
-export { a as c, b as d } from './0' assert { a: "a", b: "b", c: "c" }
+export { a, b } from './0' with {}
+export { a as c, b as d } from './0' with { a: "a", b: "b", c: "c" }

--- a/tests/cases/conformance/importAssertion/importAssertion3.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion3.ts
@@ -6,10 +6,10 @@
 export interface I { }
 
 // @filename: 1.ts
-export type {} from './0' assert { type: "json" }
-export type { I } from './0' assert { type: "json" }
+export type {} from './0' with { type: "json" }
+export type { I } from './0' with { type: "json" }
 
 // @filename: 2.ts
-import type { I } from './0'  assert { type: "json" }
-import type * as foo from './0' assert { type: "json" }
+import type { I } from './0'  with { type: "json" }
+import type * as foo from './0' with { type: "json" }
 

--- a/tests/cases/conformance/importAssertion/importAssertion4.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion4.ts
@@ -1,3 +1,3 @@
 // @module: commonjs
 // @target: es2015
-import * as f from "./first" assert
+import * as f from "./first" with

--- a/tests/cases/conformance/importAssertion/importAssertion5.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion5.ts
@@ -1,3 +1,3 @@
 // @module: commonjs
 // @target: es2015
-import * as f from "./first" assert {
+import * as f from "./first" with {

--- a/tests/cases/conformance/moduleResolution/resolutionModeTypeOnlyImport1.ts
+++ b/tests/cases/conformance/moduleResolution/resolutionModeTypeOnlyImport1.ts
@@ -24,15 +24,15 @@ export declare const x: "script";
 
 // @Filename: /app.ts
 import type { x as Default } from "foo";
-import type { x as Import } from "foo" assert { "resolution-mode": "import" };
-import type { x as Require } from "foo" assert { "resolution-mode": "require" };
+import type { x as Import } from "foo" with { "resolution-mode": "import" };
+import type { x as Require } from "foo" with { "resolution-mode": "require" };
 type _Default = typeof Default;
 type _Import = typeof Import;
 type _Require = typeof Require;
 
 // resolution-mode does not enforce file extension in `bundler`, just sets conditions
-import type { x as ImportRelative } from "./other" assert { "resolution-mode": "import" };
-import type { x as RequireRelative } from "./other" assert { "resolution-mode": "require" };
+import type { x as ImportRelative } from "./other" with { "resolution-mode": "import" };
+import type { x as RequireRelative } from "./other" with { "resolution-mode": "require" };
 type _ImportRelative = typeof ImportRelative;
 type _RequireRelative = typeof RequireRelative;
 

--- a/tests/cases/conformance/node/nodeModulesImportAssertions.ts
+++ b/tests/cases/conformance/node/nodeModulesImportAssertions.ts
@@ -2,10 +2,10 @@
 // @module: node16,node18,node20,nodenext
 // @resolveJsonModule: true
 // @filename: index.ts
-import json from "./package.json" assert { type: "json" };
+import json from "./package.json" with { type: "json" };
 // @filename: otherc.cts
-import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
-const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
+import json from "./package.json" with { type: "json" }; // should error, cjs mode imports don't support attributes
+const json2 = import("./package.json", { with: { type: "json" } }); // should be fine
 // @filename: package.json
 {
     "name": "pkg",

--- a/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts
+++ b/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts
@@ -17,14 +17,14 @@ export interface ImportInterface {}
 // @filename: /node_modules/pkg/require.d.ts
 export interface RequireInterface {}
 // @filename: /index.ts
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts
+++ b/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts
@@ -22,14 +22,14 @@ export interface RequireInterface {}
     "type": "module"
 }
 // @filename: /index.ts
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-import type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+import type { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 
-import {type RequireInterface as Req} from "pkg" assert { "resolution-mode": "require" };
-import {type ImportInterface as Imp} from "pkg" assert { "resolution-mode": "import" };
+import {type RequireInterface as Req} from "pkg" with { "resolution-mode": "require" };
+import {type ImportInterface as Imp} from "pkg" with { "resolution-mode": "import" };
 export interface Loc extends Req, Imp {}
 
-export type { RequireInterface } from "pkg" assert { "resolution-mode": "require" };
-export type { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+export type { RequireInterface } from "pkg" with { "resolution-mode": "require" };
+export type { ImportInterface } from "pkg" with { "resolution-mode": "import" };

--- a/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmitErrors1.ts
+++ b/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmitErrors1.ts
@@ -18,11 +18,11 @@ export interface ImportInterface {}
 export interface RequireInterface {}
 // @filename: /index.ts
 // incorrect mode
-import type { RequireInterface } from "pkg" assert { "resolution-mode": "foobar" };
+import type { RequireInterface } from "pkg" with { "resolution-mode": "foobar" };
 // not type-only
-import { ImportInterface } from "pkg" assert { "resolution-mode": "import" };
+import { ImportInterface } from "pkg" with { "resolution-mode": "import" };
 // not exclusively type-only
-import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" assert { "resolution-mode": "require" };
+import {type RequireInterface as Req, RequireInterface as Req2} from "pkg" with { "resolution-mode": "require" };
 
 export interface LocalInterface extends RequireInterface, ImportInterface {}
 

--- a/tests/cases/fourslash/getOccurrencesNonStringImportAssertion.ts
+++ b/tests/cases/fourslash/getOccurrencesNonStringImportAssertion.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts" />
 
 // @module: node18
-////import * as react from "react" assert { cache: /**/0 };
+////import * as react from "react" with { cache: /**/0 };
 ////react.Children;
 
 verify.baselineDocumentHighlights("");

--- a/tests/cases/fourslash/organizeImportsAttributes.ts
+++ b/tests/cases/fourslash/organizeImportsAttributes.ts
@@ -2,8 +2,8 @@
 
 //// import { A } from "./file";
 //// import { type B } from "./file";
-//// import { C } from "./file" assert { type: "a" };
-//// import { A as D } from "./file" assert { type: "b" };
+//// import { C } from "./file" with { type: "a" };
+//// import { A as D } from "./file" with { type: "b" };
 //// import { E } from "./file" with { type: "a" };
 //// import { A as F } from "./file" with { type: "b" };
 //// 
@@ -11,10 +11,8 @@
 
 verify.organizeImports(
 `import { A, type B } from "./file";
-import { C } from "./file" assert { type: "a" };
-import { A as D } from "./file" assert { type: "b" };
-import { E } from "./file" with { type: "a" };
-import { A as F } from "./file" with { type: "b" };
+import { C, E } from "./file" with { type: "a" };
+import { A as D, A as F } from "./file" with { type: "b" };
 
 type G = A | B | C | D | E | F;`);
     

--- a/tests/cases/fourslash/organizeImportsAttributes2.ts
+++ b/tests/cases/fourslash/organizeImportsAttributes2.ts
@@ -1,20 +1,19 @@
 /// <reference path="fourslash.ts" />
 
 ////import { A } from "./a";
-////import { C } from "./a" assert { type: "a" };
+////import { C } from "./a" with { type: "a" };
 ////import { Z } from "./z";
-////import { A as D } from "./a" assert { type: "b" };
+////import { A as D } from "./a" with { type: "b" };
 ////import { E } from "./a" with { type: "a" };
-////import { F } from "./a" assert { type: "a" };
+////import { F } from "./a" with { type: "a" };
 ////import { B } from "./a";
 ////
 ////export type G = A | B | C | D | E | F | Z;
 
 verify.organizeImports(
 `import { A, B } from "./a";
-import { C, F } from "./a" assert { type: "a" };
-import { A as D } from "./a" assert { type: "b" };
-import { E } from "./a" with { type: "a" };
+import { C, E, F } from "./a" with { type: "a" };
+import { A as D } from "./a" with { type: "b" };
 import { Z } from "./z";
 
 export type G = A | B | C | D | E | F | Z;`);

--- a/tests/cases/fourslash/organizeImportsAttributes3.ts
+++ b/tests/cases/fourslash/organizeImportsAttributes3.ts
@@ -1,20 +1,20 @@
 /// <reference path="fourslash.ts" />
 
 ////import { A } from "./a";
-////import { C } from "./a" assert {      type: "a" };
+////import { C } from "./a" with {      type: "a" };
 ////import { Z } from "./z";
-////import { A as D } from "./a" assert    { type: "b" };
-////import { E } from "./a" assert { type: /* comment*/ "a"              };
-////import { F } from "./a" assert     {type: "a" };
-////import { Y } from "./a"   assert{ type: "b" /* comment*/};
+////import { A as D } from "./a" with    { type: "b" };
+////import { E } from "./a" with { type: /* comment*/ "a"              };
+////import { F } from "./a" with     {type: "a" };
+////import { Y } from "./a"   with{ type: "b" /* comment*/};
 ////import { B } from "./a";
 ////
 ////export type G = A | B | C | D | E | F | Y | Z;
 
 verify.organizeImports(
 `import { A, B } from "./a";
-import { C, E, F } from "./a" assert { type: "a" };
-import { A as D, Y } from "./a" assert { type: "b" };
+import { C, E, F } from "./a" with { type: "a" };
+import { A as D, Y } from "./a" with { type: "b" };
 import { Z } from "./z";
 
 export type G = A | B | C | D | E | F | Y | Z;`);

--- a/tests/cases/fourslash/organizeImportsAttributes4.ts
+++ b/tests/cases/fourslash/organizeImportsAttributes4.ts
@@ -1,21 +1,21 @@
 /// <reference path="fourslash.ts" />
 
-////import { A } from "./a" assert { foo: "foo", bar: "bar" };
-////import { B } from "./a" assert { bar: "bar", foo: "foo" };
-////import { D } from "./a" assert { bar: "foo", foo: "bar" };
-////import { E } from "./a" assert { foo: 'bar', bar: "foo" };
-////import { C } from "./a" assert { foo: "bar", bar: "foo" };
-////import { F } from "./a" assert { foo: "42" };
-////import { Y } from "./a" assert { foo: 42 };
-////import { Z } from "./a" assert { foo: "42" };
+////import { A } from "./a" with { foo: "foo", bar: "bar" };
+////import { B } from "./a" with { bar: "bar", foo: "foo" };
+////import { D } from "./a" with { bar: "foo", foo: "bar" };
+////import { E } from "./a" with { foo: 'bar', bar: "foo" };
+////import { C } from "./a" with { foo: "bar", bar: "foo" };
+////import { F } from "./a" with { foo: "42" };
+////import { Y } from "./a" with { foo: 42 };
+////import { Z } from "./a" with { foo: "42" };
 ////
 ////export type G = A | B | C | D | E | F | Y | Z;
 
 
 verify.organizeImports(
-`import { A, B } from "./a" assert { foo: "foo", bar: "bar" };
-import { C, D, E } from "./a" assert { bar: "foo", foo: "bar" };
-import { F, Z } from "./a" assert { foo: "42" };
-import { Y } from "./a" assert { foo: 42 };
+`import { A, B } from "./a" with { foo: "foo", bar: "bar" };
+import { C, D, E } from "./a" with { bar: "foo", foo: "bar" };
+import { F, Z } from "./a" with { foo: "42" };
+import { Y } from "./a" with { foo: 42 };
 
 export type G = A | B | C | D | E | F | Y | Z;`);

--- a/tests/cases/fourslash/outliningSpansForImportsAndExports.ts
+++ b/tests/cases/fourslash/outliningSpansForImportsAndExports.ts
@@ -10,12 +10,12 @@
 ////   b2,
 //// }|] from "b";
 //// ;
-//// import j1 from "./j" assert { type: "json" };
+//// import j1 from "./j" with { type: "json" };
 //// ;
-//// import j2 from "./j" assert {
+//// import j2 from "./j" with {
 //// };
 //// ;
-//// import j3 from "./j" assert [|{
+//// import j3 from "./j" with [|{
 ////   type: "json"
 //// }|];
 //// ;

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateInvalidLocation.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateInvalidLocation.ts
@@ -2,8 +2,8 @@
 
 //// import * as a from "/*1a*/f/*1b*/oobar";
 //// export * as b from "/*2a*/f/*2b*/oobar";
-//// import * as c from "foobar" assert { "/*3a*/f/*3b*/oobar": "something" };
-//// import * as d from "foobar" assert { "something": "/*4a*/f/*4b*/oobar" };
+//// import * as c from "foobar" with { "/*3a*/f/*3b*/oobar": "something" };
+//// import * as d from "foobar" with { "something": "/*4a*/f/*4b*/oobar" };
 //// 
 //// let x = {
 ////     "/*5a*/f/*5b*/oobar": 1234,


### PR DESCRIPTION
Fixes #62210

I updated all tests to `with`, then introduced two tests just for `assert`, deprecated and not.