### PR TITLE
Fix implement-interface codefix for invalid interface types

### DIFF
--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -5,7 +5,6 @@ import {
     createMissingMemberNodes,
     getNoopSymbolTrackerWithResolver,
     registerCodeFix,
-    TypeConstructionContext,
 } from "../_namespaces/ts.codefix.js";
 import {
     addToSeen,
@@ -13,6 +12,7 @@ import {
     ClassElement,
     ClassLikeDeclaration,
     CodeFixAction,
+    CodeFixContextBase,
     createSymbolTable,
     Debug,
     Diagnostics,
@@ -30,6 +30,7 @@ import {
     isConstructorDeclaration,
     mapDefined,
     ModifierFlags,
+    Node,
     SourceFile,
     Symbol,
     SymbolTable,
@@ -76,7 +77,7 @@ function symbolPointsToNonPrivateMember(symbol: Symbol) {
 }
 
 function addMissingDeclarations(
-    context: TypeConstructionContext,
+    context: CodeFixContextBase,
     implementedTypeNode: ExpressionWithTypeArguments,
     sourceFile: SourceFile,
     classDeclaration: ClassLikeDeclaration,
@@ -90,6 +91,12 @@ function addMissingDeclarations(
     const implementedType = checker.getTypeAtLocation(implementedTypeNode) as InterfaceType;
     const implementedTypeSymbols = checker.getPropertiesOfType(implementedType);
     const nonPrivateAndNotExistedInHeritageClauseMembers = implementedTypeSymbols.filter(and(symbolPointsToNonPrivateMember, symbol => !maybeHeritageClauseSymbol.has(symbol.escapedName)));
+    if (
+        hasBlockingSemanticError(context, implementedTypeNode) ||
+        nonPrivateAndNotExistedInHeritageClauseMembers.some(symbol => symbol.getDeclarations()?.some(declaration => hasBlockingSemanticError(context, declaration)))
+    ) {
+        return;
+    }
 
     const classType = checker.getTypeAtLocation(classDeclaration);
     const constructor = find(classDeclaration.members, m => isConstructorDeclaration(m));
@@ -121,6 +128,12 @@ function addMissingDeclarations(
             changeTracker.insertMemberAtStart(sourceFile, cls, newElement);
         }
     }
+}
+
+function hasBlockingSemanticError(context: CodeFixContextBase, node: Node): boolean {
+    return context.program
+        .getSemanticDiagnostics(node.getSourceFile(), context.cancellationToken, [node])
+        .some(diagnostic => !errorCodes.includes(diagnostic.code));
 }
 
 function getHeritageClauseSymbolTable(classDeclaration: ClassLikeDeclaration, checker: TypeChecker): SymbolTable {

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -15,6 +15,7 @@ import {
     CodeFixContextBase,
     createSymbolTable,
     Debug,
+    Diagnostic,
     Diagnostics,
     ExpressionWithTypeArguments,
     find,
@@ -91,9 +92,10 @@ function addMissingDeclarations(
     const implementedType = checker.getTypeAtLocation(implementedTypeNode) as InterfaceType;
     const implementedTypeSymbols = checker.getPropertiesOfType(implementedType);
     const nonPrivateAndNotExistedInHeritageClauseMembers = implementedTypeSymbols.filter(and(symbolPointsToNonPrivateMember, symbol => !maybeHeritageClauseSymbol.has(symbol.escapedName)));
+    const semanticDiagnostics = new Map<SourceFile, readonly Diagnostic[]>();
     if (
-        hasBlockingSemanticError(context, implementedTypeNode) ||
-        nonPrivateAndNotExistedInHeritageClauseMembers.some(symbol => symbol.getDeclarations()?.some(declaration => hasBlockingSemanticError(context, declaration)))
+        hasBlockingSemanticError(context, semanticDiagnostics, implementedTypeNode) ||
+        nonPrivateAndNotExistedInHeritageClauseMembers.some(symbol => symbol.getDeclarations()?.some(declaration => hasBlockingSemanticError(context, semanticDiagnostics, declaration)))
     ) {
         return;
     }
@@ -130,10 +132,20 @@ function addMissingDeclarations(
     }
 }
 
-function hasBlockingSemanticError(context: CodeFixContextBase, node: Node): boolean {
-    return context.program
-        .getSemanticDiagnostics(node.getSourceFile(), context.cancellationToken, [node])
-        .some(diagnostic => !errorCodes.includes(diagnostic.code));
+function hasBlockingSemanticError(context: CodeFixContextBase, semanticDiagnostics: Map<SourceFile, readonly Diagnostic[]>, node: Node): boolean {
+    const sourceFile = node.getSourceFile();
+    let diagnostics = semanticDiagnostics.get(sourceFile);
+    if (!diagnostics) {
+        diagnostics = context.program.getSemanticDiagnostics(sourceFile, context.cancellationToken);
+        semanticDiagnostics.set(sourceFile, diagnostics);
+    }
+    return diagnostics.some(diagnostic =>
+        diagnostic.start !== undefined &&
+        diagnostic.length !== undefined &&
+        !errorCodes.includes(diagnostic.code) &&
+        diagnostic.start >= node.pos &&
+        diagnostic.start + diagnostic.length <= node.end
+    );
 }
 
 function getHeritageClauseSymbolTable(classDeclaration: ClassLikeDeclaration, checker: TypeChecker): SymbolTable {

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceTypeParamInstantiateError.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceTypeParamInstantiateError.ts
@@ -8,5 +8,4 @@
 
 // TODO: (arozga) Don't know how to instantiate in codeFix
 // if instantiation is invalid.
-// Should be verify.codeFixAvailable([]);
-verify.codeFixAvailable([{ description: "Implement interface 'I<number>'" }]);
+verify.codeFixAvailable([]);

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceUndeclaredSymbol.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceUndeclaredSymbol.ts
@@ -15,5 +15,4 @@
 // Since we can't guess the programmer's intent here, we do nothing.
 
 // TODO: (aozgaa) Acknowledge other errors on class/implemented interface/extended abstract class.
-// Should be verify.codeFixAvailable([]);
-verify.codeFixAvailable([{ description: "Implement interface 'I'" }]);
+verify.codeFixAvailable([]);


### PR DESCRIPTION
Fixes #63465

This updates the implement-interface codefix so it is not offered when the implemented interface reference or required member types are already semantically invalid.

The existing fourslash coverage already documented these cases as undesirable, but still expected the fix to be available. This PR updates those tests to assert that no codefix is offered for:

- invalid type argument instantiation
- unresolved member type symbols

Validation:

- `npx.cmd hereby runtests --tests=tests/cases/fourslash/codeFixClassImplementInterfaceTypeParamInstantiateError.ts --light=false`
- `npx.cmd hereby runtests --tests=tests/cases/fourslash/codeFixClassImplementInterfaceUndeclaredSymbol.ts --light=false`
- `npx.cmd hereby runtests --tests=tests/cases/fourslash/codeFixClassImplementInterfaceTypeParamInstantiateNumber.ts --light=false`
- `git diff --check`