### PR TITLE
docs: improve Math.sign JSDoc grammar and clarity

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -94,7 +94,7 @@ interface Math {
     imul(x: number, y: number): number;
 
     /**
-     * Returns the sign of the x, indicating whether x is positive, negative or zero.
+     * Returns the sign of x, indicating whether x is positive, negative, or zero.
      * @param x The numeric expression to test
      */
     sign(x: number): number;


### PR DESCRIPTION
Fixes #63432

Corrected a grammatical issue in the JSDoc comment for `Math.sign` in `src/lib/es2015.core.d.ts`.

- Replaced “the sign of the x” with “the sign of x”
- Added a comma before “or zero” for consistency

This aligns with similar documentation in the file (e.g., `log1p`, `expm1`) which uses “of x” phrasing.