### PR TITLE
Fix Intl.Collator compare declaration

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4419,7 +4419,7 @@ declare namespace Intl {
     }
 
     interface Collator {
-        compare(x: string, y: string): number;
+        readonly compare: (this: void, x: string, y: string) => number;
         resolvedOptions(): ResolvedCollatorOptions;
     }
 

--- a/tests/baselines/reference/intlCollatorCompareAccessor.errors.txt
+++ b/tests/baselines/reference/intlCollatorCompareAccessor.errors.txt
@@ -1,0 +1,25 @@
+intlCollatorCompareAccessor.ts(7,7): error TS2322: Type '(this: Intl.Collator, x: string, y: string) => number' is not assignable to type '(this: void, x: string, y: string) => number'.
+  The 'this' types of each signature are incompatible.
+    Type 'void' is not assignable to type 'Collator'.
+intlCollatorCompareAccessor.ts(11,10): error TS2540: Cannot assign to 'compare' because it is a read-only property.
+
+
+==== intlCollatorCompareAccessor.ts (2 errors) ====
+    declare const collator: Intl.Collator;
+    
+    collator.compare("a", "b");
+    ["a", "b"].sort(collator.compare);
+    
+    const compare: (this: void, x: string, y: string) => number = collator.compare;
+    const compareWithThis: Intl.Collator["compare"] = function (this: Intl.Collator, x: string, y: string) {
+          ~~~~~~~~~~~~~~~
+!!! error TS2322: Type '(this: Intl.Collator, x: string, y: string) => number' is not assignable to type '(this: void, x: string, y: string) => number'.
+!!! error TS2322:   The 'this' types of each signature are incompatible.
+!!! error TS2322:     Type 'void' is not assignable to type 'Collator'.
+        return 0;
+    };
+    
+    collator.compare = (x: string, y: string) => 0;
+             ~~~~~~~
+!!! error TS2540: Cannot assign to 'compare' because it is a read-only property.
+    

--- a/tests/cases/compiler/intlCollatorCompareAccessor.ts
+++ b/tests/cases/compiler/intlCollatorCompareAccessor.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+declare const collator: Intl.Collator;
+
+collator.compare("a", "b");
+["a", "b"].sort(collator.compare);
+
+const compare: (this: void, x: string, y: string) => number = collator.compare;
+const compareWithThis: Intl.Collator["compare"] = function (this: Intl.Collator, x: string, y: string) {
+    return 0;
+};
+
+collator.compare = (x: string, y: string) => 0;


### PR DESCRIPTION
Fixes #62048

## Summary
- Model `Intl.Collator#compare` as a readonly function-valued property with `this: void`.
- Add a compiler baseline test covering direct bound-function usage, rejection of `this`-dependent replacements, and readonly assignment behavior.

## Validation
- [x] There is an associated issue in the `Backlog` milestone
- [x] Code is up-to-date with the `main` branch
- [x] Ran `hereby runtests` locally:
  - `npx hereby runtests --tests=intlCollatorCompareAccessor --runner=compiler`
  - `npx hereby runtests --tests=localesObjectArgument --runner=compiler`
- [x] There are new or updated unit tests validating the change

## AI Assistance
This PR was authored with assistance from OpenAI Codex.
