### PR TITLE
Fixed a crash related to computed enum member keys

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13549,7 +13549,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 for (const declaration of symbol.declarations) {
                     if (declaration.kind === SyntaxKind.EnumDeclaration) {
                         for (const member of (declaration as EnumDeclaration).members) {
-                            if (hasBindableName(member)) {
+                            if (!hasDynamicName(member)) {
                                 const memberSymbol = getSymbolOfDeclaration(member);
                                 const value = getEnumMemberValue(member).value;
                                 const memberType = getFreshTypeOfLiteralType(

--- a/tests/baselines/reference/computedEnumMemberKeyNoCrash1.errors.txt
+++ b/tests/baselines/reference/computedEnumMemberKeyNoCrash1.errors.txt
@@ -1,0 +1,15 @@
+computedEnumMemberKeyNoCrash1.ts(4,5): error TS1164: Computed property names are not allowed in enums.
+
+
+==== computedEnumMemberKeyNoCrash1.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/63173
+    
+    declare const enum E {
+        [foo] = 1,
+        ~~~~~
+!!! error TS1164: Computed property names are not allowed in enums.
+        A,
+        foo = 10,
+    }
+    E.A.toString();
+    

--- a/tests/baselines/reference/computedEnumMemberKeyNoCrash1.symbols
+++ b/tests/baselines/reference/computedEnumMemberKeyNoCrash1.symbols
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts] ////
+
+=== computedEnumMemberKeyNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+>E : Symbol(E, Decl(computedEnumMemberKeyNoCrash1.ts, 0, 0))
+
+    [foo] = 1,
+>[foo] : Symbol(E[foo], Decl(computedEnumMemberKeyNoCrash1.ts, 2, 22))
+>foo : Symbol(E.foo, Decl(computedEnumMemberKeyNoCrash1.ts, 4, 6))
+
+    A,
+>A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+
+    foo = 10,
+>foo : Symbol(E.foo, Decl(computedEnumMemberKeyNoCrash1.ts, 4, 6))
+}
+E.A.toString();
+>E.A.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>E.A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+>E : Symbol(E, Decl(computedEnumMemberKeyNoCrash1.ts, 0, 0))
+>A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/computedEnumMemberKeyNoCrash1.types
+++ b/tests/baselines/reference/computedEnumMemberKeyNoCrash1.types
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts] ////
+
+=== computedEnumMemberKeyNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+>E : E
+>  : ^
+
+    [foo] = 1,
+>[foo] : E
+>      : ^
+>foo : E.foo
+>    : ^^^^^
+>1 : 1
+>  : ^
+
+    A,
+>A : E.A
+>  : ^^^
+
+    foo = 10,
+>foo : E.foo
+>    : ^^^^^
+>10 : 10
+>   : ^^
+}
+E.A.toString();
+>E.A.toString() : string
+>               : ^^^^^^
+>E.A.toString : (radix?: number) => string
+>             : ^     ^^^      ^^^^^      
+>E.A : E.A
+>    : ^^^
+>E : typeof E
+>  : ^^^^^^^^
+>A : E.A
+>  : ^^^
+>toString : (radix?: number) => string
+>         : ^     ^^^      ^^^^^      
+

--- a/tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts
+++ b/tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+    [foo] = 1,
+    A,
+    foo = 10,
+}
+E.A.toString();


### PR DESCRIPTION
Enum members are in the scope of the enum declaration as this is allowed:
```ts
declare const enum E {
  foo = "foo",
  foobar = foo + "bar",
}
```

That allows the identifier in the computed key to attempt resolving in the same way. However, that leads to a cycle with enums:
`getDeclaredTypeOfEnum(E)` -> `hasBindableName` -> `isLateBindableName` -> `checkComputedPropertyName` -> `checkExpression` -> `checkIdentifier` -> `getNarrowedTypeOfSymbol` -> `getTypeOfSymbol` -> `getTypeOfEnumMember(E.foo)` -> `getTypeOfEnumMember` -> `getDeclaredTypeOfEnumMember` -> `getDeclaredTypeOfEnum(E)`

Given enums can't really have computed keys (as shown in the added tests given the reported "TS1164: Computed property names are not allowed in enums." diagnostic), the simplest fix is to just check if the member `!hasDynamicName(member)` instead of `hasBindableName(member)` (the latter calls `|| isLateBindableName(member)`)

fixes https://github.com/microsoft/TypeScript/issues/63173