### PR TITLE
fix(parser): reject 'new super()' syntax with error TS2824

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3830,6 +3830,10 @@
         "category": "Error",
         "code": 2823
     },
+    "'super' cannot be used with 'new' keyword.": {
+        "category": "Error",
+        "code": 2824
+    },
     "Cannot find namespace '{0}'. Did you mean '{1}'?": {
         "category": "Error",
         "code": 2833

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6801,6 +6801,17 @@ namespace Parser {
     function parseNewExpressionOrNewDotTarget(): NewExpression | MetaProperty {
         const pos = getNodePos();
         parseExpected(SyntaxKind.NewKeyword);
+        
+        // Validate that 'new' is not used with 'super' - this is not JavaScript syntax
+        if (token() === SyntaxKind.SuperKeyword) {
+            parseErrorAtCurrentToken(Diagnostics.super_cannot_be_used_with_new_keyword);
+            return finishNode(factoryCreateNewExpression(
+                createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ false),
+                /*typeArguments*/ undefined,
+                /*argumentsArray*/ undefined
+            ), pos);
+        }
+        
         if (parseOptional(SyntaxKind.DotToken)) {
             const name = parseIdentifierName();
             return finishNode(factory.createMetaProperty(SyntaxKind.NewKeyword, name), pos);

--- a/tests/cases/compiler/newSuperError.ts
+++ b/tests/cases/compiler/newSuperError.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @target: ES2020
+
+// Repro for #63451 - 'new super()' should be a parse error
+
+class A extends class {} {
+  static {
+    new super(); // expect error TS2824
+  }
+
+  static f() {
+    new super(); // expect error TS2824
+  }
+}
+
+console.log("If you see this, the test failed (compilation should show error)");


### PR DESCRIPTION
## Overview
Fixes #63451 - TypeScript incorrectly allows `new super()` in static contexts, which is invalid JavaScript syntax and causes runtime errors.

## Changes
- Added validation in `parseNewExpressionOrNewDotTarget` to detect `new` followed by `super` keyword
- Added diagnostic message TS2824: `'super' cannot be used with 'new' keyword`
- Added test case `tests/cases/compiler/newSuperError.ts`

## Files Changed
| File | Change |
|------|--------|
| `src/compiler/parser.ts` | Added validation check |
| `src/compiler/diagnosticMessages.json` | Added error message with code 2824 |
| `tests/cases/compiler/newSuperError.ts` | Added test case |

