### PR TITLE
Narrow String#toLowerCase/toUpperCase return types via Lowercase/Uppercase

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -481,13 +481,13 @@ interface String {
     substring(start: number, end?: number): string;
 
     /** Converts all the alphabetic characters in a string to lowercase. */
-    toLowerCase(): string;
+    toLowerCase<T extends string>(this: T): string extends T ? string : Lowercase<T>;
 
     /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
     toLocaleLowerCase(locales?: string | string[]): string;
 
     /** Converts all the alphabetic characters in a string to uppercase. */
-    toUpperCase(): string;
+    toUpperCase<T extends string>(this: T): string extends T ? string : Uppercase<T>;
 
     /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
     toLocaleUpperCase(locales?: string | string[]): string;

--- a/tests/baselines/reference/abstractPropertyInConstructor.types
+++ b/tests/baselines/reference/abstractPropertyInConstructor.types
@@ -32,16 +32,16 @@ abstract class AbstractClass {
 >    : ^^^^^^
 >this.prop.toLowerCase() : string
 >                        : ^^^^^^
->this.prop.toLowerCase : () => string
->                      : ^^^^^^      
+>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                      : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >this.prop : string
 >          : ^^^^^^
 >this : this
 >     : ^^^^
 >prop : string
 >     : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
         if (!str) {
 >!str : boolean
@@ -215,16 +215,16 @@ abstract class DerivedAbstractClass extends AbstractClass {
 >   : ^ ^^      ^^^^^^^^^
 >this.prop.toLowerCase() : string
 >                        : ^^^^^^
->this.prop.toLowerCase : () => string
->                      : ^^^^^^      
+>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                      : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >this.prop : string
 >          : ^^^^^^
 >this : this
 >     : ^^^^
 >prop : string
 >     : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
         this.method(1);
 >this.method(1) : void

--- a/tests/baselines/reference/arrayconcat.errors.txt
+++ b/tests/baselines/reference/arrayconcat.errors.txt
@@ -1,9 +1,13 @@
 arrayconcat.ts(12,9): error TS2564: Property 'options' has no initializer and is not definitely assigned in the constructor.
+arrayconcat.ts(16,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 arrayconcat.ts(16,25): error TS18048: 'a.name' is possibly 'undefined'.
+arrayconcat.ts(17,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 arrayconcat.ts(17,25): error TS18048: 'b.name' is possibly 'undefined'.
 
 
-==== arrayconcat.ts (3 errors) ====
+==== arrayconcat.ts (5 errors) ====
     interface IOptions {
         name?: string;
         flag?: boolean;
@@ -23,8 +27,14 @@ arrayconcat.ts(17,25): error TS18048: 'b.name' is possibly 'undefined'.
     		this.options = this.options.sort(function(a, b) {
                 var aName = a.name.toLowerCase();
                             ~~~~~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+                            ~~~~~~
 !!! error TS18048: 'a.name' is possibly 'undefined'.
                 var bName = b.name.toLowerCase();
+                            ~~~~~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
                             ~~~~~~
 !!! error TS18048: 'b.name' is possibly 'undefined'.
     

--- a/tests/baselines/reference/arrayconcat.types
+++ b/tests/baselines/reference/arrayconcat.types
@@ -78,32 +78,32 @@ class parser {
 >      : ^^^^^^
 >a.name.toLowerCase() : string
 >                     : ^^^^^^
->a.name.toLowerCase : () => string
->                   : ^^^^^^      
+>a.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                   : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a.name : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >a : IOptions
 >  : ^^^^^^^^
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
             var bName = b.name.toLowerCase();
 >bName : string
 >      : ^^^^^^
 >b.name.toLowerCase() : string
 >                     : ^^^^^^
->b.name.toLowerCase : () => string
->                   : ^^^^^^      
+>b.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                   : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >b.name : string | undefined
 >       : ^^^^^^^^^^^^^^^^^^
 >b : IOptions
 >  : ^^^^^^^^
 >name : string | undefined
 >     : ^^^^^^^^^^^^^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
             if (aName > bName) {
 >aName > bName : boolean

--- a/tests/baselines/reference/bestChoiceType.types
+++ b/tests/baselines/reference/bestChoiceType.types
@@ -32,12 +32,12 @@
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 // Similar cases
 
@@ -86,12 +86,12 @@ function f1() {
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 }
 
 function f2() {
@@ -141,11 +141,11 @@ function f2() {
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 }
 

--- a/tests/baselines/reference/checkJsdocSatisfiesTag13.types
+++ b/tests/baselines/reference/checkJsdocSatisfiesTag13.types
@@ -15,12 +15,12 @@ const t1 = { f: s => s.toLowerCase() }; // should work
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 /** @satisfies {{ f: (x: string) => string }} */
 const t2 = { g: "oops" }; // should error

--- a/tests/baselines/reference/commaOperatorWithSecondOperandObjectType.types
+++ b/tests/baselines/reference/commaOperatorWithSecondOperandObjectType.types
@@ -182,12 +182,12 @@ STRING.toLowerCase(), new CLASS()
 >                                  : ^^^^^
 >STRING.toLowerCase() : string
 >                     : ^^^^^^
->STRING.toLowerCase : () => string
->                   : ^^^^^^      
+>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                   : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >STRING : string
 >       : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >new CLASS() : CLASS
 >            : ^^^^^
 >CLASS : typeof CLASS
@@ -274,12 +274,12 @@ var resultIsObject11 = (STRING.toLowerCase(), new CLASS());
 >                                  : ^^^^^
 >STRING.toLowerCase() : string
 >                     : ^^^^^^
->STRING.toLowerCase : () => string
->                   : ^^^^^^      
+>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                   : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >STRING : string
 >       : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >new CLASS() : CLASS
 >            : ^^^^^
 >CLASS : typeof CLASS

--- a/tests/baselines/reference/completionsStringMethods.baseline
+++ b/tests/baselines/reference/completionsStringMethods.baseline
@@ -18,9 +18,9 @@
 // | (method) String.substring(start: number, end?: number): string
 // | (method) String.toLocaleLowerCase(locales?: string | string[]): string
 // | (method) String.toLocaleUpperCase(locales?: string | string[]): string
-// | (method) String.toLowerCase(): string
+// | (method) String.toLowerCase<T extends string>(this: T): string extends T ? string : Lowercase<T>
 // | (method) String.toString(): string
-// | (method) String.toUpperCase(): string
+// | (method) String.toUpperCase<T extends string>(this: T): string extends T ? string : Uppercase<T>
 // | (method) String.trim(): string
 // | (method) String.valueOf(): string
 // | (method) String.substr(from: number, length?: number): string
@@ -1976,8 +1976,52 @@
               "kind": "methodName"
             },
             {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
             },
             {
               "text": ")",
@@ -1994,6 +2038,66 @@
             {
               "text": "string",
               "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Lowercase",
+              "kind": "aliasName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "documentation": [
@@ -2100,8 +2204,52 @@
               "kind": "methodName"
             },
             {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
             },
             {
               "text": ")",
@@ -2118,6 +2266,66 @@
             {
               "text": "string",
               "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Uppercase",
+              "kind": "aliasName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "documentation": [

--- a/tests/baselines/reference/conditionalOperatorConditoinIsStringType.types
+++ b/tests/baselines/reference/conditionalOperatorConditoinIsStringType.types
@@ -202,12 +202,12 @@ typeof condString ? exprAny1 : exprAny2;
 condString.toUpperCase ? exprBoolean1 : exprBoolean2;
 >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
 >                                                     : ^^^^^^^
->condString.toUpperCase : () => string
->                       : ^^^^^^      
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                       : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >condString : string
 >           : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >exprBoolean1 : boolean
 >             : ^^^^^^^
 >exprBoolean2 : boolean
@@ -429,12 +429,12 @@ var resultIsBoolean3 = condString.toUpperCase ? exprBoolean1 : exprBoolean2;
 >                 : ^^^^^^^
 >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
 >                                                     : ^^^^^^^
->condString.toUpperCase : () => string
->                       : ^^^^^^      
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                       : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >condString : string
 >           : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >exprBoolean1 : boolean
 >             : ^^^^^^^
 >exprBoolean2 : boolean
@@ -505,12 +505,12 @@ var resultIsStringOrBoolean4 = condString.toUpperCase ? exprString1 : exprBoolea
 >                         : ^^^^^^^^^^^^^^^^
 >condString.toUpperCase ? exprString1 : exprBoolean1 : string | boolean
 >                                                    : ^^^^^^^^^^^^^^^^
->condString.toUpperCase : () => string
->                       : ^^^^^^      
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                       : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >condString : string
 >           : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >exprString1 : string
 >            : ^^^^^^
 >exprBoolean1 : boolean

--- a/tests/baselines/reference/configFileExtendsAsList.types
+++ b/tests/baselines/reference/configFileExtendsAsList.types
@@ -14,10 +14,10 @@ let y: string;
 y.toLowerCase(); // strictNullChecks error
 >y.toLowerCase() : string
 >                : ^^^^^^
->y.toLowerCase : () => string
->              : ^^^^^^      
+>y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >y : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
+++ b/tests/baselines/reference/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
@@ -23,12 +23,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 
     if (typeof e === 'string') {
@@ -43,12 +43,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -99,12 +99,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 

--- a/tests/baselines/reference/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
+++ b/tests/baselines/reference/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
@@ -25,12 +25,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 
     if (typeof e === 'string') {
@@ -46,12 +46,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -108,12 +108,12 @@ catch (e) {
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 

--- a/tests/baselines/reference/controlFlowComputedPropertyNames.types
+++ b/tests/baselines/reference/controlFlowComputedPropertyNames.types
@@ -26,16 +26,16 @@ function f1(obj: Record<string, unknown>, key: string) {
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
 >                       : ^^^^^^
->obj[key].toUpperCase : () => string
->                     : ^^^^^^      
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key] : string
 >         : ^^^^^^
 >obj : Record<string, unknown>
 >    : ^^^^^^^^^^^^^^^^^^^^^^^
 >key : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -62,16 +62,16 @@ function f2(obj: Record<string, string | undefined>, key: string) {
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
 >                       : ^^^^^^
->obj[key].toUpperCase : () => string
->                     : ^^^^^^      
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key] : string
 >         : ^^^^^^
 >obj : Record<string, string | undefined>
 >    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
     let key2 = key + key;
 >key2 : string
@@ -98,16 +98,16 @@ function f2(obj: Record<string, string | undefined>, key: string) {
         obj[key2].toUpperCase();
 >obj[key2].toUpperCase() : string
 >                        : ^^^^^^
->obj[key2].toUpperCase : () => string
->                      : ^^^^^^      
+>obj[key2].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                      : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key2] : string
 >          : ^^^^^^
 >obj : Record<string, string | undefined>
 >    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key2 : string
 >     : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
     const key3 = key + key;
 >key3 : string
@@ -134,16 +134,16 @@ function f2(obj: Record<string, string | undefined>, key: string) {
         obj[key3].toUpperCase();
 >obj[key3].toUpperCase() : string
 >                        : ^^^^^^
->obj[key3].toUpperCase : () => string
->                      : ^^^^^^      
+>obj[key3].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                      : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key3] : string
 >          : ^^^^^^
 >obj : Record<string, string | undefined>
 >    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key3 : string
 >     : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -194,16 +194,16 @@ function f3(obj: Thing, key: keyof Thing) {
             obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
 >                       : ^^^^^^
->obj[key].toUpperCase : () => string
->                     : ^^^^^^      
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key] : string
 >         : ^^^^^^
 >obj : Thing
 >    : ^^^^^
 >key : keyof Thing
 >    : ^^^^^^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
         }
         if (typeof obj[key] === "number") {
 >typeof obj[key] === "number" : boolean
@@ -255,16 +255,16 @@ function f4<K extends string>(obj: Record<K, string | undefined>, key: K) {
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
 >                       : ^^^^^^
->obj[key].toUpperCase : () => string
->                     : ^^^^^^      
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >obj[key] : string
 >         : ^^^^^^
 >obj : Record<K, string | undefined>
 >    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >key : K
 >    : ^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 

--- a/tests/baselines/reference/controlFlowPropertyDeclarations.types
+++ b/tests/baselines/reference/controlFlowPropertyDeclarations.types
@@ -56,12 +56,12 @@ for (var propname in HTMLDOMPropertyConfig.Properties) {
 >         : ^^^^^^
 >propname.toLowerCase() : string
 >                       : ^^^^^^
->propname.toLowerCase : () => string
->                     : ^^^^^^      
+>propname.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >propname : string
 >         : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 }
 
 /**

--- a/tests/baselines/reference/dependentDestructuredVariables.types
+++ b/tests/baselines/reference/dependentDestructuredVariables.types
@@ -58,12 +58,12 @@ function f10({ kind, payload }: Action) {
         payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -110,12 +110,12 @@ function f11(action: Action) {
         payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -153,12 +153,12 @@ function f12({ kind, payload }: Action) {
             payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
             break;
         default:
@@ -206,12 +206,12 @@ function f13<T extends Action>({ kind, payload }: T) {
         payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+>                    : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
     }
 }
 
@@ -258,12 +258,12 @@ function f14<T extends Action>(t: T) {
         payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+>                    : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
     }
 }
 
@@ -324,12 +324,12 @@ function f20({ kind, payload }: Action2) {
             payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
         }
     }
 }
@@ -381,12 +381,12 @@ function f21(action: Action2) {
             payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
         }
     }
 }
@@ -442,12 +442,12 @@ function f22(action: Action2) {
             payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
         }
     }
 }
@@ -490,12 +490,12 @@ function f23({ kind, payload }: Action2) {
                 payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
                 break;
             default:
@@ -634,12 +634,12 @@ function f40(...[kind, data]: Args) {
         data.toUpperCase();
 >data.toUpperCase() : string
 >                   : ^^^^^^
->data.toUpperCase : () => string
->                 : ^^^^^^      
+>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >data : string
 >     : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 
@@ -868,12 +868,12 @@ f50((kind, data) => {
         data.toUpperCase();
 >data.toUpperCase() : string
 >                   : ^^^^^^
->data.toUpperCase : () => string
->                 : ^^^^^^      
+>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >data : string
 >     : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 });
 
@@ -918,12 +918,12 @@ const f51: (...args: ['A', number] | ['B', string]) => void = (kind, payload) =>
         payload.toUpperCase();
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 };
 
@@ -1451,12 +1451,12 @@ const f60: Func = (kind, payload) => {
         payload.toUpperCase();  // error
 >payload.toUpperCase() : string
 >                      : ^^^^^^
->payload.toUpperCase : () => string
->                    : ^^^^^^      
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >payload : string
 >        : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 };
 

--- a/tests/baselines/reference/destructureTupleWithVariableElement.errors.txt
+++ b/tests/baselines/reference/destructureTupleWithVariableElement.errors.txt
@@ -1,9 +1,15 @@
+destructureTupleWithVariableElement.ts(9,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(9,1): error TS18048: 's1' is possibly 'undefined'.
+destructureTupleWithVariableElement.ts(10,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(10,1): error TS18048: 's2' is possibly 'undefined'.
+destructureTupleWithVariableElement.ts(18,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'undefined'.
 
 
-==== destructureTupleWithVariableElement.ts (3 errors) ====
+==== destructureTupleWithVariableElement.ts (6 errors) ====
     // repro from #52302
     
     type NonEmptyStringArray = [string, ...Array<string>]
@@ -14,8 +20,14 @@ destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'u
     s0.toUpperCase()
     s1.toUpperCase() 
     ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+    ~~
 !!! error TS18048: 's1' is possibly 'undefined'.
     s2.toUpperCase()
+    ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
     ~~
 !!! error TS18048: 's2' is possibly 'undefined'.
     
@@ -26,6 +38,9 @@ destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'u
     s3.toUpperCase()
     s4.toUpperCase() 
     s5.toUpperCase()
+    ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
     ~~
 !!! error TS18048: 's5' is possibly 'undefined'.
     

--- a/tests/baselines/reference/destructureTupleWithVariableElement.types
+++ b/tests/baselines/reference/destructureTupleWithVariableElement.types
@@ -30,32 +30,32 @@ const [s0, s1, s2] = strings;
 s0.toUpperCase()
 >s0.toUpperCase() : string
 >                 : ^^^^^^
->s0.toUpperCase : () => string
->               : ^^^^^^      
+>s0.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s0 : string
 >   : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 s1.toUpperCase() 
 >s1.toUpperCase() : string
 >                 : ^^^^^^
->s1.toUpperCase : () => string
->               : ^^^^^^      
+>s1.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s1 : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 s2.toUpperCase()
 >s2.toUpperCase() : string
 >                 : ^^^^^^
->s2.toUpperCase : () => string
->               : ^^^^^^      
+>s2.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s2 : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 declare const strings2: [string, ...Array<string>, string]
 >strings2 : [string, ...string[], string]
@@ -74,30 +74,30 @@ const [s3, s4, s5] = strings2;
 s3.toUpperCase()
 >s3.toUpperCase() : string
 >                 : ^^^^^^
->s3.toUpperCase : () => string
->               : ^^^^^^      
+>s3.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s3 : string
 >   : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 s4.toUpperCase() 
 >s4.toUpperCase() : string
 >                 : ^^^^^^
->s4.toUpperCase : () => string
->               : ^^^^^^      
+>s4.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s4 : string
 >   : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 s5.toUpperCase()
 >s5.toUpperCase() : string
 >                 : ^^^^^^
->s5.toUpperCase : () => string
->               : ^^^^^^      
+>s5.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>               : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s5 : string | undefined
 >   : ^^^^^^^^^^^^^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/exportedVariable1.types
+++ b/tests/baselines/reference/exportedVariable1.types
@@ -16,14 +16,14 @@ var upper = foo.name.toUpperCase();
 >      : ^^^^^^
 >foo.name.toUpperCase() : string
 >                       : ^^^^^^
->foo.name.toUpperCase : () => string
->                     : ^^^^^^      
+>foo.name.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >foo.name : string
 >         : ^^^^^^
 >foo : { name: string; }
 >    : ^^^^^^^^^^^^^^^^^
 >name : string
 >     : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/fixingTypeParametersRepeatedly1.types
+++ b/tests/baselines/reference/fixingTypeParametersRepeatedly1.types
@@ -32,12 +32,12 @@ f("", x => null, x => x.toLowerCase());
 >  : ^^^^^^
 >x.toLowerCase() : string
 >                : ^^^^^^
->x.toLowerCase : () => string
->              : ^^^^^^      
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 // First overload of g should type check just like f
 declare function g<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
@@ -74,10 +74,10 @@ g("", x => null, x => x.toLowerCase());
 >  : ^^^^^^
 >x.toLowerCase() : string
 >                : ^^^^^^
->x.toLowerCase : () => string
->              : ^^^^^^      
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/functionTypeArgumentAssignmentCompat.types
+++ b/tests/baselines/reference/functionTypeArgumentAssignmentCompat.types
@@ -30,20 +30,20 @@ f = g;
 >  : ^ ^^^^^^^   
 
 var s = f("str").toUpperCase();
->s : string
->  : ^^^^^^
->f("str").toUpperCase() : string
->                       : ^^^^^^
->f("str").toUpperCase : () => string
->                     : ^^^^^^      
+>s : "STR"
+>  : ^^^^^
+>f("str").toUpperCase() : "STR"
+>                       : ^^^^^
+>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >f("str") : "str"
 >         : ^^^^^
 >f : <T>(x: T) => T
 >  : ^ ^^ ^^ ^^^^^ 
 >"str" : "str"
 >      : ^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 console.log(s);
 >console.log(s) : void
@@ -54,6 +54,6 @@ console.log(s);
 >        : ^^^^^^^
 >log : (...data: any[]) => void
 >    : ^^^^    ^^     ^^^^^    
->s : string
->  : ^^^^^^
+>s : "STR"
+>  : ^^^^^
 

--- a/tests/baselines/reference/genericFunctionCallSignatureReturnTypeMismatch.types
+++ b/tests/baselines/reference/genericFunctionCallSignatureReturnTypeMismatch.types
@@ -22,20 +22,20 @@ f = g;
 >  : ^ ^^^^^^^   
 
 var s = f("str").toUpperCase();
->s : string
->  : ^^^^^^
->f("str").toUpperCase() : string
->                       : ^^^^^^
->f("str").toUpperCase : () => string
->                     : ^^^^^^      
+>s : "STR"
+>  : ^^^^^
+>f("str").toUpperCase() : "STR"
+>                       : ^^^^^
+>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >f("str") : "str"
 >         : ^^^^^
 >f : <T>(x: T) => T
 >  : ^ ^^ ^^ ^^^^^ 
 >"str" : "str"
 >      : ^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 console.log(s);
 >console.log(s) : void
@@ -46,6 +46,6 @@ console.log(s);
 >        : ^^^^^^^
 >log : (...data: any[]) => void
 >    : ^^^^    ^^     ^^^^^    
->s : string
->  : ^^^^^^
+>s : "STR"
+>  : ^^^^^
 

--- a/tests/baselines/reference/gettersAndSetters.types
+++ b/tests/baselines/reference/gettersAndSetters.types
@@ -267,36 +267,36 @@ if (typeof x === "string") {
 >  : ^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
     get prop() { return x.toUpperCase() },
 >prop : any
 >     : ^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
     method() { return x.toUpperCase() }
 >method : () => string
 >       : ^^^^^^^^^^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
   }
 }
 

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes1.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes1.types
@@ -408,12 +408,12 @@ testSet.transform(
 >  : ^^^^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
   )
 )

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes2.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes2.types
@@ -766,12 +766,12 @@ const t1 = testSet.transform(
 >  : ^^^^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
   )
 )
@@ -851,12 +851,12 @@ const t2 = testSet.transform(
 >  : ^^^^^^
 >x.toUpperCase() : string
 >                : ^^^^^^
->x.toUpperCase : () => string
->              : ^^^^^^      
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
   )
 )

--- a/tests/baselines/reference/intersectionsOfLargeUnions.types
+++ b/tests/baselines/reference/intersectionsOfLargeUnions.types
@@ -63,16 +63,16 @@ export function assertNodeTagName<
 >            : ^^^^^^
 >node.tagName.toLowerCase() : string
 >                           : ^^^^^^
->node.tagName.toLowerCase : () => string
->                         : ^^^^^^      
+>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>                         : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >node.tagName : string
 >             : ^^^^^^
 >node : Element
 >     : ^^^^^^^
 >tagName : string
 >        : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 
          return nodeTagName === tagName;
 >nodeTagName === tagName : boolean

--- a/tests/baselines/reference/intersectionsOfLargeUnions2.types
+++ b/tests/baselines/reference/intersectionsOfLargeUnions2.types
@@ -80,16 +80,16 @@ export function assertNodeTagName<
 >            : ^^^^^^
 >node.tagName.toLowerCase() : string
 >                           : ^^^^^^
->node.tagName.toLowerCase : () => string
->                         : ^^^^^^      
+>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>                         : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >node.tagName : string
 >             : ^^^^^^
 >node : Element
 >     : ^^^^^^^
 >tagName : string
 >        : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 
          return nodeTagName === tagName;
 >nodeTagName === tagName : boolean

--- a/tests/baselines/reference/isolatedDeclarationOutFile.types
+++ b/tests/baselines/reference/isolatedDeclarationOutFile.types
@@ -14,12 +14,12 @@ export class A {
         return msg.toUpperCase();
 >msg.toUpperCase() : string
 >                  : ^^^^^^
->msg.toUpperCase : () => string
->                : ^^^^^^      
+>msg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >msg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
 }
 

--- a/tests/baselines/reference/jsDeclarationsPrivateFields01.types
+++ b/tests/baselines/reference/jsDeclarationsPrivateFields01.types
@@ -35,14 +35,14 @@ export class C {
         return this.#hello.toUpperCase();
 >this.#hello.toUpperCase() : string
 >                          : ^^^^^^
->this.#hello.toUpperCase : () => string
->                        : ^^^^^^      
+>this.#hello.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                        : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >this.#hello : string
 >            : ^^^^^^
 >this : this
 >     : ^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
     /** @param value {string} */
     set #screamingHello(value) {

--- a/tests/baselines/reference/jsdocParamTagOnPropertyInitializer.types
+++ b/tests/baselines/reference/jsdocParamTagOnPropertyInitializer.types
@@ -15,11 +15,11 @@ class Foo {
 >  : ^^^^^^
 >x.toLowerCase() : string
 >                : ^^^^^^
->x.toLowerCase : () => string
->              : ^^^^^^      
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 }
 

--- a/tests/baselines/reference/jsxEmitWithAttributes.types
+++ b/tests/baselines/reference/jsxEmitWithAttributes.types
@@ -98,16 +98,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/jsxFactoryAndReactNamespace.types
+++ b/tests/baselines/reference/jsxFactoryAndReactNamespace.types
@@ -101,16 +101,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/jsxFactoryIdentifier.types
+++ b/tests/baselines/reference/jsxFactoryIdentifier.types
@@ -98,16 +98,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.types
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.types
@@ -101,16 +101,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.types
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.types
@@ -101,16 +101,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/jsxFactoryQualifiedName.types
+++ b/tests/baselines/reference/jsxFactoryQualifiedName.types
@@ -98,16 +98,16 @@ function toCamelCase(text: string): string {
 >                                          : ^^^^^^
 >text[0].toLowerCase() : string
 >                      : ^^^^^^
->text[0].toLowerCase : () => string
->                    : ^^^^^^      
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text[0] : string
 >        : ^^^^^^
 >text : string
 >     : ^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >text.substring(1) : string
 >                  : ^^^^^^
 >text.substring : (start: number, end?: number) => string

--- a/tests/baselines/reference/logicalOrExpressionIsNotContextuallyTyped.types
+++ b/tests/baselines/reference/logicalOrExpressionIsNotContextuallyTyped.types
@@ -29,10 +29,10 @@ var r = a || ((a) => a.toLowerCase());
 >  : ^^^^^^
 >a.toLowerCase() : string
 >                : ^^^^^^
->a.toLowerCase : () => string
->              : ^^^^^^      
+>a.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/mergedWithLocalValue.types
+++ b/tests/baselines/reference/mergedWithLocalValue.types
@@ -17,12 +17,12 @@ const A: A = "a";
 >    : ^^^
 
 A.toUpperCase();
->A.toUpperCase() : string
->                : ^^^^^^
->A.toUpperCase : () => string
->              : ^^^^^^      
+>A.toUpperCase() : "A"
+>                : ^^^
+>A.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >A : "a"
 >  : ^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationDeclarationEmit2.types
+++ b/tests/baselines/reference/moduleAugmentationDeclarationEmit2.types
@@ -126,14 +126,14 @@ let z2 = Observable.someAnotherValue.toLowerCase();
 >   : ^^^^^^
 >Observable.someAnotherValue.toLowerCase() : string
 >                                          : ^^^^^^
->Observable.someAnotherValue.toLowerCase : () => string
->                                        : ^^^^^^      
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                                        : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >Observable.someAnotherValue : string
 >                            : ^^^^^^
 >Observable : typeof Observable
 >           : ^^^^^^^^^^^^^^^^^
 >someAnotherValue : string
 >                 : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationExtendAmbientModule2.types
+++ b/tests/baselines/reference/moduleAugmentationExtendAmbientModule2.types
@@ -55,16 +55,16 @@ let z2 = Observable.someAnotherValue.toLowerCase();
 >   : ^^^^^^
 >Observable.someAnotherValue.toLowerCase() : string
 >                                          : ^^^^^^
->Observable.someAnotherValue.toLowerCase : () => string
->                                        : ^^^^^^      
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                                        : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >Observable.someAnotherValue : string
 >                            : ^^^^^^
 >Observable : typeof Observable
 >           : ^^^^^^^^^^^^^^^^^
 >someAnotherValue : string
 >                 : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 === map.ts ===
 import { Observable } from "observable"

--- a/tests/baselines/reference/moduleAugmentationExtendFileModule2.types
+++ b/tests/baselines/reference/moduleAugmentationExtendFileModule2.types
@@ -126,14 +126,14 @@ let z2 = Observable.someAnotherValue.toLowerCase();
 >   : ^^^^^^
 >Observable.someAnotherValue.toLowerCase() : string
 >                                          : ^^^^^^
->Observable.someAnotherValue.toLowerCase : () => string
->                                        : ^^^^^^      
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                                        : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >Observable.someAnotherValue : string
 >                            : ^^^^^^
 >Observable : typeof Observable
 >           : ^^^^^^^^^^^^^^^^^
 >someAnotherValue : string
 >                 : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationGlobal2.types
+++ b/tests/baselines/reference/moduleAugmentationGlobal2.types
@@ -35,8 +35,8 @@ let y = x.getCountAsString().toLowerCase();
 >  : ^^^^^^
 >x.getCountAsString().toLowerCase() : string
 >                                   : ^^^^^^
->x.getCountAsString().toLowerCase : () => string
->                                 : ^^^^^^      
+>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x.getCountAsString() : string
 >                     : ^^^^^^
 >x.getCountAsString : () => string
@@ -45,6 +45,6 @@ let y = x.getCountAsString().toLowerCase();
 >  : ^^^^^^^^
 >getCountAsString : () => string
 >                 : ^^^^^^      
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationGlobal3.types
+++ b/tests/baselines/reference/moduleAugmentationGlobal3.types
@@ -38,8 +38,8 @@ let y = x.getCountAsString().toLowerCase();
 >  : ^^^^^^
 >x.getCountAsString().toLowerCase() : string
 >                                   : ^^^^^^
->x.getCountAsString().toLowerCase : () => string
->                                 : ^^^^^^      
+>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >x.getCountAsString() : string
 >                     : ^^^^^^
 >x.getCountAsString : () => string
@@ -48,6 +48,6 @@ let y = x.getCountAsString().toLowerCase();
 >  : ^^^^^^^^
 >getCountAsString : () => string
 >                 : ^^^^^^      
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationsBundledOutput1(target=es2015).types
+++ b/tests/baselines/reference/moduleAugmentationsBundledOutput1(target=es2015).types
@@ -197,8 +197,8 @@ c.foo().toExponential();
 c.bar().toLowerCase();
 >c.bar().toLowerCase() : string
 >                      : ^^^^^^
->c.bar().toLowerCase : () => string
->                    : ^^^^^^      
+>c.bar().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >c.bar() : string
 >        : ^^^^^^
 >c.bar : () => string
@@ -207,8 +207,8 @@ c.bar().toLowerCase();
 >  : ^^^
 >bar : () => string
 >    : ^^^^^^      
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 c.baz1().x.toExponential();
 >c.baz1().x.toExponential() : string
@@ -233,8 +233,8 @@ c.baz1().x.toExponential();
 c.baz2().x.toLowerCase();
 >c.baz2().x.toLowerCase() : string
 >                         : ^^^^^^
->c.baz2().x.toLowerCase : () => string
->                       : ^^^^^^      
+>c.baz2().x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                       : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >c.baz2().x : string
 >           : ^^^^^^
 >c.baz2() : import("m3").C2
@@ -247,6 +247,6 @@ c.baz2().x.toLowerCase();
 >     : ^^^^^^       ^^^^  ^^
 >x : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationsBundledOutput1(target=es5).types
+++ b/tests/baselines/reference/moduleAugmentationsBundledOutput1(target=es5).types
@@ -197,8 +197,8 @@ c.foo().toExponential();
 c.bar().toLowerCase();
 >c.bar().toLowerCase() : string
 >                      : ^^^^^^
->c.bar().toLowerCase : () => string
->                    : ^^^^^^      
+>c.bar().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >c.bar() : string
 >        : ^^^^^^
 >c.bar : () => string
@@ -207,8 +207,8 @@ c.bar().toLowerCase();
 >  : ^^^
 >bar : () => string
 >    : ^^^^^^      
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 c.baz1().x.toExponential();
 >c.baz1().x.toExponential() : string
@@ -233,8 +233,8 @@ c.baz1().x.toExponential();
 c.baz2().x.toLowerCase();
 >c.baz2().x.toLowerCase() : string
 >                         : ^^^^^^
->c.baz2().x.toLowerCase : () => string
->                       : ^^^^^^      
+>c.baz2().x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                       : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >c.baz2().x : string
 >           : ^^^^^^
 >c.baz2() : import("m3").C2
@@ -247,6 +247,6 @@ c.baz2().x.toLowerCase();
 >     : ^^^^^^       ^^^^  ^^
 >x : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationsImports1.types
+++ b/tests/baselines/reference/moduleAugmentationsImports1.types
@@ -135,8 +135,8 @@ let c = a.getCls().y.toLowerCase();
 >  : ^^^^^^
 >a.getCls().y.toLowerCase() : string
 >                           : ^^^^^^
->a.getCls().y.toLowerCase : () => string
->                         : ^^^^^^      
+>a.getCls().y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                         : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a.getCls().y : string
 >             : ^^^^^^
 >a.getCls() : import("C").Cls
@@ -149,6 +149,6 @@ let c = a.getCls().y.toLowerCase();
 >       : ^^^^^^       ^^^  ^^^
 >y : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationsImports2.types
+++ b/tests/baselines/reference/moduleAugmentationsImports2.types
@@ -141,8 +141,8 @@ let c = a.getCls().y.toLowerCase();
 >  : ^^^^^^
 >a.getCls().y.toLowerCase() : string
 >                           : ^^^^^^
->a.getCls().y.toLowerCase : () => string
->                         : ^^^^^^      
+>a.getCls().y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                         : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a.getCls().y : string
 >             : ^^^^^^
 >a.getCls() : import("C").Cls
@@ -155,6 +155,6 @@ let c = a.getCls().y.toLowerCase();
 >       : ^^^^^^       ^^^  ^^^
 >y : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/moduleAugmentationsImports3.types
+++ b/tests/baselines/reference/moduleAugmentationsImports3.types
@@ -40,8 +40,8 @@ let c = a.getCls().y.toLowerCase();
 >  : ^^^^^^
 >a.getCls().y.toLowerCase() : string
 >                           : ^^^^^^
->a.getCls().y.toLowerCase : () => string
->                         : ^^^^^^      
+>a.getCls().y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                         : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a.getCls().y : string
 >             : ^^^^^^
 >a.getCls() : import("C").Cls
@@ -54,8 +54,8 @@ let c = a.getCls().y.toLowerCase();
 >       : ^^^^^^       ^^^  ^^^
 >y : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 === a.ts ===
 export class A {}

--- a/tests/baselines/reference/moduleAugmentationsImports4.types
+++ b/tests/baselines/reference/moduleAugmentationsImports4.types
@@ -41,8 +41,8 @@ let c = a.getCls().y.toLowerCase();
 >  : ^^^^^^
 >a.getCls().y.toLowerCase() : string
 >                           : ^^^^^^
->a.getCls().y.toLowerCase : () => string
->                         : ^^^^^^      
+>a.getCls().y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                         : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >a.getCls().y : string
 >             : ^^^^^^
 >a.getCls() : import("C").Cls
@@ -55,8 +55,8 @@ let c = a.getCls().y.toLowerCase();
 >       : ^^^^^^       ^^^  ^^^
 >y : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 === a.ts ===
 export class A {}

--- a/tests/baselines/reference/moduleExportDuplicateAlias3.types
+++ b/tests/baselines/reference/moduleExportDuplicateAlias3.types
@@ -86,20 +86,20 @@ exports.apply = 'ok'
 >     : ^^^^
 
 var OK = exports.apply.toUpperCase()
->OK : string
->   : ^^^^^^
->exports.apply.toUpperCase() : string
->                            : ^^^^^^
->exports.apply.toUpperCase : () => string
->                          : ^^^^^^      
+>OK : "OK"
+>   : ^^^^
+>exports.apply.toUpperCase() : "OK"
+>                            : ^^^^
+>exports.apply.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                          : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >exports.apply : "ok"
 >              : ^^^^
 >exports : typeof import("./moduleExportAliasDuplicateAlias")
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >apply : "ok"
 >      : ^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 exports.apply = 1
 >exports.apply = 1 : 1

--- a/tests/baselines/reference/narrowingInCaseClauseAfterCaseClauseWithReturn.types
+++ b/tests/baselines/reference/narrowingInCaseClauseAfterCaseClauseWithReturn.types
@@ -28,12 +28,12 @@ function test1(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"A" : "A"
 >    : ^^^
 
@@ -46,12 +46,12 @@ function test1(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"B" : "B"
 >    : ^^^
 
@@ -60,12 +60,12 @@ function test1(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"C" : "C"
 >    : ^^^
 
@@ -74,12 +74,12 @@ function test1(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"D" : "D"
 >    : ^^^
 
@@ -118,12 +118,12 @@ function test2(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"A" : "A"
 >    : ^^^
 
@@ -132,12 +132,12 @@ function test2(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"B" : "B"
 >    : ^^^
 
@@ -146,12 +146,12 @@ function test2(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"C" : "C"
 >    : ^^^
 
@@ -164,12 +164,12 @@ function test2(arg: string | undefined) {
 >                          : ^^^^^^^
 >arg.toUpperCase() : string
 >                  : ^^^^^^
->arg.toUpperCase : () => string
->                : ^^^^^^      
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >arg : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"D" : "D"
 >    : ^^^
 

--- a/tests/baselines/reference/nullishCoalescingOperator9.types
+++ b/tests/baselines/reference/nullishCoalescingOperator9.types
@@ -24,12 +24,12 @@ let g = f || (abc => { void abc.toLowerCase() })
 >                       : ^^^^^^^^^
 >abc.toLowerCase() : string
 >                  : ^^^^^^
->abc.toLowerCase : () => string
->                : ^^^^^^      
+>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >abc : string
 >    : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 let gg = f ?? (abc => { void abc.toLowerCase() })
 >gg : (x: string) => void
@@ -48,10 +48,10 @@ let gg = f ?? (abc => { void abc.toLowerCase() })
 >                       : ^^^^^^^^^
 >abc.toLowerCase() : string
 >                  : ^^^^^^
->abc.toLowerCase : () => string
->                : ^^^^^^      
+>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >abc : string
 >    : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/operatorsAndIntersectionTypes.types
+++ b/tests/baselines/reference/operatorsAndIntersectionTypes.types
@@ -104,16 +104,16 @@ const s1 = "{" + guid + "}";
 >    : ^^^
 
 const s2 = guid.toLowerCase();
->s2 : string
->   : ^^^^^^
->guid.toLowerCase() : string
->                   : ^^^^^^
->guid.toLowerCase : () => string
->                 : ^^^^^^      
+>s2 : Lowercase<`${Guid}`>
+>   : ^^^^^^^^^^^^^^^^^^^^
+>guid.toLowerCase() : Lowercase<`${Guid}`>
+>                   : ^^^^^^^^^^^^^^^^^^^^
+>guid.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >guid : Guid
 >     : ^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 const s3 = guid + guid;
 >s3 : string

--- a/tests/baselines/reference/propertyAccess7.types
+++ b/tests/baselines/reference/propertyAccess7.types
@@ -8,10 +8,10 @@ var foo: string;
 foo.toUpperCase();
 >foo.toUpperCase() : string
 >                  : ^^^^^^
->foo.toUpperCase : () => string
->                : ^^^^^^      
+>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >foo : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/protectedMembersThisParameter.types
+++ b/tests/baselines/reference/protectedMembersThisParameter.types
@@ -274,14 +274,14 @@ function bString<T extends string>(this: T, arg: B) {
 >    : ^
 
   this.toLowerCase();
->this.toLowerCase() : string
->                   : ^^^^^^
->this.toLowerCase : () => string
->                 : ^^^^^^      
+>this.toLowerCase() : string extends T ? T : Lowercase<T>
+>                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>this.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>                 : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >this : T
 >     : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 
   arg.a(); // should error
 >arg.a() : void

--- a/tests/baselines/reference/strictTypeofUnionNarrowing.types
+++ b/tests/baselines/reference/strictTypeofUnionNarrowing.types
@@ -22,12 +22,12 @@ function stringify1(anything: { toString(): string } | undefined): string {
 >         : ^^^^^^^^
 >anything.toUpperCase() : string
 >                       : ^^^^^^
->anything.toUpperCase : () => string
->                     : ^^^^^^      
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >anything : string
 >         : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"" : ""
 >   : ^^
 }
@@ -51,12 +51,12 @@ function stringify2(anything: {} | undefined): string {
 >         : ^^^^^^^^
 >anything.toUpperCase() : string
 >                       : ^^^^^^
->anything.toUpperCase : () => string
->                     : ^^^^^^      
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >anything : string
 >         : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"" : ""
 >   : ^^
 }
@@ -80,12 +80,12 @@ function stringify3(anything: unknown | undefined): string { // should simplify 
 >         : ^^^^^^^^
 >anything.toUpperCase() : string
 >                       : ^^^^^^
->anything.toUpperCase : () => string
->                     : ^^^^^^      
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >anything : string
 >         : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"" : ""
 >   : ^^
 }
@@ -111,12 +111,12 @@ function stringify4(anything: { toString?(): string } | undefined): string {
 >         : ^^^^^^^^
 >anything.toUpperCase() : string
 >                       : ^^^^^^
->anything.toUpperCase : () => string
->                     : ^^^^^^      
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >anything : string
 >         : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >"" : ""
 >   : ^^
 }

--- a/tests/baselines/reference/stringLiteralTypeIsSubtypeOfString.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypeIsSubtypeOfString.errors.txt
@@ -1,8 +1,12 @@
-stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly implements interface 'String'.
-  Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
+stringLiteralTypeIsSubtypeOfString.ts(56,5): error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
+  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
+    Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
+stringLiteralTypeIsSubtypeOfString.ts(58,5): error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
+  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
+    Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
 
 
-==== stringLiteralTypeIsSubtypeOfString.ts (1 errors) ====
+==== stringLiteralTypeIsSubtypeOfString.ts (2 errors) ====
     // string literal types are subtypes of string, any
     
     // ok
@@ -45,9 +49,6 @@ stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly
     function f9(x: any) { }
     
     class C implements String {
-          ~
-!!! error TS2420: Class 'C' incorrectly implements interface 'String'.
-!!! error TS2420:   Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
         toString(): string { return null; }
         charAt(pos: number): string { return null; }
         charCodeAt(index: number): number { return null; }
@@ -62,8 +63,16 @@ stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly
         split(separator: any, limit?: number): string[] { return null; }
         substring(start: number, end?: number): string { return null; }
         toLowerCase(): string { return null; }
+        ~~~~~~~~~~~
+!!! error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
+!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
+!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
         toLocaleLowerCase(): string { return null; }
         toUpperCase(): string { return null; }
+        ~~~~~~~~~~~
+!!! error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
+!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
+!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
         toLocaleUpperCase(): string { return null; }
         trim(): string { return null; }
         length: number;

--- a/tests/baselines/reference/switchWithConstrainedTypeVariable.types
+++ b/tests/baselines/reference/switchWithConstrainedTypeVariable.types
@@ -18,26 +18,26 @@ function function1<T extends 'a' | 'b'>(key: T) {
 >    : ^^^
 
       key.toLowerCase();
->key.toLowerCase() : string
->                  : ^^^^^^
->key.toLowerCase : () => string
->                : ^^^^^^      
+>key.toLowerCase() : "a"
+>                  : ^^^
+>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>                : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >key : "a"
 >    : ^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 
       break;
     default:
       key.toLowerCase();
->key.toLowerCase() : string
->                  : ^^^^^^
->key.toLowerCase : () => string
->                : ^^^^^^      
+>key.toLowerCase() : "b"
+>                  : ^^^
+>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>                : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 >key : "b"
 >    : ^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+>            : ^^^^^^^^^^^^^      ^^    ^^   ^^^^^                                            
 
       break;
   }

--- a/tests/baselines/reference/targetTypingOnFunctions.types
+++ b/tests/baselines/reference/targetTypingOnFunctions.types
@@ -12,12 +12,12 @@ var fu: (s: string) => string = function (s) { return s.toLowerCase() };
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 var zu = fu = function (s) { return s.toLowerCase() };
 >zu : (s: string) => string
@@ -32,10 +32,10 @@ var zu = fu = function (s) { return s.toLowerCase() };
 >  : ^^^^^^
 >s.toLowerCase() : string
 >                : ^^^^^^
->s.toLowerCase : () => string
->              : ^^^^^^      
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >s : string
 >  : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/typeAliases.types
+++ b/tests/baselines/reference/typeAliases.types
@@ -246,8 +246,8 @@ declare function f15(a: Meters): string;
 f15(E.x).toLowerCase();
 >f15(E.x).toLowerCase() : string
 >                       : ^^^^^^
->f15(E.x).toLowerCase : () => string
->                     : ^^^^^^      
+>f15(E.x).toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >f15(E.x) : string
 >         : ^^^^^^
 >f15 : { (a: string): boolean; (a: Meters): string; }
@@ -258,8 +258,8 @@ f15(E.x).toLowerCase();
 >  : ^^^^^^^^
 >x : E
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 type StringAndBoolean = [string, boolean]
 >StringAndBoolean : StringAndBoolean
@@ -296,14 +296,14 @@ var y: StringAndBoolean = ["1", false];
 y[0].toLowerCase();
 >y[0].toLowerCase() : string
 >                   : ^^^^^^
->y[0].toLowerCase : () => string
->                 : ^^^^^^      
+>y[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                 : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >y[0] : string
 >     : ^^^^^^
 >y : StringAndBoolean
 >  : ^^^^^^^^^^^^^^^^
 >0 : 0
 >  : ^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 

--- a/tests/baselines/reference/typeGuardsOnClassProperty.types
+++ b/tests/baselines/reference/typeGuardsOnClassProperty.types
@@ -141,16 +141,16 @@ if (typeof o.prop1 === "string" && o.prop1.toLowerCase()) {}
 >         : ^^^^^^^^
 >o.prop1.toLowerCase() : string
 >                      : ^^^^^^
->o.prop1.toLowerCase : () => string
->                    : ^^^^^^      
+>o.prop1.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                    : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >o.prop1 : string
 >        : ^^^^^^
 >o : { prop1: number | string; prop2: boolean | string; }
 >  : ^^^^^^^^^               ^^^^^^^^^                ^^^
 >prop1 : string
 >      : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 var prop1 = o.prop1;
 >prop1 : string | number

--- a/tests/baselines/reference/unionAndIntersectionInference1.types
+++ b/tests/baselines/reference/unionAndIntersectionInference1.types
@@ -203,16 +203,16 @@ let foo: Maybe<string>;
 get(foo).toUpperCase(); // Ok
 >get(foo).toUpperCase() : string
 >                       : ^^^^^^
->get(foo).toUpperCase : () => string
->                     : ^^^^^^      
+>get(foo).toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                     : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >get(foo) : string
 >         : ^^^^^^
 >get : <U>(x: U | void) => U
 >    : ^ ^^ ^^        ^^^^^ 
 >foo : Maybe<string>
 >    : ^^^^^^^^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 // Repro from #5456
 

--- a/tests/baselines/reference/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
+++ b/tests/baselines/reference/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
@@ -186,12 +186,12 @@ const displayEnum = (value: string) => upperFirst(value.toLowerCase())
 >           : ^ ^^^^^^^^^      ^^   ^^ ^^^^^             
 >value.toLowerCase() : string
 >                    : ^^^^^^
->value.toLowerCase : () => string
->                  : ^^^^^^      
+>value.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>                  : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >value : string
 >      : ^^^^^^
->toLowerCase : () => string
->            : ^^^^^^      
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 
 function Comp() {
 >Comp : () => React.JSX.Element

--- a/tests/baselines/reference/useUnknownInCatchVariables01.types
+++ b/tests/baselines/reference/useUnknownInCatchVariables01.types
@@ -60,12 +60,12 @@ catch (e) {
 >    : ^^^^    ^^     ^^^^^    
 >e.toUpperCase() : string
 >                : ^^^^^^
->e.toUpperCase : () => string
->              : ^^^^^^      
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>              : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >e : string
 >  : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
     }
     if (e instanceof Error) {
 >e instanceof Error : boolean
@@ -78,16 +78,16 @@ catch (e) {
         e.stack?.toUpperCase();
 >e.stack?.toUpperCase() : string | undefined
 >                       : ^^^^^^^^^^^^^^^^^^
->e.stack?.toUpperCase : (() => string) | undefined
->                     : ^^^^^^^      ^^^^^^^^^^^^^
+>e.stack?.toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
+>                     : ^^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        ^^^^^^^^^^^^^
 >e.stack : string | undefined
 >        : ^^^^^^^^^^^^^^^^^^
 >e : Error
 >  : ^^^^^
 >stack : string | undefined
 >      : ^^^^^^^^^^^^^^^^^^
->toUpperCase : (() => string) | undefined
->            : ^^^^^^^      ^^^^^^^^^^^^^
+>toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
+>            : ^^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        ^^^^^^^^^^^^^
     }
     if (typeof e === "number") {
 >typeof e === "number" : boolean

--- a/tests/baselines/reference/voidUndefinedReduction.types
+++ b/tests/baselines/reference/voidUndefinedReduction.types
@@ -47,11 +47,11 @@ if (isDefined(foo)) {
 >    : ^^^^    ^^     ^^^^^    
 >foo.toUpperCase() : string
 >                  : ^^^^^^
->foo.toUpperCase : () => string
->                : ^^^^^^      
+>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>                : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 >foo : string
 >    : ^^^^^^
->toUpperCase : () => string
->            : ^^^^^^      
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+>            : ^ ^^^^^^^^^      ^^    ^^ ^^^^^                                        
 }
 


### PR DESCRIPTION
Make String.prototype.toLowerCase and toUpperCase preserve string-literal types in their return type, by typing them as
`<T extends string>(this: T): Lowercase<T>` and `Uppercase<T>` respectively.

For non-literal `string` receivers, `Lowercase<string>` resolves to `string`, preserving existing behavior. For literal receivers (e.g. `"FOO".toLowerCase()`), the result narrows to the corresponding literal (`"foo"`).

Also filed as https://github.com/microsoft/typescript-go/pull/3711