### PR TITLE
Sort JSDoc parameter suggestions by argument position

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -420,7 +420,7 @@ export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): Comple
     const fn = jsdoc.parent;
     if (!isFunctionLike(fn)) return [];
 
-    return mapDefined(fn.parameters, param => {
+    return mapDefined(fn.parameters, (param, index) => {
         if (!isIdentifier(param.name)) return undefined;
 
         const name = param.name.text;
@@ -431,7 +431,9 @@ export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): Comple
             return undefined;
         }
 
-        return { name, kind: ScriptElementKind.parameterElement, kindModifiers: "", sortText: Completions.SortText.LocationPriority };
+        // Sort by parameter position so that e.g. `@param z` from `foo(z, a)` comes before `@param a`
+        const sortText = `${index.toString().padStart(2, "0")}` as string & { __sortText: any };
+        return { name, kind: ScriptElementKind.parameterElement, kindModifiers: "", sortText };
     });
 }
 


### PR DESCRIPTION
Good day

## Summary

This PR fixes issue #20183 by sorting JSDoc parameter suggestions by their position in the function signature rather than alphabetically.

### Problem
When triggering completions after `@param` in a JSDoc comment, all parameters had the same `sortText` (LocationPriority = "11"), causing them to be sorted alphabetically instead of by their actual position in the function.

For example, in `foo(z, a)`:
- **Before**: `a` and `z` both had sortText="11", sorted alphabetically
- **After**: `z` (index 0) comes before `a` (index 1) because "00" < "01"

### Solution
Modified `getJSDocParameterNameCompletions` in `src/services/jsDoc.ts` to use the parameter's array index to generate a unique sortText prefixed with its position (e.g., "00", "01", "02").

### Changes
- `src/services/jsDoc.ts`: Use parameter position index for sortText instead of LocationPriority

### Testing
- Compiled successfully with `npm run build:compiler`
- The fix follows the same pattern as other completion entries that use position-based sorting

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof