### PR TITLE
fix: improve confusing TS1107 error for mislabeled jump targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -53028,15 +53028,22 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkGrammarBreakOrContinueStatement(node: BreakOrContinueStatement): boolean {
         let current: Node = node;
+        let crossedFunctionBoundary = false;
+
         while (current) {
             if (isFunctionLikeOrClassStaticBlockDeclaration(current)) {
-                return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
+                crossedFunctionBoundary = true;
             }
 
             switch (current.kind) {
                 case SyntaxKind.LabeledStatement:
                     if (node.label && (current as LabeledStatement).label.escapedText === node.label.escapedText) {
                         // found matching label - verify that label usage is correct
+
+                        if (crossedFunctionBoundary) {
+                            return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
+                        }
+
                         // continue can only target labels that are on iteration statements
                         const isMisplacedContinueLabel = node.kind === SyntaxKind.ContinueStatement
                             && !isIterationStatement((current as LabeledStatement).statement, /*lookInLabeledStatements*/ true);
@@ -53051,12 +53058,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.SwitchStatement:
                     if (node.kind === SyntaxKind.BreakStatement && !node.label) {
                         // unlabeled break within switch statement - ok
+                        if (crossedFunctionBoundary) {
+                            return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
+                        }
                         return false;
                     }
                     break;
                 default:
                     if (isIterationStatement(current, /*lookInLabeledStatements*/ false) && !node.label) {
                         // unlabeled break or continue within iteration statement - ok
+                        if (crossedFunctionBoundary) {
+                            return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
+                        }
                         return false;
                     }
                     break;

--- a/tests/baselines/reference/invalidContinueInDownlevelAsync.errors.txt
+++ b/tests/baselines/reference/invalidContinueInDownlevelAsync.errors.txt
@@ -1,4 +1,4 @@
-invalidContinueInDownlevelAsync.ts(3,9): error TS1107: Jump target cannot cross function boundary.
+invalidContinueInDownlevelAsync.ts(3,9): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 
 
 ==== invalidContinueInDownlevelAsync.ts (1 errors) ====
@@ -6,7 +6,7 @@ invalidContinueInDownlevelAsync.ts(3,9): error TS1107: Jump target cannot cross 
         if (true) {
             continue;
             ~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
         }
         else {
             await 1;

--- a/tests/baselines/reference/issue30408.errors.txt
+++ b/tests/baselines/reference/issue30408.errors.txt
@@ -1,0 +1,23 @@
+issue30408.ts(4,9): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
+issue30408.ts(12,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
+
+
+==== issue30408.ts (2 errors) ====
+    function foo() {
+        for (let i = 0; i < 10; i++) {
+            console.log(`${i}`);
+            continue loopend;
+            ~~~~~~~~~~~~~~~~~
+!!! error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
+        }
+    
+        loopend:
+        console.log('end of loop');
+    }
+    
+    function bar() {
+        continue loopend;
+        ~~~~~~~~~~~~~~~~~
+!!! error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
+    }
+    

--- a/tests/baselines/reference/issue30408.js
+++ b/tests/baselines/reference/issue30408.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/issue30408.ts] ////
+
+//// [issue30408.ts]
+function foo() {
+    for (let i = 0; i < 10; i++) {
+        console.log(`${i}`);
+        continue loopend;
+    }
+
+    loopend:
+    console.log('end of loop');
+}
+
+function bar() {
+    continue loopend;
+}
+
+
+//// [issue30408.js]
+"use strict";
+function foo() {
+    for (let i = 0; i < 10; i++) {
+        console.log(`${i}`);
+        continue loopend;
+    }
+    loopend: console.log('end of loop');
+}
+function bar() {
+    continue loopend;
+}

--- a/tests/baselines/reference/issue30408.symbols
+++ b/tests/baselines/reference/issue30408.symbols
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/issue30408.ts] ////
+
+=== issue30408.ts ===
+function foo() {
+>foo : Symbol(foo, Decl(issue30408.ts, 0, 0))
+
+    for (let i = 0; i < 10; i++) {
+>i : Symbol(i, Decl(issue30408.ts, 1, 12))
+>i : Symbol(i, Decl(issue30408.ts, 1, 12))
+>i : Symbol(i, Decl(issue30408.ts, 1, 12))
+
+        console.log(`${i}`);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(issue30408.ts, 1, 12))
+
+        continue loopend;
+    }
+
+    loopend:
+    console.log('end of loop');
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+}
+
+function bar() {
+>bar : Symbol(bar, Decl(issue30408.ts, 8, 1))
+
+    continue loopend;
+}
+

--- a/tests/baselines/reference/issue30408.types
+++ b/tests/baselines/reference/issue30408.types
@@ -1,0 +1,68 @@
+//// [tests/cases/compiler/issue30408.ts] ////
+
+=== issue30408.ts ===
+function foo() {
+>foo : () => void
+>    : ^^^^^^^^^^
+
+    for (let i = 0; i < 10; i++) {
+>i : number
+>  : ^^^^^^
+>0 : 0
+>  : ^
+>i < 10 : boolean
+>       : ^^^^^^^
+>i : number
+>  : ^^^^^^
+>10 : 10
+>   : ^^
+>i++ : number
+>    : ^^^^^^
+>i : number
+>  : ^^^^^^
+
+        console.log(`${i}`);
+>console.log(`${i}`) : void
+>                    : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>`${i}` : string
+>       : ^^^^^^
+>i : number
+>  : ^^^^^^
+
+        continue loopend;
+>loopend : any
+>        : ^^^
+    }
+
+    loopend:
+>loopend : any
+>        : ^^^
+
+    console.log('end of loop');
+>console.log('end of loop') : void
+>                           : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>'end of loop' : "end of loop"
+>              : ^^^^^^^^^^^^^
+}
+
+function bar() {
+>bar : () => void
+>    : ^^^^^^^^^^
+
+    continue loopend;
+>loopend : any
+>        : ^^^
+}
+

--- a/tests/baselines/reference/plainJSBinderErrors.errors.txt
+++ b/tests/baselines/reference/plainJSBinderErrors.errors.txt
@@ -12,7 +12,7 @@ plainJSBinderErrors.js(22,15): error TS1210: Code contained in a class is evalua
 plainJSBinderErrors.js(23,15): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 plainJSBinderErrors.js(27,9): error TS1101: 'with' statements are not allowed in strict mode.
 plainJSBinderErrors.js(33,13): error TS1344: 'A label is not allowed here.
-plainJSBinderErrors.js(34,13): error TS1107: Jump target cannot cross function boundary.
+plainJSBinderErrors.js(34,13): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSBinderErrors.js(39,7): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
 plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules are automatically in strict mode.
 
@@ -83,7 +83,7 @@ plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules 
 !!! error TS1344: 'A label is not allowed here.
                 break label
                 ~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
             }
             return x
         }

--- a/tests/baselines/reference/plainJSGrammarErrors.errors.txt
+++ b/tests/baselines/reference/plainJSGrammarErrors.errors.txt
@@ -90,7 +90,7 @@ plainJSGrammarErrors.js(167,12): error TS1197: Catch clause variable cannot have
 plainJSGrammarErrors.js(170,5): error TS1114: Duplicate label 'label'.
 plainJSGrammarErrors.js(179,13): error TS1107: Jump target cannot cross function boundary.
 plainJSGrammarErrors.js(187,13): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-plainJSGrammarErrors.js(191,5): error TS1107: Jump target cannot cross function boundary.
+plainJSGrammarErrors.js(191,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSGrammarErrors.js(194,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSGrammarErrors.js(195,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 plainJSGrammarErrors.js(197,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
@@ -479,7 +479,7 @@ plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot
     function jumpToLabelOnly(x) {
         break jumpToLabelOnly
         ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
     }
     for (;;) {
         break toplevel

--- a/tests/cases/compiler/issue30408.ts
+++ b/tests/cases/compiler/issue30408.ts
@@ -1,0 +1,15 @@
+// @strict: true
+
+function foo() {
+    for (let i = 0; i < 10; i++) {
+        console.log(`${i}`);
+        continue loopend;
+    }
+
+    loopend:
+    console.log('end of loop');
+}
+
+function bar() {
+    continue loopend;
+}


### PR DESCRIPTION
**Problem**
Prior to this fix, the TypeScript compiler would eagerly output the confusing error `TS1107: Jump target cannot cross function boundary.` whenever a jump target check reached a function boundary, even if the label existed nowhere in the code and should just be a regular "invalid label target" error.

**Solution**
Modified `checkGrammarBreakOrContinueStatement` inside `src/compiler/checker.ts` to keep traversing the ancestor chain while remembering that a function boundary was crossed. If it actually finds the label *after* crossing a function boundary, only then will it output `TS1107`. Otherwise, it falls back to the native label missing errors such as `TS1104` or `TS1116`.

**Testing**
* Built the compiler to ensure syntax works
* Added specific compiler test `tests/cases/compiler/issue30408.ts` containing the reproduction code.
* Generated updated compiler test baselines across the legacy test suite.

Fixes: #30408
