### PR TITLE
Fix missing lib files in reused programs

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2555,6 +2555,9 @@ export function createProgram(_rootNamesOrOptions: readonly string[] | CreatePro
         Debug.assert(newSourceFiles.length === oldProgram.getSourceFiles().length);
         for (const newSourceFile of newSourceFiles) {
             filesByName.set(newSourceFile.path, newSourceFile);
+            if (oldProgram.isSourceFileDefaultLibrary(newSourceFile)) {
+                libFiles.add(newSourceFile.path);
+            }
         }
         const oldFilesByNameMap = oldProgram.getFilesByNameMap();
         oldFilesByNameMap.forEach((oldFile, path) => {

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -769,6 +769,35 @@ describe("unittests:: reuseProgramStructure:: General", () => {
         baselineDiagnostics(baselines, program4);
         runBaseline("handles file preprocessing dignostics when diagnostics are not queried", baselines);
     });
+
+    it("isSourceFileDefaultLibrary is preserved after program reuse", () => {
+        const libFile = { name: "/lib.d.ts", text: SourceText.New("", "", "declare var console: any;") };
+        const mainFile = { name: "/main.ts", text: SourceText.New("", "", "var x = 1;") };
+        const files = [libFile, mainFile];
+
+        const host = createTestCompilerHost(files, target);
+        host.getDefaultLibFileName = () => "/lib.d.ts";
+
+        const options: ts.CompilerOptions = { target };
+        const program1 = ts.createProgram(["/main.ts"], options, host) as ProgramWithSourceTexts;
+        program1.sourceTexts = files;
+        program1.host = host;
+        program1.version = 1;
+
+        const libSourceFile1 = program1.getSourceFile("/lib.d.ts")!;
+        assert.isDefined(libSourceFile1, "lib file should exist in program 1");
+        assert.isTrue(program1.isSourceFileDefaultLibrary(libSourceFile1), "lib file should be a default library in program 1");
+
+        // Update main file only (code change) -> should trigger complete structure reuse
+        mainFile.text = mainFile.text.updateProgram("var x = 2;");
+        const host2 = createTestCompilerHost(files, target, program1);
+        host2.getDefaultLibFileName = () => "/lib.d.ts";
+        const program2 = ts.createProgram(["/main.ts"], options, host2, program1);
+
+        const libSourceFile2 = program2.getSourceFile("/lib.d.ts")!;
+        assert.isDefined(libSourceFile2, "lib file should exist in program 2");
+        assert.isTrue(program2.isSourceFileDefaultLibrary(libSourceFile2), "lib file should still be a default library in program 2 after reuse");
+    });
 });
 
 describe("unittests:: reuseProgramStructure:: host is optional", () => {

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/file-is-deleted-and-created-as-part-of-change.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/file-is-deleted-and-created-as-part-of-change.js
@@ -126,6 +126,5 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/username/projects/project/app/file.ts (computed .d.ts)
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-carriageReturn-lineFeed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-carriageReturn-lineFeed.js
@@ -115,6 +115,5 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/app.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-lineFeed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-lineFeed.js
@@ -115,6 +115,5 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/app.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-all-files-if-a-global-file-changed-shape.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-all-files-if-a-global-file-changed-shape.js
@@ -189,7 +189,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/b/globalfile3.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/b/modulefile1.ts (computed .d.ts)
 /home/src/projects/a/b/file1consumer1.ts (computed .d.ts)
 /home/src/projects/a/b/file1consumer2.ts (computed .d.ts)

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
@@ -142,7 +142,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined
@@ -200,7 +199,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
@@ -150,7 +150,6 @@ No cached semantic diagnostics in the builder::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined
@@ -211,7 +210,6 @@ No cached semantic diagnostics in the builder::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/b.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
+++ b/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
@@ -169,7 +169,6 @@ No cached semantic diagnostics in the builder::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/a/rootfolder/project/scripts/typescript.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /home/src/projects/a/rootfolder/project/scripts/javascript.js (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-with-incremental.js
@@ -258,7 +258,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -547,7 +546,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-without-dts-enabled-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-without-dts-enabled-with-incremental.js
@@ -210,7 +210,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -448,7 +447,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-without-dts-enabled.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors-without-dts-enabled.js
@@ -116,7 +116,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -262,7 +261,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/dts-errors.js
@@ -129,7 +129,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -295,7 +294,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors-with-incremental.js
@@ -229,7 +229,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -486,7 +485,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors.js
+++ b/tests/baselines/reference/tscWatch/noEmit/multiFile/semantic-errors.js
@@ -121,7 +121,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -272,7 +271,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /home/src/projects/project/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/programUpdates/handle-recreated-files-correctly.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/handle-recreated-files-correctly.js
@@ -153,7 +153,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/workspace/solution/projects/project/commonfile2.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /user/username/workspace/solution/projects/project/commonfile1.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/should-reflect-change-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-reflect-change-in-config-file.js
@@ -152,7 +152,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/workspace/solution/projects/project/commonfile2.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /user/username/workspace/solution/projects/project/commonfile1.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-default-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-default-options.js
@@ -117,7 +117,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -170,6 +169,5 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipDefaultLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipDefaultLibCheck.js
@@ -114,12 +114,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -168,11 +166,9 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipLibCheck.js
@@ -114,12 +114,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -168,11 +166,9 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-default-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-default-options.js
@@ -117,7 +117,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -171,6 +170,5 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipDefaultLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipDefaultLibCheck.js
@@ -114,12 +114,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -169,11 +167,9 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipLibCheck.js
@@ -114,12 +114,10 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 
@@ -169,11 +167,9 @@ Program files::
 /user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 /user/username/projects/myproject/a.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/myproject/a.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
@@ -243,6 +243,7 @@ Program files::
 /user/username/projects/myproject/b.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 
 No shapes updated in the builder::
 
@@ -297,6 +298,7 @@ Program files::
 /user/username/projects/myproject/b.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/fsEvent-for-change-is-repeated.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/fsEvent-for-change-is-repeated.js
@@ -126,7 +126,6 @@ main.ts
 
 Shape signatures in builder refreshed for::
 /user/username/projects/project/main.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-dynamic-priority-polling.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-dynamic-priority-polling.js
@@ -708,7 +708,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /a/username/projects/project/typescript.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-fixed-chunk-size-polling.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-fixed-chunk-size-polling.js
@@ -194,7 +194,6 @@ Semantic diagnostics in builder refreshed for::
 
 Shape signatures in builder refreshed for::
 /user/username/projects/project/commonfile1.ts (computed .d.ts)
-/home/src/tslibs/ts/lib/lib.es2025.full.d.ts (used version)
 /user/username/projects/project/commonfile2.ts (computed .d.ts)
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tsserver/compileOnSave/configProjects-global-file-shape-changed.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/configProjects-global-file-shape-changed.js
@@ -345,7 +345,6 @@ Info seq  [hh:mm:ss:mss] response:
           "projectFileName": "/home/src/workspace/projects/b/tsconfig.json",
           "fileNames": [
             "/home/src/workspace/projects/b/globalFile3.ts",
-            "/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts",
             "/home/src/workspace/projects/b/moduleFile1.ts",
             "/home/src/workspace/projects/b/file1Consumer1.ts",
             "/home/src/workspace/projects/b/file1Consumer2.ts",

--- a/tests/baselines/reference/tsserver/compileOnSave/emit-in-project-with-module.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/emit-in-project-with-module.js
@@ -697,7 +697,6 @@ Info seq  [hh:mm:ss:mss] response:
           "projectFileName": "/user/username/projects/myproject/tsconfig.json",
           "fileNames": [
             "/user/username/projects/myproject/file2.ts",
-            "/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts",
             "/user/username/projects/myproject/file1.ts",
             "/user/username/projects/myproject/file3.ts",
             "/user/username/projects/myproject/module.ts"

--- a/tests/baselines/reference/tsserver/compileOnSave/emit-in-project.js
+++ b/tests/baselines/reference/tsserver/compileOnSave/emit-in-project.js
@@ -659,7 +659,6 @@ Info seq  [hh:mm:ss:mss] response:
           "projectFileName": "/user/username/projects/myproject/tsconfig.json",
           "fileNames": [
             "/user/username/projects/myproject/file2.ts",
-            "/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts",
             "/user/username/projects/myproject/file1.ts",
             "/user/username/projects/myproject/file3.ts"
           ],


### PR DESCRIPTION
Fixes #63228

I should have noticed this in the baselines from my original change, but I did not.

This should be cherry-picked to 6.0.