### PR TITLE
Don't attempt to report signature candidate errors on relation overflows

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2388,6 +2388,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var comparableRelation = new Map<string, RelationComparisonResult>();
     var identityRelation = new Map<string, RelationComparisonResult>();
     var enumRelation = new Map<string, RelationComparisonResult>();
+    var relationOverflowed = false;
 
     // Extensions suggested for path imports when module resolution is node16 or higher.
     // The first element of each tuple is the extension a file has.
@@ -22412,6 +22413,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             reportIncompatibleStack();
         }
         if (overflow) {
+            relationOverflowed = true;
             // Record this relation as having failed such that we don't attempt the overflowing operation again.
             const id = getRelationKey(source, target, /*intersectionState*/ IntersectionState.None, relation, /*ignoreConstraints*/ false);
             relation.set(id, RelationComparisonResult.Failed | (relationCount <= 0 ? RelationComparisonResult.ComplexityOverflow : RelationComparisonResult.StackDepthOverflow));
@@ -36539,7 +36541,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isJsxOpeningOrSelfClosingElement = isJsxOpeningLikeElement(node);
         const isJsxOpenFragment = isJsxOpeningFragment(node);
         const isInstanceof = node.kind === SyntaxKind.BinaryExpression;
-        const reportErrors = !isInferencePartiallyBlocked && !candidatesOutArray;
+        let reportErrors = !isInferencePartiallyBlocked && !candidatesOutArray;
 
         // The following variables are captured and modified by calls to chooseOverload.
         // If overload resolution or type argument inference fails, we want to report the
@@ -36612,6 +36614,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // If we are in signature help, a trailing comma indicates that we intend to provide another argument,
         // so we will only accept overloads with arity at least 1 higher than the current number of provided arguments.
         const signatureHelpTrailingComma = !!(checkMode & CheckMode.IsForSignatureHelp) && node.kind === SyntaxKind.CallExpression && node.arguments.hasTrailingComma;
+        const saveRelationOverflowed = relationOverflowed;
+        relationOverflowed = false;
 
         // Section 4.12.1:
         // if the candidate list contains one or more signatures for which the type of each argument
@@ -36629,6 +36633,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!result) {
             result = chooseOverload(candidates, assignableRelation, isSingleNonGenericCandidate, signatureHelpTrailingComma);
         }
+        // Disable error reporting if relation overflowed during the overload resolution given the oveflow error was already reported.
+        // By attempting to report the error below the overflow could not happen again (given some of the caches would already be populated)
+        // and the compiler would crash with "No error for last overload signature".
+        reportErrors &&= !relationOverflowed;
+        relationOverflowed = saveRelationOverflowed;
+
         const links = getNodeLinks(node);
         if (links.resolvedSignature !== resolvingSignature && !candidatesOutArray) {
             // There are 2 situations in which it's good to preemptively return the cached result here:


### PR DESCRIPTION
This is tricky and I don't have a test case that could be committed to cover for this (I have one that times out on me locally unless I bump the timeout significantly and it would surely time out on CI).

It is possible for `chooseOverload` to run into an excessive complexity error when checking the argument's type against the parameter's type. But that doesn't guarantee the same error failure will happen when `getSignatureApplicabilityError` gets called again for error reporting purposes. 

At this time, the relation caches might be "partially" warm already and the same-ish relation check might, this time, run under the limit and produce no error. This is, likely, especially true when dealing with object literals - given each `checkObjectLiteral` produces a new type identity (and thus that type itself won't reuse spoiled/failed entries from the relation cache). 

This can lead to hitting an existing assert: "No error for last overload signature". It can be observed after:
- checking out [`d1633a1c44dd2423623bd52cad8224213ed5ebed`](https://github.com/microsoft/TypeScript/compare/microsoft:87aa917befa8f6182f5535df3c77287209692a04...Andarist:d1633a1c44dd2423623bd52cad8224213ed5ebed)
- running `npx hereby runtests --tests="crossProductUnionIntersectionRepeatedPropDeclarationsNoOOM2" --no-lint --timeout 24000000` (it should complete way before the specified timeout but the chances it won't complete under default 40s are high)
- dropping `0a222aa53e03c20233fdd52d6e47e69517cad04a` (that's the cherry-picked commit from this PR)
- re-running the above test command. This time it should hit the assert