### PR TITLE
fix: handle inspector session leak on Profiler.enable/start failure

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1655,8 +1655,18 @@ export let sys: System = (() => {
             const session = new inspector.Session();
             session.connect();
 
-            session.post("Profiler.enable", () => {
-                session.post("Profiler.start", () => {
+            session.post("Profiler.enable", (enableErr) => {
+                if (enableErr) {
+                    session.disconnect();
+                    cb();
+                    return;
+                }
+                session.post("Profiler.start", (startErr) => {
+                    if (startErr) {
+                        session.disconnect();
+                        cb();
+                        return;
+                    }
                     activeSession = session;
                     profilePath = path;
                     cb();


### PR DESCRIPTION
## Summary

`enableCPUProfiler` in `src/compiler/sys.ts` calls `session.connect()` but the callbacks for `Profiler.enable` and `Profiler.start` ignore the error parameter. If either V8 API call fails, the inspector session is never disconnected.

## Bug verification

1. `session.connect()` is called at line 1657
2. `session.post("Profiler.enable", callback)` -- callback signature is `(err, result)` but `err` is ignored
3. If `Profiler.enable` fails (e.g., profiler already active), `activeSession` is never set
4. `disableCPUProfiler` checks `activeSession` before calling `session.disconnect()` -- it will never find the leaked session
5. The session stays connected until process exit

## Fix

Add error parameters to both callbacks. On failure, disconnect the session immediately and invoke the continuation callback so the caller is not left hanging.

Found by [Gnosis Polyglot Scanner](https://gnosis.church), an open-source static analysis tool that detects resource leaks across languages via topological analysis of control flow graphs.

Signed-off-by: Taylor Buley <taylor@forkjoin.ai>
