### PR TITLE
fix: correct diagnostic code 6910

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6637,7 +6637,7 @@
     },
     "`nodenext` if `module` is `nodenext`; `node16` if `module` is `node16` or `node18`; otherwise, `bundler`.": {
         "category": "Message",
-        "code": 69010
+        "code": 6910
     },
     "Computed from the list of input files": {
         "category": "Message",


### PR DESCRIPTION
Fixes #61971

This corrects the diagnostic code for the `module` option message from `69010` to `6910`, matching its position between `6909` and `6911`.

Verification:
- Parsed `src/compiler/diagnosticMessages.json` with Node, checked diagnostic codes are unique, and confirmed the target message now uses code `6910`.