### PR TITLE
Ensure node is installed in release publisher

### DIFF
--- a/azure-pipelines.release-publish.yml
+++ b/azure-pipelines.release-publish.yml
@@ -73,6 +73,10 @@ extends:
                   targetPath: '$(Pipeline.Workspace)/tgz'
             steps:
               - checkout: none
+              - task: NodeTool@0
+                inputs:
+                  versionSpec: 20.x
+                displayName: 'Install Node'
               - task: CmdLine@2
                 displayName: Copy versioned drop to typescript.tgz
                 inputs:


### PR DESCRIPTION
npm was kicked out of the base image at some point since we last run this. Yay.