### PR TITLE
fix(lib): add missing -1 return documentation for Array indexOf/lastIndexOf

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1205,13 +1205,13 @@ interface ReadonlyArray<T> {
      */
     slice(start?: number, end?: number): T[];
     /**
-     * Returns the index of the first occurrence of a value in an array.
+     * Returns the index of the first occurrence of a value in an array, or -1 if it is not present.
      * @param searchElement The value to locate in the array.
      * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
      */
     indexOf(searchElement: T, fromIndex?: number): number;
     /**
-     * Returns the index of the last occurrence of a specified value in an array.
+     * Returns the index of the last occurrence of a specified value in an array, or -1 if it is not present.
      * @param searchElement The value to locate in the array.
      * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
      */


### PR DESCRIPTION
Fixes #63403                                                                                                                                        
                                                                                                                                                             
  The `Array` interface's `indexOf` and `lastIndexOf` JSDoc descriptions are missing the ", or -1 if it is not present" clause that is consistently present
  in `ReadonlyArray` and all TypedArray interfaces.                                                                                                          
                                                                                                                                                           
  This is the same style of improvement as #60569 (indexOf) and #63344 (charCodeAt). 