### PR TITLE
fix: allow bracket-notation enum access as computed property name in type positions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13790,7 +13790,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return false;
         }
         const expr = isComputedPropertyName(node) ? node.expression : node.argumentExpression;
-        return isEntityNameExpression(expr);
+        if (isEntityNameExpression(expr)) {
+            return true;
+        }
+        // Also allow element access on an entity name with a literal key, e.g. Enum['non-identifier-key'].
+        // This covers enum members whose names are not valid identifiers.
+        return isElementAccessExpression(expr)
+            && isEntityNameExpression(expr.expression)
+            && isStringOrNumericLiteralLike(skipParentheses(expr.argumentExpression));
     }
 
     function isTypeUsableAsIndexSignature(type: Type): boolean {

--- a/tests/baselines/reference/enumBracketComputedPropertyName.js
+++ b/tests/baselines/reference/enumBracketComputedPropertyName.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/enumBracketComputedPropertyName.ts] ////
+
+//// [enumBracketComputedPropertyName.ts]
+// Enum members with non-identifier names should be usable as computed property
+// keys in type literals, interfaces, and class members (GH#25083).
+
+enum E {
+    "hello world" = "hw",
+    "3x14" = "pi",
+    normal = "n",
+}
+
+// type literal
+type T1 = { [E["hello world"]]: string };
+type T2 = { [E["3x14"]]: boolean };
+type T3 = { [E["normal"]]: number };   // bracket access to a normal-identifier member
+
+// interface
+interface I1 {
+    [E["hello world"]]: string;
+}
+
+// access back through the computed key
+declare const t1: T1;
+const v1: string = t1[E["hello world"]];
+const v2: string = t1["hw"];   // literal value
+
+
+//// [enumBracketComputedPropertyName.js]
+"use strict";
+// Enum members with non-identifier names should be usable as computed property
+// keys in type literals, interfaces, and class members (GH#25083).
+var E;
+(function (E) {
+    E["hello world"] = "hw";
+    E["3x14"] = "pi";
+    E["normal"] = "n";
+})(E || (E = {}));
+const v1 = t1[E["hello world"]];
+const v2 = t1["hw"]; // literal value

--- a/tests/baselines/reference/enumBracketComputedPropertyName.symbols
+++ b/tests/baselines/reference/enumBracketComputedPropertyName.symbols
@@ -1,0 +1,64 @@
+//// [tests/cases/compiler/enumBracketComputedPropertyName.ts] ////
+
+=== enumBracketComputedPropertyName.ts ===
+// Enum members with non-identifier names should be usable as computed property
+// keys in type literals, interfaces, and class members (GH#25083).
+
+enum E {
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+
+    "hello world" = "hw",
+>"hello world" : Symbol(E["hello world"], Decl(enumBracketComputedPropertyName.ts, 3, 8))
+
+    "3x14" = "pi",
+>"3x14" : Symbol(E["3x14"], Decl(enumBracketComputedPropertyName.ts, 4, 25))
+
+    normal = "n",
+>normal : Symbol(E.normal, Decl(enumBracketComputedPropertyName.ts, 5, 18))
+}
+
+// type literal
+type T1 = { [E["hello world"]]: string };
+>T1 : Symbol(T1, Decl(enumBracketComputedPropertyName.ts, 7, 1))
+>[E["hello world"]] : Symbol([E["hello world"]], Decl(enumBracketComputedPropertyName.ts, 10, 11))
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+>"hello world" : Symbol(E["hello world"], Decl(enumBracketComputedPropertyName.ts, 3, 8))
+
+type T2 = { [E["3x14"]]: boolean };
+>T2 : Symbol(T2, Decl(enumBracketComputedPropertyName.ts, 10, 41))
+>[E["3x14"]] : Symbol([E["3x14"]], Decl(enumBracketComputedPropertyName.ts, 11, 11))
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+>"3x14" : Symbol(E["3x14"], Decl(enumBracketComputedPropertyName.ts, 4, 25))
+
+type T3 = { [E["normal"]]: number };   // bracket access to a normal-identifier member
+>T3 : Symbol(T3, Decl(enumBracketComputedPropertyName.ts, 11, 35))
+>[E["normal"]] : Symbol([E["normal"]], Decl(enumBracketComputedPropertyName.ts, 12, 11))
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+>"normal" : Symbol(E.normal, Decl(enumBracketComputedPropertyName.ts, 5, 18))
+
+// interface
+interface I1 {
+>I1 : Symbol(I1, Decl(enumBracketComputedPropertyName.ts, 12, 36))
+
+    [E["hello world"]]: string;
+>[E["hello world"]] : Symbol(I1[E["hello world"]], Decl(enumBracketComputedPropertyName.ts, 15, 14))
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+>"hello world" : Symbol(E["hello world"], Decl(enumBracketComputedPropertyName.ts, 3, 8))
+}
+
+// access back through the computed key
+declare const t1: T1;
+>t1 : Symbol(t1, Decl(enumBracketComputedPropertyName.ts, 20, 13))
+>T1 : Symbol(T1, Decl(enumBracketComputedPropertyName.ts, 7, 1))
+
+const v1: string = t1[E["hello world"]];
+>v1 : Symbol(v1, Decl(enumBracketComputedPropertyName.ts, 21, 5))
+>t1 : Symbol(t1, Decl(enumBracketComputedPropertyName.ts, 20, 13))
+>E : Symbol(E, Decl(enumBracketComputedPropertyName.ts, 0, 0))
+>"hello world" : Symbol(E["hello world"], Decl(enumBracketComputedPropertyName.ts, 3, 8))
+
+const v2: string = t1["hw"];   // literal value
+>v2 : Symbol(v2, Decl(enumBracketComputedPropertyName.ts, 22, 5))
+>t1 : Symbol(t1, Decl(enumBracketComputedPropertyName.ts, 20, 13))
+>"hw" : Symbol([E["hello world"]], Decl(enumBracketComputedPropertyName.ts, 10, 11))
+

--- a/tests/baselines/reference/enumBracketComputedPropertyName.types
+++ b/tests/baselines/reference/enumBracketComputedPropertyName.types
@@ -1,0 +1,108 @@
+//// [tests/cases/compiler/enumBracketComputedPropertyName.ts] ////
+
+=== enumBracketComputedPropertyName.ts ===
+// Enum members with non-identifier names should be usable as computed property
+// keys in type literals, interfaces, and class members (GH#25083).
+
+enum E {
+>E : E
+>  : ^
+
+    "hello world" = "hw",
+>"hello world" : (typeof E)["hello world"]
+>              : ^^^^^^^^^^^^^^^^^^^^^^^^^
+>"hw" : "hw"
+>     : ^^^^
+
+    "3x14" = "pi",
+>"3x14" : (typeof E)["3x14"]
+>       : ^^^^^^^^^^^^^^^^^^
+>"pi" : "pi"
+>     : ^^^^
+
+    normal = "n",
+>normal : E.normal
+>       : ^^^^^^^^
+>"n" : "n"
+>    : ^^^
+}
+
+// type literal
+type T1 = { [E["hello world"]]: string };
+>T1 : T1
+>   : ^^
+>[E["hello world"]] : string
+>                   : ^^^^^^
+>E["hello world"] : (typeof E)["hello world"]
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"hello world" : "hello world"
+>              : ^^^^^^^^^^^^^
+
+type T2 = { [E["3x14"]]: boolean };
+>T2 : T2
+>   : ^^
+>[E["3x14"]] : boolean
+>            : ^^^^^^^
+>E["3x14"] : (typeof E)["3x14"]
+>          : ^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"3x14" : "3x14"
+>       : ^^^^^^
+
+type T3 = { [E["normal"]]: number };   // bracket access to a normal-identifier member
+>T3 : T3
+>   : ^^
+>[E["normal"]] : number
+>              : ^^^^^^
+>E["normal"] : E.normal
+>            : ^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"normal" : "normal"
+>         : ^^^^^^^^
+
+// interface
+interface I1 {
+    [E["hello world"]]: string;
+>[E["hello world"]] : string
+>                   : ^^^^^^
+>E["hello world"] : (typeof E)["hello world"]
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"hello world" : "hello world"
+>              : ^^^^^^^^^^^^^
+}
+
+// access back through the computed key
+declare const t1: T1;
+>t1 : T1
+>   : ^^
+
+const v1: string = t1[E["hello world"]];
+>v1 : string
+>   : ^^^^^^
+>t1[E["hello world"]] : string
+>                     : ^^^^^^
+>t1 : T1
+>   : ^^
+>E["hello world"] : (typeof E)["hello world"]
+>                 : ^^^^^^^^^^^^^^^^^^^^^^^^^
+>E : typeof E
+>  : ^^^^^^^^
+>"hello world" : "hello world"
+>              : ^^^^^^^^^^^^^
+
+const v2: string = t1["hw"];   // literal value
+>v2 : string
+>   : ^^^^^^
+>t1["hw"] : string
+>         : ^^^^^^
+>t1 : T1
+>   : ^^
+>"hw" : "hw"
+>     : ^^^^
+

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.errors.txt
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.errors.txt
@@ -1,6 +1,6 @@
 isolatedDeclarationLazySymbols.ts(1,17): error TS9007: Function must have an explicit return type annotation with --isolatedDeclarations.
+isolatedDeclarationLazySymbols.ts(12,1): error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
 isolatedDeclarationLazySymbols.ts(13,1): error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
-isolatedDeclarationLazySymbols.ts(16,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 isolatedDeclarationLazySymbols.ts(16,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
 isolatedDeclarationLazySymbols.ts(21,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
 isolatedDeclarationLazySymbols.ts(22,5): error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
@@ -22,14 +22,14 @@ isolatedDeclarationLazySymbols.ts(22,5): error TS9038: Computed property names o
     } as const
     
     foo[o["prop.inner"]] ="A";
+    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
     foo[o.prop.inner] = "B";
     ~~~~~~~~~~~~~~~~~
 !!! error TS9023: Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
     
     export class Foo {
         [o["prop.inner"]] ="A"
-        ~~~~~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~~~~~~~~~~~~~~~~~
 !!! error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
         [o.prop.inner] = "B"

--- a/tests/baselines/reference/isolatedDeclarationLazySymbols.types
+++ b/tests/baselines/reference/isolatedDeclarationLazySymbols.types
@@ -40,8 +40,8 @@ const o = {
 foo[o["prop.inner"]] ="A";
 >foo[o["prop.inner"]] ="A" : "A"
 >                          : ^^^
->foo[o["prop.inner"]] : any
->                     : ^^^
+>foo[o["prop.inner"]] : string
+>                     : ^^^^^^
 >foo : typeof foo
 >    : ^^^^^^^^^^
 >o["prop.inner"] : "a"

--- a/tests/cases/compiler/enumBracketComputedPropertyName.ts
+++ b/tests/cases/compiler/enumBracketComputedPropertyName.ts
@@ -1,0 +1,25 @@
+// @strict: true
+
+// Enum members with non-identifier names should be usable as computed property
+// keys in type literals, interfaces, and class members (GH#25083).
+
+enum E {
+    "hello world" = "hw",
+    "3x14" = "pi",
+    normal = "n",
+}
+
+// type literal
+type T1 = { [E["hello world"]]: string };
+type T2 = { [E["3x14"]]: boolean };
+type T3 = { [E["normal"]]: number };   // bracket access to a normal-identifier member
+
+// interface
+interface I1 {
+    [E["hello world"]]: string;
+}
+
+// access back through the computed key
+declare const t1: T1;
+const v1: string = t1[E["hello world"]];
+const v2: string = t1["hw"];   // literal value


### PR DESCRIPTION
## Problem

Enum members with non-identifier names (e.g. `'hello world'`, `'3x14'`) could not be used as computed property keys in type literals or interfaces using bracket notation, even though the expression evaluates to a well-known string literal type.

```ts
enum E { "hello world" = "hw" }

// Works fine:
type A = { [E.normal]: string };

// Error TS1170 — but shouldn't be:
type B = { [E["hello world"]]: string };
interface C { [E["hello world"]]: string; }
```

The error message says _"must refer to an expression whose type is a literal type"_ — but `E["hello world"]` IS a string literal type. The check was incorrectly using expression shape (entity name expression) as a proxy for the type.

Fixes #25083.

## Root Cause

`isLateBindableAST` only recognised `EntityNameExpression` forms (identifiers and property-access chains like `A.B.C`) as potentially late-bindable. Element-access expressions like `E["hello world"]` were unconditionally rejected, making `isNonBindableDynamicName` return `true` and triggering the grammar error.

## Fix

Extended `isLateBindableAST` to also return `true` when the expression is an `ElementAccessExpression` whose object is an entity name and whose argument is a string or numeric literal:

```ts
// Also allow element access on an entity name with a literal key, e.g. Enum['non-identifier-key'].
return isElementAccessExpression(expr)
    && isEntityNameExpression(expr.expression)
    && isStringOrNumericLiteralLike(skipParentheses(expr.argumentExpression));
```

`isLateBindableName` already checks `isTypeUsableAsPropertyName` on the resolved type, so this only opens the door for expressions that actually evaluate to a usable property name type (string/number literal or unique symbol).

## Tests

Added `tests/cases/compiler/enumBracketComputedPropertyName.ts` covering:
- Type literal with bracket-notation enum key (`E["hello world"]`, `E["3x14"]`)
- Interface with bracket-notation enum key
- Round-trip access through the computed key

Updated `isolatedDeclarationLazySymbols` baselines to reflect improved behaviour: `TS1166` no longer fires for `[o["prop.inner"]]` in a class (correct — the type is a literal), and `foo[o["prop.inner"]]` now correctly resolves to `string` instead of `any`.