### PR TITLE
Add `Intl.PluralRules.selectRange` typing to es2023.intl

### DIFF
--- a/src/lib/es2023.intl.d.ts
+++ b/src/lib/es2023.intl.d.ts
@@ -43,4 +43,8 @@ declare namespace Intl {
         formatRange(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): string;
         formatRangeToParts(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): NumberRangeFormatPart[];
     }
+
+    interface PluralRules {
+        selectRange(start: number, end: number): LDMLPluralRule;
+    }
 }

--- a/tests/baselines/reference/intlPluralRulesSelectRangeES2023.js
+++ b/tests/baselines/reference/intlPluralRulesSelectRangeES2023.js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/es2023/intlPluralRulesSelectRangeES2023.ts] ////
+
+//// [intlPluralRulesSelectRangeES2023.ts]
+const pr = new Intl.PluralRules("en-US");
+const category = pr.selectRange(1, 2);
+
+const exact: Intl.LDMLPluralRule = category;
+
+
+//// [intlPluralRulesSelectRangeES2023.js]
+"use strict";
+const pr = new Intl.PluralRules("en-US");
+const category = pr.selectRange(1, 2);
+const exact = category;

--- a/tests/baselines/reference/intlPluralRulesSelectRangeES2023.symbols
+++ b/tests/baselines/reference/intlPluralRulesSelectRangeES2023.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/conformance/es2023/intlPluralRulesSelectRangeES2023.ts] ////
+
+=== intlPluralRulesSelectRangeES2023.ts ===
+const pr = new Intl.PluralRules("en-US");
+>pr : Symbol(pr, Decl(intlPluralRulesSelectRangeES2023.ts, 0, 5))
+>Intl.PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+
+const category = pr.selectRange(1, 2);
+>category : Symbol(category, Decl(intlPluralRulesSelectRangeES2023.ts, 1, 5))
+>pr.selectRange : Symbol(Intl.PluralRules.selectRange, Decl(lib.es2023.intl.d.ts, --, --))
+>pr : Symbol(pr, Decl(intlPluralRulesSelectRangeES2023.ts, 0, 5))
+>selectRange : Symbol(Intl.PluralRules.selectRange, Decl(lib.es2023.intl.d.ts, --, --))
+
+const exact: Intl.LDMLPluralRule = category;
+>exact : Symbol(exact, Decl(intlPluralRulesSelectRangeES2023.ts, 3, 5))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>LDMLPluralRule : Symbol(Intl.LDMLPluralRule, Decl(lib.es2018.intl.d.ts, --, --))
+>category : Symbol(category, Decl(intlPluralRulesSelectRangeES2023.ts, 1, 5))
+

--- a/tests/baselines/reference/intlPluralRulesSelectRangeES2023.types
+++ b/tests/baselines/reference/intlPluralRulesSelectRangeES2023.types
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/es2023/intlPluralRulesSelectRangeES2023.ts] ////
+
+=== intlPluralRulesSelectRangeES2023.ts ===
+const pr = new Intl.PluralRules("en-US");
+>pr : Intl.PluralRules
+>   : ^^^^^^^^^^^^^^^^
+>new Intl.PluralRules("en-US") : Intl.PluralRules
+>                              : ^^^^^^^^^^^^^^^^
+>Intl.PluralRules : Intl.PluralRulesConstructor
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Intl : typeof Intl
+>     : ^^^^^^^^^^^
+>PluralRules : Intl.PluralRulesConstructor
+>            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>"en-US" : "en-US"
+>        : ^^^^^^^
+
+const category = pr.selectRange(1, 2);
+>category : Intl.LDMLPluralRule
+>         : ^^^^^^^^^^^^^^^^^^^
+>pr.selectRange(1, 2) : Intl.LDMLPluralRule
+>                     : ^^^^^^^^^^^^^^^^^^^
+>pr.selectRange : (start: number, end: number) => Intl.LDMLPluralRule
+>               : ^     ^^      ^^   ^^      ^^^^^^^^^^^^^^^^^^^^^^^^
+>pr : Intl.PluralRules
+>   : ^^^^^^^^^^^^^^^^
+>selectRange : (start: number, end: number) => Intl.LDMLPluralRule
+>            : ^     ^^      ^^   ^^      ^^^^^^^^^^^^^^^^^^^^^^^^
+>1 : 1
+>  : ^
+>2 : 2
+>  : ^
+
+const exact: Intl.LDMLPluralRule = category;
+>exact : Intl.LDMLPluralRule
+>      : ^^^^^^^^^^^^^^^^^^^
+>Intl : any
+>     : ^^^
+>category : Intl.LDMLPluralRule
+>         : ^^^^^^^^^^^^^^^^^^^
+

--- a/tests/cases/conformance/es2023/intlPluralRulesSelectRangeES2023.ts
+++ b/tests/cases/conformance/es2023/intlPluralRulesSelectRangeES2023.ts
@@ -1,0 +1,8 @@
+// @target: es2022
+// @lib: es2022,es2023.intl
+// @strict: true
+
+const pr = new Intl.PluralRules("en-US");
+const category = pr.selectRange(1, 2);
+
+const exact: Intl.LDMLPluralRule = category;


### PR DESCRIPTION
Split from #58084

This adds the missing [`Intl.PluralRules.prototype.selectRange`](https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.selectrange) typing to `src/lib/es2023.intl.d.ts`

