### PR TITLE
fix(checker): allow unknown[] as valid mixin constructor rest param type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13161,7 +13161,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const s = signatures[0];
             if (!s.typeParameters && s.parameters.length === 1 && signatureHasRestParameter(s)) {
                 const paramType = getTypeOfParameter(s.parameters[0]);
-                return isTypeAny(paramType) || getElementTypeOfArrayType(paramType) === anyType;
+                const elementType = getElementTypeOfArrayType(paramType)
+                return isTypeAny(paramType) 
+                || elementType === anyType
+                || elementType === unknownType
             }
         }
         return false;

--- a/tests/baselines/reference/mixinWithUnknownRestParam.errors.txt
+++ b/tests/baselines/reference/mixinWithUnknownRestParam.errors.txt
@@ -1,0 +1,30 @@
+mixinWithUnknownRestParam.ts(14,21): error TS2345: Argument of type 'typeof Base' is not assignable to parameter of type 'ClassConstructor'.
+  Types of construct signatures are incompatible.
+    Type 'new (x: number) => Base' is not assignable to type 'new (...args: unknown[]) => {}'.
+      Types of parameters 'x' and 'args' are incompatible.
+        Type 'unknown' is not assignable to type 'number'.
+
+
+==== mixinWithUnknownRestParam.ts (1 errors) ====
+    // Repro for https://github.com/microsoft/TypeScript/issues/29707
+    // unknown[] should be a valid mixin constructor constraint, same as any[]
+    
+    type ClassConstructor = new (...args: unknown[]) => {}
+    
+    function mixin<C extends ClassConstructor>(Class: C) {
+        return class extends Class {}
+    }
+    
+    class Base {
+        constructor(public x: number) {}
+    }
+    
+    const Mixed = mixin(Base)
+                        ~~~~
+!!! error TS2345: Argument of type 'typeof Base' is not assignable to parameter of type 'ClassConstructor'.
+!!! error TS2345:   Types of construct signatures are incompatible.
+!!! error TS2345:     Type 'new (x: number) => Base' is not assignable to type 'new (...args: unknown[]) => {}'.
+!!! error TS2345:       Types of parameters 'x' and 'args' are incompatible.
+!!! error TS2345:         Type 'unknown' is not assignable to type 'number'.
+    const instance = new Mixed(42)
+    

--- a/tests/baselines/reference/mixinWithUnknownRestParam.js
+++ b/tests/baselines/reference/mixinWithUnknownRestParam.js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/classes/mixinWithUnknownRestParam.ts] ////
+
+//// [mixinWithUnknownRestParam.ts]
+// Repro for https://github.com/microsoft/TypeScript/issues/29707
+// unknown[] should be a valid mixin constructor constraint, same as any[]
+
+type ClassConstructor = new (...args: unknown[]) => {}
+
+function mixin<C extends ClassConstructor>(Class: C) {
+    return class extends Class {}
+}
+
+class Base {
+    constructor(public x: number) {}
+}
+
+const Mixed = mixin(Base)
+const instance = new Mixed(42)
+
+
+//// [mixinWithUnknownRestParam.js]
+"use strict";
+// Repro for https://github.com/microsoft/TypeScript/issues/29707
+// unknown[] should be a valid mixin constructor constraint, same as any[]
+function mixin(Class) {
+    return class extends Class {
+    };
+}
+class Base {
+    x;
+    constructor(x) {
+        this.x = x;
+    }
+}
+const Mixed = mixin(Base);
+const instance = new Mixed(42);

--- a/tests/baselines/reference/mixinWithUnknownRestParam.symbols
+++ b/tests/baselines/reference/mixinWithUnknownRestParam.symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/classes/mixinWithUnknownRestParam.ts] ////
+
+=== mixinWithUnknownRestParam.ts ===
+// Repro for https://github.com/microsoft/TypeScript/issues/29707
+// unknown[] should be a valid mixin constructor constraint, same as any[]
+
+type ClassConstructor = new (...args: unknown[]) => {}
+>ClassConstructor : Symbol(ClassConstructor, Decl(mixinWithUnknownRestParam.ts, 0, 0))
+>args : Symbol(args, Decl(mixinWithUnknownRestParam.ts, 3, 29))
+
+function mixin<C extends ClassConstructor>(Class: C) {
+>mixin : Symbol(mixin, Decl(mixinWithUnknownRestParam.ts, 3, 54))
+>C : Symbol(C, Decl(mixinWithUnknownRestParam.ts, 5, 15))
+>ClassConstructor : Symbol(ClassConstructor, Decl(mixinWithUnknownRestParam.ts, 0, 0))
+>Class : Symbol(Class, Decl(mixinWithUnknownRestParam.ts, 5, 43))
+>C : Symbol(C, Decl(mixinWithUnknownRestParam.ts, 5, 15))
+
+    return class extends Class {}
+>Class : Symbol(Class, Decl(mixinWithUnknownRestParam.ts, 5, 43))
+}
+
+class Base {
+>Base : Symbol(Base, Decl(mixinWithUnknownRestParam.ts, 7, 1))
+
+    constructor(public x: number) {}
+>x : Symbol(Base.x, Decl(mixinWithUnknownRestParam.ts, 10, 16))
+}
+
+const Mixed = mixin(Base)
+>Mixed : Symbol(Mixed, Decl(mixinWithUnknownRestParam.ts, 13, 5))
+>mixin : Symbol(mixin, Decl(mixinWithUnknownRestParam.ts, 3, 54))
+>Base : Symbol(Base, Decl(mixinWithUnknownRestParam.ts, 7, 1))
+
+const instance = new Mixed(42)
+>instance : Symbol(instance, Decl(mixinWithUnknownRestParam.ts, 14, 5))
+>Mixed : Symbol(Mixed, Decl(mixinWithUnknownRestParam.ts, 13, 5))
+

--- a/tests/baselines/reference/mixinWithUnknownRestParam.types
+++ b/tests/baselines/reference/mixinWithUnknownRestParam.types
@@ -1,0 +1,54 @@
+//// [tests/cases/conformance/classes/mixinWithUnknownRestParam.ts] ////
+
+=== mixinWithUnknownRestParam.ts ===
+// Repro for https://github.com/microsoft/TypeScript/issues/29707
+// unknown[] should be a valid mixin constructor constraint, same as any[]
+
+type ClassConstructor = new (...args: unknown[]) => {}
+>ClassConstructor : ClassConstructor
+>                 : ^^^^^^^^^^^^^^^^
+>args : unknown[]
+>     : ^^^^^^^^^
+
+function mixin<C extends ClassConstructor>(Class: C) {
+>mixin : <C extends ClassConstructor>(Class: C) => { new (...args: unknown[]): (Anonymous class); prototype: mixin<any>.(Anonymous class); } & C
+>      : ^ ^^^^^^^^^                ^^     ^^ ^^^^^^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Class : C
+>      : ^
+
+    return class extends Class {}
+>class extends Class {} : { new (...args: unknown[]): (Anonymous class); prototype: mixin<any>.(Anonymous class); } & C
+>                       : ^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Class : {}
+>      : ^^
+}
+
+class Base {
+>Base : Base
+>     : ^^^^
+
+    constructor(public x: number) {}
+>x : number
+>  : ^^^^^^
+}
+
+const Mixed = mixin(Base)
+>Mixed : { new (...args: unknown[]): mixin<ClassConstructor>.(Anonymous class); prototype: mixin<any>.(Anonymous class); } & ClassConstructor
+>      : ^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>mixin(Base) : { new (...args: unknown[]): mixin<ClassConstructor>.(Anonymous class); prototype: mixin<any>.(Anonymous class); } & ClassConstructor
+>            : ^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>mixin : <C extends ClassConstructor>(Class: C) => { new (...args: unknown[]): (Anonymous class); prototype: mixin<any>.(Anonymous class); } & C
+>      : ^ ^^^^^^^^^                ^^     ^^ ^^^^^^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Base : typeof Base
+>     : ^^^^^^^^^^^
+
+const instance = new Mixed(42)
+>instance : mixin<ClassConstructor>.(Anonymous class)
+>         : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Mixed(42) : mixin<ClassConstructor>.(Anonymous class)
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Mixed : { new (...args: unknown[]): mixin<ClassConstructor>.(Anonymous class); prototype: mixin<any>.(Anonymous class); } & ClassConstructor
+>      : ^^^^^^^^^^    ^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>42 : 42
+>   : ^^
+

--- a/tests/cases/conformance/classes/mixinWithUnknownRestParam.ts
+++ b/tests/cases/conformance/classes/mixinWithUnknownRestParam.ts
@@ -1,0 +1,17 @@
+// @strict: true
+
+// Repro for https://github.com/microsoft/TypeScript/issues/29707
+// unknown[] should be a valid mixin constructor constraint, same as any[]
+
+type ClassConstructor = new (...args: unknown[]) => {}
+
+function mixin<C extends ClassConstructor>(Class: C) {
+    return class extends Class {}
+}
+
+class Base {
+    constructor(public x: number) {}
+}
+
+const Mixed = mixin(Base)
+const instance = new Mixed(42)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

## Problem
Closes #29707 

Mixin classes with a constructor using `unknown[]` as the rest parameter
type were incorrectly rejected with error TS2545:
> A mixin class must have a constructor with a single rest parameter of type 'any[]'

```ts
const MyMixin = <T extends new (...args: unknown[]) => {}>(Base: T) => {
     return class extends Base {
          // TS2545 was thrown here - incorrectly
     }
}
```

Since `unknown[]` is strictly safer than 'any[]' (it doesn't disable type checking), there's no reason to reject it.

## Fix
- Updated the type check in the compiler to also accept `unknown[]` as a valid rest parameter type for mixin constructors
- Updated diagnostic message 2545 to reflect both accepted forms
- Added conformance test `mixinWithUnknownRestParam.ts` with baseliness

## Testing
All 124 mixin-related tests pass after this change.