### PR TITLE
Fix Debug Failure crash when resolving overloaded decorators with explicit tuple rest parameters

### DIFF
--- a/bug_repro_63094.js
+++ b/bug_repro_63094.js
@@ -1,0 +1,16 @@
+"use strict";
+// @experimentalDecorators: true
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+class Greeter {
+    greet1() {
+        return "Hello, " + this.greeting;
+    }
+}
+__decorate([
+    deco
+], Greeter.prototype, "greet1", null);

--- a/bug_repro_63094.ts
+++ b/bug_repro_63094.ts
@@ -1,0 +1,10 @@
+// @experimentalDecorators: true
+
+class Greeter {
+    @deco
+    greet1() {
+        return "Hello, " + this.greeting;
+    }
+}
+
+declare function deco(...args: [any, any, any]): any;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36344,7 +36344,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
                 // For decorators with only two parameters we supply only two arguments
-                return signature.parameters.length <= 2 ? 2 : 3;
+                return getParameterCount(signature) <= 2 ? 2 : 3;
             case SyntaxKind.Parameter:
                 return 3;
             default:

--- a/tests/cases/compiler/decoratorArityCrash.ts
+++ b/tests/cases/compiler/decoratorArityCrash.ts
@@ -1,0 +1,11 @@
+// @experimentalDecorators: true
+// @target: es5
+
+declare function deco(...args: [any, any, any]): any;
+
+class Greeter {
+    @deco
+    greet1() {
+        return "Hello, " + this.greeting;
+    }
+}


### PR DESCRIPTION
Fixes #63094

**Description**
When utilizing `--experimentalDecorators` on methods or accessors, the compiler crashed with a `Debug Failure. False expression.` at `getArgumentArityError` if a decorator had an explicitly typed tuple rest parameter (e.g. `...args: [any, any, any]`) and an overload match failed.

This happened because `getLegacyDecoratorArgumentCount` incorrectly evaluated `signature.parameters.length` instead of `getParameterCount(signature)` when deciding whether the decorator expects 2 or 3 parameters. Since the node length of a rest parameter is `1` (e.g., `...args`), the function erroneously returned `2`, which bypassed some argument arity checks and later dropped into `getArgumentArityError` with `args.length = 3` and `max = 3`. This triggered a crash trying to get `first()` on `args.slice(3)`.

This PR fixes the crash by using `getParameterCount(signature)` within `getLegacyDecoratorArgumentCount` to appropriately count effective parameters over rest arguments.

A compiler test is included.
