### PR TITLE
Fix Debug Failure crash when importing from mapped type module exports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4017,13 +4017,21 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (valueSymbol.flags & (SymbolFlags.Type | SymbolFlags.Namespace)) {
             return valueSymbol;
         }
-        const result = createSymbol(valueSymbol.flags | typeSymbol.flags, valueSymbol.escapedName);
+        const valueCheckFlags = getCheckFlags(valueSymbol);
+        const result = createSymbol(valueSymbol.flags | typeSymbol.flags, valueSymbol.escapedName, valueCheckFlags & CheckFlags.Mapped);
         Debug.assert(valueSymbol.declarations || typeSymbol.declarations);
         result.declarations = deduplicate(concatenate(valueSymbol.declarations!, typeSymbol.declarations), equateValues);
         result.parent = valueSymbol.parent || typeSymbol.parent;
         if (valueSymbol.valueDeclaration) result.valueDeclaration = valueSymbol.valueDeclaration;
         if (typeSymbol.members) result.members = new Map(typeSymbol.members);
         if (valueSymbol.exports) result.exports = new Map(valueSymbol.exports);
+        if (valueCheckFlags & CheckFlags.Mapped) {
+            const valueLinks = (valueSymbol as MappedSymbol).links;
+            (result as MappedSymbol).links.mappedType = valueLinks.mappedType;
+            (result as MappedSymbol).links.keyType = valueLinks.keyType;
+            if (valueLinks.nameType) (result as MappedSymbol).links.nameType = valueLinks.nameType;
+            if (valueLinks.syntheticOrigin) (result as MappedSymbol).links.syntheticOrigin = valueLinks.syntheticOrigin;
+        }
         return result;
     }
 

--- a/tests/baselines/reference/mappedTypeCombineValueAndTypeSymbolMinimal.symbols
+++ b/tests/baselines/reference/mappedTypeCombineValueAndTypeSymbolMinimal.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/types/mapped/mappedTypeCombineValueAndTypeSymbolMinimal.ts] ////
+
+=== assert.d.ts ===
+declare namespace assert {
+>assert : Symbol(assert, Decl(assert.d.ts, 0, 0))
+
+  class AssertionError extends Error {}
+>AssertionError : Symbol(AssertionError, Decl(assert.d.ts, 0, 26))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+  const strict: Omit<typeof assert, never>;
+>strict : Symbol(strict, Decl(assert.d.ts, 2, 7))
+>Omit : Symbol(Omit, Decl(lib.es5.d.ts, --, --))
+>assert : Symbol(assert, Decl(assert.d.ts, 0, 0))
+}
+
+export = assert.strict;
+>assert.strict : Symbol(assert.strict, Decl(assert.d.ts, 2, 7))
+>assert : Symbol(assert, Decl(assert.d.ts, 0, 0))
+>strict : Symbol(assert.strict, Decl(assert.d.ts, 2, 7))
+
+=== index.ts ===
+import { AssertionError } from "./assert";
+>AssertionError : Symbol(AssertionError, Decl(index.ts, 0, 8))
+
+new AssertionError("assert");
+>AssertionError : Symbol(AssertionError, Decl(index.ts, 0, 8))
+

--- a/tests/baselines/reference/mappedTypeCombineValueAndTypeSymbolMinimal.types
+++ b/tests/baselines/reference/mappedTypeCombineValueAndTypeSymbolMinimal.types
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/types/mapped/mappedTypeCombineValueAndTypeSymbolMinimal.ts] ////
+
+=== assert.d.ts ===
+declare namespace assert {
+>assert : typeof assert
+>       : ^^^^^^^^^^^^^
+
+  class AssertionError extends Error {}
+>AssertionError : AssertionError
+>               : ^^^^^^^^^^^^^^
+>Error : Error
+>      : ^^^^^
+
+  const strict: Omit<typeof assert, never>;
+>strict : Omit<typeof assert, never>
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+>assert : typeof assert
+>       : ^^^^^^^^^^^^^
+}
+
+export = assert.strict;
+>assert.strict : Omit<typeof assert, never>
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+>assert : typeof assert
+>       : ^^^^^^^^^^^^^
+>strict : Omit<typeof assert, never>
+>       : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== index.ts ===
+import { AssertionError } from "./assert";
+>AssertionError : typeof assert.AssertionError
+>               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+new AssertionError("assert");
+>new AssertionError("assert") : assert.AssertionError
+>                             : ^^^^^^^^^^^^^^^^^^^^^
+>AssertionError : typeof assert.AssertionError
+>               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"assert" : "assert"
+>         : ^^^^^^^^
+

--- a/tests/cases/conformance/types/mapped/mappedTypeCombineValueAndTypeSymbolMinimal.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeCombineValueAndTypeSymbolMinimal.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+// @filename: assert.d.ts
+declare namespace assert {
+  class AssertionError extends Error {}
+  const strict: Omit<typeof assert, never>;
+}
+
+export = assert.strict;
+
+// @filename: index.ts
+import { AssertionError } from "./assert";
+new AssertionError("assert");


### PR DESCRIPTION
Fixes #58534

## Problem

When importing a named export from a module that re-exports via a mapped type (e.g. `Omit<typeof ns, never>`), the compiler crashes with `Error: Debug Failure` inside `getTypeOfVariableOrParameterOrPropertyWorker`.

Minimal reproduction:
```ts
// assert.d.ts
declare namespace assert {
  class AssertionError extends Error {}
  const strict: Omit<typeof assert, never>;
}
export = assert.strict;

// index.ts
import { AssertionError } from "./assert";
new AssertionError("assert"); // Debug Failure crash
```

This also affects real-world code importing `AssertionError` from `node:assert/strict` (with `@types/node`).

## Root Cause

`combineValueAndTypeSymbols` creates a combined symbol for names that resolve to both a value and a type. When the value symbol is a property of a mapped type (has `CheckFlags.Mapped`), the function was not preserving the mapped symbol's check flags or link properties (`mappedType`, `keyType`).

This caused `getTypeOfSymbol` to skip the `CheckFlags.Mapped` branch and fall through to `getTypeOfVariableOrParameterOrProperty`, which then hit `Debug.assertIsDefined(symbol.valueDeclaration)` — mapped symbols don't have a `valueDeclaration`, so this crashed.

## Fix

Propagate `CheckFlags.Mapped` and the mapped symbol link properties (`mappedType`, `keyType`, `nameType`, `syntheticOrigin`) from the value symbol to the combined symbol in `combineValueAndTypeSymbols`. This ensures `getTypeOfSymbol` correctly dispatches to `getTypeOfMappedSymbol` for the combined symbol.

The fix is intentionally conservative — only `CheckFlags.Mapped` is propagated, not other check flags that might require different symbol link structures.