### PR TITLE
fix: pin 5 unpinned action(s)

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -177,7 +177,7 @@ jobs:
 
             return commentBody;
 
-      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@master
+      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@7676a9e9baa8a77a92206e4a9d434bbe45c81959 # master
         if: ${{ !cancelled() && inputs.distinct_id }}
         with:
           success_comment: ${{ steps.open-pr.outputs.result }}

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -87,7 +87,7 @@ jobs:
           git commit -m "Bump version to $PACKAGE_VERSION and LKG"
           git push --set-upstream origin "$BRANCH_NAME"
 
-      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@master
+      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@7676a9e9baa8a77a92206e4a9d434bbe45c81959 # master
         if: ${{ !cancelled() && inputs.distinct_id }}
         with:
           success_comment: "I've created ${{ inputs.branch_name }} with version ${{ inputs.package_version }} for you."

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -90,7 +90,7 @@ jobs:
           git commit -m "Bump version to $PACKAGE_VERSION and LKG"
           git push
 
-      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@master
+      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@7676a9e9baa8a77a92206e4a9d434bbe45c81959 # master
         if: ${{ !cancelled() && inputs.distinct_id }}
         with:
           success_comment: "I've set the version of ${{ inputs.branch_name }} to ${{ inputs.package_version }} for you."

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -64,7 +64,7 @@ jobs:
           git commit -m 'Update LKG'
           git push
 
-      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@master
+      - uses: microsoft/typescript-bot-test-triggerer/.github/actions/post-workflow-result@7676a9e9baa8a77a92206e4a9d434bbe45c81959 # master
         if: ${{ !cancelled() && inputs.distinct_id }}
         with:
           success_comment: "I've pulled main into ${{ inputs.branch_name }} for you."

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 'lts/*'
-      - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
+      - uses: microsoft/TypeScript-Twoslash-Repro-Action@896a8519c4a94659aae0e27c9c92d6115bfb6ad8 # master
         with:
           github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
           issue: ${{ github.event.inputs.issue }}


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/create-cherry-pick-pr.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/new-release-branch.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/set-version.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/sync-branch.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/twoslash-repros.yaml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.