### PR TITLE
Clarify charCodeAt and codePointAt documentation

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -383,7 +383,7 @@ interface RegExpConstructor {
 
 interface String {
     /**
-     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
+     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the Unicode code point
      * value of the UTF-16 encoded code point starting at the string element at position pos in
      * the String resulting from converting this object to a String.
      * If there is no element at that position, the result is undefined.

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -400,8 +400,8 @@ interface String {
     charAt(pos: number): string;
 
     /**
-     * Returns the Unicode value of the character at the specified location, or NaN if the index is out of bounds.
-     * @param index The zero-based index of the desired character.
+     * Returns the UTF-16 code unit value at the specified location, or NaN if the index is out of bounds.
+     * @param index The zero-based index of the desired UTF-16 code unit.
      */
     charCodeAt(index: number): number;
 


### PR DESCRIPTION
Fixes #49561

This updates the library JSDoc for `String` methods to use more precise terminology:

- `charCodeAt` now describes returning a UTF-16 code unit value rather than an ambiguous Unicode value.
- `codePointAt` now explicitly says Unicode code point while preserving the existing UTF-16/surrogate-pair details for indexing behavior.

Validation:
- Checked the word diff; this is a docs-only declaration comment change.
- Confirmed the edited lib files preserve their existing CRLF line endings.