### PR TITLE
Fix crash when inferring from tuple with middle rest and trailing variadic elements

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27422,7 +27422,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                     if (constraint && isTupleType(constraint) && !(constraint.target.combinedFlags & ElementFlags.Variable)) {
                                         const impliedArity = constraint.target.fixedLength;
                                         inferFromTypes(sliceTupleType(source, startLength, sourceArity - (startLength + impliedArity)), elementTypes[startLength]);
-                                        inferFromTypes(getElementTypeOfSliceOfTupleType(source, startLength + impliedArity, endLength)!, elementTypes[startLength + 1]);
+                                        const restType = getElementTypeOfSliceOfTupleType(source, startLength + impliedArity, endLength);
+                                        if (restType) {
+                                            inferFromTypes(restType, elementTypes[startLength + 1]);
+                                        }
                                     }
                                 }
                                 else if (elementFlags[startLength] & ElementFlags.Rest && elementFlags[startLength + 1] & ElementFlags.Variadic) {
@@ -27435,8 +27438,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                         const endIndex = sourceArity - getEndElementCount(target.target, ElementFlags.Fixed);
                                         const startIndex = endIndex - impliedArity;
                                         const trailingSlice = createTupleType(getTypeArguments(source).slice(startIndex, endIndex), source.target.elementFlags.slice(startIndex, endIndex), /*readonly*/ false, source.target.labeledElementDeclarations && source.target.labeledElementDeclarations.slice(startIndex, endIndex));
-
-                                        inferFromTypes(getElementTypeOfSliceOfTupleType(source, startLength, endLength + impliedArity)!, elementTypes[startLength]);
+                                        const restType = getElementTypeOfSliceOfTupleType(source, startLength, endLength + impliedArity);
+                                        if (restType) {
+                                            inferFromTypes(restType, elementTypes[startLength]);
+                                        }
                                         inferFromTypes(trailingSlice, elementTypes[startLength + 1]);
                                     }
                                 }

--- a/tests/baselines/reference/inferTypesWithFixedTupleExtendsAtVariadicPosition.symbols
+++ b/tests/baselines/reference/inferTypesWithFixedTupleExtendsAtVariadicPosition.symbols
@@ -160,3 +160,26 @@ type SubTup2TrailingVariadicWithTrailingFixedElementsTest2 = SubTup2TrailingVari
 >SubTup2TrailingVariadicWithTrailingFixedElementsTest2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 68, 140))
 >SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 58, 129))
 
+// repro #63005 - should not crash when implied arity consumes entire source tuple
+type SubTup2RestAndTrailingVariadic3<T extends unknown[]> = T extends [
+>SubTup2RestAndTrailingVariadic3 : Symbol(SubTup2RestAndTrailingVariadic3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 69, 147))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 72, 37))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 72, 37))
+
+    ...(infer C)[],
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 73, 13))
+
+    ...infer B extends [any, any, any]
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 74, 12))
+
+]
+    ? [C, ...B]
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 73, 13))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 74, 12))
+
+    : never;
+
+type SubTup2RestAndTrailingVariadic3Test = SubTup2RestAndTrailingVariadic3<[...a: 0[], b: 1, c: 2]>;
+>SubTup2RestAndTrailingVariadic3Test : Symbol(SubTup2RestAndTrailingVariadic3Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 77, 12))
+>SubTup2RestAndTrailingVariadic3 : Symbol(SubTup2RestAndTrailingVariadic3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition.ts, 69, 147))
+

--- a/tests/baselines/reference/inferTypesWithFixedTupleExtendsAtVariadicPosition.types
+++ b/tests/baselines/reference/inferTypesWithFixedTupleExtendsAtVariadicPosition.types
@@ -119,3 +119,18 @@ type SubTup2TrailingVariadicWithTrailingFixedElementsTest2 = SubTup2TrailingVari
 >SubTup2TrailingVariadicWithTrailingFixedElementsTest2 : [c: 2, d: 3]
 >                                                      : ^^^^^^^^^^^^
 
+// repro #63005 - should not crash when implied arity consumes entire source tuple
+type SubTup2RestAndTrailingVariadic3<T extends unknown[]> = T extends [
+>SubTup2RestAndTrailingVariadic3 : SubTup2RestAndTrailingVariadic3<T>
+>                                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    ...(infer C)[],
+    ...infer B extends [any, any, any]
+]
+    ? [C, ...B]
+    : never;
+
+type SubTup2RestAndTrailingVariadic3Test = SubTup2RestAndTrailingVariadic3<[...a: 0[], b: 1, c: 2]>;
+>SubTup2RestAndTrailingVariadic3Test : never
+>                                    : ^^^^^
+

--- a/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition.ts
+++ b/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition.ts
@@ -72,3 +72,13 @@ type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T e
 
 type SubTup2TrailingVariadicWithTrailingFixedElementsTest = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2, d: 3]>;
 type SubTup2TrailingVariadicWithTrailingFixedElementsTest2 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+
+// repro #63005 - should not crash when implied arity consumes entire source tuple
+type SubTup2RestAndTrailingVariadic3<T extends unknown[]> = T extends [
+    ...(infer C)[],
+    ...infer B extends [any, any, any]
+]
+    ? [C, ...B]
+    : never;
+
+type SubTup2RestAndTrailingVariadic3Test = SubTup2RestAndTrailingVariadic3<[...a: 0[], b: 1, c: 2]>;


### PR DESCRIPTION
## Summary

Fixes #63005

When inferring from a tuple type that has middle rest elements and trailing variadic elements (e.g., `[...(infer C)[], ...infer B extends [any, any, any]]`), the compiler crashes with `TypeError: Cannot read properties of undefined (reading 'aliasSymbol')`.

**Root cause:** `getElementTypeOfSliceOfTupleType` returns `undefined` when the implied arity from the variadic constraint consumes the entire source tuple, but the result was passed to `inferFromTypes` via a non-null assertion (`!`).

**Fix:** Add null checks before calling `inferFromTypes` in both the `[...T, ...rest]` and `[...rest, ...T]` inference branches, consistent with the existing pattern at the single-rest-element branch nearby.

## Test plan

- Added a test case to `inferTypesWithFixedTupleExtendsAtVariadicPosition.ts` that previously crashed
- All existing variadic tuple inference tests continue to pass