### PR TITLE
fix(30408): improve error message for labels used before definition

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -53030,7 +53030,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let current: Node = node;
         while (current) {
             if (isFunctionLikeOrClassStaticBlockDeclaration(current)) {
-                return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
+                return grammarErrorOnNode(node, Diagnostics.Jump_target_0_cannot_cross_function_boundary, node.label ? node.label.text : "");
             }
 
             switch (current.kind) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -307,6 +307,10 @@
         "category": "Error",
         "code": 1107
     },
+    "Jump target '{0}' cannot cross function boundary.": {
+        "category": "Error",
+        "code": 1107
+    },
     "A 'return' statement can only be used within a function body.": {
         "category": "Error",
         "code": 1108


### PR DESCRIPTION
## Description

The error message 'Jump target cannot cross function boundary' was confusing because it didn't indicate which label was causing the issue. This change adds the label name to the error message when available.

## Changes

- Added new error message format: "Jump target '{0}' cannot cross function boundary."
- Updated checker.ts to use the new message format with the label name

## Before

```
Jump target cannot cross function boundary.
```

## After

```
Jump target 'loopend' cannot cross function boundary.
```

## Example

```typescript
function foo() {
    for (let i = 0; i < 10; i++) {
        console.log(`${i}`);
        continue loopend;  // Error: Jump target 'loopend' cannot cross function boundary.
    }

    loopend:
    console.log('end of loop');
}
```

Fixes #30408