### PR TITLE
Fix Set size doc comment grammar

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -94,7 +94,7 @@ interface Set<T> {
      */
     has(value: T): boolean;
     /**
-     * @returns the number of (unique) elements in Set.
+     * @returns the number of (unique) elements in the Set.
      */
     readonly size: number;
 }


### PR DESCRIPTION
Fixes #63480

Updates the `Set#size` return documentation from “in Set” to “in the Set”.

Validation:
- `git diff --check`