### PR TITLE
feat(watch): show file-level error summary in watch mode

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1539,7 +1539,6 @@
         "category": "Error",
         "code": 1464
     },
-
     "The 'import.meta' meta-property is not allowed in files which will build into CommonJS output.": {
         "category": "Error",
         "code": 1470
@@ -1860,7 +1859,6 @@
         "category": "Message",
         "code": 1549
     },
-
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",
         "code": 2200
@@ -1901,7 +1899,6 @@
         "category": "Error",
         "code": 2208
     },
-
     "The project root is ambiguous, but is required to resolve export map entry '{0}' in file '{1}'. Supply the `rootDir` compiler option to disambiguate.": {
         "category": "Error",
         "code": 2209
@@ -1918,7 +1915,6 @@
         "category": "Message",
         "code": 2212
     },
-
     "Duplicate identifier '{0}'.": {
         "category": "Error",
         "code": 2300
@@ -2899,7 +2895,6 @@
         "category": "Error",
         "code": 2568
     },
-
     "Could not find name '{0}'. Did you mean '{1}'?": {
         "category": "Error",
         "code": 2570
@@ -3140,7 +3135,6 @@
         "category": "Error",
         "code": 2639
     },
-
     "Cannot augment module '{0}' with value exports because it resolves to a non-module entity.": {
         "category": "Error",
         "code": 2649
@@ -4022,7 +4016,6 @@
         "category": "Error",
         "code": 2882
     },
-
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000
@@ -4467,7 +4460,6 @@
         "category": "Error",
         "code": 4128
     },
-
     "The current host does not support the '{0}' option.": {
         "category": "Error",
         "code": 5001
@@ -4744,7 +4736,6 @@
         "category": "Error",
         "code": 5112
     },
-
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",
         "code": 6000
@@ -5401,6 +5392,10 @@
         "category": "Message",
         "code": 6194
     },
+    "{0} Watching for file changes.": {
+        "category": "Message",
+        "code": 6499
+    },
     "Resolve 'keyof' to string valued property names only (no numbers or symbols).": {
         "category": "Message",
         "code": 6195
@@ -5688,7 +5683,6 @@
         "category": "Error",
         "code": 6266
     },
-
     "Directory '{0}' has no containing package.json scope. Imports will not resolve.": {
         "category": "Message",
         "code": 6270
@@ -5781,7 +5775,6 @@
         "category": "Message",
         "code": 6294
     },
-
     "Enable project compilation": {
         "category": "Message",
         "code": 6302
@@ -6064,7 +6057,6 @@
         "category": "Message",
         "code": 6421
     },
-
     "The expected type comes from property '{0}' which is declared here on type '{1}'": {
         "category": "Message",
         "code": 6500
@@ -6593,7 +6585,6 @@
         "category": "Message",
         "code": 6809
     },
-
     "one of:": {
         "category": "Message",
         "code": 6900
@@ -6610,7 +6601,6 @@
         "category": "Message",
         "code": 6903
     },
-
     "`true`, unless `strict` is `false`": {
         "category": "Message",
         "code": 6905
@@ -6723,7 +6713,6 @@
         "category": "Message",
         "code": 6932
     },
-
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005
@@ -6946,7 +6935,6 @@
         "category": "Error",
         "code": 7061
     },
-
     "You cannot rename this element.": {
         "category": "Error",
         "code": 8000
@@ -7091,7 +7079,6 @@
         "category": "Error",
         "code": 8039
     },
-
     "Declaration emit for this file requires using private name '{0}'. An explicit type annotation may unblock declaration emit.": {
         "category": "Error",
         "code": 9005
@@ -7324,7 +7311,6 @@
         "category": "Error",
         "code": 18003
     },
-
     "File is a CommonJS module; it may be converted to an ES module.": {
         "category": "Suggestion",
         "code": 80001
@@ -7365,7 +7351,6 @@
         "category": "Suggestion",
         "code": 80010
     },
-
     "Add missing 'super()' call": {
         "category": "Message",
         "code": 90001
@@ -7586,7 +7571,6 @@
         "category": "Message",
         "code": 90071
     },
-
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001
@@ -8355,7 +8339,6 @@
         "category": "Message",
         "code": 95197
     },
-
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",
         "code": 18004

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -263,6 +263,14 @@ export function getWatchErrorSummaryDiagnosticMessage(errorCount: number): Diagn
         Diagnostics.Found_0_errors_Watching_for_file_changes;
 }
 
+export function getWatchErrorSummaryDiagnostic(errorCount: number, filesInError: (ReportFileInError | undefined)[], newLine: string, host: HasCurrentDirectory, options: CompilerOptions): Diagnostic {
+    if (errorCount === 0) {
+        return createCompilerDiagnostic(Diagnostics.Found_0_errors_Watching_for_file_changes, 0);
+    }
+    const errorSummary = getErrorSummaryText(errorCount, filesInError, newLine, host);
+    return createCompilerDiagnostic(Diagnostics._0_Watching_for_file_changes, errorSummary);
+}
+
 function prettyPathForFileError(error: ReportFileInError, cwd: string) {
     const line = formatColorAndReset(":" + error.line, ForegroundColorEscapeSequences.Grey);
     if (pathIsAbsolute(error.fileName) && pathIsAbsolute(cwd)) {
@@ -293,7 +301,7 @@ export function getErrorSummaryText(
     else {
         messageAndArgs = distinctFileNamesWithLines.length === 0 ? [Diagnostics.Found_0_errors, errorCount] :
             distinctFileNamesWithLines.length === 1 ? [Diagnostics.Found_0_errors_in_the_same_file_starting_at_Colon_1, errorCount, firstFileReference] :
-            [Diagnostics.Found_0_errors_in_1_files, errorCount, distinctFileNamesWithLines.length];
+                [Diagnostics.Found_0_errors_in_1_files, errorCount, distinctFileNamesWithLines.length];
     }
 
     const d = createCompilerDiagnostic(...messageAndArgs);
@@ -524,8 +532,8 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
                         Diagnostics.Output_from_referenced_project_0_included_because_1_specified :
                         Diagnostics.Source_from_referenced_project_0_included_because_1_specified :
                     isOutput ?
-                    Diagnostics.Output_from_referenced_project_0_included_because_module_is_specified_as_none :
-                    Diagnostics.Source_from_referenced_project_0_included_because_module_is_specified_as_none,
+                        Diagnostics.Output_from_referenced_project_0_included_because_module_is_specified_as_none :
+                        Diagnostics.Source_from_referenced_project_0_included_because_module_is_specified_as_none,
                 toFileName(referencedResolvedRef.sourceFile.fileName, fileNameConvertor),
                 options.outFile ? "--outFile" : "--out",
             );
@@ -535,8 +543,8 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
                     [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)] :
                     [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions, reason.typeReference] :
                 reason.packageId ?
-                [Diagnostics.Entry_point_for_implicit_type_library_0_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)] :
-                [Diagnostics.Entry_point_for_implicit_type_library_0, reason.typeReference];
+                    [Diagnostics.Entry_point_for_implicit_type_library_0_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)] :
+                    [Diagnostics.Entry_point_for_implicit_type_library_0, reason.typeReference];
 
             return chainDiagnosticMessages(/*details*/ undefined, ...messageAndArgs);
         }
@@ -880,9 +888,9 @@ function createWatchCompilerHost<T extends BuilderProgram = EmitAndSemanticDiagn
             builderProgram,
             reportDiagnostic,
             write,
-            errorCount =>
+            (errorCount, filesInError) =>
                 result.onWatchStatusChange!(
-                    createCompilerDiagnostic(getWatchErrorSummaryDiagnosticMessage(errorCount), errorCount),
+                    getWatchErrorSummaryDiagnostic(errorCount, filesInError, newLine, result, compilerOptions),
                     newLine,
                     compilerOptions,
                     errorCount,

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
@@ -53,7 +53,10 @@ Output::
 [7m4[0m     "outFile": "/home/src/projects/a/b/out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -186,7 +189,10 @@ Output::
 [7m4[0m     "outFile": "/home/src/projects/a/b/out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-the-reference-map-changes.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-the-reference-map-changes.js
@@ -149,7 +149,10 @@ Output::
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file1Consumer1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -211,7 +214,10 @@ Output::
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file1Consumer1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -346,7 +352,14 @@ Output::
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 3 files.
+
+Errors  Files
+     1  file1Consumer1.ts[90m:1[0m
+     1  file1Consumer2.ts[90m:1[0m
+     1  moduleFile1.ts[90m:1[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-non-existing-code-file.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-non-existing-code-file.js
@@ -37,7 +37,10 @@ Output::
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: referenceFile1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -122,7 +125,10 @@ Output::
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m                                     ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: referenceFile1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -199,7 +205,10 @@ Output::
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m                                     ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: referenceFile1.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-removed-code-file.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-removed-code-file.js
@@ -35,7 +35,10 @@ Output::
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in referenceFile1.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -119,7 +122,10 @@ Output::
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: referenceFile1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
@@ -38,7 +38,10 @@ Output::
 [7m3[0m     "out": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -118,7 +121,10 @@ Output::
 [7m3[0m     "out": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -179,7 +185,10 @@ Output::
 [7m3[0m     "out": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
@@ -38,7 +38,10 @@ Output::
 [7m3[0m     "outFile": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -111,7 +114,10 @@ Output::
 [7m3[0m     "outFile": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -169,7 +175,10 @@ Output::
 [7m3[0m     "outFile": "/home/src/projects/a/out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
@@ -62,7 +62,10 @@ Output::
 [7m4[0m     "target": "es5"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/without---outFile-and-multiple-declaration-files-in-the-program.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/without---outFile-and-multiple-declaration-files-in-the-program.js
@@ -57,7 +57,10 @@ Output::
 [7m4[0m     "target": "es5"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
+++ b/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
@@ -49,7 +49,10 @@ Output::
 [7m5[0m     "outDir": "Static/scripts/"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -136,7 +139,10 @@ Output::
 [7m5[0m     "outDir": "Static/scripts/"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/errors-for-.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/errors-for-.ts-change-with-incremental.js
@@ -213,7 +213,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -380,7 +383,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -544,7 +550,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/errors-for-.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/errors-for-.ts-change.js
@@ -142,7 +142,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -212,7 +215,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -279,7 +285,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -316,7 +319,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -537,7 +543,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -750,7 +759,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -189,7 +192,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -259,7 +265,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -321,7 +330,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -347,7 +350,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -589,7 +595,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -821,7 +830,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -206,7 +209,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -279,7 +285,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -342,7 +351,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -392,7 +398,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -637,7 +649,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -882,7 +900,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -240,7 +246,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -333,7 +345,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -426,7 +444,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -373,7 +376,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -595,7 +601,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -817,7 +826,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -221,7 +224,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -291,7 +297,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -361,7 +370,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -417,7 +420,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -658,7 +664,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -899,7 +908,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -247,7 +250,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -318,7 +324,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -389,7 +398,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
@@ -203,7 +203,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -470,7 +473,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.d.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.d.ts-change.js
@@ -130,7 +130,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -247,7 +250,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.ts-change-with-incremental.js
@@ -209,7 +209,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -511,7 +514,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/errors-for-.ts-change.js
@@ -141,7 +141,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -273,7 +276,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -521,7 +527,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -281,7 +287,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -312,7 +315,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -529,7 +535,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -726,7 +735,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -188,7 +191,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -257,7 +263,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -322,7 +331,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -343,7 +346,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -581,7 +587,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -794,7 +803,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -205,7 +208,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -277,7 +283,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -344,7 +353,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
@@ -215,7 +215,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -500,7 +503,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.d.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.d.ts-change.js
@@ -135,7 +135,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -256,7 +259,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.ts-change-with-incremental.js
@@ -242,7 +242,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -571,7 +574,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/errors-for-.ts-change.js
@@ -159,7 +159,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -308,7 +311,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -591,7 +597,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -325,7 +331,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -371,7 +374,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -599,7 +605,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -827,7 +836,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -220,7 +223,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -297,7 +303,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -374,7 +383,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -415,7 +418,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -664,7 +670,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -913,7 +922,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -246,7 +249,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -326,7 +332,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -406,7 +415,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
@@ -204,7 +204,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -473,7 +476,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.d.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.d.ts-change.js
@@ -131,7 +131,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -250,7 +253,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.ts-change-with-incremental.js
@@ -210,7 +210,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -499,7 +502,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/errors-for-.ts-change.js
@@ -142,7 +142,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -273,7 +276,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -503,7 +509,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -279,7 +285,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -313,7 +316,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -506,7 +512,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -699,7 +708,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -189,7 +192,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -254,7 +260,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -319,7 +328,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -344,7 +347,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -553,7 +559,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -762,7 +771,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -206,7 +209,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -273,7 +279,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -340,7 +349,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.d.ts-change-with-incremental.js
@@ -216,7 +216,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -503,7 +506,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.d.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.d.ts-change.js
@@ -136,7 +136,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -259,7 +262,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.ts-change-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.ts-change-with-incremental.js
@@ -243,7 +243,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -572,7 +575,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.ts-change.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/errors-for-.ts-change.js
@@ -160,7 +160,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -309,7 +312,10 @@ Output::
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes-with-incremental.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -592,7 +598,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -72,7 +72,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -326,7 +332,13 @@ Output::
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  c.ts[90m:6[0m
+     1  d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/no-circular-import/export-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/no-circular-import/export-with-incremental.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -372,7 +375,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -600,7 +606,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -828,7 +837,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/no-circular-import/export.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/no-circular-import/export.js
@@ -69,7 +69,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -221,7 +224,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -298,7 +304,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -375,7 +384,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/yes-circular-import/exports-with-incremental.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -416,7 +419,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -665,7 +671,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -914,7 +923,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/yes-circular-import/exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/transitive-exports/yes-circular-import/exports.js
@@ -75,7 +75,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -247,7 +250,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -327,7 +333,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -407,7 +416,10 @@ Output::
 [7m6[0m     "baseUrl": "."
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/extends/configDir-template.js
+++ b/tests/baselines/reference/tscWatch/extends/configDir-template.js
@@ -181,7 +181,10 @@ root2/other/sometype2/index.d.ts
   Imported via "other/sometype2" from file 'src/secondary.ts'
 src/secondary.ts
   Matched by include pattern '${configDir}/src' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/src 1 {"excludeFiles":["/home/src/projects/myproject/main.ts"]} Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/src 1 {"excludeFiles":["/home/src/projects/myproject/main.ts"]} Wild card directory
@@ -405,7 +408,10 @@ root2/other/sometype2/index.d.ts
   Imported via "other/sometype2" from file 'src/secondary.ts'
 src/secondary.ts
   Matched by include pattern '${configDir}/src' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
@@ -73,7 +73,10 @@ node_modules/react/Jsx-Runtime/index.d.ts
   Imported via "react/jsx-runtime" from file 'index.tsx' with packageId 'react/jsx-runtime/index.d.ts@0.0.1' to import 'jsx' and 'jsxs' factory functions
 index.tsx
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
@@ -73,7 +73,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -225,7 +228,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
@@ -119,7 +119,10 @@ Output::
 [7m1[0m import { logger } from "./Logger"; new logger();
 [7m [0m [91m                       ~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in another.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
@@ -73,7 +73,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -225,7 +228,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-is-included-from-multiple-places-with-different-casing.js
@@ -303,7 +303,14 @@ src/anotherFile.ts
   Matched by default include pattern '**/*'
 src/oneMore.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 7 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 7 errors in 3 files.
+
+Errors  Files
+     3  src/anotherFile.ts[90m:2[0m
+     2  src/oneMore.ts[90m:2[0m
+     2  src/Struct.d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -669,7 +676,14 @@ src/anotherFile.ts
   Matched by default include pattern '**/*'
 src/oneMore.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 7 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 7 errors in 3 files.
+
+Errors  Files
+     3  src/anotherFile.ts[90m:2[0m
+     2  src/oneMore.ts[90m:2[0m
+     2  src/Struct.d.ts[90m:2[0m
+ Watching for file changes.
 
 
 
@@ -935,7 +949,14 @@ src/anotherFile.ts
   Matched by default include pattern '**/*'
 src/oneMore.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 6 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 6 errors in 3 files.
+
+Errors  Files
+     3  src/anotherFile.ts[90m:2[0m
+     2  src/oneMore.ts[90m:2[0m
+     1  src/Struct.d.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -73,7 +73,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -225,7 +228,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
@@ -70,7 +70,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -199,7 +202,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -73,7 +73,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -225,7 +228,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
@@ -70,7 +70,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -199,7 +202,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -73,7 +73,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -225,7 +228,10 @@ link/a.ts
   Imported via "./link/a" from file 'b.ts'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
@@ -70,7 +70,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -199,7 +202,10 @@ link.ts
   Matched by default include pattern '**/*'
 b.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-relative-information-file-location-changes.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-relative-information-file-location-changes.js
@@ -84,7 +84,13 @@ moduleA.ts
   Matched by default include pattern '**/*'
 moduleB.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 4 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 4 errors in 2 files.
+
+Errors  Files
+     2  moduleA.ts[90m:1[0m
+     2  moduleB.ts[90m:1[0m
+ Watching for file changes.
 
 
 
@@ -220,7 +226,13 @@ moduleA.ts
   Matched by default include pattern '**/*'
 moduleB.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 4 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 4 errors in 2 files.
+
+Errors  Files
+     2  moduleA.ts[90m:2[0m
+     2  moduleB.ts[90m:1[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-renaming-file-with-different-casing.js
@@ -117,7 +117,10 @@ Output::
 [7m1[0m import { logger } from "./logger"; new logger();
 [7m [0m [91m                       ~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in another.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/with-nodeNext-resolution.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/with-nodeNext-resolution.js
@@ -101,7 +101,10 @@ node_modules/@types/yargs/index.d.mts
   Imported via "yargs" from file 'src/bin.ts' with packageId 'yargs/index.d.mts@17.0.12'
 src/bin.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/editing-module-augmentation-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/editing-module-augmentation-watch.js
@@ -42,7 +42,10 @@ Output::
 [7m1[0m export {}; declare module "classnames" { interface Result { foo } }
 [7m [0m [91m                                                            ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/types/classnames.d.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -268,7 +271,10 @@ Output::
 [7m1[0m import classNames from "classnames"; classNames().foo;
 [7m [0m [91m                                                  ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
@@ -48,7 +48,10 @@ Output::
 [7m1[0m export const App = () => <div propA={true}></div>;
 [7m [0m [91m                                           ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: index.tsx[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
@@ -240,7 +240,10 @@ Output::
 [7m1[0m export const App = () => <div propA={true}></div>;
 [7m [0m [91m                                           ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: index.tsx[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -272,7 +272,10 @@ node_modules/preact/jsx-runtime/index.d.ts
   Imported via "preact/jsx-runtime" from file 'index.tsx' with packageId 'preact/jsx-runtime/index.d.ts@0.0.1' to import 'jsx' and 'jsxs' factory functions
 index.tsx
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.tsx[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
@@ -40,7 +40,10 @@ Output::
 [7m1[0m export const y: string = 20;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -198,7 +201,10 @@ Output::
 [7m1[0m export const y: string = 20;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
@@ -38,7 +38,10 @@ Output::
 [7m1[0m const y: string = 20;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -193,7 +196,10 @@ Output::
 [7m1[0m const y: string = 20;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
@@ -167,7 +167,10 @@ Output::
 [7m1[0m console.log(Config.value);
 [7m [0m [91m            ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
@@ -39,7 +39,10 @@ Output::
 [7m4[0m     "outFile": "out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/libraryResolution/unknwon-lib.js
+++ b/tests/baselines/reference/tscWatch/libraryResolution/unknwon-lib.js
@@ -120,7 +120,10 @@ project1/index.ts
   Matched by default include pattern '**/*'
 project1/utils.d.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project1/file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/workspace/projects/project1 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/workspace/projects/project1 1 undefined Wild card directory
@@ -375,7 +378,10 @@ project1/index.ts
   Matched by default include pattern '**/*'
 project1/utils.d.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project1/file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -570,7 +576,10 @@ project1/index.ts
   Matched by default include pattern '**/*'
 project1/utils.d.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project1/file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -771,7 +780,10 @@ project1/index.ts
   Matched by default include pattern '**/*'
 project1/utils.d.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project1/file2.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/libraryResolution/without-config-with-redirection.js
+++ b/tests/baselines/reference/tscWatch/libraryResolution/without-config-with-redirection.js
@@ -447,7 +447,10 @@ project1/index.ts
   Root file specified for compilation
 project1/file2.ts
   Root file specified for compilation
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/libraryResolution/without-config.js
+++ b/tests/baselines/reference/tscWatch/libraryResolution/without-config.js
@@ -412,7 +412,10 @@ project1/index.ts
   Root file specified for compilation
 project1/file2.ts
   Root file specified for compilation
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/alternateResult.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/alternateResult.js
@@ -373,7 +373,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/projects/project/tscon
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Triggered with /home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt :: WatchInfo: /home/src/projects/project 0 undefined Failed Lookup Locations
 Scheduling invalidateFailedLookup, Cancelled earlier one
@@ -702,7 +705,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -859,7 +865,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -1026,7 +1035,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -1172,7 +1184,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -1311,7 +1326,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -1605,7 +1623,10 @@ Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /home/src/projects/node_modu
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -1969,7 +1990,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modu
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -2290,7 +2314,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/project/node_modules/foo2/in
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -2610,7 +2637,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -2767,7 +2797,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -2934,7 +2967,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -3080,7 +3116,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/diagnostics-from-cache.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/diagnostics-from-cache.js
@@ -76,7 +76,10 @@ File '/package.json' does not exist.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -202,7 +205,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/module-resolutions-from-file-are-partially-used.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/module-resolutions-from-file-are-partially-used.js
@@ -159,7 +159,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -325,7 +328,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/module-resolutions-from-files-with-partially-used-import-attributes.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/module-resolutions-from-files-with-partially-used-import-attributes.js
@@ -159,7 +159,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -325,7 +328,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
@@ -88,7 +88,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/package.json 
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is ECMAScript module because 'package.json' has field "type" with value "module"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Wild card directory
@@ -244,7 +247,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' does not have field "type"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -395,7 +401,10 @@ Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/mypr
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is ECMAScript module because 'package.json' has field "type" with value "module"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -554,7 +563,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -696,7 +708,10 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' does not have field "type"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -834,7 +849,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/package-json-file-is-edited.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/package-json-file-is-edited.js
@@ -94,7 +94,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/package.json 
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' does not have field "type"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Wild card directory
@@ -250,7 +253,10 @@ Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/mypr
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is ECMAScript module because 'package.json' has field "type" with value "module"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -405,7 +411,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' does not have field "type"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -548,7 +557,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -693,7 +705,10 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is ECMAScript module because 'package.json' has field "type" with value "module"
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -854,7 +869,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/package.json 2000 undef
 src/fileA.ts
   Matched by default include pattern '**/*'
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/fileA.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/type-reference-resolutions-reuse.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/type-reference-resolutions-reuse.js
@@ -145,7 +145,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -305,7 +308,10 @@ File '/package.json' does not exist according to earlier cached lookups.
 [7m2[0m   "compilerOptions": {
 [7m [0m [91m  ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/type-reference-resolutions-with-impliedMode.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/type-reference-resolutions-with-impliedMode.js
@@ -110,7 +110,10 @@ node_modules/@types/pkg/import.d.ts
   File is CommonJS module because 'node_modules/@types/pkg/package.json' does not have field "type"
 index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/watches-for-changes-to-package-json-main-fields.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/watches-for-changes-to-package-json-main-fields.js
@@ -222,7 +222,10 @@ Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/bui
 [7m1[0m import type { TheNum } from 'pkg2'
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/pkg1/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental-as-modules.js
@@ -45,7 +45,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -501,7 +504,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -652,7 +658,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -798,7 +807,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental.js
@@ -42,7 +42,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -445,7 +448,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -585,7 +591,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -719,7 +728,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors.js
@@ -41,7 +41,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -269,7 +272,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -332,7 +338,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -398,7 +407,10 @@ Output::
     [7m [0m [96m      ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental-as-modules.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m export const a: number = "hello"
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -442,7 +445,10 @@ Output::
 [7m1[0m export const a: number = "hello"
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -567,7 +573,10 @@ Output::
 [7m1[0m export const a: number = "hello"
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -685,7 +694,10 @@ Output::
 [7m1[0m export const a: number = "hello"
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental.js
@@ -36,7 +36,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -400,7 +403,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -518,7 +524,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -627,7 +636,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors.js
@@ -35,7 +35,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -247,7 +250,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -302,7 +308,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -355,7 +364,10 @@ Output::
 [7m1[0m const a: number = "hello"
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors-with-incremental-as-modules.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -435,7 +438,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -546,7 +552,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -665,7 +674,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors-with-incremental.js
@@ -36,7 +36,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -380,7 +383,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -478,7 +484,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -585,7 +594,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/syntax-errors.js
@@ -35,7 +35,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -243,7 +246,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -295,7 +301,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -354,7 +363,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-with-incremental-as-modules.js
@@ -47,7 +47,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -161,7 +164,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -267,7 +273,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -406,7 +415,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -466,7 +478,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -580,7 +595,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  a.ts[90m:1[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -736,7 +757,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-with-incremental.js
@@ -38,7 +38,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -134,7 +137,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -223,7 +229,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -327,7 +336,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -379,7 +391,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -477,7 +492,13 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  a.ts[90m:1[0m
+     1  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -602,7 +623,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled-with-incremental-as-modules.js
@@ -46,7 +46,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -158,7 +161,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -261,7 +267,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -388,7 +397,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -447,7 +459,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -548,7 +563,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -678,7 +696,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled-with-incremental.js
@@ -37,7 +37,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -131,7 +134,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -217,7 +223,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -314,7 +323,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -365,7 +377,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -450,7 +465,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -549,7 +567,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors-without-dts-enabled.js
@@ -36,7 +36,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -99,7 +102,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -153,7 +159,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -212,7 +221,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -262,7 +274,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -316,7 +331,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -377,7 +395,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/dts-errors.js
@@ -37,7 +37,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -101,7 +104,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -157,7 +163,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -222,7 +231,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -273,7 +285,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -339,7 +354,13 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  a.ts[90m:1[0m
+     1  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -402,7 +423,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors-with-incremental-as-modules.js
@@ -46,7 +46,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -158,7 +161,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -261,7 +267,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -388,7 +397,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -447,7 +459,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -548,7 +563,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -661,7 +679,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors-with-incremental.js
@@ -37,7 +37,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -131,7 +134,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -217,7 +223,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -314,7 +323,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -365,7 +377,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -450,7 +465,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -543,7 +561,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/semantic-errors.js
@@ -36,7 +36,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -99,7 +102,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -153,7 +159,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -212,7 +221,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -262,7 +274,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -316,7 +331,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -371,7 +389,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors-with-incremental-as-modules.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors-with-incremental-as-modules.js
@@ -41,7 +41,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -153,7 +156,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -256,7 +262,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -383,7 +392,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -437,7 +449,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -533,7 +548,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -655,7 +673,10 @@ Output::
 [7m1[0m export const a = "hello
 [7m [0m [91m                       [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors-with-incremental.js
@@ -37,7 +37,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -131,7 +134,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -217,7 +223,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -314,7 +323,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -365,7 +377,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -450,7 +465,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -547,7 +565,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/outFile/syntax-errors.js
@@ -36,7 +36,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -99,7 +102,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -153,7 +159,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -212,7 +221,10 @@ Output::
 [7m3[0m     "outFile": "../outFile.js",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -262,7 +274,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -316,7 +331,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -375,7 +393,10 @@ Output::
 [7m1[0m const a = "hello
 [7m [0m [91m                [0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-declaration-with-incremental.js
@@ -53,7 +53,10 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -410,7 +413,10 @@ Output::
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -737,7 +743,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-declaration.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-declaration.js
@@ -52,7 +52,10 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -252,7 +255,10 @@ Output::
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -409,7 +415,10 @@ Output::
     [7m [0m [96m             ~[0m
     Add a type annotation to the variable a.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError-with-incremental.js
@@ -52,7 +52,10 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -387,7 +390,10 @@ Output::
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/multiFile/noEmitOnError.js
@@ -51,7 +51,10 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -235,7 +238,10 @@ Output::
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration-with-incremental.js
@@ -64,7 +64,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:4[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -212,7 +218,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -346,7 +355,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:2[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -488,7 +503,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -618,7 +636,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -748,7 +769,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-declaration.js
@@ -63,7 +63,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:4[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -165,7 +171,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -253,7 +262,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:2[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -336,7 +351,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -420,7 +438,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -504,7 +525,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError-with-incremental.js
@@ -63,7 +63,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:4[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -209,7 +215,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -341,7 +350,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:2[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -481,7 +496,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -609,7 +627,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -737,7 +758,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/noEmitOnError/outFile/noEmitOnError.js
@@ -62,7 +62,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:4[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -163,7 +169,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -250,7 +259,13 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  src/main.ts[90m:2[0m
+     2  tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -332,7 +347,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -415,7 +433,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -498,7 +519,10 @@ Output::
 [7m4[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/nodeNextWatch/esm-mode-file-is-edited.js
+++ b/tests/baselines/reference/tscWatch/nodeNextWatch/esm-mode-file-is-edited.js
@@ -54,7 +54,10 @@ Output::
 [7m7[0m     "outDir": "../dist"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:7[0m
+
+ Watching for file changes.
 
 
 
@@ -152,7 +155,10 @@ Output::
 [7m7[0m     "outDir": "../dist"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:7[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Configure-file-diagnostics-events-are-generated-when-the-config-file-has-errors.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Configure-file-diagnostics-events-are-generated-when-the-config-file-has-errors.js
@@ -41,7 +41,10 @@ Output::
 [7m4[0m                             "allowJS": true
 [7m [0m [91m                            ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Options-Diagnostic-locations-reported-correctly-with-changes-in-configFile-contents-when-options-change.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Options-Diagnostic-locations-reported-correctly-with-changes-in-configFile-contents-when-options-change.js
@@ -49,7 +49,10 @@ Output::
 [7m7[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -135,7 +138,10 @@ Output::
 [7m5[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Proper-errors-document-is-not-contained-in-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Proper-errors-document-is-not-contained-in-project.js
@@ -36,7 +36,10 @@ Output::
     [7m [0m [96m~[0m
     The parser expected to find a '}' to match the '{' token here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Reports-errors-when-the-config-file-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Reports-errors-when-the-config-file-changes.js
@@ -100,7 +100,10 @@ Output::
 [7m3[0m                             "haha": 123
 [7m [0m [91m                            ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -41,7 +41,10 @@ Output::
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -120,7 +123,10 @@ Output::
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -192,7 +198,10 @@ Output::
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
@@ -106,7 +106,10 @@ Output::
 [7m1[0m label: while (1) {}
 [7m [0m [91m~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/add-the-missing-module-file-for-inferred-project-should-remove-the-module-not-found-error.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/add-the-missing-module-file-for-inferred-project-should-remove-the-module-not-found-error.js
@@ -28,7 +28,10 @@ Output::
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
@@ -120,7 +120,10 @@ Output::
 [7m3[0m     "outFile": "out.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/change-module-to-none.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/change-module-to-none.js
@@ -100,7 +100,10 @@ Output::
 [7m3[0m     "module": "none"
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
@@ -59,7 +59,10 @@ Output::
 [7m1[0m var x: Promise<string>;
 [7m [0m [91m       ~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in app.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
@@ -34,7 +34,10 @@ Output::
 [7m2[0m                 import {f} from "./module"
 [7m [0m [91m                        ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/app.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
@@ -109,7 +109,10 @@ Output::
 [7m1[0m export * from "./f2"
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project/f1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
@@ -108,7 +108,10 @@ Output::
 [7m1[0m export * from "./f2"
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project/f1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/file-in-files-is-deleted.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/file-in-files-is-deleted.js
@@ -114,7 +114,10 @@ Output::
     [7m [0m [96m    ~~~~~~~[0m
     File is matched by 'files' list specified here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/handles-the-missing-files---that-were-added-to-program-because-they-were-added-with-tripleSlashRefs.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/handles-the-missing-files---that-were-added-to-program-because-they-were-added-with-tripleSlashRefs.js
@@ -34,7 +34,10 @@ Output::
 [7m2[0m                     let x = y
 [7m [0m [91m                            ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: commonFile1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
@@ -40,7 +40,10 @@ Output::
 [7m3[0m   "files": []
 [7m [0m [91m           ~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
@@ -31,7 +31,10 @@ Output::
 
 [91merror[0m[90m TS18003: [0mNo inputs were found in config file '/user/username/workspace/solution/projects/project/tsconfig.json'. Specified 'include' paths were '["app/*","test/**/*","something"]' and 'exclude' paths were '[]'.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-configured-projects.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-configured-projects.js
@@ -112,7 +112,10 @@ Output::
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
@@ -100,7 +100,10 @@ Output::
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in file1.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-file-not-in-rootDir.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-file-not-in-rootDir.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m import { x } from "../b";
 [7m [0m [91m                  ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -121,7 +124,10 @@ Output::
 [7m3[0m import { x } from "../b";
 [7m [0m [91m                  ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-isolatedModules.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-isolatedModules.js
@@ -115,7 +115,10 @@ Output::
 [7m2[0m const b: string = a;
 [7m [0m [91m      ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-ignore-non-existing-files-specified-in-the-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-ignore-non-existing-files-specified-in-the-config-file.js
@@ -44,7 +44,10 @@ Output::
     [7m [0m [96m                        ~~~~~~~~~~~~~~~~[0m
     File is matched by 'files' list specified here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
@@ -40,7 +40,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -149,7 +152,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
@@ -41,7 +41,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -151,7 +154,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
@@ -39,7 +39,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -139,7 +142,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
@@ -44,7 +44,10 @@ Output::
 [7m4[0m     "outFile": "build/outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -143,7 +146,10 @@ Output::
 [7m4[0m     "outFile": "build/outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
@@ -39,7 +39,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -147,7 +150,10 @@ Output::
 [7m3[0m     "module": "amd",
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
@@ -38,7 +38,10 @@ Output::
 [7m3[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -137,7 +140,10 @@ Output::
 [7m3[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
@@ -43,7 +43,10 @@ Output::
 [7m3[0m                         "moduleResolution": "node"
 [7m [0m [91m                                            ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -133,7 +136,10 @@ Output::
 [7m3[0m                             "moduleResolution": "classic"
 [7m [0m [91m                                                ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
@@ -45,7 +45,10 @@ Output::
 [7m4[0m                             "allowAnything": true
 [7m [0m [91m                            ~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/types-should-not-load-from-config-file-path-if-config-exists-but-does-not-specifies-typeRoots.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/types-should-not-load-from-config-file-path-if-config-exists-but-does-not-specifies-typeRoots.js
@@ -45,7 +45,10 @@ Output::
     [7m [0m [96m      ~~~~~~[0m
     File is entry point of type library specified here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
@@ -40,7 +40,10 @@ Output::
 
 [91merror[0m[90m TS2318: [0mCannot find global type 'ClassDecoratorContext'.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
@@ -36,7 +36,10 @@ Output::
 [7m2[0m class D extends C { prop = 1; }
 [7m [0m [91m                    ~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -120,7 +123,10 @@ Output::
 [7m2[0m class D extends C { prop = 1; }
 [7m [0m [91m                    ~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-add.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-add.js
@@ -39,7 +39,10 @@ Output::
 [7m2[0m const d = <div />;
 [7m [0m [91m          ~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: index.tsx[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -109,7 +112,10 @@ Output::
 [7m2[0m const d = <div />;
 [7m [0m [91m          ~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.tsx[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-change.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-change.js
@@ -36,7 +36,10 @@ Output::
 [7m2[0m const d = <div />;
 [7m [0m [91m          ~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.tsx[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -107,7 +110,10 @@ Output::
 [7m2[0m const d = <div />;
 [7m [0m [91m          ~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in index.tsx[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-correctly-when-declaration-emit-is-disabled-in-compiler-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-correctly-when-declaration-emit-is-disabled-in-compiler-options.js
@@ -116,7 +116,10 @@ Output::
 [7m2[0m test(4, 5);
 [7m [0m [91m     ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -236,7 +239,13 @@ Output::
 [7m2[0m     return x + y / 5;
 [7m [0m [91m               ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  a.ts[90m:2[0m
+     1  b.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-ambient-modules-of-program-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-ambient-modules-of-program-changes.js
@@ -114,7 +114,13 @@ Output::
     [7m [0m [96m       ~~~[0m
     'foo' was also declared here.
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  a.ts[90m:2[0m
+     1  b.ts[90m:2[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
@@ -127,7 +127,10 @@ Output::
     [7m [0m [96m                ~~~~~[0m
     File is included via import here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-noErrorTruncation-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-noErrorTruncation-changes.js
@@ -42,7 +42,10 @@ Output::
 [7m10[0m v === 'foo';
 [7m  [0m [91m~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:10[0m
+
+ Watching for file changes.
 
 
 
@@ -116,7 +119,10 @@ Output::
 [7m10[0m v === 'foo';
 [7m  [0m [91m~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:10[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-strictNullChecks-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-strictNullChecks-changes.js
@@ -34,7 +34,10 @@ Output::
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -108,7 +111,10 @@ Output::
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -163,7 +169,10 @@ Output::
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -220,7 +229,10 @@ Output::
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-moduleResolution-when-resolveJsonModule-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-moduleResolution-when-resolveJsonModule-changes.js
@@ -39,7 +39,10 @@ Output::
 [7m3[0m     "moduleResolution": "node"
 [7m [0m [91m                        ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -119,7 +122,10 @@ Output::
 [7m3[0m     "moduleResolution": "node",
 [7m [0m [91m                        ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-changing-`allowImportingTsExtensions`-of-config-file-2.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-changing-`allowImportingTsExtensions`-of-config-file-2.js
@@ -47,7 +47,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m1[0m export * as a from "./a.ts";
 [7m [0m [91m                   ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory

--- a/tests/baselines/reference/tscWatch/programUpdates/when-changing-`allowImportingTsExtensions`-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-changing-`allowImportingTsExtensions`-of-config-file.js
@@ -47,7 +47,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m1[0m import "./a.ts";
 [7m [0m [91m       ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory

--- a/tests/baselines/reference/tscWatch/programUpdates/when-changing-checkJs-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-changing-checkJs-of-config-file.js
@@ -49,7 +49,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 [7m1[0m import { aNumber } from "./a.js";
 [7m [0m [91m                        ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in b.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -140,7 +143,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a.js 250 unde
 [7m1[0m export const aNumber: number = "string"
 [7m [0m [91m                      ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.js[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-changing-noUncheckedSideEffectImports-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-changing-noUncheckedSideEffectImports-of-config-file.js
@@ -145,7 +145,10 @@ CreatingProgramWith::
 [7m1[0m import "does-not-exist";
 [7m [0m [91m       ~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
@@ -58,7 +58,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m3[0m     "baseUrl": "client",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/client 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/client 1 undefined Wild card directory
@@ -165,7 +168,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 [7m3[0m     "baseUrl": "client",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
@@ -68,7 +68,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
@@ -253,7 +256,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -365,7 +371,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -571,7 +580,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -759,7 +771,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
@@ -281,7 +281,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -503,7 +506,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -649,7 +655,10 @@ nrefs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -826,7 +835,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -981,7 +993,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1133,7 +1148,10 @@ b/index.d.ts
   File is output of project reference source 'b/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1279,7 +1297,10 @@ b/index.ts
   Imported via '../b' from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1432,7 +1453,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1578,7 +1602,13 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  b/tsconfig.json[90m:12[0m
+     1  c/tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -1722,7 +1752,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
@@ -290,7 +290,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -510,7 +513,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -659,7 +665,10 @@ nrefs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -837,7 +846,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -993,7 +1005,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1148,7 +1163,10 @@ b/index.d.ts
   File is output of project reference source 'b/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1290,7 +1308,10 @@ b/index.ts
   Imported via '../b' from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1440,7 +1461,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -1584,7 +1608,13 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  b/tsconfig.json[90m:15[0m
+     1  c/tsconfig.json[90m:3[0m
+ Watching for file changes.
 
 
 
@@ -1729,7 +1759,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c/index.ts'
 c/index.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in c/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-with-nodenext.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-with-nodenext.js
@@ -350,7 +350,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -627,7 +630,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -803,7 +809,10 @@ nrefs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1022,7 +1031,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1226,7 +1238,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1418,7 +1433,10 @@ b.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1599,7 +1617,10 @@ b.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1789,7 +1810,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 
@@ -1969,7 +1993,13 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  tsconfig.b.json[90m:17[0m
+     1  tsconfig.c.json[90m:8[0m
+ Watching for file changes.
 
 
 
@@ -2152,7 +2182,10 @@ refs/a.d.ts
 c.ts
   Part of 'files' list in tsconfig.json
   File is CommonJS module because 'package.json' was not found
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:8[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references.js
@@ -287,7 +287,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -502,7 +505,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -643,7 +649,10 @@ nrefs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -809,7 +818,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -959,7 +971,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -1106,7 +1121,10 @@ b.d.ts
   File is output of project reference source 'b.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -1242,7 +1260,10 @@ b.ts
   Imported via './b' from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -1383,7 +1404,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -1516,7 +1540,13 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  tsconfig.b.json[90m:15[0m
+     1  tsconfig.c.json[90m:6[0m
+ Watching for file changes.
 
 
 
@@ -1650,7 +1680,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/when-referenced-project-uses-different-module-resolution.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/when-referenced-project-uses-different-module-resolution.js
@@ -280,7 +280,10 @@ refs/a.d.ts
   Imported via "@ref/a" from file 'c.ts'
 c.ts
   Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.c.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/caching-works.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/caching-works.js
@@ -28,7 +28,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -102,7 +105,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -156,7 +162,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -232,7 +241,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/loads-missing-files-from-disk.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/loads-missing-files-from-disk.js
@@ -25,7 +25,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -99,7 +102,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/reusing-type-ref-resolution.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/reusing-type-ref-resolution.js
@@ -186,7 +186,13 @@ node_modules/pkg2/index.d.ts
   Type library referenced via 'pkg2' from file 'fileWithTypeRefs.ts'
 fileWithTypeRefs.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  fileWithImports.ts[90m:2[0m
+     2  fileWithTypeRefs.ts[90m:2[0m
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project 1 undefined Wild card directory
@@ -547,7 +553,10 @@ node_modules/pkg2/index.d.ts
   Type library referenced via 'pkg2' from file 'fileWithTypeRefs.ts'
 fileWithTypeRefs.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: fileWithTypeRefs.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 
@@ -893,7 +902,10 @@ node_modules/pkg3/index.d.ts
   Type library referenced via 'pkg3' from file 'fileWithTypeRefs.ts'
 fileWithTypeRefs.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in fileWithTypeRefs.ts[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/scoped-package-installation.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/scoped-package-installation.js
@@ -83,7 +83,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 [7m1[0m import { myapp } from "@myapp/ts-types";
 [7m [0m [91m                      ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in lib/app.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
@@ -276,7 +279,10 @@ Directory '/node_modules' does not exist, skipping all lookups in it.
 [7m1[0m import { myapp } from "@myapp/ts-types";
 [7m [0m [91m                      ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in lib/app.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -403,7 +409,10 @@ Directory '/node_modules' does not exist, skipping all lookups in it.
 [7m1[0m import { myapp } from "@myapp/ts-types";
 [7m [0m [91m                      ~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in lib/app.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/should-compile-correctly-when-resolved-module-goes-missing-and-then-comes-back.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/should-compile-correctly-when-resolved-module-goes-missing-and-then-comes-back.js
@@ -28,7 +28,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -94,7 +97,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 
@@ -172,7 +178,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/when-dir-watcher-is-invoked-without-file-change.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/when-dir-watcher-is-invoked-without-file-change.js
@@ -183,7 +183,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/workspaces/project/src/app/services/g
 [7m1[0m import { y } from "./app/services/generated";
 [7m [0m [91m                  ~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
@@ -47,7 +47,10 @@ Output::
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -172,7 +175,10 @@ Output::
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
@@ -64,7 +64,10 @@ Output::
 [7m5[0m     "baseUrl": ".",
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
@@ -40,7 +40,10 @@ Output::
 [7m2[0m import * as fs from "fs";
 [7m [0m [91m                    ~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in foo.ts[90m:2[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -285,7 +285,10 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/
 [7m1[0m process.on("uncaughtException");
 [7m [0m [91m~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in worker.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -430,7 +433,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/package.json 2000 undef
 [7m1[0m process.on("uncaughtException");
 [7m [0m [91m~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in worker.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -539,7 +545,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node
     [7m [0m [96m                                 ~~~[0m
     File is entry point of type library specified here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -27,7 +27,10 @@ Output::
   The file is in the program because:
     Entry point of type library 'node' specified in compilerOptions
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
@@ -31,7 +31,10 @@ Output::
 [7m1[0m import * as q from "qqq";
 [7m [0m [91m                   ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in a.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
@@ -48,7 +48,10 @@ Output::
 [7m6[0m     "moduleResolution": "node",
 [7m [0m [91m                        ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 
@@ -155,7 +158,10 @@ Output::
 [7m6[0m     "moduleResolution": "node",
 [7m [0m [91m                        ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/tsconfig.json[90m:6[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/resolveJsonModule/incremental-always-prefers-declaration-file-over-document.js
+++ b/tests/baselines/reference/tscWatch/resolveJsonModule/incremental-always-prefers-declaration-file-over-document.js
@@ -41,7 +41,10 @@ Output::
 [7m1[0m import data from "./data.json"; let x: string = data;
 [7m [0m [91m                 ~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -190,7 +193,10 @@ Output::
 [7m1[0m import data from "./data.json"; let x: string = data;
 [7m [0m [91m                 ~~~~~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-Linux.js
+++ b/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-Linux.js
@@ -164,7 +164,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package1/pa
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package2 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package2 1 undefined Wild card directory
@@ -607,7 +610,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modu
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Triggered with /home/src/projects/project/node_modules :: WatchInfo: /home/src/projects/project/node_modules 1 undefined Failed Lookup Locations
 Scheduling invalidateFailedLookup
@@ -782,7 +788,10 @@ Directory '/node_modules' does not exist, skipping all lookups in it.
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-package1-built-Linux.js
+++ b/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-package1-built-Linux.js
@@ -382,7 +382,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modu
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 sysLog:: onTimerToUpdateChildWatches:: 3
 sysLog:: invokingWatchers:: Elapsed:: *ms:: 0
@@ -560,7 +563,10 @@ Directory '/node_modules' does not exist, skipping all lookups in it.
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-package1-built.js
+++ b/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked-package1-built.js
@@ -342,7 +342,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modu
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked.js
+++ b/tests/baselines/reference/tscWatch/symlinks/monorepo-style-sibling-packages-symlinked.js
@@ -164,7 +164,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package1/pa
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package2 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/project/packages/package2 1 undefined Wild card directory
@@ -531,7 +534,10 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modu
   Default library for target 'es2016'
 packages/package2/src/index.ts
   Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in packages/package2/src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-Linux.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-Linux.js
@@ -190,7 +190,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/projects/b/2/b-impl/b/
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
@@ -921,7 +924,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-MacOs.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-MacOs.js
@@ -190,7 +190,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/projects/b/2/b-impl/b/
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
@@ -899,7 +902,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-Windows.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-Windows.js
@@ -190,7 +190,10 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /home/src/projects/b/2/b-impl/b/
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/b/2/b-impl/b/src 1 undefined Wild card directory
@@ -839,7 +842,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-Linux.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-Linux.js
@@ -654,7 +654,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-MacOs.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-MacOs.js
@@ -696,7 +696,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-Windows.js
+++ b/tests/baselines/reference/tscWatch/symlinks/packages-outside-project-folder-built-Windows.js
@@ -636,7 +636,10 @@ FileWatcher:: Close:: WatchInfo: /home/src/projects/c/3/c-impl/c/package.json 20
   Default library for target 'es2025'
 src/index.ts
   Matched by include pattern 'src/**/*.ts' in 'tsconfig.json'
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/multiFile/noEmitOnError-with-composite-with-emit-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/multiFile/noEmitOnError-with-composite-with-emit-builder.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m export const x: string = 10;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -194,7 +197,10 @@ Output::
 [7m1[0m export const x: string = 10;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/multiFile/noEmitOnError-with-composite-with-semantic-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/multiFile/noEmitOnError-with-composite-with-semantic-builder.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m export const x: string = 10;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -201,7 +204,10 @@ Output::
 [7m1[0m export const x: string = 10;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/multiFile/semantic-builder-emitOnlyDts.js
+++ b/tests/baselines/reference/tscWatch/watchApi/multiFile/semantic-builder-emitOnlyDts.js
@@ -39,7 +39,10 @@ Output::
 [7m1[0m export const x: string = 10;
 [7m [0m [91m             ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/multiFile/when-emitting-with-emitOnlyDtsFiles.js
+++ b/tests/baselines/reference/tscWatch/watchApi/multiFile/when-emitting-with-emitOnlyDtsFiles.js
@@ -57,7 +57,13 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in 2 files.
+
+Errors  Files
+     1  b.ts[90m:1[0m
+     1  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-emit-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-emit-builder.js
@@ -45,7 +45,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -143,7 +146,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -309,7 +315,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -405,7 +414,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -564,7 +576,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-semantic-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmit-with-composite-with-semantic-builder.js
@@ -45,7 +45,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -150,7 +153,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -323,7 +329,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -426,7 +435,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 
@@ -592,7 +604,10 @@ Output::
 [7m5[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:4[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-emit-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-emit-builder.js
@@ -51,7 +51,13 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  main.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 
@@ -193,7 +199,13 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  main.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 
@@ -327,7 +339,10 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:5[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-semantic-builder.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/noEmitOnError-with-composite-with-semantic-builder.js
@@ -51,7 +51,13 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  main.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 
@@ -200,7 +206,13 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  main.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 
@@ -341,7 +353,10 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:5[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/semantic-builder-emitOnlyDts.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/semantic-builder-emitOnlyDts.js
@@ -51,7 +51,13 @@ Output::
 [7m6[0m     "module": "amd"
 [7m [0m [91m              ~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  main.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/verifies-that-noEmit-is-handled-on-createSemanticDiagnosticsBuilderProgram.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/verifies-that-noEmit-is-handled-on-createSemanticDiagnosticsBuilderProgram.js
@@ -33,7 +33,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors.
+
+ Watching for file changes.
 
 
 
@@ -100,7 +103,10 @@ Output::
 
 [91merror[0m[90m TS5107: [0mOption 'module=AMD' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors.
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/outFile/when-emitting-with-emitOnlyDtsFiles.js
+++ b/tests/baselines/reference/tscWatch/watchApi/outFile/when-emitting-with-emitOnlyDtsFiles.js
@@ -63,7 +63,13 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m6[0m     "outFile": "outFile.js"
 [7m [0m [91m    ~~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 3 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 3 errors in 2 files.
+
+Errors  Files
+     1  b.ts[90m:1[0m
+     2  tsconfig.json[90m:5[0m
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/verify-that-the-error-count-is-correctly-passed-down-to-the-watch-status-reporter.js
+++ b/tests/baselines/reference/tscWatch/watchApi/verify-that-the-error-count-is-correctly-passed-down-to-the-watch-status-reporter.js
@@ -48,7 +48,10 @@ Output::
 [7m1[0m let compiler = new Compiler(); for (let i = 0; j < 5; i++) {}
 [7m [0m [91m                                               ~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: index.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
@@ -68,7 +68,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
@@ -251,7 +254,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -361,7 +367,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -565,7 +574,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -751,7 +763,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
@@ -68,7 +68,10 @@ FileWatcher:: Added:: WatchInfo: /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts 25
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Wild card directory
@@ -238,7 +241,10 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/proj
 [7m3[0m     "module": "none",
 [7m [0m [91m              ~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in project2/tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode-when-rename-event-ends-with-tilde.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode-when-rename-event-ends-with-tilde.js
@@ -183,7 +183,10 @@ CreatingProgramWith::
     [7m [0m [96m                ~~~~[0m
     'foo2' is declared here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode-when-rename-occurs-when-file-is-still-on-the-disk.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode-when-rename-occurs-when-file-is-still-on-the-disk.js
@@ -151,7 +151,10 @@ CreatingProgramWith::
     [7m [0m [96m                        ~~~~[0m
     'foo2' is declared here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-on-inode.js
@@ -171,7 +171,10 @@ CreatingProgramWith::
     [7m [0m [96m                ~~~~[0m
     'foo2' is declared here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-when-rename-occurs-when-file-is-still-on-the-disk.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsWatch/when-using-file-watching-thats-when-rename-occurs-when-file-is-still-on-the-disk.js
@@ -136,7 +136,10 @@ CreatingProgramWith::
     [7m [0m [96m                        ~~~~[0m
     'foo2' is declared here.
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in main.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders-with-synchronousWatchDirectory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders-with-synchronousWatchDirectory.js
@@ -320,7 +320,10 @@ FileWatcher:: Close:: WatchInfo: /home/user/projects/package.json 2000 {"synchro
 [7m1[0m import * as a from "a"
 [7m [0m [91m                   ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/file.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
@@ -303,7 +303,10 @@ FileWatcher:: Close:: WatchInfo: /home/user/projects/package.json 2000 undefined
 [7m1[0m import * as a from "a"
 [7m [0m [91m                   ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/file.ts[90m:1[0m
+
+ Watching for file changes.
 
 sysLog:: onTimerToUpdateChildWatches:: 3
 sysLog:: invokingWatchers:: Elapsed:: *ms:: 0
@@ -481,7 +484,10 @@ Directory '/node_modules' does not exist, skipping all lookups in it.
 [7m1[0m import * as a from "a"
 [7m [0m [91m                   ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in src/file.ts[90m:1[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-renaming-a-file.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-renaming-a-file.js
@@ -39,7 +39,10 @@ Output::
 [7m3[0m     "outDir": "dist"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -163,7 +166,10 @@ Output::
 [7m3[0m     "outDir": "dist"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 2 errors. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 2 errors in the same file, starting at: tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -244,7 +250,10 @@ Output::
 [7m3[0m     "outDir": "dist"
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
@@ -40,7 +40,10 @@ Output::
 [7m3[0m     "outDir": "dist",
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 
@@ -163,7 +166,10 @@ Output::
 [7m3[0m     "outDir": "dist",
 [7m [0m [91m    ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:3[0m
+
+ Watching for file changes.
 
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
@@ -35,7 +35,10 @@ Output::
 [7m1[0m { "compilerOptions": { "moduleResolution": "node10" } }
 [7m [0m [91m                                           ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -180,7 +183,10 @@ Output::
 [7m1[0m { "compilerOptions": { "moduleResolution": "node10" } }
 [7m [0m [91m                                           ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -280,7 +286,10 @@ Output::
 [7m1[0m { "compilerOptions": { "moduleResolution": "node10" } }
 [7m [0m [91m                                           ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:1[0m
+
+ Watching for file changes.
 
 
 
@@ -436,7 +445,10 @@ Output::
 [7m1[0m { "compilerOptions": { "moduleResolution": "node10" } }
 [7m [0m [91m                                           ~~~~~~~~[0m
 
-[[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
+[[90mHH:MM:SS AM[0m] 
+Found 1 error in tsconfig.json[90m:1[0m
+
+ Watching for file changes.
 
 
 


### PR DESCRIPTION
This change updates the watch mode error reporting to include a detailed summary of errors per file, similar to non-watch mode.
It uses 'getErrorSummaryText' to generate the summary and introduces a new diagnostic message '_0_Watching_for_file_changes' to display it alongside the watch status.

Verification:
- Verified manually with reproduction case (single error and zero errors).
- Ran existing 'tscWatch' tests and updated baselines for 213 scenarios.
- All 454 watch mode tests passed.