### PR TITLE
fix(compiler): small improvement to error message handling

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2357,7 +2357,7 @@ namespace Parser {
 
     /**
      * Provides a better error message than the generic "';' expected" if possible for
-     * known common variants of a missing semicolon, such as from a mispelled names.
+     * known common variants of a missing semicolon, such as from misspelled names.
      *
      * @param node Node preceding the expected semicolon location.
      */
@@ -2421,7 +2421,7 @@ namespace Parser {
             return;
         }
 
-        // Otherwise, we know this some kind of unknown word, not just a missing expected semicolon.
+        // Otherwise, we know this is some kind of unknown word, not just a missing expected semicolon.
         parseErrorAt(pos, node.end, Diagnostics.Unexpected_keyword_or_identifier);
     }
 


### PR DESCRIPTION
## What problem exists
A small typo/grammar issue in `parseErrorForMissingSemicolonAfter`'s documentation can be a minor distraction when working on parser diagnostics.

## Why this change is useful
This PR corrects wording in two nearby comments in `src/compiler/parser.ts`, making the intent clearer without changing any compiler behavior.

## Files modified
- `src/compiler/parser.ts`

## Tests
- Not added (comment-only change).
- Local verification: `npm run build`.
- Note: `npm test` fails locally with `EMFILE: too many open files, watch` in `unittests:: sys:: symlinkWatching::` (environment/FS watcher limit); the change does not affect runtime or test logic.

Made with [Cursor](https://cursor.com)