### PR TITLE
Fixed a crash coming from hitting the instantiation depth limit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21027,6 +21027,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // that perpetually generate new type identities, so we stop the recursion here by yielding the error type.
             tracing?.instant(tracing.Phase.CheckTypes, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });
             error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
+            // set this to a max value to "propagate" the error through any further instantiations within the currently checked node
+            // this can skip a bunch of redundant work in the case of hitting the depth limit
+            instantiationCount = 5000000;
             return errorType;
         }
         const index = findActiveMapper(mapper);

--- a/tests/baselines/reference/recursiveConditionalCrash5.errors.txt
+++ b/tests/baselines/reference/recursiveConditionalCrash5.errors.txt
@@ -1,0 +1,21 @@
+recursiveConditionalCrash5.ts(13,6): error TS2589: Type instantiation is excessively deep and possibly infinite.
+
+
+==== recursiveConditionalCrash5.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/62966
+    
+    type Prepend<Elm, T extends unknown[]> = T extends unknown
+      ? ((arg: Elm, ...rest: T) => void) extends (...args: infer T2) => void
+        ? T2
+        : never
+      : never;
+    
+    type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+    
+    type Conv<T, U = T> = {
+      0: [T];
+      1: Prepend<T, Conv<ExactExtract<U, T>>>;
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
+    }[U extends T ? 0 : 1];
+    

--- a/tests/baselines/reference/recursiveConditionalCrash5.symbols
+++ b/tests/baselines/reference/recursiveConditionalCrash5.symbols
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/recursiveConditionalCrash5.ts] ////
+
+=== recursiveConditionalCrash5.ts ===
+// https://github.com/microsoft/TypeScript/issues/62966
+
+type Prepend<Elm, T extends unknown[]> = T extends unknown
+>Prepend : Symbol(Prepend, Decl(recursiveConditionalCrash5.ts, 0, 0))
+>Elm : Symbol(Elm, Decl(recursiveConditionalCrash5.ts, 2, 13))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 2, 17))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 2, 17))
+
+  ? ((arg: Elm, ...rest: T) => void) extends (...args: infer T2) => void
+>arg : Symbol(arg, Decl(recursiveConditionalCrash5.ts, 3, 6))
+>Elm : Symbol(Elm, Decl(recursiveConditionalCrash5.ts, 2, 13))
+>rest : Symbol(rest, Decl(recursiveConditionalCrash5.ts, 3, 15))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 2, 17))
+>args : Symbol(args, Decl(recursiveConditionalCrash5.ts, 3, 46))
+>T2 : Symbol(T2, Decl(recursiveConditionalCrash5.ts, 3, 60))
+
+    ? T2
+>T2 : Symbol(T2, Decl(recursiveConditionalCrash5.ts, 3, 60))
+
+    : never
+  : never;
+
+type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+>ExactExtract : Symbol(ExactExtract, Decl(recursiveConditionalCrash5.ts, 6, 10))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 8, 18))
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 8, 20))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 8, 18))
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 8, 20))
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 8, 20))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 8, 18))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 8, 18))
+
+type Conv<T, U = T> = {
+>Conv : Symbol(Conv, Decl(recursiveConditionalCrash5.ts, 8, 83))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 10, 12))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+
+  0: [T];
+>0 : Symbol(0, Decl(recursiveConditionalCrash5.ts, 10, 23))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+
+  1: Prepend<T, Conv<ExactExtract<U, T>>>;
+>1 : Symbol(1, Decl(recursiveConditionalCrash5.ts, 11, 9))
+>Prepend : Symbol(Prepend, Decl(recursiveConditionalCrash5.ts, 0, 0))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+>Conv : Symbol(Conv, Decl(recursiveConditionalCrash5.ts, 8, 83))
+>ExactExtract : Symbol(ExactExtract, Decl(recursiveConditionalCrash5.ts, 6, 10))
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 10, 12))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+
+}[U extends T ? 0 : 1];
+>U : Symbol(U, Decl(recursiveConditionalCrash5.ts, 10, 12))
+>T : Symbol(T, Decl(recursiveConditionalCrash5.ts, 10, 10))
+

--- a/tests/baselines/reference/recursiveConditionalCrash5.types
+++ b/tests/baselines/reference/recursiveConditionalCrash5.types
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/recursiveConditionalCrash5.ts] ////
+
+=== Performance Stats ===
+Instantiation count: 5,000
+
+=== recursiveConditionalCrash5.ts ===
+// https://github.com/microsoft/TypeScript/issues/62966
+
+type Prepend<Elm, T extends unknown[]> = T extends unknown
+>Prepend : Prepend<Elm, T>
+>        : ^^^^^^^^^^^^^^^
+
+  ? ((arg: Elm, ...rest: T) => void) extends (...args: infer T2) => void
+>arg : Elm
+>    : ^^^
+>rest : T
+>     : ^
+>args : T2
+>     : ^^
+
+    ? T2
+    : never
+  : never;
+
+type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+>ExactExtract : ExactExtract<T, U>
+>             : ^^^^^^^^^^^^^^^^^^
+
+type Conv<T, U = T> = {
+>Conv : Conv<T, U>
+>     : ^^^^^^^^^^
+
+  0: [T];
+>0 : [T]
+>  : ^^^
+
+  1: Prepend<T, Conv<ExactExtract<U, T>>>;
+>1 : Prepend<T, Conv<ExactExtract<U, T>, ExactExtract<U, T>>>
+>  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+}[U extends T ? 0 : 1];
+

--- a/tests/cases/compiler/recursiveConditionalCrash5.ts
+++ b/tests/cases/compiler/recursiveConditionalCrash5.ts
@@ -1,0 +1,17 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/62966
+
+type Prepend<Elm, T extends unknown[]> = T extends unknown
+  ? ((arg: Elm, ...rest: T) => void) extends (...args: infer T2) => void
+    ? T2
+    : never
+  : never;
+
+type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+
+type Conv<T, U = T> = {
+  0: [T];
+  1: Prepend<T, Conv<ExactExtract<U, T>>>;
+}[U extends T ? 0 : 1];


### PR DESCRIPTION
Since https://github.com/microsoft/TypeScript/pull/61505 the compiler started to skip a lot of already performed instantiation work. Before the PR it would re-explore the same types over and over again and, in this case, it would eventually hit the `instantiationCount` limit. This results in a persistent situation in which further instantiations return `errorType` - given the `instantiationCount` never decrements (until it gets reset completely).

The situation with `instantiationDepth` is different, this one is decremented and further work happens. But it seems to me that every time we hit this - for either reason - it should be fine to "propagate" the `errorType`. Instantiation happens on types that are meant to be used one way or another and `errorType` propagate through all "operations" (like `errorType[K]` is `errorType` and so on). Perhaps it can change what happens with `{ a: errorType, b: Foo<T> }` but given such object type will contain an `errorType` anyway... I think this is more than acceptable and this should allow the compiler to skip a bunch of redundant work. 

fixes https://github.com/microsoft/TypeScript/issues/62966