### PR TITLE
Refine label diagnostics for unresolved targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -53032,9 +53032,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isFunctionLikeOrClassStaticBlockDeclaration(current)) {
                 if (node.label && !hasContainingLabel(node, current)) {
                     const label = findLabelInCurrentFunction(node);
-                    if (label && label.pos > node.pos) {
-                        return grammarErrorOnNodeWithRelatedLabel(node, Diagnostics.A_label_cannot_be_referenced_prior_to_its_declared_location, label);
+                    if (label) {
+                        const message = label.pos > node.pos
+                            ? Diagnostics.A_label_cannot_be_referenced_prior_to_its_declared_location
+                            : node.kind === SyntaxKind.BreakStatement
+                            ? Diagnostics.A_break_statement_can_only_jump_to_a_label_of_an_enclosing_statement
+                            : Diagnostics.A_continue_statement_can_only_jump_to_a_label_of_an_enclosing_iteration_statement;
+                        return grammarErrorOnNodeWithRelatedLabel(node, message, label);
                     }
+
+                    return grammarErrorOnNode(node, Diagnostics.Cannot_find_label_0, idText(node.label));
                 }
 
                 return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -53030,6 +53030,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let current: Node = node;
         while (current) {
             if (isFunctionLikeOrClassStaticBlockDeclaration(current)) {
+                if (node.label && !hasContainingLabel(node, current)) {
+                    const label = findLabelInCurrentFunction(node);
+                    if (label && label.pos > node.pos) {
+                        return grammarErrorOnNodeWithRelatedLabel(node, Diagnostics.A_label_cannot_be_referenced_prior_to_its_declared_location, label);
+                    }
+                }
+
                 return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
             }
 
@@ -53078,6 +53085,64 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 : Diagnostics.A_continue_statement_can_only_be_used_within_an_enclosing_iteration_statement;
             return grammarErrorOnNode(node, message);
         }
+    }
+
+    function hasContainingLabel(node: BreakOrContinueStatement, boundary: Node): boolean {
+        Debug.assert(!!node.label);
+
+        for (let current = boundary.parent; current; current = current.parent) {
+            if (
+                current.kind === SyntaxKind.LabeledStatement &&
+                current.pos <= boundary.pos &&
+                boundary.end <= current.end &&
+                (current as LabeledStatement).label.escapedText === node.label.escapedText
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function findLabelInCurrentFunction(node: BreakOrContinueStatement): LabeledStatement | undefined {
+        Debug.assert(!!node.label);
+
+        for (let current: Node = node; current && !isFunctionLikeOrClassStaticBlockDeclaration(current); current = current.parent) {
+            if (!current.parent) {
+                break;
+            }
+            const statements = getStatementContainerStatements(current.parent);
+            if (statements) {
+                const label = find(statements, statement => statement.kind === SyntaxKind.LabeledStatement && (statement as LabeledStatement).label.escapedText === node.label!.escapedText) as LabeledStatement | undefined;
+                if (label) {
+                    return label;
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    function getStatementContainerStatements(node: Node): NodeArray<Statement> | undefined {
+        switch (node.kind) {
+            case SyntaxKind.SourceFile:
+                return (node as SourceFile).statements;
+            case SyntaxKind.Block:
+            case SyntaxKind.ModuleBlock:
+                return (node as Block | ModuleBlock).statements;
+            case SyntaxKind.CaseClause:
+            case SyntaxKind.DefaultClause:
+                return (node as CaseOrDefaultClause).statements;
+        }
+    }
+
+    function grammarErrorOnNodeWithRelatedLabel(node: BreakOrContinueStatement, message: DiagnosticMessage, label: LabeledStatement): boolean {
+        const sourceFile = getSourceFileOfNode(node);
+        if (!hasParseDiagnostics(sourceFile)) {
+            addRelatedInfo(error(node, message), createDiagnosticForNode(label.label, Diagnostics._0_is_declared_here, idText(label.label)));
+            return true;
+        }
+        return false;
     }
 
     function checkGrammarBindingElement(node: BindingElement) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -311,6 +311,10 @@
         "category": "Error",
         "code": 18001
     },
+    "Cannot find label '{0}'.": {
+        "category": "Error",
+        "code": 18005
+    },
     "A 'return' statement can only be used within a function body.": {
         "category": "Error",
         "code": 1108

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -307,6 +307,10 @@
         "category": "Error",
         "code": 1107
     },
+    "A label cannot be referenced prior to its declared location.": {
+        "category": "Error",
+        "code": 18001
+    },
     "A 'return' statement can only be used within a function body.": {
         "category": "Error",
         "code": 1108

--- a/tests/baselines/reference/labelReferenceDiagnostics.errors.txt
+++ b/tests/baselines/reference/labelReferenceDiagnostics.errors.txt
@@ -1,0 +1,76 @@
+labelReferenceDiagnostics.ts(2,5): error TS18001: A label cannot be referenced prior to its declared location.
+labelReferenceDiagnostics.ts(8,5): error TS18001: A label cannot be referenced prior to its declared location.
+labelReferenceDiagnostics.ts(14,5): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(18,5): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(23,9): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(30,5): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(37,9): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(44,9): error TS1107: Jump target cannot cross function boundary.
+
+
+==== labelReferenceDiagnostics.ts (8 errors) ====
+    function breakToLaterLabel() {
+        break target;
+        ~~~~~~~~~~~~~
+!!! error TS18001: A label cannot be referenced prior to its declared location.
+!!! related TS2728 labelReferenceDiagnostics.ts:3:5: 'target' is declared here.
+        target:
+        while (true) {}
+    }
+    
+    function continueToLaterLabel() {
+        continue target;
+        ~~~~~~~~~~~~~~~~
+!!! error TS18001: A label cannot be referenced prior to its declared location.
+!!! related TS2728 labelReferenceDiagnostics.ts:9:5: 'target' is declared here.
+        target:
+        while (true) {}
+    }
+    
+    function breakToMissingLabel() {
+        break target;
+        ~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+    }
+    
+    function breakToFunctionNameLabel() {
+        break breakToFunctionNameLabel;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+    }
+    
+    function continueToMissingLabel() {
+        while (true) {
+            continue target;
+            ~~~~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+        }
+    }
+    
+    function breakToNonEnclosingLabel() {
+        target:
+        console.log("target");
+        break target;
+        ~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+    }
+    
+    function continueToNonEnclosingLabel() {
+        target:
+        while (true) {}
+        while (true) {
+            continue target;
+            ~~~~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+        }
+    }
+    
+    target:
+    while (true) {
+        function crossesFunctionBoundary() {
+            break target;
+            ~~~~~~~~~~~~~
+!!! error TS1107: Jump target cannot cross function boundary.
+        }
+    }
+    

--- a/tests/baselines/reference/labelReferenceDiagnostics.errors.txt
+++ b/tests/baselines/reference/labelReferenceDiagnostics.errors.txt
@@ -1,10 +1,10 @@
 labelReferenceDiagnostics.ts(2,5): error TS18001: A label cannot be referenced prior to its declared location.
 labelReferenceDiagnostics.ts(8,5): error TS18001: A label cannot be referenced prior to its declared location.
-labelReferenceDiagnostics.ts(14,5): error TS1107: Jump target cannot cross function boundary.
-labelReferenceDiagnostics.ts(18,5): error TS1107: Jump target cannot cross function boundary.
-labelReferenceDiagnostics.ts(23,9): error TS1107: Jump target cannot cross function boundary.
-labelReferenceDiagnostics.ts(30,5): error TS1107: Jump target cannot cross function boundary.
-labelReferenceDiagnostics.ts(37,9): error TS1107: Jump target cannot cross function boundary.
+labelReferenceDiagnostics.ts(14,5): error TS18005: Cannot find label 'target'.
+labelReferenceDiagnostics.ts(18,5): error TS18005: Cannot find label 'breakToFunctionNameLabel'.
+labelReferenceDiagnostics.ts(23,9): error TS18005: Cannot find label 'target'.
+labelReferenceDiagnostics.ts(30,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
+labelReferenceDiagnostics.ts(37,9): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 labelReferenceDiagnostics.ts(44,9): error TS1107: Jump target cannot cross function boundary.
 
 
@@ -30,20 +30,20 @@ labelReferenceDiagnostics.ts(44,9): error TS1107: Jump target cannot cross funct
     function breakToMissingLabel() {
         break target;
         ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18005: Cannot find label 'target'.
     }
     
     function breakToFunctionNameLabel() {
         break breakToFunctionNameLabel;
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18005: Cannot find label 'breakToFunctionNameLabel'.
     }
     
     function continueToMissingLabel() {
         while (true) {
             continue target;
             ~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18005: Cannot find label 'target'.
         }
     }
     
@@ -52,7 +52,8 @@ labelReferenceDiagnostics.ts(44,9): error TS1107: Jump target cannot cross funct
         console.log("target");
         break target;
         ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
+!!! related TS2728 labelReferenceDiagnostics.ts:28:5: 'target' is declared here.
     }
     
     function continueToNonEnclosingLabel() {
@@ -61,7 +62,8 @@ labelReferenceDiagnostics.ts(44,9): error TS1107: Jump target cannot cross funct
         while (true) {
             continue target;
             ~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
+!!! related TS2728 labelReferenceDiagnostics.ts:34:5: 'target' is declared here.
         }
     }
     

--- a/tests/baselines/reference/labelReferenceDiagnostics.js
+++ b/tests/baselines/reference/labelReferenceDiagnostics.js
@@ -1,0 +1,87 @@
+//// [tests/cases/compiler/labelReferenceDiagnostics.ts] ////
+
+//// [labelReferenceDiagnostics.ts]
+function breakToLaterLabel() {
+    break target;
+    target:
+    while (true) {}
+}
+
+function continueToLaterLabel() {
+    continue target;
+    target:
+    while (true) {}
+}
+
+function breakToMissingLabel() {
+    break target;
+}
+
+function breakToFunctionNameLabel() {
+    break breakToFunctionNameLabel;
+}
+
+function continueToMissingLabel() {
+    while (true) {
+        continue target;
+    }
+}
+
+function breakToNonEnclosingLabel() {
+    target:
+    console.log("target");
+    break target;
+}
+
+function continueToNonEnclosingLabel() {
+    target:
+    while (true) {}
+    while (true) {
+        continue target;
+    }
+}
+
+target:
+while (true) {
+    function crossesFunctionBoundary() {
+        break target;
+    }
+}
+
+
+//// [labelReferenceDiagnostics.js]
+"use strict";
+function breakToLaterLabel() {
+    break target;
+    target: while (true) { }
+}
+function continueToLaterLabel() {
+    continue target;
+    target: while (true) { }
+}
+function breakToMissingLabel() {
+    break target;
+}
+function breakToFunctionNameLabel() {
+    break breakToFunctionNameLabel;
+}
+function continueToMissingLabel() {
+    while (true) {
+        continue target;
+    }
+}
+function breakToNonEnclosingLabel() {
+    target: console.log("target");
+    break target;
+}
+function continueToNonEnclosingLabel() {
+    target: while (true) { }
+    while (true) {
+        continue target;
+    }
+}
+target: while (true) {
+    function crossesFunctionBoundary() {
+        break target;
+    }
+}

--- a/tests/baselines/reference/labelReferenceDiagnostics.symbols
+++ b/tests/baselines/reference/labelReferenceDiagnostics.symbols
@@ -1,0 +1,70 @@
+//// [tests/cases/compiler/labelReferenceDiagnostics.ts] ////
+
+=== labelReferenceDiagnostics.ts ===
+function breakToLaterLabel() {
+>breakToLaterLabel : Symbol(breakToLaterLabel, Decl(labelReferenceDiagnostics.ts, 0, 0))
+
+    break target;
+    target:
+    while (true) {}
+}
+
+function continueToLaterLabel() {
+>continueToLaterLabel : Symbol(continueToLaterLabel, Decl(labelReferenceDiagnostics.ts, 4, 1))
+
+    continue target;
+    target:
+    while (true) {}
+}
+
+function breakToMissingLabel() {
+>breakToMissingLabel : Symbol(breakToMissingLabel, Decl(labelReferenceDiagnostics.ts, 10, 1))
+
+    break target;
+}
+
+function breakToFunctionNameLabel() {
+>breakToFunctionNameLabel : Symbol(breakToFunctionNameLabel, Decl(labelReferenceDiagnostics.ts, 14, 1))
+
+    break breakToFunctionNameLabel;
+}
+
+function continueToMissingLabel() {
+>continueToMissingLabel : Symbol(continueToMissingLabel, Decl(labelReferenceDiagnostics.ts, 18, 1))
+
+    while (true) {
+        continue target;
+    }
+}
+
+function breakToNonEnclosingLabel() {
+>breakToNonEnclosingLabel : Symbol(breakToNonEnclosingLabel, Decl(labelReferenceDiagnostics.ts, 24, 1))
+
+    target:
+    console.log("target");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+    break target;
+}
+
+function continueToNonEnclosingLabel() {
+>continueToNonEnclosingLabel : Symbol(continueToNonEnclosingLabel, Decl(labelReferenceDiagnostics.ts, 30, 1))
+
+    target:
+    while (true) {}
+    while (true) {
+        continue target;
+    }
+}
+
+target:
+while (true) {
+    function crossesFunctionBoundary() {
+>crossesFunctionBoundary : Symbol(crossesFunctionBoundary, Decl(labelReferenceDiagnostics.ts, 41, 14))
+
+        break target;
+    }
+}
+

--- a/tests/baselines/reference/labelReferenceDiagnostics.types
+++ b/tests/baselines/reference/labelReferenceDiagnostics.types
@@ -1,0 +1,134 @@
+//// [tests/cases/compiler/labelReferenceDiagnostics.ts] ////
+
+=== labelReferenceDiagnostics.ts ===
+function breakToLaterLabel() {
+>breakToLaterLabel : () => void
+>                  : ^^^^^^^^^^
+
+    break target;
+>target : any
+>       : ^^^
+
+    target:
+>target : any
+>       : ^^^
+
+    while (true) {}
+>true : true
+>     : ^^^^
+}
+
+function continueToLaterLabel() {
+>continueToLaterLabel : () => void
+>                     : ^^^^^^^^^^
+
+    continue target;
+>target : any
+>       : ^^^
+
+    target:
+>target : any
+>       : ^^^
+
+    while (true) {}
+>true : true
+>     : ^^^^
+}
+
+function breakToMissingLabel() {
+>breakToMissingLabel : () => void
+>                    : ^^^^^^^^^^
+
+    break target;
+>target : any
+>       : ^^^
+}
+
+function breakToFunctionNameLabel() {
+>breakToFunctionNameLabel : () => void
+>                         : ^^^^^^^^^^
+
+    break breakToFunctionNameLabel;
+>breakToFunctionNameLabel : any
+>                         : ^^^
+}
+
+function continueToMissingLabel() {
+>continueToMissingLabel : () => void
+>                       : ^^^^^^^^^^
+
+    while (true) {
+>true : true
+>     : ^^^^
+
+        continue target;
+>target : any
+>       : ^^^
+    }
+}
+
+function breakToNonEnclosingLabel() {
+>breakToNonEnclosingLabel : () => void
+>                         : ^^^^^^^^^^
+
+    target:
+>target : any
+>       : ^^^
+
+    console.log("target");
+>console.log("target") : void
+>                      : ^^^^
+>console.log : (...data: any[]) => void
+>            : ^^^^    ^^     ^^^^^    
+>console : Console
+>        : ^^^^^^^
+>log : (...data: any[]) => void
+>    : ^^^^    ^^     ^^^^^    
+>"target" : "target"
+>         : ^^^^^^^^
+
+    break target;
+>target : any
+>       : ^^^
+}
+
+function continueToNonEnclosingLabel() {
+>continueToNonEnclosingLabel : () => void
+>                            : ^^^^^^^^^^
+
+    target:
+>target : any
+>       : ^^^
+
+    while (true) {}
+>true : true
+>     : ^^^^
+
+    while (true) {
+>true : true
+>     : ^^^^
+
+        continue target;
+>target : any
+>       : ^^^
+    }
+}
+
+target:
+>target : any
+>       : ^^^
+
+while (true) {
+>true : true
+>     : ^^^^
+
+    function crossesFunctionBoundary() {
+>crossesFunctionBoundary : () => void
+>                        : ^^^^^^^^^^
+
+        break target;
+>target : any
+>       : ^^^
+    }
+}
+

--- a/tests/baselines/reference/plainJSBinderErrors.errors.txt
+++ b/tests/baselines/reference/plainJSBinderErrors.errors.txt
@@ -12,7 +12,7 @@ plainJSBinderErrors.js(22,15): error TS1210: Code contained in a class is evalua
 plainJSBinderErrors.js(23,15): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 plainJSBinderErrors.js(27,9): error TS1101: 'with' statements are not allowed in strict mode.
 plainJSBinderErrors.js(33,13): error TS1344: A label is not allowed here.
-plainJSBinderErrors.js(34,13): error TS1107: Jump target cannot cross function boundary.
+plainJSBinderErrors.js(34,13): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSBinderErrors.js(39,7): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
 plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules are automatically in strict mode.
 
@@ -83,7 +83,8 @@ plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules 
 !!! error TS1344: A label is not allowed here.
                 break label
                 ~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
+!!! related TS2728 plainJSBinderErrors.js:33:13: 'label' is declared here.
             }
             return x
         }

--- a/tests/baselines/reference/plainJSGrammarErrors.errors.txt
+++ b/tests/baselines/reference/plainJSGrammarErrors.errors.txt
@@ -90,7 +90,6 @@ plainJSGrammarErrors.js(167,12): error TS1197: Catch clause variable cannot have
 plainJSGrammarErrors.js(170,5): error TS1114: Duplicate label 'label'.
 plainJSGrammarErrors.js(179,13): error TS1107: Jump target cannot cross function boundary.
 plainJSGrammarErrors.js(187,13): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-plainJSGrammarErrors.js(191,5): error TS1107: Jump target cannot cross function boundary.
 plainJSGrammarErrors.js(194,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSGrammarErrors.js(195,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 plainJSGrammarErrors.js(197,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
@@ -102,7 +101,7 @@ plainJSGrammarErrors.js(204,30): message TS1450: Dynamic imports can only accept
 plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot be spread element.
 
 
-==== plainJSGrammarErrors.js (102 errors) ====
+==== plainJSGrammarErrors.js (101 errors) ====
     class C {
         // #private mistakes
         q = #unbound
@@ -478,8 +477,6 @@ plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot
     }
     function jumpToLabelOnly(x) {
         break jumpToLabelOnly
-        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
     }
     for (;;) {
         break toplevel

--- a/tests/cases/compiler/labelReferenceDiagnostics.ts
+++ b/tests/cases/compiler/labelReferenceDiagnostics.ts
@@ -1,0 +1,49 @@
+// @target: es2015
+// @allowUnusedLabels: true
+
+function breakToLaterLabel() {
+    break target;
+    target:
+    while (true) {}
+}
+
+function continueToLaterLabel() {
+    continue target;
+    target:
+    while (true) {}
+}
+
+function breakToMissingLabel() {
+    break target;
+}
+
+function breakToFunctionNameLabel() {
+    break breakToFunctionNameLabel;
+}
+
+function continueToMissingLabel() {
+    while (true) {
+        continue target;
+    }
+}
+
+function breakToNonEnclosingLabel() {
+    target:
+    console.log("target");
+    break target;
+}
+
+function continueToNonEnclosingLabel() {
+    target:
+    while (true) {}
+    while (true) {
+        continue target;
+    }
+}
+
+target:
+while (true) {
+    function crossesFunctionBoundary() {
+        break target;
+    }
+}


### PR DESCRIPTION
### Reason for this change

Some labeled `break`/`continue` diagnostics collapse distinct failure modes into the same generic label-target message. In particular, missing labels and labels that exist in the current function but are not valid enclosing targets can be reported imprecisely.

### Description of changes

This refines the grammar check for labeled `break`/`continue` statements:

- reports a new `Cannot find label '{0}'.` diagnostic when no matching label exists in the current function
- reports the more specific invalid-target diagnostic when a matching label exists but is not an enclosing statement/iteration target
- keeps the existing forward-reference related-label diagnostic for labels declared later
- updates compiler and JavaScript baseline expectations

### Validation

Run with Node 22.22.0, matching the repo Volta pin:

- `npx -y -p node@22.22.0 node node_modules/hereby/bin/hereby.js runtests --tests=labelReferenceDiagnostics --light=false`
- `npx -y -p node@22.22.0 node node_modules/hereby/bin/hereby.js runtests --tests=plainJSBinderErrors --light=false`
- `npx -y -p node@22.22.0 node node_modules/hereby/bin/hereby.js runtests --tests=plainJSGrammarErrors --light=false`
