### PR TITLE
fix(completions): sort JSDoc @param suggestions by declaration order

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -944,10 +944,13 @@ function getJSDocParameterCompletions(
     const isJs = isSourceFileJS(sourceFile);
     const isSnippet = preferences.includeCompletionsWithSnippetText || undefined;
     const paramTagCount = countWhere(jsDoc.tags, tag => isJSDocParameterTag(tag) && tag.getEnd() <= position);
-    return mapDefined(func.parameters, param => {
+    return mapDefined(func.parameters, (param, paramIndex) => {
         if (getJSDocParameterTags(param).length) {
             return undefined; // Parameter is already annotated.
         }
+        // Sort completions by the parameter's declaration order so that
+        // `@param` suggestions appear in the same order as the function signature.
+        const sortText = (SortText.LocationPriority + String(paramIndex).padStart(4, "0")) as SortText;
         if (isIdentifier(param.name)) { // Named parameter
             const tabstopCounter = { tabstop: 1 };
             const paramName = param.name.text;
@@ -983,7 +986,7 @@ function getJSDocParameterCompletions(
             return {
                 name: displayText,
                 kind: ScriptElementKind.parameterElement,
-                sortText: SortText.LocationPriority,
+                sortText,
                 insertText: isSnippet ? snippetText : undefined,
                 isSnippet,
             };
@@ -1023,7 +1026,7 @@ function getJSDocParameterCompletions(
             return {
                 name: displayText,
                 kind: ScriptElementKind.parameterElement,
-                sortText: SortText.LocationPriority,
+                sortText,
                 insertText: isSnippet ? snippetText : undefined,
                 isSnippet,
             };


### PR DESCRIPTION
## What this change intends to do

Fixes #20183

When triggering completions after `@param` in a JSDoc comment, all parameter suggestions had the same `sortText: "11"` (`SortText.LocationPriority`), causing them to sort **alphabetically** rather than in **declaration order**.

```ts
/**
 * @param |
 */
function foo(z, a) {}
// Before fix: ["a", "z"]  (alphabetical — wrong)
// After fix:  ["z", "a"]  (declaration order — correct)
```

## Fix

Expose the parameter index from the `mapDefined` callback and encode the declaration position into the sort key:

```diff
-return mapDefined(func.parameters, param => {
+return mapDefined(func.parameters, (param, paramIndex) => {
     ...
+    const sortText = (SortText.LocationPriority + String(paramIndex).padStart(4, "0")) as SortText;
     return {
         ...
-        sortText: SortText.LocationPriority,
+        sortText,
     };
 });
```

This produces sort keys `"110000"`, `"110001"`, … — parameters stay within the same priority tier (`"11"` prefix) but are ordered by their position in the function signature. The fix applies to both **named parameters** and **destructuring parameters**.

**File changed:** `src/services/completions.ts` — 6 insertions, 3 deletions

## Tests

This PR does not currently include a new test case. The existing JSDoc completion tests in `tests/cases/fourslash/` continue to pass. A fourslash test covering parameter sort order would be the right addition — I can add one if a maintainer confirms this direction is correct before I invest the time.

## AI Assistance Disclosure

This PR was developed with the assistance of [Claude Code](https://claude.ai/code) (Anthropic), as required to be disclosed per the [CONTRIBUTING.md](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md#use-of-ai-assistance) guidelines.