### PR TITLE
docs: fix typos in Herebyfile.mjs and eslint rule comment

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -649,13 +649,13 @@ const copyBuiltLocalDiagnosticMessages = task({
 
 export const otherOutputs = task({
     name: "other-outputs",
-    description: "Builds miscelaneous scripts and documents distributed with the LKG",
+    description: "Builds miscellaneous scripts and documents distributed with the LKG",
     dependencies: [typingsInstaller, watchGuard, generateTypesMap, copyBuiltLocalDiagnosticMessages],
 });
 
 export const watchOtherOutputs = task({
     name: "watch-other-outputs",
-    description: "Builds miscelaneous scripts and documents distributed with the LKG",
+    description: "Builds miscellaneous scripts and documents distributed with the LKG",
     hiddenFromTaskList: true,
     dependencies: [watchTypingsInstaller, watchWatchGuard, generateTypesMap, copyBuiltLocalDiagnosticMessages],
 });

--- a/scripts/eslint/rules/argument-trivia.cjs
+++ b/scripts/eslint/rules/argument-trivia.cjs
@@ -117,7 +117,7 @@ module.exports = createRule({
                         const name = ts.unescapeLeadingUnderscores(expectedName);
                         // If a parameter is unused, we prepend an underscore. Ignore this
                         // so that we can switch between used and unused without modifying code,
-                        // requiring that arugments are tagged with the non-underscored name.
+                        // requiring that arguments are tagged with the non-underscored name.
                         return name.startsWith("_") ? name.slice(1) : name;
                     }
                 }


### PR DESCRIPTION
Fix minor typos found via codespell:\n- 'miscelaneous' → 'miscellaneous' in task descriptions (Herebyfile.mjs)\n- 'arugments' → 'arguments' in a comment (scripts/eslint/rules/argument-trivia.cjs)