### PR TITLE
Fix #29707: Adjust ClassConstructor type for better type safety

### DIFF
--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,0 +1,5 @@
+type ClassConstructor = new(...args: unknown[]) => {};
+
+function mixin<C extends ClassConstructor>(Class: C) {
+  return class extends Class {};
+}


### PR DESCRIPTION
## Summary
This fix changes the `ClassConstructor` type to use `unknown[]` instead of `any[]`, improving type safety and clarity in the mixin function.