### PR TITLE
fix(checker): mark getter/setter as deprecated when any declaration has @deprecated

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2608,7 +2608,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isDeprecatedSymbol(symbol: Symbol) {
         const parentSymbol = getParentOfSymbol(symbol);
         if (parentSymbol && length(symbol.declarations) > 1) {
-            return parentSymbol.flags & SymbolFlags.Interface ? some(symbol.declarations, isDeprecatedDeclaration) : every(symbol.declarations, isDeprecatedDeclaration);
+            if (parentSymbol.flags & SymbolFlags.Interface || symbol.flags & SymbolFlags.Accessor) {
+                return some(symbol.declarations, isDeprecatedDeclaration);
+            }
+            return every(symbol.declarations, isDeprecatedDeclaration);
         }
         return !!symbol.valueDeclaration && isDeprecatedDeclaration(symbol.valueDeclaration)
             || length(symbol.declarations) && every(symbol.declarations, isDeprecatedDeclaration);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -6085,7 +6085,11 @@ function symbolCanBeReferencedAtTypeLocation(symbol: Symbol, checker: TypeChecke
 }
 
 function isDeprecated(symbol: Symbol, checker: TypeChecker) {
-    const declarations = skipAlias(symbol, checker).declarations;
+    const resolvedSymbol = skipAlias(symbol, checker);
+    const declarations = resolvedSymbol.declarations;
+    if (resolvedSymbol.flags & SymbolFlags.Accessor) {
+        return !!length(declarations) && some(declarations, isDeprecatedDeclaration);
+    }
     return !!length(declarations) && every(declarations, isDeprecatedDeclaration);
 }
 

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -222,7 +222,12 @@ function getNormalizedSymbolModifiers(symbol: Symbol) {
             : ModifierFlags.None;
         const modifiers = getNodeModifiers(declaration, excludeFlags);
         if (modifiers) {
-            return modifiers.split(",");
+            const result = modifiers.split(",");
+            // For getter/setter pairs, include deprecated if any accessor has @deprecated
+            if (symbol.flags & SymbolFlags.Accessor && !result.includes("deprecated") && some(symbol.declarations, isDeprecatedDeclaration)) {
+                result.push("deprecated");
+            }
+            return result;
         }
     }
     return [];

--- a/tests/cases/fourslash/completionsWithDeprecatedGetterSetter.ts
+++ b/tests/cases/fourslash/completionsWithDeprecatedGetterSetter.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// Tests that @deprecated on getter/setter pairs correctly marks the property as deprecated in completions.
+// Regression from #41941, reported in #62965.
+
+//// class Test {
+////     /** @deprecated */
+////     public get test1() { return 0; }
+////     public set test1(_value: number) {}
+////
+////     public get test2() { return 0; }
+////     /** @deprecated */
+////     public set test2(_value: number) {}
+////
+////     /** @deprecated */
+////     public get test3() { return 0; }
+////     /** @deprecated */
+////     public set test3(_value: number) {}
+////
+////     public get test4() { return 0; }
+////     public set test4(_value: number) {}
+//// }
+////
+//// const t = new Test();
+//// t./*1*/;
+
+verify.completions({
+    marker: "1",
+    includes: [
+        { name: "test1", kind: "getter", kindModifiers: "public,deprecated", sortText: completion.SortText.Deprecated(completion.SortText.LocationPriority) },
+        { name: "test2", kind: "getter", kindModifiers: "public,deprecated", sortText: completion.SortText.Deprecated(completion.SortText.LocationPriority) },
+        { name: "test3", kind: "getter", kindModifiers: "public,deprecated", sortText: completion.SortText.Deprecated(completion.SortText.LocationPriority) },
+        { name: "test4", kind: "getter", kindModifiers: "public", sortText: completion.SortText.LocationPriority },
+    ],
+});

--- a/tests/cases/fourslash/jsdocDeprecated_suggestionGetterSetter.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_suggestionGetterSetter.ts
@@ -1,0 +1,50 @@
+/// <reference path="fourslash.ts" />
+
+// Tests that @deprecated on getter/setter pairs produces suggestion diagnostics.
+// Regression from #41941, reported in #62965.
+
+//// class Test {
+////     /** @deprecated */
+////     public get test1() { return 0; }
+////     public set test1(_value: number) {}
+////
+////     public get test2() { return 0; }
+////     /** @deprecated */
+////     public set test2(_value: number) {}
+////
+////     /** @deprecated */
+////     public get test3() { return 0; }
+////     /** @deprecated */
+////     public set test3(_value: number) {}
+////
+////     public get test4() { return 0; }
+////     public set test4(_value: number) {}
+//// }
+////
+//// const t = new Test();
+//// const a = t.[|test1|];
+//// const b = t.[|test2|];
+//// const c = t.[|test3|];
+//// const d = t.test4;
+
+const ranges = test.ranges();
+verify.getSuggestionDiagnostics([
+    {
+        "code": 6385,
+        "message": "'test1' is deprecated.",
+        "reportsDeprecated": true,
+        "range": ranges[0],
+    },
+    {
+        "code": 6385,
+        "message": "'test2' is deprecated.",
+        "reportsDeprecated": true,
+        "range": ranges[1],
+    },
+    {
+        "code": 6385,
+        "message": "'test3' is deprecated.",
+        "reportsDeprecated": true,
+        "range": ranges[2],
+    },
+]);


### PR DESCRIPTION
## Summary

Fixes #62965

`@deprecated` JSDoc tag on a getter or setter no longer marks the property as deprecated in completions or suggestion diagnostics when only one accessor of the pair has the tag. This is a regression introduced in #41941.

## Problem

Getter/setter pairs share a single symbol with two declarations. PR #41941 changed the deprecation check to require **all** declarations to be deprecated (using `every()`), which is correct for function overloads but incorrect for accessor pairs. If only the getter has `@deprecated`, the property should still appear deprecated when reading it — and vice versa for the setter.

Three locations needed fixing:

1. **`src/compiler/checker.ts` — `isDeprecatedSymbol()`**: For symbols with `SymbolFlags.Accessor`, use `some()` instead of `every()` to check declarations, matching the existing behavior for interface members.

2. **`src/services/completions.ts` — `isDeprecated()`**: Same fix — use `some()` for accessor symbols so completion items get the deprecated sort text.

3. **`src/services/symbolDisplay.ts` — `getNormalizedSymbolModifiers()`**: The existing logic strips the deprecated modifier when the first declaration is deprecated but others aren't. For accessor symbols, re-add the deprecated modifier if any declaration has `@deprecated`.

## Tests

- `completionsWithDeprecatedGetterSetter.ts` — verifies deprecated `kindModifiers` and `sortText` in completions for getter/setter pairs where only one accessor has `@deprecated`
- `jsdocDeprecated_suggestionGetterSetter.ts` — verifies suggestion diagnostics (strikethrough) for the same scenarios

All existing `completionsWithDeprecatedTag*` and `jsdocDeprecated_suggestion*` tests continue to pass.

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.