### PR TITLE
Add missing diagnostic message for private method quick fix

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7490,6 +7490,10 @@
         "category": "Message",
         "code": 90035
     },
+    "Declare private method '{0}'": {
+        "category": "Message",
+        "code": 90038
+    },
     "Replace '{0}' with 'Promise<{1}>'": {
         "category": "Message",
         "code": 90036


### PR DESCRIPTION
Fixes #37782

## Summary
The code fix logic for adding missing private methods already existed (code 90038), but the diagnostic message was missing from `diagnosticMessages.json`.

## Changes
Added the diagnostic message `"Declare private method '{0}'"` with code 90038 to enable the quick fix to appear in the IDE.

## Testing
The fix can be verified by:
1. Building the compiler: `npm install && npm run build`
2. Creating a test file with a missing private method reference
3. Confirming the quick fix appears in the IDE