### PR TITLE
Fix duplicate error message for literal union types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22636,7 +22636,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!(target.flags & TypeFlags.Never) && isLiteralType(source) && !typeCouldHaveTopLevelSingletonTypes(target)) {
                 generalizedSource = getBaseTypeOfLiteralType(source);
                 Debug.assert(!isTypeAssignableTo(generalizedSource, target), "generalized source shouldn't be assignable");
-                generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);
+                // When a non-enum union of literals generalizes to a single non-union
+                // base type (e.g. "a" | "b" -> string), skip the generalization for
+                // display purposes. The per-member elaboration already shows the base
+                // type, so using it here would produce a duplicate message (see #63050).
+                if (source.flags & TypeFlags.Union && !(source.flags & TypeFlags.EnumLiteral) && !(generalizedSource.flags & TypeFlags.Union)) {
+                    generalizedSource = source;
+                }
+                else {
+                    generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);
+                }
             }
 
             // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting

--- a/tests/baselines/reference/bigintPropertyName.errors.txt
+++ b/tests/baselines/reference/bigintPropertyName.errors.txt
@@ -23,7 +23,7 @@ g.ts(32,3): error TS2538: Type 'bigint' cannot be used as an index type.
 g.ts(33,4): error TS2538: Type 'bigint' cannot be used as an index type.
 g.ts(35,1): error TS1434: Unexpected keyword or identifier.
 g.ts(35,2): error TS1353: A bigint literal must be an integer.
-q.ts(2,19): error TS2322: Type 'bigint' is not assignable to type 'string | number | symbol'.
+q.ts(2,19): error TS2322: Type 'Q' is not assignable to type 'string | number | symbol'.
   Type 'bigint' is not assignable to type 'string | number | symbol'.
 
 
@@ -138,6 +138,6 @@ q.ts(2,19): error TS2322: Type 'bigint' is not assignable to type 'string | numb
     type Q = 6n | 7n | 8n;
     type T = { [t in  Q]: string };
                       ~
-!!! error TS2322: Type 'bigint' is not assignable to type 'string | number | symbol'.
+!!! error TS2322: Type 'Q' is not assignable to type 'string | number | symbol'.
 !!! error TS2322:   Type 'bigint' is not assignable to type 'string | number | symbol'.
     

--- a/tests/baselines/reference/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.errors.txt
+++ b/tests/baselines/reference/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.errors.txt
@@ -2,14 +2,14 @@ complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts(33,5): error TS2322
   Type '{ type: T; localChannelId: string; }' is not assignable to type 'Pick<ChannelOfType<T, TextChannel> | ChannelOfType<T, EmailChannel>, "type">'.
     Types of property 'type' are incompatible.
       Type 'T' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
-        Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
+        Type '"text" | "email"' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
           Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
             Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
               Type '"text"' is not assignable to type 'T & "text"'.
                 Type '"text"' is not assignable to type 'T'.
                   '"text"' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint '"text" | "email"'.
                     Type 'T' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
-                      Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
+                      Type '"text" | "email"' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
                         Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
                           Type '"text"' is not assignable to type 'T & "text"'.
                             Type '"text"' is not assignable to type 'T'.
@@ -63,14 +63,14 @@ complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts(33,5): error TS2322
 !!! error TS2322:   Type '{ type: T; localChannelId: string; }' is not assignable to type 'Pick<ChannelOfType<T, TextChannel> | ChannelOfType<T, EmailChannel>, "type">'.
 !!! error TS2322:     Types of property 'type' are incompatible.
 !!! error TS2322:       Type 'T' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
-!!! error TS2322:         Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
+!!! error TS2322:         Type '"text" | "email"' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
 !!! error TS2322:           Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"] & ChannelOfType<T, EmailChannel>["type"]'.
 !!! error TS2322:             Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
 !!! error TS2322:               Type '"text"' is not assignable to type 'T & "text"'.
 !!! error TS2322:                 Type '"text"' is not assignable to type 'T'.
 !!! error TS2322:                   '"text"' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint '"text" | "email"'.
 !!! error TS2322:                     Type 'T' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
-!!! error TS2322:                       Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
+!!! error TS2322:                       Type '"text" | "email"' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
 !!! error TS2322:                         Type 'string' is not assignable to type 'ChannelOfType<T, TextChannel>["type"]'.
 !!! error TS2322:                           Type '"text"' is not assignable to type 'T & "text"'.
 !!! error TS2322:                             Type '"text"' is not assignable to type 'T'.

--- a/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.errors.txt
+++ b/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.errors.txt
@@ -1,0 +1,23 @@
+noDoubleErrorForLiteralUnionFromAmbient.ts(7,7): error TS2322: Type '"a" | "b"' is not assignable to type 'number'.
+  Type 'string' is not assignable to type 'number'.
+noDoubleErrorForLiteralUnionFromAmbient.ts(11,7): error TS2322: Type 'string' is not assignable to type 'number'.
+
+
+==== noDoubleErrorForLiteralUnionFromAmbient.ts (2 errors) ====
+    // Repro from #63050
+    // When assigning a union of string literals from an ambient declaration to
+    // an incompatible type, the error should not show the same message twice.
+    
+    declare const x: "a" | "b"
+    
+    const y: number = x
+          ~
+!!! error TS2322: Type '"a" | "b"' is not assignable to type 'number'.
+!!! error TS2322:   Type 'string' is not assignable to type 'number'.
+    
+    declare const single: "hello"
+    
+    const z: number = single
+          ~
+!!! error TS2322: Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.js
+++ b/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/noDoubleErrorForLiteralUnionFromAmbient.ts] ////
+
+//// [noDoubleErrorForLiteralUnionFromAmbient.ts]
+// Repro from #63050
+// When assigning a union of string literals from an ambient declaration to
+// an incompatible type, the error should not show the same message twice.
+
+declare const x: "a" | "b"
+
+const y: number = x
+
+declare const single: "hello"
+
+const z: number = single
+
+
+//// [noDoubleErrorForLiteralUnionFromAmbient.js]
+"use strict";
+// Repro from #63050
+// When assigning a union of string literals from an ambient declaration to
+// an incompatible type, the error should not show the same message twice.
+const y = x;
+const z = single;

--- a/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.symbols
+++ b/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/noDoubleErrorForLiteralUnionFromAmbient.ts] ////
+
+=== noDoubleErrorForLiteralUnionFromAmbient.ts ===
+// Repro from #63050
+// When assigning a union of string literals from an ambient declaration to
+// an incompatible type, the error should not show the same message twice.
+
+declare const x: "a" | "b"
+>x : Symbol(x, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 4, 13))
+
+const y: number = x
+>y : Symbol(y, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 6, 5))
+>x : Symbol(x, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 4, 13))
+
+declare const single: "hello"
+>single : Symbol(single, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 8, 13))
+
+const z: number = single
+>z : Symbol(z, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 10, 5))
+>single : Symbol(single, Decl(noDoubleErrorForLiteralUnionFromAmbient.ts, 8, 13))
+

--- a/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.types
+++ b/tests/baselines/reference/noDoubleErrorForLiteralUnionFromAmbient.types
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/noDoubleErrorForLiteralUnionFromAmbient.ts] ////
+
+=== noDoubleErrorForLiteralUnionFromAmbient.ts ===
+// Repro from #63050
+// When assigning a union of string literals from an ambient declaration to
+// an incompatible type, the error should not show the same message twice.
+
+declare const x: "a" | "b"
+>x : "a" | "b"
+>  : ^^^^^^^^^
+
+const y: number = x
+>y : number
+>  : ^^^^^^
+>x : "a" | "b"
+>  : ^^^^^^^^^
+
+declare const single: "hello"
+>single : "hello"
+>       : ^^^^^^^
+
+const z: number = single
+>z : number
+>  : ^^^^^^
+>single : "hello"
+>       : ^^^^^^^
+

--- a/tests/baselines/reference/typeOfOperator1.errors.txt
+++ b/tests/baselines/reference/typeOfOperator1.errors.txt
@@ -1,4 +1,4 @@
-typeOfOperator1.ts(3,5): error TS2322: Type 'string' is not assignable to type 'number'.
+typeOfOperator1.ts(3,5): error TS2322: Type '"string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"' is not assignable to type 'number'.
   Type 'string' is not assignable to type 'number'.
 
 
@@ -7,5 +7,5 @@ typeOfOperator1.ts(3,5): error TS2322: Type 'string' is not assignable to type '
     var y: string = typeof x;
     var z: number = typeof x;
         ~
-!!! error TS2322: Type 'string' is not assignable to type 'number'.
+!!! error TS2322: Type '"string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"' is not assignable to type 'number'.
 !!! error TS2322:   Type 'string' is not assignable to type 'number'.

--- a/tests/cases/compiler/noDoubleErrorForLiteralUnionFromAmbient.ts
+++ b/tests/cases/compiler/noDoubleErrorForLiteralUnionFromAmbient.ts
@@ -1,0 +1,13 @@
+// @strict: true
+
+// Repro from #63050
+// When assigning a union of string literals from an ambient declaration to
+// an incompatible type, the error should not show the same message twice.
+
+declare const x: "a" | "b"
+
+const y: number = x
+
+declare const single: "hello"
+
+const z: number = single


### PR DESCRIPTION
Fixes #63050

## Problem

When assigning a non-enum union of string/number/bigint literals to an incompatible type, the error message would display the same information twice. For example:

```typescript
declare const x: "a" | "b"
const y: number = x
```

Previously produced:
```
Type 'string' is not assignable to type 'number'.
  Type 'string' is not assignable to type 'number'.
```

The union `"a" | "b"` was generalized to `string`, which is identical to the per-member elaboration (each member also generalizes to `string`), resulting in a duplicate message.

## Fix

In `reportRelationError`, after computing the generalized base type, check whether the source is a non-enum union whose members all share the same base type (i.e., the generalized form is a single non-union type). In that case, skip the generalization for display purposes so the error shows the original literal union instead:

```
Type '"a" | "b"' is not assignable to type 'number'.
  Type 'string' is not assignable to type 'number'.
```

The two lines now provide complementary information: the first shows _what_ the type is, the second shows _why_ it's incompatible.

Unions with mixed base types (e.g. `1 | ""` → `number | string`) are still generalized as before, since the generalized form differs from any single member's elaboration.

## Baseline changes

Three existing baselines are updated — all had duplicate messages that are now fixed:

- **typeOfOperator1**: `typeof x` result union was generalized to `string`, duplicating the elaboration
- **bigintPropertyName**: `6n | 7n | 8n` (type alias `Q`) was generalized to `bigint`, duplicating the elaboration
- **complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound**: `"text" | "email"` was generalized to `string`, duplicating the elaboration