### PR TITLE
fix(lib): correct typo in es5.d.ts — paramater -> parameter

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1379,7 +1379,7 @@ interface Array<T> {
      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
      * @param start The zero-based location in the array from which to start removing elements.
      * @param deleteCount The number of elements to remove. Omitting this argument will remove all elements from the start
-     * paramater location to end of the array. If value of this argument is either a negative number, zero, undefined, or a type
+     * parameter location to end of the array. If value of this argument is either a negative number, zero, undefined, or a type
      * that cannot be converted to an integer, the function will evaluate the argument as zero and not remove any elements.
      * @returns An array containing the elements that were deleted.
      */


### PR DESCRIPTION
Fixes a typo in the JSDoc comment for `Array.prototype.splice` in `src/lib/es5.d.ts` (line 1382): `paramater` → `parameter`.

Closes #63352