### PR TITLE
fix(lib): allow CSSStyleValue in Keyframe index signature

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -1373,7 +1373,7 @@ interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | null | undefined | CSSStyleValue;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {


### PR DESCRIPTION
## Summary

Fixes #63325

Issue has been fixed with the help of Claude Code

The Web Animations API is compatible with the CSS Typed Object Model — properties like `transform` can accept `CSSTransformValue` objects (`CSSRotate`, `CSSTranslate`, etc.) at runtime in modern browsers. However, the `Keyframe` index signature only allowed `string | number | null | undefined`, causing a type error on valid code:

```ts
element.animate([
    { transform: 'rotate(0deg)' },
    { transform: new CSSRotate(45, 0, 0, CSSNumericValue.parse('90deg')) } // ❌ TS error before fix
], { duration: 500 })
```

## Fix

Add `CSSStyleValue` — the common base class for **all** CSS Typed OM types — to the index signature:

```diff
 interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | null | undefined | CSSStyleValue;
 }
```

Using the base class rather than enumerating individual subclasses (`CSSTransformValue`, `CSSNumericValue`, `CSSKeywordValue`, …) keeps the change minimal and future-proof — any CSS Typed OM subclass is automatically covered.

## Spec reference

The [Web Animations spec](https://www.w3.org/TR/web-animations-1/#processing-a-keyframes-argument) and [MDN `element.animate()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate) confirm that CSS Typed OM values are valid for keyframe properties in supporting browsers.