### PR TITLE
Sort JSDoc @param completions by argument position

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -944,7 +944,7 @@ function getJSDocParameterCompletions(
     const isJs = isSourceFileJS(sourceFile);
     const isSnippet = preferences.includeCompletionsWithSnippetText || undefined;
     const paramTagCount = countWhere(jsDoc.tags, tag => isJSDocParameterTag(tag) && tag.getEnd() <= position);
-    return mapDefined(func.parameters, param => {
+    return mapDefined(func.parameters, (param, parameterIndex) => {
         if (getJSDocParameterTags(param).length) {
             return undefined; // Parameter is already annotated.
         }
@@ -983,7 +983,7 @@ function getJSDocParameterCompletions(
             return {
                 name: displayText,
                 kind: ScriptElementKind.parameterElement,
-                sortText: SortText.LocationPriority,
+                sortText: SortText.LocationPriority + String(parameterIndex) as SortText,
                 insertText: isSnippet ? snippetText : undefined,
                 isSnippet,
             };
@@ -1023,7 +1023,7 @@ function getJSDocParameterCompletions(
             return {
                 name: displayText,
                 kind: ScriptElementKind.parameterElement,
-                sortText: SortText.LocationPriority,
+                sortText: SortText.LocationPriority + String(parameterIndex) as SortText,
                 insertText: isSnippet ? snippetText : undefined,
                 isSnippet,
             };

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -431,7 +431,7 @@ export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): Comple
             return undefined;
         }
 
-        return { name, kind: ScriptElementKind.parameterElement, kindModifiers: "", sortText: Completions.SortText.LocationPriority };
+        return { name, kind: ScriptElementKind.parameterElement, kindModifiers: "", sortText: Completions.SortText.LocationPriority + String(fn.parameters.indexOf(param)) as Completions.SortText };
     });
 }
 

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
@@ -2740,7 +2740,7 @@
         {
           "name": "param value ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -2753,7 +2753,7 @@
         {
           "name": "param maximumFractionDigits ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "111",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -3877,7 +3877,7 @@
         {
           "name": "param param0 ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -3890,7 +3890,7 @@
         {
           "name": "param b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "111",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -5014,7 +5014,7 @@
         {
           "name": "@param b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -6138,7 +6138,7 @@
         {
           "name": "param param0 ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -7262,7 +7262,7 @@
         {
           "name": "param param0 ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -8386,7 +8386,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {number} [param0.a=1] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -8399,7 +8399,7 @@
         {
           "name": "param {*} b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "111",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -9523,7 +9523,7 @@
         {
           "name": "@param {*} b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -10647,7 +10647,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -11771,7 +11771,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {Object} param0.a \r\n* @param {*} param0.a.b \r\n* @param {*} param0.a.c \r\n* @param {*} param0.d ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -12895,7 +12895,7 @@
         {
           "name": "param {*} param0 ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -14019,7 +14019,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {*} param0.a ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -15143,7 +15143,7 @@
         {
           "name": "param {*} a ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -16267,7 +16267,7 @@
         {
           "name": "param {Object} param1 \r\n* @param {*} param1.b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "111",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -17391,7 +17391,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {*} param0.b \r\n* @param {...*} param0.c ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -17404,7 +17404,7 @@
         {
           "name": "param {...*} a ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "111",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -18528,7 +18528,7 @@
         {
           "name": "param {...*} param0 ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -19652,7 +19652,7 @@
         {
           "name": "param {...*} a ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -20776,7 +20776,7 @@
         {
           "name": "param {*} [a] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
@@ -1580,7 +1580,7 @@
         {
           "name": "@param b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "insertText": "@param b ${1}",
           "isSnippet": true,
           "kindModifiers": "",
@@ -2706,7 +2706,7 @@
         {
           "name": "@param {*} b ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "insertText": "@param {${1:*}} b ${2}",
           "isSnippet": true,
           "kindModifiers": "",
@@ -3832,7 +3832,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "insertText": "param {Object} param0 ${1}\r\n* @param {Object} [param0.b={ a: 1, c: 3 }] ${2}\r\n* @param {${3:*}} param0.b.a ${4}\r\n* @param {${5:*}} param0.b.c ${6}",
           "isSnippet": true,
           "kindModifiers": "",
@@ -4958,7 +4958,7 @@
         {
           "name": "param {...*} a ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "insertText": "param {...${1:*}} a ${2}",
           "isSnippet": true,
           "kindModifiers": "",
@@ -6084,7 +6084,7 @@
         {
           "name": "param {number} [a=3] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "insertText": "param {number} [a=3] ${1}",
           "isSnippet": true,
           "kindModifiers": "",

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion3.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion3.baseline
@@ -1672,7 +1672,7 @@
         {
           "name": "param {number} [a=3] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -2796,7 +2796,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {number} [param0.a=3] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -3920,7 +3920,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {*} param0.o.c ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -5044,7 +5044,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {[number, boolean]} [param0.o.c=[1, true]] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -6168,7 +6168,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {(number | boolean)[]} [param0.a=[1, true]] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {
@@ -7292,7 +7292,7 @@
         {
           "name": "param {Object} param0 \r\n* @param {*} [param0.a=random()] ",
           "kind": "",
-          "sortText": "11",
+          "sortText": "110",
           "kindModifiers": "",
           "displayParts": [
             {

--- a/tests/cases/fourslash/jsdocParameterNameCompletion.ts
+++ b/tests/cases/fourslash/jsdocParameterNameCompletion.ts
@@ -23,7 +23,22 @@
 ////function i(foo, bar) {}
 
 verify.completions(
-    { marker: ["0", "3", "4"], exact: ["foo", "bar"] },
-    { marker: "1", exact: "bar" },
-    { marker: "2", exact: ["canary", "canoodle"] },
+    {
+        marker: ["0", "3", "4"],
+        exact: [
+            { name: "foo", kind: "parameter", sortText: completion.SortText.LocationPriority + "0" },
+            { name: "bar", kind: "parameter", sortText: completion.SortText.LocationPriority + "1" },
+        ],
+    },
+    {
+        marker: "1",
+        exact: { name: "bar", kind: "parameter", sortText: completion.SortText.LocationPriority + "1" },
+    },
+    {
+        marker: "2",
+        exact: [
+            { name: "canary", kind: "parameter", sortText: completion.SortText.LocationPriority + "1" },
+            { name: "canoodle", kind: "parameter", sortText: completion.SortText.LocationPriority + "2" },
+        ],
+    },
 );

--- a/tests/cases/fourslash/jsdocParameterNameSortOrder.ts
+++ b/tests/cases/fourslash/jsdocParameterNameSortOrder.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+/////**
+//// * @param /**/
+//// */
+////function foo(z: string, a: number, m: boolean) {}
+
+verify.completions({
+    marker: "",
+    exact: [
+        { name: "z", kind: "parameter", sortText: completion.SortText.LocationPriority + "0" },
+        { name: "a", kind: "parameter", sortText: completion.SortText.LocationPriority + "1" },
+        { name: "m", kind: "parameter", sortText: completion.SortText.LocationPriority + "2" },
+    ],
+});


### PR DESCRIPTION
Fixes #20183

## Problem

When writing JSDoc `@param` tags, the completions for parameter names are sorted alphabetically instead of by their position in the function signature.

For example, given:
```ts
/**
 * @param |
 */
function foo(z, a) {}
```

Triggering completions at `|` returns `a` before `z`, because both entries have the same `sortText` value (`"11"` / `LocationPriority`), causing the editor to fall back to alphabetical sorting.

## Fix

Set `sortText` for each JSDoc `@param` completion to `LocationPriority + parameterIndex` (e.g., `"110"`, `"111"`, `"112"`). This ensures completions appear in the same order as the function's parameter list.

### Changes:
- **`src/services/completions.ts`**: Updated `getJSDocParameterCompletions` to use parameter index in `sortText` for both named and destructuring parameters
- **`src/services/jsDoc.ts`**: Updated `getJSDocParameterNameCompletions` to use parameter index in `sortText`
- **Updated existing tests** and baselines to reflect new `sortText` values
- **Added new test** `jsdocParameterNameSortOrder.ts` that explicitly verifies the sort order