### PR TITLE
fix: remove grammatically incorrect 'the' before x in Math.sign JSDoc

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -94,7 +94,7 @@ interface Math {
     imul(x: number, y: number): number;
 
     /**
-     * Returns the sign of the x, indicating whether x is positive, negative or zero.
+     * Returns the sign of x, indicating whether x is positive, negative or zero.
      * @param x The numeric expression to test
      */
     sign(x: number): number;


### PR DESCRIPTION
Fixes microsoft/TypeScript#63432

## Issue
Grammatical typo in Math.sign JSDoc comment:
- **Before:** 'Returns the sign of the x, indicating whether x is positive...'
- **After:** 'Returns the sign of x, indicating whether x is positive...'

The article 'the' before 'x' is grammatically incorrect. The correct form is 'Returns the sign of x' not 'Returns the sign of the x'.

## Changes
- : Fixed JSDoc description for 