### PR TITLE
Document charAt edge case behavior

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -394,7 +394,7 @@ interface String {
     toString(): string;
 
     /**
-     * Returns the character at the specified index.
+     * Returns the character at the specified index, or an empty string if the index is out of bounds.
      * @param pos The zero-based index of the desired character.
      */
     charAt(pos: number): string;


### PR DESCRIPTION
Similar to PR #63344, this clarifies what happens when charAt is called with an out-of-bounds index (returns empty string).

Improves documentation consistency across String methods.