### PR TITLE
Fix silentNeverType leak through keyof in return type inference

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18989,6 +18989,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
             getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
             type === wildcardType ? wildcardType :
+            type === silentNeverType ? silentNeverType :
             type.flags & TypeFlags.Unknown ? neverType :
             type.flags & (TypeFlags.Any | TypeFlags.Never) ? stringNumberSymbolType :
             getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike), indexFlags === IndexFlags.None);

--- a/tests/baselines/reference/silentNeverTypeKeyofLeak.symbols
+++ b/tests/baselines/reference/silentNeverTypeKeyofLeak.symbols
@@ -1,0 +1,143 @@
+//// [tests/cases/compiler/silentNeverTypeKeyofLeak.ts] ////
+
+=== silentNeverTypeKeyofLeak.ts ===
+// Repro from #62824
+
+// Minimal repro: silentNeverType leaks through keyof in mapped types
+// when a nested generic call has no inference candidates during the
+// outer call's inference pass.
+
+type Fn<T> = (arg: T) => void;
+>Fn : Symbol(Fn, Decl(silentNeverTypeKeyofLeak.ts, 0, 0))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 6, 8))
+>arg : Symbol(arg, Decl(silentNeverTypeKeyofLeak.ts, 6, 14))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 6, 8))
+
+declare function fn1<T>(): Fn<T>;
+>fn1 : Symbol(fn1, Decl(silentNeverTypeKeyofLeak.ts, 6, 30))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 8, 21))
+>Fn : Symbol(Fn, Decl(silentNeverTypeKeyofLeak.ts, 0, 0))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 8, 21))
+
+declare function fn2<T>(
+>fn2 : Symbol(fn2, Decl(silentNeverTypeKeyofLeak.ts, 8, 33))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 10, 21))
+
+  ac: Fn<{
+>ac : Symbol(ac, Decl(silentNeverTypeKeyofLeak.ts, 10, 24))
+>Fn : Symbol(Fn, Decl(silentNeverTypeKeyofLeak.ts, 0, 0))
+
+    [K in keyof T & string]: T[K];
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 12, 5))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 10, 21))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 10, 21))
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 12, 5))
+
+  }>,
+): void;
+
+fn2(fn1());
+>fn2 : Symbol(fn2, Decl(silentNeverTypeKeyofLeak.ts, 8, 33))
+>fn1 : Symbol(fn1, Decl(silentNeverTypeKeyofLeak.ts, 6, 30))
+
+// Shorter repro from issue
+type Values<T> = T[keyof T];
+>Values : Symbol(Values, Decl(silentNeverTypeKeyofLeak.ts, 16, 11))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 19, 12))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 19, 12))
+>T : Symbol(T, Decl(silentNeverTypeKeyofLeak.ts, 19, 12))
+
+interface ParameterizedObject {
+>ParameterizedObject : Symbol(ParameterizedObject, Decl(silentNeverTypeKeyofLeak.ts, 19, 28))
+
+  type: string;
+>type : Symbol(ParameterizedObject.type, Decl(silentNeverTypeKeyofLeak.ts, 21, 31))
+
+  params?: unknown;
+>params : Symbol(ParameterizedObject.params, Decl(silentNeverTypeKeyofLeak.ts, 22, 15))
+}
+
+type ActionFunction<TParams, TAction extends ParameterizedObject> = {
+>ActionFunction : Symbol(ActionFunction, Decl(silentNeverTypeKeyofLeak.ts, 24, 1))
+>TParams : Symbol(TParams, Decl(silentNeverTypeKeyofLeak.ts, 26, 20))
+>TAction : Symbol(TAction, Decl(silentNeverTypeKeyofLeak.ts, 26, 28))
+>ParameterizedObject : Symbol(ParameterizedObject, Decl(silentNeverTypeKeyofLeak.ts, 19, 28))
+
+  (params: TParams): void;
+>params : Symbol(params, Decl(silentNeverTypeKeyofLeak.ts, 27, 3))
+>TParams : Symbol(TParams, Decl(silentNeverTypeKeyofLeak.ts, 26, 20))
+
+  _out_TAction?: TAction;
+>_out_TAction : Symbol(_out_TAction, Decl(silentNeverTypeKeyofLeak.ts, 27, 26))
+>TAction : Symbol(TAction, Decl(silentNeverTypeKeyofLeak.ts, 26, 28))
+
+};
+
+type ToParameterizedObject<TParameterizedMap> = Values<{
+>ToParameterizedObject : Symbol(ToParameterizedObject, Decl(silentNeverTypeKeyofLeak.ts, 29, 2))
+>TParameterizedMap : Symbol(TParameterizedMap, Decl(silentNeverTypeKeyofLeak.ts, 31, 27))
+>Values : Symbol(Values, Decl(silentNeverTypeKeyofLeak.ts, 16, 11))
+
+  [K in keyof TParameterizedMap & string]: {
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 32, 3))
+>TParameterizedMap : Symbol(TParameterizedMap, Decl(silentNeverTypeKeyofLeak.ts, 31, 27))
+
+    type: K;
+>type : Symbol(type, Decl(silentNeverTypeKeyofLeak.ts, 32, 44))
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 32, 3))
+
+    params: TParameterizedMap[K];
+>params : Symbol(params, Decl(silentNeverTypeKeyofLeak.ts, 33, 12))
+>TParameterizedMap : Symbol(TParameterizedMap, Decl(silentNeverTypeKeyofLeak.ts, 31, 27))
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 32, 3))
+
+  };
+}>;
+
+declare function enqueueActions<TParams, TAction extends ParameterizedObject>(
+>enqueueActions : Symbol(enqueueActions, Decl(silentNeverTypeKeyofLeak.ts, 36, 3))
+>TParams : Symbol(TParams, Decl(silentNeverTypeKeyofLeak.ts, 38, 32))
+>TAction : Symbol(TAction, Decl(silentNeverTypeKeyofLeak.ts, 38, 40))
+>ParameterizedObject : Symbol(ParameterizedObject, Decl(silentNeverTypeKeyofLeak.ts, 19, 28))
+
+  collect: (params: TParams) => void,
+>collect : Symbol(collect, Decl(silentNeverTypeKeyofLeak.ts, 38, 78))
+>params : Symbol(params, Decl(silentNeverTypeKeyofLeak.ts, 39, 12))
+>TParams : Symbol(TParams, Decl(silentNeverTypeKeyofLeak.ts, 38, 32))
+
+): ActionFunction<TParams, TAction>;
+>ActionFunction : Symbol(ActionFunction, Decl(silentNeverTypeKeyofLeak.ts, 24, 1))
+>TParams : Symbol(TParams, Decl(silentNeverTypeKeyofLeak.ts, 38, 32))
+>TAction : Symbol(TAction, Decl(silentNeverTypeKeyofLeak.ts, 38, 40))
+
+declare function setup<TActions>(actions: {
+>setup : Symbol(setup, Decl(silentNeverTypeKeyofLeak.ts, 40, 36))
+>TActions : Symbol(TActions, Decl(silentNeverTypeKeyofLeak.ts, 42, 23))
+>actions : Symbol(actions, Decl(silentNeverTypeKeyofLeak.ts, 42, 33))
+
+  [K in keyof TActions]: ActionFunction<
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 43, 3))
+>TActions : Symbol(TActions, Decl(silentNeverTypeKeyofLeak.ts, 42, 23))
+>ActionFunction : Symbol(ActionFunction, Decl(silentNeverTypeKeyofLeak.ts, 24, 1))
+
+    TActions[K],
+>TActions : Symbol(TActions, Decl(silentNeverTypeKeyofLeak.ts, 42, 23))
+>K : Symbol(K, Decl(silentNeverTypeKeyofLeak.ts, 43, 3))
+
+    ToParameterizedObject<TActions>
+>ToParameterizedObject : Symbol(ToParameterizedObject, Decl(silentNeverTypeKeyofLeak.ts, 29, 2))
+>TActions : Symbol(TActions, Decl(silentNeverTypeKeyofLeak.ts, 42, 23))
+
+  >;
+}): void;
+
+setup({
+>setup : Symbol(setup, Decl(silentNeverTypeKeyofLeak.ts, 40, 36))
+
+  doStuff: enqueueActions((params: number) => {}),
+>doStuff : Symbol(doStuff, Decl(silentNeverTypeKeyofLeak.ts, 49, 7))
+>enqueueActions : Symbol(enqueueActions, Decl(silentNeverTypeKeyofLeak.ts, 36, 3))
+>params : Symbol(params, Decl(silentNeverTypeKeyofLeak.ts, 50, 27))
+
+});
+

--- a/tests/baselines/reference/silentNeverTypeKeyofLeak.types
+++ b/tests/baselines/reference/silentNeverTypeKeyofLeak.types
@@ -1,0 +1,132 @@
+//// [tests/cases/compiler/silentNeverTypeKeyofLeak.ts] ////
+
+=== silentNeverTypeKeyofLeak.ts ===
+// Repro from #62824
+
+// Minimal repro: silentNeverType leaks through keyof in mapped types
+// when a nested generic call has no inference candidates during the
+// outer call's inference pass.
+
+type Fn<T> = (arg: T) => void;
+>Fn : Fn<T>
+>   : ^^^^^
+>arg : T
+>    : ^
+
+declare function fn1<T>(): Fn<T>;
+>fn1 : <T>() => Fn<T>
+>    : ^ ^^^^^^^     
+
+declare function fn2<T>(
+>fn2 : <T>(ac: Fn<{ [K in keyof T & string]: T[K]; }>) => void
+>    : ^ ^^  ^^                                      ^^^^^    
+
+  ac: Fn<{
+>ac : Fn<{ [K in keyof T & string]: T[K]; }>
+>   : ^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    [K in keyof T & string]: T[K];
+  }>,
+): void;
+
+fn2(fn1());
+>fn2(fn1()) : void
+>           : ^^^^
+>fn2 : <T>(ac: Fn<{ [K in keyof T & string]: T[K]; }>) => void
+>    : ^ ^^  ^^                                      ^^^^^    
+>fn1() : Fn<{}>
+>      : ^^^^^^
+>fn1 : <T>() => Fn<T>
+>    : ^ ^^^^^^^     
+
+// Shorter repro from issue
+type Values<T> = T[keyof T];
+>Values : Values<T>
+>       : ^^^^^^^^^
+
+interface ParameterizedObject {
+  type: string;
+>type : string
+>     : ^^^^^^
+
+  params?: unknown;
+>params : unknown
+>       : ^^^^^^^
+}
+
+type ActionFunction<TParams, TAction extends ParameterizedObject> = {
+>ActionFunction : ActionFunction<TParams, TAction>
+>               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  (params: TParams): void;
+>params : TParams
+>       : ^^^^^^^
+
+  _out_TAction?: TAction;
+>_out_TAction : TAction | undefined
+>             : ^^^^^^^^^^^^^^^^^^^
+
+};
+
+type ToParameterizedObject<TParameterizedMap> = Values<{
+>ToParameterizedObject : ToParameterizedObject<TParameterizedMap>
+>                      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  [K in keyof TParameterizedMap & string]: {
+    type: K;
+>type : K
+>     : ^
+
+    params: TParameterizedMap[K];
+>params : TParameterizedMap[K]
+>       : ^^^^^^^^^^^^^^^^^^^^
+
+  };
+}>;
+
+declare function enqueueActions<TParams, TAction extends ParameterizedObject>(
+>enqueueActions : <TParams, TAction extends ParameterizedObject>(collect: (params: TParams) => void) => ActionFunction<TParams, TAction>
+>               : ^       ^^       ^^^^^^^^^                   ^^       ^^                         ^^^^^                                
+
+  collect: (params: TParams) => void,
+>collect : (params: TParams) => void
+>        : ^      ^^       ^^^^^    
+>params : TParams
+>       : ^^^^^^^
+
+): ActionFunction<TParams, TAction>;
+
+declare function setup<TActions>(actions: {
+>setup : <TActions>(actions: { [K in keyof TActions]: ActionFunction<TActions[K], ToParameterizedObject<TActions>>; }) => void
+>      : ^        ^^       ^^                                                                                        ^^^^^    
+>actions : { [K in keyof TActions]: ActionFunction<TActions[K], ToParameterizedObject<TActions>>; }
+>        : ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  [K in keyof TActions]: ActionFunction<
+    TActions[K],
+    ToParameterizedObject<TActions>
+  >;
+}): void;
+
+setup({
+>setup({  doStuff: enqueueActions((params: number) => {}),}) : void
+>                                                            : ^^^^
+>setup : <TActions>(actions: { [K in keyof TActions]: ActionFunction<TActions[K], ToParameterizedObject<TActions>>; }) => void
+>      : ^        ^^       ^^                                                                                        ^^^^^    
+>{  doStuff: enqueueActions((params: number) => {}),} : { doStuff: ActionFunction<number, never>; }
+>                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  doStuff: enqueueActions((params: number) => {}),
+>doStuff : ActionFunction<number, never>
+>        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>enqueueActions((params: number) => {}) : ActionFunction<number, never>
+>                                       : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>enqueueActions : <TParams, TAction extends ParameterizedObject>(collect: (params: TParams) => void) => ActionFunction<TParams, TAction>
+>               : ^       ^^       ^^^^^^^^^                   ^^       ^^                         ^^^^^                                
+>(params: number) => {} : (params: number) => void
+>                       : ^      ^^      ^^^^^^^^^
+>params : number
+>       : ^^^^^^
+
+});
+

--- a/tests/cases/compiler/silentNeverTypeKeyofLeak.ts
+++ b/tests/cases/compiler/silentNeverTypeKeyofLeak.ts
@@ -1,0 +1,55 @@
+// @strict: true
+// @noEmit: true
+
+// Repro from #62824
+
+// Minimal repro: silentNeverType leaks through keyof in mapped types
+// when a nested generic call has no inference candidates during the
+// outer call's inference pass.
+
+type Fn<T> = (arg: T) => void;
+
+declare function fn1<T>(): Fn<T>;
+
+declare function fn2<T>(
+  ac: Fn<{
+    [K in keyof T & string]: T[K];
+  }>,
+): void;
+
+fn2(fn1());
+
+// Shorter repro from issue
+type Values<T> = T[keyof T];
+
+interface ParameterizedObject {
+  type: string;
+  params?: unknown;
+}
+
+type ActionFunction<TParams, TAction extends ParameterizedObject> = {
+  (params: TParams): void;
+  _out_TAction?: TAction;
+};
+
+type ToParameterizedObject<TParameterizedMap> = Values<{
+  [K in keyof TParameterizedMap & string]: {
+    type: K;
+    params: TParameterizedMap[K];
+  };
+}>;
+
+declare function enqueueActions<TParams, TAction extends ParameterizedObject>(
+  collect: (params: TParams) => void,
+): ActionFunction<TParams, TAction>;
+
+declare function setup<TActions>(actions: {
+  [K in keyof TActions]: ActionFunction<
+    TActions[K],
+    ToParameterizedObject<TActions>
+  >;
+}): void;
+
+setup({
+  doStuff: enqueueActions((params: number) => {}),
+});


### PR DESCRIPTION
Fixes #62824

## Summary

- `silentNeverType`, an internal sentinel used during nested generic call inference, was leaking into user-facing error messages as an unexpected `never`
- The `keyof` operator in `getIndexType` fell through to the `TypeFlags.Never` branch, resolving `silentNeverType` to `string | number | symbol` and stripping its `NonInferrableType` flag
- Added an identity check for `silentNeverType` in `getIndexType`, matching the existing `wildcardType` pattern, so the sentinel propagates intact through mapped type instantiation

## Test plan

- [x] Added `silentNeverTypeKeyofLeak.ts` test case covering minimal and issue repros
- [x] `npx hereby runtests --tests=silentNeverTypeKeyofLeak` passes (6/6)
- [x] Baselines (.symbols, .types) generated and verified