### PR TITLE
Preserve error elaboration for indexed access type assignments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22656,7 +22656,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     );
                 }
                 else {
-                    errorInfo = undefined;
+                    // When the target is an indexed access type (e.g. this["faa"]), preserve any
+                    // specific error elaboration from the constraint comparison (e.g., missing
+                    // property or type mismatch errors) rather than discarding them. For plain
+                    // type parameters, clear the error info as the constraint-based errors may
+                    // be misleading.
+                    if (!(target.flags & TypeFlags.IndexedAccess)) {
+                        errorInfo = undefined;
+                    }
                     reportError(
                         Diagnostics._0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1,
                         targetType,

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -10,15 +10,23 @@ mappedTypeRelationships.ts(25,5): error TS2536: Type 'K' cannot be used to index
 mappedTypeRelationships.ts(26,12): error TS2536: Type 'K' cannot be used to index type 'T'.
 mappedTypeRelationships.ts(30,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'T[keyof T] | undefined'.
+    Type 'undefined' is not assignable to type 'T[keyof T]'.
+      'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
 mappedTypeRelationships.ts(35,5): error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'T[K] | undefined'.
+    Type 'undefined' is not assignable to type 'T[K]'.
+      'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
 mappedTypeRelationships.ts(40,5): error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'U[keyof T] | undefined'.
+    Type 'undefined' is not assignable to type 'T[keyof T]'.
+      'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
 mappedTypeRelationships.ts(41,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
   Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[keyof T] | undefined'.
     Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
 mappedTypeRelationships.ts(45,5): error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'U[K] | undefined'.
+    Type 'undefined' is not assignable to type 'T[K]'.
+      'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
 mappedTypeRelationships.ts(46,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
   Type 'T[keyof T]' is not assignable to type 'U[K] | undefined'.
     Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'U[K] | undefined'.
@@ -125,6 +133,8 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
         ~~~~
 !!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
 !!! error TS2322:   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'T[keyof T] | undefined'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:       'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
         y[k] = x[k];
     }
     
@@ -133,6 +143,8 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
         ~~~~
 !!! error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
 !!! error TS2322:   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'T[K] | undefined'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:       'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
         y[k] = x[k];
     }
     
@@ -141,6 +153,8 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
         ~~~~
 !!! error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
 !!! error TS2322:   'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'U[keyof T] | undefined'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:       'T[keyof T]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
         y[k] = x[k];  // Error
         ~~~~
 !!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
@@ -153,6 +167,8 @@ mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is n
         ~~~~
 !!! error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
 !!! error TS2322:   'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'U[K] | undefined'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:       'T[K]' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
         y[k] = x[k];  // Error
         ~~~~
 !!! error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.

--- a/tests/baselines/reference/nonPrimitiveConstraintOfIndexAccessType.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveConstraintOfIndexAccessType.errors.txt
@@ -8,6 +8,7 @@ nonPrimitiveConstraintOfIndexAccessType.ts(12,5): error TS2322: Type 'string' is
   'T[P]' could be instantiated with an arbitrary type which could be unrelated to 'string'.
 nonPrimitiveConstraintOfIndexAccessType.ts(15,5): error TS2322: Type 'string' is not assignable to type 'T[P]'.
   'T[P]' could be instantiated with an arbitrary type which could be unrelated to 'string'.
+    Type 'string' is not assignable to type 'never'.
 nonPrimitiveConstraintOfIndexAccessType.ts(18,5): error TS2322: Type 'string' is not assignable to type 'T[P]'.
   'T[P]' could be instantiated with an arbitrary type which could be unrelated to 'string'.
 nonPrimitiveConstraintOfIndexAccessType.ts(21,5): error TS2322: Type 'string' is not assignable to type 'T[P]'.
@@ -51,6 +52,7 @@ nonPrimitiveConstraintOfIndexAccessType.ts(30,5): error TS2322: Type 'string' is
         ~~
 !!! error TS2322: Type 'string' is not assignable to type 'T[P]'.
 !!! error TS2322:   'T[P]' could be instantiated with an arbitrary type which could be unrelated to 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'never'.
     }
     function k<T extends number, P extends keyof T>(s: string, tp: T[P]): void {
         tp = s;


### PR DESCRIPTION
Fixes #63206

When assigning to an indexed access type (e.g. `this["faa"]`), the checker resolves the constraint and performs a structural comparison that generates specific error messages (missing properties, type mismatches, etc.). However, `reportRelationError` unconditionally clears `errorInfo` before reporting the generic *"could be instantiated with an arbitrary type"* message, discarding the useful elaboration.

This change preserves `errorInfo` when the target is an `IndexedAccess` type, so users see both the generic message and the specific details.

### Before

```ts
this.foo = {}
// Type '{}' is not assignable to type 'this["faa"]'.
//   'this["faa"]' could be instantiated with an arbitrary type which could be unrelated to '{}'.
```

### After

```ts
this.foo = {}
// Type '{}' is not assignable to type 'this["faa"]'.
//   'this["faa"]' could be instantiated with an arbitrary type which could be unrelated to '{}'.
//     Property 'key' is missing in type '{}' but required in type '{ key: number | null; }'.

this.foo = {key: "str"}
// Type '{ key: string; }' is not assignable to type 'this["faa"]'.
//   'this["faa"]' could be instantiated with an arbitrary type which could be unrelated to '{ key: string; }'.
//     Type '{ key: string; }' is not assignable to type '{ key: number | null; }'.
//       Types of property 'key' are incompatible.
//         Type 'string' is not assignable to type 'number'.
```

Two existing baselines updated to reflect the additional elaboration (no errors removed, only more specific detail added).