### PR TITLE
discrete pluralizer for lib.esnext.temporal unit unions

### DIFF
--- a/src/lib/esnext.temporal.d.ts
+++ b/src/lib/esnext.temporal.d.ts
@@ -61,7 +61,7 @@ declare namespace Temporal {
 
     type DateUnit = "year" | "month" | "week" | "day";
     type TimeUnit = "hour" | "minute" | "second" | "millisecond" | "microsecond" | "nanosecond";
-    type MaybePluralUnit<T extends DateUnit | TimeUnit> =
+    type PluralizeUnit<T extends DateUnit | TimeUnit> =
         | T
         | {
             year: "years";
@@ -89,13 +89,13 @@ declare namespace Temporal {
     }
 
     interface RoundingOptions<Units extends DateUnit | TimeUnit> {
-        smallestUnit?: MaybePluralUnit<Units> | undefined;
+        smallestUnit?: PluralizeUnit<Units> | undefined;
         roundingIncrement?: number | undefined;
         roundingMode?: "ceil" | "floor" | "expand" | "trunc" | "halfCeil" | "halfFloor" | "halfExpand" | "halfTrunc" | "halfEven" | undefined;
     }
 
     interface RoundingOptionsWithLargestUnit<Units extends DateUnit | TimeUnit> extends RoundingOptions<Units> {
-        largestUnit?: "auto" | MaybePluralUnit<Units> | undefined;
+        largestUnit?: "auto" | PluralizeUnit<Units> | undefined;
     }
 
     interface ToStringRoundingOptions<Units extends DateUnit | TimeUnit> extends Pick<RoundingOptions<Units>, "smallestUnit" | "roundingMode"> {}
@@ -181,7 +181,7 @@ declare namespace Temporal {
         until(other: PlainTimeLike, options?: RoundingOptionsWithLargestUnit<TimeUnit>): Duration;
         since(other: PlainTimeLike, options?: RoundingOptionsWithLargestUnit<TimeUnit>): Duration;
         equals(other: PlainTimeLike): boolean;
-        round(roundTo: MaybePluralUnit<TimeUnit>): PlainTime;
+        round(roundTo: PluralizeUnit<TimeUnit>): PlainTime;
         round(roundTo: RoundingOptions<TimeUnit>): PlainTime;
         toString(options?: PlainTimeToStringOptions): string;
         toLocaleString(locales?: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string;
@@ -230,7 +230,7 @@ declare namespace Temporal {
         subtract(duration: DurationLike, options?: OverflowOptions): PlainDateTime;
         until(other: PlainDateTimeLike, options?: RoundingOptionsWithLargestUnit<DateUnit | TimeUnit>): Duration;
         since(other: PlainDateTimeLike, options?: RoundingOptionsWithLargestUnit<DateUnit | TimeUnit>): Duration;
-        round(roundTo: MaybePluralUnit<"day" | TimeUnit>): PlainDateTime;
+        round(roundTo: PluralizeUnit<"day" | TimeUnit>): PlainDateTime;
         round(roundTo: RoundingOptions<"day" | TimeUnit>): PlainDateTime;
         equals(other: PlainDateTimeLike): boolean;
         toString(options?: PlainDateTimeToStringOptions): string;
@@ -297,7 +297,7 @@ declare namespace Temporal {
         subtract(duration: DurationLike, options?: OverflowOptions): ZonedDateTime;
         until(other: ZonedDateTimeLike, options?: RoundingOptionsWithLargestUnit<DateUnit | TimeUnit>): Duration;
         since(other: ZonedDateTimeLike, options?: RoundingOptionsWithLargestUnit<DateUnit | TimeUnit>): Duration;
-        round(roundTo: MaybePluralUnit<"day" | TimeUnit>): ZonedDateTime;
+        round(roundTo: PluralizeUnit<"day" | TimeUnit>): ZonedDateTime;
         round(roundTo: RoundingOptions<"day" | TimeUnit>): ZonedDateTime;
         equals(other: ZonedDateTimeLike): boolean;
         toString(options?: ZonedDateTimeToStringOptions): string;
@@ -331,7 +331,7 @@ declare namespace Temporal {
     interface DurationToStringOptions extends ToStringRoundingOptionsWithFractionalSeconds<Exclude<TimeUnit, "hour" | "minute">> {}
 
     interface DurationTotalOptions extends DurationRelativeToOptions {
-        unit: MaybePluralUnit<DateUnit | TimeUnit>;
+        unit: PluralizeUnit<DateUnit | TimeUnit>;
     }
 
     interface Duration {
@@ -352,9 +352,9 @@ declare namespace Temporal {
         abs(): Duration;
         add(other: DurationLike): Duration;
         subtract(other: DurationLike): Duration;
-        round(roundTo: MaybePluralUnit<"day" | TimeUnit>): Duration;
+        round(roundTo: PluralizeUnit<"day" | TimeUnit>): Duration;
         round(roundTo: DurationRoundingOptions): Duration;
-        total(totalOf: MaybePluralUnit<"day" | TimeUnit>): number;
+        total(totalOf: PluralizeUnit<"day" | TimeUnit>): number;
         total(totalOf: DurationTotalOptions): number;
         toString(options?: DurationToStringOptions): string;
         toLocaleString(locales?: Intl.LocalesArgument, options?: Intl.DurationFormatOptions): string;
@@ -382,7 +382,7 @@ declare namespace Temporal {
         subtract(duration: DurationLike): Instant;
         until(other: InstantLike, options?: RoundingOptionsWithLargestUnit<TimeUnit>): Duration;
         since(other: InstantLike, options?: RoundingOptionsWithLargestUnit<TimeUnit>): Duration;
-        round(roundTo: MaybePluralUnit<TimeUnit>): Instant;
+        round(roundTo: PluralizeUnit<TimeUnit>): Instant;
         round(roundTo: RoundingOptions<TimeUnit>): Instant;
         equals(other: InstantLike): boolean;
         toString(options?: InstantToStringOptions): string;

--- a/tests/baselines/reference/temporal.types
+++ b/tests/baselines/reference/temporal.types
@@ -1197,12 +1197,12 @@ Type Count: 2,500
     instant.round({ smallestUnit: "second" }); // => 2019-03-30T02:46:00Z
 >instant.round({ smallestUnit: "second" }) : Temporal.Instant
 >                                          : ^^^^^^^^^^^^^^^^
->instant.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>instant.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >instant : Temporal.Instant
 >        : ^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "second" } : { smallestUnit: "second"; }
 >                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "second"
@@ -1214,12 +1214,12 @@ Type Count: 2,500
     instant.round({ roundingIncrement: 60, smallestUnit: "minute" });
 >instant.round({ roundingIncrement: 60, smallestUnit: "minute" }) : Temporal.Instant
 >                                                                 : ^^^^^^^^^^^^^^^^
->instant.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>instant.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >instant : Temporal.Instant
 >        : ^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 60, smallestUnit: "minute" } : { roundingIncrement: number; smallestUnit: "minute"; }
 >                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -1236,12 +1236,12 @@ Type Count: 2,500
     instant.round({ roundingIncrement: 60, smallestUnit: "minute", roundingMode: "floor" });
 >instant.round({ roundingIncrement: 60, smallestUnit: "minute", roundingMode: "floor" }) : Temporal.Instant
 >                                                                                        : ^^^^^^^^^^^^^^^^
->instant.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>instant.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>              : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >instant : Temporal.Instant
 >        : ^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.Instant; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.Instant; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 60, smallestUnit: "minute", roundingMode: "floor" } : { roundingIncrement: number; smallestUnit: "minute"; roundingMode: "floor"; }
 >                                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -3864,12 +3864,12 @@ Type Count: 2,500
     zdt.round({ smallestUnit: "hour" });
 >zdt.round({ smallestUnit: "hour" }) : Temporal.ZonedDateTime
 >                                    : ^^^^^^^^^^^^^^^^^^^^^^
->zdt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>zdt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >zdt : Temporal.ZonedDateTime
 >    : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "hour" } : { smallestUnit: "hour"; }
 >                         : ^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "hour"
@@ -3882,12 +3882,12 @@ Type Count: 2,500
     zdt.round({ roundingIncrement: 30, smallestUnit: "minute" });
 >zdt.round({ roundingIncrement: 30, smallestUnit: "minute" }) : Temporal.ZonedDateTime
 >                                                             : ^^^^^^^^^^^^^^^^^^^^^^
->zdt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>zdt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >zdt : Temporal.ZonedDateTime
 >    : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute" } : { roundingIncrement: number; smallestUnit: "minute"; }
 >                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -3904,12 +3904,12 @@ Type Count: 2,500
     zdt.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" });
 >zdt.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" }) : Temporal.ZonedDateTime
 >                                                                                    : ^^^^^^^^^^^^^^^^^^^^^^
->zdt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>zdt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>          : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >zdt : Temporal.ZonedDateTime
 >    : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.ZonedDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" } : { roundingIncrement: number; smallestUnit: "minute"; roundingMode: "floor"; }
 >                                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -7802,12 +7802,12 @@ Type Count: 2,500
     time.round({ smallestUnit: "hour" }); // => 20:00:00
 >time.round({ smallestUnit: "hour" }) : Temporal.PlainTime
 >                                     : ^^^^^^^^^^^^^^^^^^
->time.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>time.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >time : Temporal.PlainTime
 >     : ^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "hour" } : { smallestUnit: "hour"; }
 >                         : ^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "hour"
@@ -7819,12 +7819,12 @@ Type Count: 2,500
     time.round({ roundingIncrement: 30, smallestUnit: "minute" });
 >time.round({ roundingIncrement: 30, smallestUnit: "minute" }) : Temporal.PlainTime
 >                                                              : ^^^^^^^^^^^^^^^^^^
->time.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>time.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >time : Temporal.PlainTime
 >     : ^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute" } : { roundingIncrement: number; smallestUnit: "minute"; }
 >                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -7841,12 +7841,12 @@ Type Count: 2,500
     time.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "ceil" });
 >time.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "ceil" }) : Temporal.PlainTime
 >                                                                                    : ^^^^^^^^^^^^^^^^^^
->time.round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>time.round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>           : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >time : Temporal.PlainTime
 >     : ^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<Temporal.TimeUnit>): Temporal.PlainTime; (roundTo: Temporal.RoundingOptions<Temporal.TimeUnit>): Temporal.PlainTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "ceil" } : { roundingIncrement: number; smallestUnit: "minute"; roundingMode: "ceil"; }
 >                                                                        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -10311,12 +10311,12 @@ Type Count: 2,500
     dt.round({ smallestUnit: "hour" }); // => 1995-12-07T03:00:00
 >dt.round({ smallestUnit: "hour" }) : Temporal.PlainDateTime
 >                                   : ^^^^^^^^^^^^^^^^^^^^^^
->dt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>dt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >dt : Temporal.PlainDateTime
 >   : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "hour" } : { smallestUnit: "hour"; }
 >                         : ^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "hour"
@@ -10328,12 +10328,12 @@ Type Count: 2,500
     dt.round({ roundingIncrement: 30, smallestUnit: "minute" });
 >dt.round({ roundingIncrement: 30, smallestUnit: "minute" }) : Temporal.PlainDateTime
 >                                                            : ^^^^^^^^^^^^^^^^^^^^^^
->dt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>dt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >dt : Temporal.PlainDateTime
 >   : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute" } : { roundingIncrement: number; smallestUnit: "minute"; }
 >                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -10350,12 +10350,12 @@ Type Count: 2,500
     dt.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" });
 >dt.round({ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" }) : Temporal.PlainDateTime
 >                                                                                   : ^^^^^^^^^^^^^^^^^^^^^^
->dt.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>dt.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>         : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >dt : Temporal.PlainDateTime
 >   : ^^^^^^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; (roundTo: Temporal.RoundingOptions<"day" | Temporal.TimeUnit>): Temporal.PlainDateTime; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ roundingIncrement: 30, smallestUnit: "minute", roundingMode: "floor" } : { roundingIncrement: number; smallestUnit: "minute"; roundingMode: "floor"; }
 >                                                                         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >roundingIncrement : number
@@ -14355,8 +14355,8 @@ Type Count: 2,500
     one.subtract(two).round({ largestUnit: "hour" }); // => PT2H59M30S
 >one.subtract(two).round({ largestUnit: "hour" }) : Temporal.Duration
 >                                                 : ^^^^^^^^^^^^^^^^^
->one.subtract(two).round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->                        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>one.subtract(two).round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>                        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >one.subtract(two) : Temporal.Duration
 >                  : ^^^^^^^^^^^^^^^^^
 >one.subtract : (other: Temporal.DurationLike) => Temporal.Duration
@@ -14367,8 +14367,8 @@ Type Count: 2,500
 >         : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >two : Temporal.Duration
 >    : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ largestUnit: "hour" } : { largestUnit: "hour"; }
 >                        : ^^^^^^^^^^^^^^^^^^^^^^^^
 >largestUnit : "hour"
@@ -14653,12 +14653,12 @@ Type Count: 2,500
     d.round({ largestUnit: "day" }); // => PT2H10M
 >d.round({ largestUnit: "day" }) : Temporal.Duration
 >                                : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ largestUnit: "day" } : { largestUnit: "day"; }
 >                       : ^^^^^^^^^^^^^^^^^^^^^^^
 >largestUnit : "day"
@@ -14698,12 +14698,12 @@ Type Count: 2,500
     d.round({ smallestUnit: "minute" }); // => PT11M
 >d.round({ smallestUnit: "minute" }) : Temporal.Duration
 >                                    : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "minute" } : { smallestUnit: "minute"; }
 >                           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "minute"
@@ -14714,12 +14714,12 @@ Type Count: 2,500
     d.round({ smallestUnit: "minute", roundingMode: "trunc" }); // => PT10M
 >d.round({ smallestUnit: "minute", roundingMode: "trunc" }) : Temporal.Duration
 >                                                           : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ smallestUnit: "minute", roundingMode: "trunc" } : { smallestUnit: "minute"; roundingMode: "trunc"; }
 >                                                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >smallestUnit : "minute"
@@ -14757,12 +14757,12 @@ Type Count: 2,500
 >                                           : ^^^^^^
 >d.round({ largestUnit: "second" }) : Temporal.Duration
 >                                   : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ largestUnit: "second" } : { largestUnit: "second"; }
 >                          : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >largestUnit : "second"
@@ -14800,12 +14800,12 @@ Type Count: 2,500
     d.round({
 >d.round({        relativeTo: "2020-01-01T00:00+01:00[Europe/Rome]",        largestUnit: "year",    }) : Temporal.Duration
 >                                                                                                      : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{        relativeTo: "2020-01-01T00:00+01:00[Europe/Rome]",        largestUnit: "year",    } : { relativeTo: string; largestUnit: "year"; }
 >                                                                                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -14826,12 +14826,12 @@ Type Count: 2,500
     d.round({
 >d.round({        relativeTo: "2020-01-01",        largestUnit: "year",    }) : Temporal.Duration
 >                                                                             : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{        relativeTo: "2020-01-01",        largestUnit: "year",    } : { relativeTo: string; largestUnit: "year"; }
 >                                                                    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -14896,12 +14896,12 @@ Type Count: 2,500
     d.round({ relativeTo: refDate, largestUnit: "year" }); // => P6M8D
 >d.round({ relativeTo: refDate, largestUnit: "year" }) : Temporal.Duration
 >                                                      : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ relativeTo: refDate, largestUnit: "year" } : { relativeTo: Temporal.PlainDate; largestUnit: "year"; }
 >                                             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >relativeTo : Temporal.PlainDate
@@ -14917,12 +14917,12 @@ Type Count: 2,500
     d.round({
 >d.round({        relativeTo: refDate.withCalendar("hebrew"),        largestUnit: "year",    }) : Temporal.Duration
 >                                                                                               : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{        relativeTo: refDate.withCalendar("hebrew"),        largestUnit: "year",    } : { relativeTo: Temporal.PlainDate; largestUnit: "year"; }
 >                                                                                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -14976,12 +14976,12 @@ Type Count: 2,500
     d.round({
 >d.round({        smallestUnit: "minute",        roundingIncrement: 5,        roundingMode: "ceil",    }) : Temporal.Duration
 >                                                                                                         : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{        smallestUnit: "minute",        roundingIncrement: 5,        roundingMode: "ceil",    } : { smallestUnit: "minute"; roundingIncrement: number; roundingMode: "ceil"; }
 >                                                                                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15041,12 +15041,12 @@ Type Count: 2,500
 >  : ^^^^^^^^^^^^^^^^^
 >d.round({        smallestUnit: "month",        roundingIncrement: 3,        roundingMode: "trunc",        relativeTo: Temporal.Now.plainDateISO(),    }) : Temporal.Duration
 >                                                                                                                                                         : ^^^^^^^^^^^^^^^^^
->d.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>d.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{        smallestUnit: "month",        roundingIncrement: 3,        roundingMode: "trunc",        relativeTo: Temporal.Now.plainDateISO(),    } : { smallestUnit: "month"; roundingIncrement: number; roundingMode: "trunc"; relativeTo: Temporal.PlainDate; }
 >                                                                                                                                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15143,12 +15143,12 @@ Type Count: 2,500
     d.total({ unit: "second" }); // => 469200
 >d.total({ unit: "second" }) : number
 >                            : ^^^^^^
->d.total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>d.total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >{ unit: "second" } : { unit: "second"; }
 >                   : ^^^^^^^^^^^^^^^^^^^
 >unit : "second"
@@ -15180,12 +15180,12 @@ Type Count: 2,500
     d.total({ unit: "day" }); // 1428.8980208333332
 >d.total({ unit: "day" }) : number
 >                         : ^^^^^^
->d.total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>d.total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >{ unit: "day" } : { unit: "day"; }
 >                : ^^^^^^^^^^^^^^^^
 >unit : "day"
@@ -15221,12 +15221,12 @@ Type Count: 2,500
     d.total({
 >d.total({        relativeTo: "2020-01-01T00:00+01:00[Europe/Rome]",        unit: "month",    }) : number
 >                                                                                                : ^^^^^^
->d.total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>d.total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >{        relativeTo: "2020-01-01T00:00+01:00[Europe/Rome]",        unit: "month",    } : { relativeTo: string; unit: "month"; }
 >                                                                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15246,12 +15246,12 @@ Type Count: 2,500
     d.total({
 >d.total({        unit: "month",        relativeTo: "2020-01-01",    }) : number
 >                                                                       : ^^^^^^
->d.total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>d.total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>        : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >d : Temporal.Duration
 >  : ^^^^^^^^^^^^^^^^^
->total : { (totalOf: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
+>total : { (totalOf: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): number; (totalOf: Temporal.DurationTotalOptions): number; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^      ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^
 >{        unit: "month",        relativeTo: "2020-01-01",    } : { unit: "month"; relativeTo: string; }
 >                                                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15446,12 +15446,12 @@ Type Count: 2,500
 >    : ^^^^^^^^^^^^^^^^^
 >nobal.round({ largestUnit: "year" }) : Temporal.Duration
 >                                     : ^^^^^^^^^^^^^^^^^
->nobal.round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->            : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>nobal.round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>            : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >nobal : Temporal.Duration
 >      : ^^^^^^^^^^^^^^^^^
->round : { (roundTo: Temporal.MaybePluralUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
->      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>round : { (roundTo: Temporal.PluralizeUnit<"day" | Temporal.TimeUnit>): Temporal.Duration; (roundTo: Temporal.DurationRoundingOptions): Temporal.Duration; }
+>      : ^^^       ^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >{ largestUnit: "year" } : { largestUnit: "year"; }
 >                        : ^^^^^^^^^^^^^^^^^^^^^^^^
 >largestUnit : "year"


### PR DESCRIPTION
For improved interoperability, makes `DateUnit` and `TimeUnit` equivalent to their js-temporal counterparts by restricting the unions to singular nouns and using a pluralizer helper where applicable.