### PR TITLE
fix(case): apply using pnpm with store outside

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1487,6 +1487,7 @@ export let sys: System = (() => {
         const statSyncOptions = { throwIfNoEntry: false } as const;
 
         const platform: string = _os.platform();
+        const getCurrentDirectory = memoize(() => process.cwd());
         const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
         const fsRealpath = !!_fs.realpathSync.native ? process.platform === "win32" ? fsRealPathHandlingLongPath : _fs.realpathSync.native : _fs.realpathSync;
 
@@ -1498,7 +1499,6 @@ export let sys: System = (() => {
         const executingFilePath = __filename.endsWith("sys.js") ? _path.join(_path.dirname(__dirname), "__fake__.js") : __filename;
 
         const fsSupportsRecursiveFsWatch = process.platform === "win32" || isMacOs;
-        const getCurrentDirectory = memoize(() => process.cwd());
         const { watchFile, watchDirectory } = createSystemWatchFunctions({
             pollingWatchFileWorker: fsWatchFileWorker,
             getModifiedTime,
@@ -1725,7 +1725,7 @@ export let sys: System = (() => {
                 return false;
             }
             // If this file exists under a different case, we must be case-insensitve.
-            return !fileExists(swapCase(__filename));
+            return !fileExists(swapCase(getCurrentDirectory()));
         }
 
         /** Convert all lowercase chars to uppercase, and vice-versa */


### PR DESCRIPTION
on mac filesystem is CaseInsensitive but repo mount is CaseSensitive and when pnpm has virtualStore outside, the typescript think that the system is CaseInsensitive, but it is CaseSensitive

to fix that we use pnpm-patch

```
diff --git a/lib/typescript.js b/lib/typescript.js
index 2643aa12aa6497ca0b90ecd99b202f37ea0e6330..34757f4fb1a2958bec5142c6e365c4214a2f36fb 100644
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -8277,11 +8277,11 @@ var sys = (() => {
     const isLinuxOrMacOs = process.platform === "linux" || isMacOs;
     const statSyncOptions = { throwIfNoEntry: false };
     const platform = _os.platform();
+    const getCurrentDirectory = memoize(() => process.cwd());
     const useCaseSensitiveFileNames2 = isFileSystemCaseSensitive();
     const fsRealpath = !!_fs.realpathSync.native ? process.platform === "win32" ? fsRealPathHandlingLongPath : _fs.realpathSync.native : _fs.realpathSync;
     const executingFilePath = __filename.endsWith("sys.js") ? _path.join(_path.dirname(__dirname), "__fake__.js") : __filename;
     const fsSupportsRecursiveFsWatch = process.platform === "win32" || isMacOs;
-    const getCurrentDirectory = memoize(() => process.cwd());
     const { watchFile: watchFile2, watchDirectory } = createSystemWatchFunctions({
       pollingWatchFileWorker: fsWatchFileWorker,
       getModifiedTime: getModifiedTime3,
@@ -8484,7 +8484,7 @@ var sys = (() => {
       if (platform === "win32" || platform === "win64") {
         return false;
       }
-      return !fileExists(swapCase(__filename));
+      return !fileExists(swapCase(getCurrentDirectory()));
     }
     function swapCase(s) {
       return s.replace(/\w/g, (ch) => {
```

may be the time to fix that in the upstream)

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #63100