### PR TITLE
Fix crash in visitEachChildOfIndexSignatureDeclaration when type is missing

### DIFF
--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -777,7 +777,7 @@ const visitEachChildTable: VisitEachChildTable = {
             node,
             nodesVisitor(node.modifiers, visitor, isModifierLike),
             nodesVisitor(node.parameters, visitor, isParameter),
-            Debug.checkDefined(nodeVisitor(node.type, visitor, isTypeNode)),
+            nodeVisitor(node.type, visitor, isTypeNode)!, // GH#63230: node.type may be undefined for malformed index signatures
         );
     },
 


### PR DESCRIPTION
Fixes #63230

## Problem

When a malformed index signature like `{[key: string], any}` (comma instead of colon) is parsed, the `IndexSignatureDeclaration` node is created without a `type` property. This is expected — the parser already handles this case, and there's even a [TODO comment in `createIndexSignature`](https://github.com/microsoft/TypeScript/blob/main/src/compiler/factory/nodeFactory.ts#L2234) acknowledging it:

```ts
node.type = type!; // TODO(rbuckton): We mark this as required in IndexSignatureDeclaration, but it looks like the parser allows it to be elided.
```

However, `visitEachChildOfIndexSignatureDeclaration` uses `Debug.checkDefined(nodeVisitor(node.type, ...))` which throws a `Debug Failure` instead of allowing the compiler to report a proper diagnostic error.

## Fix

Replace `Debug.checkDefined(...)` with the non-null assertion operator (`!`), matching the existing pattern used by `createIndexSignature` for the same situation. When `node.type` is undefined, `nodeVisitor` returns undefined, and the `!` allows it to propagate through `updateIndexSignature` — which already handles the case gracefully (it compares `node.type !== type`, sees they're both undefined/the same, and returns the original node unchanged).

## Minimal repro (from @RyanCavanaugh's comment)

```ts
export const f = (x: {[key: string], any}) => 0;
```

Before: `Error: Debug Failure.`
After: proper diagnostic errors are reported.