### PR TITLE
Fix stack overflow in error generation for recursive mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14901,6 +14901,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 symbol.links.checkFlags & CheckFlags.StripOptional ? removeMissingOrUndefinedType(propType) :
                 propType;
             if (!popTypeResolution()) {
+                symbol.links.type = errorType;
                 error(currentNode, Diagnostics.Type_of_property_0_circularly_references_itself_in_mapped_type_1, symbolToString(symbol), typeToString(mappedType));
                 type = errorType;
             }

--- a/tests/baselines/reference/issue63090.errors.txt
+++ b/tests/baselines/reference/issue63090.errors.txt
@@ -1,0 +1,12 @@
+issue63090.ts(2,10): error TS2615: Type of property 'M' circularly references itself in mapped type '{ M: any; }'.
+issue63090.ts(2,10): error TS2615: Type of property 'M' circularly references itself in mapped type '{ [P in "M"]: any; }'.
+
+
+==== issue63090.ts (2 errors) ====
+    type N<T, K extends string> = T | { [P in K]: N<keyof T, K> }[K];
+    type M = N<number, "M">;
+             ~~~~~~~~~~~~~~
+!!! error TS2615: Type of property 'M' circularly references itself in mapped type '{ M: any; }'.
+             ~~~~~~~~~~~~~~
+!!! error TS2615: Type of property 'M' circularly references itself in mapped type '{ [P in "M"]: any; }'.
+    

--- a/tests/baselines/reference/issue63090.js
+++ b/tests/baselines/reference/issue63090.js
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/issue63090.ts] ////
+
+//// [issue63090.ts]
+type N<T, K extends string> = T | { [P in K]: N<keyof T, K> }[K];
+type M = N<number, "M">;
+
+
+//// [issue63090.js]
+"use strict";

--- a/tests/baselines/reference/issue63090.symbols
+++ b/tests/baselines/reference/issue63090.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/issue63090.ts] ////
+
+=== issue63090.ts ===
+type N<T, K extends string> = T | { [P in K]: N<keyof T, K> }[K];
+>N : Symbol(N, Decl(issue63090.ts, 0, 0))
+>T : Symbol(T, Decl(issue63090.ts, 0, 7))
+>K : Symbol(K, Decl(issue63090.ts, 0, 9))
+>T : Symbol(T, Decl(issue63090.ts, 0, 7))
+>P : Symbol(P, Decl(issue63090.ts, 0, 37))
+>K : Symbol(K, Decl(issue63090.ts, 0, 9))
+>N : Symbol(N, Decl(issue63090.ts, 0, 0))
+>T : Symbol(T, Decl(issue63090.ts, 0, 7))
+>K : Symbol(K, Decl(issue63090.ts, 0, 9))
+>K : Symbol(K, Decl(issue63090.ts, 0, 9))
+
+type M = N<number, "M">;
+>M : Symbol(M, Decl(issue63090.ts, 0, 65))
+>N : Symbol(N, Decl(issue63090.ts, 0, 0))
+

--- a/tests/baselines/reference/issue63090.types
+++ b/tests/baselines/reference/issue63090.types
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/issue63090.ts] ////
+
+=== issue63090.ts ===
+type N<T, K extends string> = T | { [P in K]: N<keyof T, K> }[K];
+>N : N<T, K>
+>  : ^^^^^^^
+
+type M = N<number, "M">;
+>M : any
+>  : ^^^
+

--- a/tests/cases/compiler/issue63090.ts
+++ b/tests/cases/compiler/issue63090.ts
@@ -1,0 +1,2 @@
+type N<T, K extends string> = T | { [P in K]: N<keyof T, K> }[K];
+type M = N<number, "M">;


### PR DESCRIPTION
Fixes #63090

### Bug Description

When a mapped type contains a deeply recursive or circular reference, TypeScript correctly identifies it as an error. However, when generating the diagnostic message (`Type_of_property_0_circularly_references_itself_in_mapped_type_1`), the compiler calls [typeToString(mappedType)](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:6239:4-6273:5) to format the error text.

Evaluating [typeToString(mappedType)](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:6239:4-6273:5) triggers property resolution, which evaluates the symbol's type by calling [getTypeOfMappedSymbol](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:14886:4-14910:5) again. Since `symbol.links.type` hasn't been cached with the `errorType` yet, this hits the same circularity, which attempts to throw another error, triggering [typeToString](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:6239:4-6273:5) again, leading to an infinite cycle and an eventual `RangeError: Maximum call stack size exceeded`.

### Fix Explanation

This PR breaks the infinite recursion by eagerly caching `symbol.links.type = errorType;` immediately *before* calling [error(...)](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:2538:4-2542:5) and [typeToString(mappedType)](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:6239:4-6273:5).

When [typeToString](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/TypeScript/src/compiler/checker.ts:6239:4-6273:5) evaluates the mapped type, it now sees the cached `errorType` for the symbol and safely halts recursion, generating the correct error message without blowing up the call stack.

### Testing

Added the provided reproduction from the issue as a compiler test case:
- `tests/cases/compiler/issue63090.ts` 
- Ran `hereby baseline-accept` so the baseline error generation accurately outputs the circularity error instead of crashing.
