### PR TITLE
fix(loc): correct reversed subject/object in zh-CN translation of TS2561

### DIFF
--- a/src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl
+++ b/src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl
@@ -10315,7 +10315,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Object literal may only specify known properties, but '{0}' does not exist in type '{1}'. Did you mean to write '{2}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[对象字面量只能指定已知的属性，但“{0}”中不存在类型“{1}”。是否要写入 {2}?]]></Val>
+            <Val><![CDATA[对象字面量只能指定已知属性，但”{0}”在类型”{1}”中不存在。您是否想写”{2}”？]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />


### PR DESCRIPTION
## What this change intends to do

Fixes #63274

Corrects the Simplified Chinese (`zh-CN`) translation of error **TS2561**, where the subject and object were swapped, causing the error message to read as the opposite of its intended meaning.

### The problem

| | Text |
|---|---|
| **English** | `Object literal may only specify known properties, but '{0}' does not exist in type '{1}'. Did you mean to write '{2}'?` |
| **Old zh-CN (wrong)** | `对象字面量只能指定已知的属性，但"{0}"中不存在类型"{1}"。是否要写入 {2}?` |
| **New zh-CN (fixed)** | `对象字面量只能指定已知属性，但"{0}"在类型"{1}"中不存在。您是否想写"{2}"？` |

The old text literally reads **"but type '{1}' does not exist in '{0}'"** — the complete opposite of the intended meaning. A Chinese-speaking developer reading this would think their *type name* is wrong, when actually their *property name* is wrong.

### Changes in the fixed translation

1. **Core fix:** `但"{0}"中不存在类型"{1}"` → `但"{0}"在类型"{1}"中不存在` (property `{0}` does not exist *in* type `{1}`, not the other way around)
2. Remove redundant `的`: `已知的属性` → `已知属性` (more natural Chinese)
3. Improve suggestion phrasing: `是否要写入 {2}?` → `您是否想写"{2}"？` (add quotes around the suggestion; more natural Chinese)

### File changed

`src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl` — 1 line changed

## Tests

This PR changes only a localization resource file (`.lcl`). There are no TypeScript compiler tests for translation strings, so no test baselines are affected. The fix can be verified by running `tsc --locale zh-CN` on a file that triggers TS2561 and confirming the error message now correctly reads that the property does not exist in the type.

## AI Assistance Disclosure

This PR was developed with the assistance of [Claude Code](https://claude.ai/code) (Anthropic), as required to be disclosed per the [CONTRIBUTING.md](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md#use-of-ai-assistance) guidelines.