### PR TITLE
Properly account for intersections in `getKeyPropertyName`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28027,7 +28027,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // We only construct maps for unions with many non-primitive constituents.
         if (
             types.length < 10 || getObjectFlags(unionType) & ObjectFlags.PrimitiveUnion ||
-            countWhere(types, t => !!(t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive))) < 10
+            countWhere(types, t => !!(t.flags & (TypeFlags.Object | TypeFlags.Intersection | TypeFlags.InstantiableNonPrimitive))) < 10
         ) {
             return undefined;
         }
@@ -28035,7 +28035,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // The candidate key property name is the name of the first property with a unit type in one of the
             // constituent types.
             const keyPropertyName = forEach(types, t =>
-                t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive) ?
+                t.flags & (TypeFlags.Object | TypeFlags.Intersection | TypeFlags.InstantiableNonPrimitive) ?
                     forEach(getPropertiesOfType(t), p => isUnitType(getTypeOfSymbol(p)) ? p.escapedName : undefined) :
                     undefined);
             const mapByKeyProperty = keyPropertyName && mapTypesByKeyProperty(types, keyPropertyName);


### PR DESCRIPTION
In the code below, `getMatchingUnionConstituentForType` (and thus  `typeRelatedToSomeType`) can't benefit from the key property optimization. So in certain situations (like this one) the source has to be related to each constituent of the target union (until it finds a match) - but it should be able to find the matching constituent using a fast path.

This issue affects `test1`. I've included `test2` for comparison purposes - the optimization kicks in there.

[TS playground](https://www.typescriptlang.org/play/?ts=6.0.0-dev.20260204#code/C4TwDgpgBAkgJhAdsAlqAPAFQHxQLxQDeUA2gNJQqJQDWEIA9gGZSYC6AXK+W1AL5QAZFACuiGogYB3RAG4AUPNCQoAQXxFaVOFwBEAQ138hm-VwDOwAE5UA5vwXLoAIQ3Ea2vQCMjA4cS8LazsHJXBoAGE3LUQdKF0AY18TYgSgm0R7PkdwqAARaI9YvThk-yg4ywysnJUAUULPeIgyzQh0kOywlQAxRuL4plbiJg7M0KcoAHF+uN1bYahbMZru6AAJWb0AC0XtlYncmC34lEWUA67JgCkT3QArRfvL2ugKAncm3RpFmhe1qAAGTuABtFiD-pMALJ3AC2i1hkNyADk7ohFogkSoAPJ3BiLBhY6AABTuYEWYCJUAAincAI6LOlUgBKdysiysVIAyndzItzFTMHdgItgFSAKp3ESLERUgBqdwAbotFVSAOp3KSLKRUgAadwAHosDVSAJp3ECLEBUgBadwAXot7f8AVCQOLECgGNQCOoAD5QVwBqIBgoBhoBvoBmYBzYB44B24BigB4EBmEB1EB3EB0kB2kB1kBnkBoUByUBhUBjUB-UB80Bm0KAFchiwiCYXIfGJzBayJYrfsMYDbCCcqCIESwrxj0LyJhiBKob1QYAQSwARgAFCIN1w3R6vYgADRQBheZ5QVvtzuQACURHkUFEG405-uCj4igA9N-ROYQngJBUFAKBRysaB7hESxVwYQYQX0YA13RVdRygBJvWAfQqAgOBKGQMdzAgJcj3MedF2Xag10sAAmHc91gBBkDQEB0APT1vWwU93y4a8O3CB9CCfF83wvT95CAA):
```ts
type Identity<T> = { [K in keyof T]: T[K] } & unknown;

type A = { kind: "a" } & { a: string };
type B = { kind: "b" } & { b: string };
type C = { kind: "c" } & { c: string };
type D = { kind: "d" } & { d: string };
type E = { kind: "e" } & { e: string };
type F = { kind: "f" } & { f: string };
type G = { kind: "g" } & { g: string };
type H = { kind: "h" } & { h: string };
type I = { kind: "i" } & { i: string };
type J = { kind: "j" } & { j: string };
type K = { kind: "k" } & { k: string };
type L = { kind: "l" } & { l: string };
type M = { kind: "m" } & { m: string };
type N = { kind: "n" } & { n: string };
type O = { kind: "o" } & { o: string };
type P = { kind: "p" } & { p: string };
type Q = { kind: "q" } & { q: string };
type R = { kind: "r" } & { r: string };
type S = { kind: "s" } & { s: string };
type T = { kind: "t" } & { t: string };
type U = { kind: "u" } & { u: string };
type V = { kind: "v" } & { v: string };
type W = { kind: "w" } & { w: string };
type X = { kind: "x" } & { x: string };
type Y = { kind: "y" } & { y: string };
type Z = { kind: "z" } & { z: string };

type MyUnion = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;

type SomeType = { kind: "z"; z: string; other: number };

function test1(u1: MyUnion, obj: SomeType) {
  u1 = obj;
}

// using Identity here just to "flatten" the contained intersections
function test2(u1: Identity<MyUnion>, obj: SomeType) {
  u1 = obj;
}
```