### PR TITLE
Narrow keyword completions for concise arrow expression bodies

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -138,6 +138,7 @@ import {
     isBinaryExpression,
     isBindingElement,
     isBindingPattern,
+    isBlock,
     isBreakOrContinueStatement,
     isCallExpression,
     isCaseBlock,
@@ -598,6 +599,7 @@ const enum KeywordCompletionFilters {
     InterfaceElementKeywords,       // Keywords inside interface body
     ConstructorParameterKeywords,   // Keywords at constructor parameter
     FunctionLikeBodyKeywords,       // Keywords at function like body
+    ArrowFunctionExpressionBodyKeywords, // Keywords valid as expression-position completions in arrow function expression bodies
     TypeAssertionKeywords,
     TypeKeywords,
     TypeKeyword,                    // Literally just `type`
@@ -3982,7 +3984,15 @@ function getCompletionData(
     }
 
     function getGlobalCompletions(): void {
-        keywordFilters = tryGetFunctionLikeBodyCompletionContainer(contextToken) ? KeywordCompletionFilters.FunctionLikeBodyKeywords : KeywordCompletionFilters.All;
+        if (isInArrowFunctionExpressionBody(contextToken)) {
+            keywordFilters = KeywordCompletionFilters.ArrowFunctionExpressionBodyKeywords;
+        }
+        else if (tryGetFunctionLikeBodyCompletionContainer(contextToken)) {
+            keywordFilters = KeywordCompletionFilters.FunctionLikeBodyKeywords;
+        }
+        else {
+            keywordFilters = KeywordCompletionFilters.All;
+        }
 
         // Get all entities in the current scope.
         completionKind = CompletionKind.Global;
@@ -4831,6 +4841,10 @@ function getCompletionData(
         }
     }
 
+    function isInArrowFunctionExpressionBody(contextToken: Node): boolean {
+        return !!findAncestor(contextToken, (node: Node) => isArrowFunctionBody(node) && !isBlock(node));
+    }
+
     function tryGetContainingJsxElement(contextToken: Node): JsxOpeningLikeElement | undefined {
         if (contextToken) {
             const parent = contextToken.parent;
@@ -5488,6 +5502,8 @@ function getTypescriptKeywordCompletions(keywordFilter: KeywordCompletionFilters
                     || isTypeKeyword(kind) && kind !== SyntaxKind.UndefinedKeyword;
             case KeywordCompletionFilters.FunctionLikeBodyKeywords:
                 return isFunctionLikeBodyKeyword(kind);
+            case KeywordCompletionFilters.ArrowFunctionExpressionBodyKeywords:
+                return isArrowFunctionExpressionBodyKeyword(kind);
             case KeywordCompletionFilters.ClassElementKeywords:
                 return isClassMemberCompletionKeyword(kind);
             case KeywordCompletionFilters.InterfaceElementKeywords:
@@ -5569,6 +5585,32 @@ function isFunctionLikeBodyKeyword(kind: SyntaxKind) {
         || kind === SyntaxKind.SatisfiesKeyword
         || kind === SyntaxKind.TypeKeyword
         || !isContextualKeyword(kind) && !isClassMemberCompletionKeyword(kind);
+}
+
+function isArrowFunctionExpressionBodyKeyword(kind: SyntaxKind): boolean {
+    switch (kind) {
+        case SyntaxKind.AsyncKeyword:
+        case SyntaxKind.AwaitKeyword:
+        case SyntaxKind.ClassKeyword:
+        case SyntaxKind.DeleteKeyword:
+        case SyntaxKind.FalseKeyword:
+        case SyntaxKind.FunctionKeyword:
+        case SyntaxKind.ImportKeyword:
+        case SyntaxKind.InKeyword:
+        case SyntaxKind.InstanceOfKeyword:
+        case SyntaxKind.NewKeyword:
+        case SyntaxKind.NullKeyword:
+        case SyntaxKind.SuperKeyword:
+        case SyntaxKind.ThisKeyword:
+        case SyntaxKind.TrueKeyword:
+        case SyntaxKind.TypeOfKeyword:
+        case SyntaxKind.VoidKeyword:
+        case SyntaxKind.AsKeyword:
+        case SyntaxKind.SatisfiesKeyword:
+            return true;
+        default:
+            return false;
+    }
 }
 
 function keywordForNode(node: Node): SyntaxKind {

--- a/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
+++ b/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
@@ -10,64 +10,41 @@
 // | (parameter) b: number
 // | var lambdaFoo: (a: number, b: number) => number
 // | var lambddaNoVarComment: (a: number, b: number) => number
-// | abstract
-// | any
 // | interface Array<T>
 // | var Array: ArrayConstructor
 // | interface ArrayBuffer
 // | var ArrayBuffer: ArrayBufferConstructor
 // | as
-// | asserts
 // | async
 // | await
-// | bigint
-// | boolean
 // | interface Boolean
 // | var Boolean: BooleanConstructor
-// | break
-// | case
-// | catch
 // | class
-// | const
-// | continue
 // | interface DataView<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
 // | var DataView: DataViewConstructor
 // | interface Date
 // | var Date: DateConstructor
-// | debugger
-// | declare
 // | function decodeURI(encodedURI: string): string
 // | function decodeURIComponent(encodedURIComponent: string): string
-// | default
 // | delete
-// | do
-// | else
 // | function encodeURI(uri: string): string
 // | function encodeURIComponent(uriComponent: string | number | boolean): string
-// | enum
 // | interface Error
 // | var Error: ErrorConstructor
 // | function eval(x: string): any
 // | interface EvalError
 // | var EvalError: EvalErrorConstructor
-// | export
-// | extends
 // | false
-// | finally
 // | interface Float32Array<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
 // | var Float32Array: Float32ArrayConstructor
 // | interface Float64Array<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
 // | var Float64Array: Float64ArrayConstructor
-// | for
 // | function
 // | interface Function
 // | var Function: FunctionConstructor
 // | module globalThis
-// | if
-// | implements
 // | import
 // | in
-// | infer
 // | var Infinity: number
 // | instanceof
 // | interface Int8Array<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
@@ -76,53 +53,36 @@
 // | var Int16Array: Int16ArrayConstructor
 // | interface Int32Array<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
 // | var Int32Array: Int32ArrayConstructor
-// | interface
 // | namespace Intl
 // | function isFinite(number: number): boolean
 // | function isNaN(number: number): boolean
 // | interface JSON
 // | var JSON: JSON
-// | keyof
-// | let
 // | interface Math
 // | var Math: Math
-// | module
-// | namespace
 // | var NaN: number
-// | never
 // | new
 // | null
-// | number
 // | interface Number
 // | var Number: NumberConstructor
-// | object
 // | interface Object
 // | var Object: ObjectConstructor
-// | package
 // | function parseFloat(string: string): number
 // | function parseInt(string: string, radix?: number): number
 // | interface RangeError
 // | var RangeError: RangeErrorConstructor
-// | readonly
 // | interface ReferenceError
 // | var ReferenceError: ReferenceErrorConstructor
 // | interface RegExp
 // | var RegExp: RegExpConstructor
-// | return
 // | satisfies
-// | string
 // | interface String
 // | var String: StringConstructor
 // | super
-// | switch
-// | symbol
 // | interface SyntaxError
 // | var SyntaxError: SyntaxErrorConstructor
 // | this
-// | throw
 // | true
-// | try
-// | type
 // | interface TypeError
 // | var TypeError: TypeErrorConstructor
 // | typeof
@@ -135,16 +95,9 @@
 // | interface Uint32Array<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>
 // | var Uint32Array: Uint32ArrayConstructor
 // | var undefined
-// | unique
-// | unknown
 // | interface URIError
 // | var URIError: URIErrorConstructor
-// | using
-// | var
 // | void
-// | while
-// | with
-// | yield
 // | function escape(string: string): string
 // | function unescape(string: string): string
 // | ----------------------------------------------------------------------
@@ -1108,30 +1061,6 @@
           ]
         },
         {
-          "name": "abstract",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "abstract",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "any",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "any",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "Array",
           "kind": "var",
           "kindModifiers": "declare",
@@ -1259,18 +1188,6 @@
           ]
         },
         {
-          "name": "asserts",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "asserts",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "async",
           "kind": "keyword",
           "kindModifiers": "",
@@ -1290,30 +1207,6 @@
           "displayParts": [
             {
               "text": "await",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "bigint",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "bigint",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "boolean",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "boolean",
               "kind": "keyword"
             }
           ]
@@ -1368,42 +1261,6 @@
           "documentation": []
         },
         {
-          "name": "break",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "break",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "case",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "case",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "catch",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "catch",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "class",
           "kind": "keyword",
           "kindModifiers": "",
@@ -1411,30 +1268,6 @@
           "displayParts": [
             {
               "text": "class",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "const",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "const",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "continue",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "continue",
               "kind": "keyword"
             }
           ]
@@ -1583,30 +1416,6 @@
             {
               "text": "Enables basic storage and retrieval of dates and times.",
               "kind": "text"
-            }
-          ]
-        },
-        {
-          "name": "debugger",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "debugger",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "declare",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "declare",
-              "kind": "keyword"
             }
           ]
         },
@@ -1773,18 +1582,6 @@
           ]
         },
         {
-          "name": "default",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "default",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "delete",
           "kind": "keyword",
           "kindModifiers": "",
@@ -1792,30 +1589,6 @@
           "displayParts": [
             {
               "text": "delete",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "do",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "do",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "else",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "else",
               "kind": "keyword"
             }
           ]
@@ -2015,18 +1788,6 @@
           ]
         },
         {
-          "name": "enum",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "enum",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "Error",
           "kind": "var",
           "kindModifiers": "declare",
@@ -2206,30 +1967,6 @@
           "documentation": []
         },
         {
-          "name": "export",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "export",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "extends",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "extends",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "false",
           "kind": "keyword",
           "kindModifiers": "",
@@ -2237,18 +1974,6 @@
           "displayParts": [
             {
               "text": "false",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "finally",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "finally",
               "kind": "keyword"
             }
           ]
@@ -2450,18 +2175,6 @@
           ]
         },
         {
-          "name": "for",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "for",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "function",
           "kind": "keyword",
           "kindModifiers": "",
@@ -2549,30 +2262,6 @@
           "documentation": []
         },
         {
-          "name": "if",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "if",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "implements",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "implements",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "import",
           "kind": "keyword",
           "kindModifiers": "",
@@ -2592,18 +2281,6 @@
           "displayParts": [
             {
               "text": "in",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "infer",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "infer",
               "kind": "keyword"
             }
           ]
@@ -2948,18 +2625,6 @@
           ]
         },
         {
-          "name": "interface",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "interface",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "Intl",
           "kind": "module",
           "kindModifiers": "declare",
@@ -3197,30 +2862,6 @@
           ]
         },
         {
-          "name": "keyof",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "keyof",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "let",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "let",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "Math",
           "kind": "var",
           "kindModifiers": "declare",
@@ -3275,30 +2916,6 @@
           ]
         },
         {
-          "name": "module",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "module",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "namespace",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "namespace",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "NaN",
           "kind": "var",
           "kindModifiers": "declare",
@@ -3332,18 +2949,6 @@
           "documentation": []
         },
         {
-          "name": "never",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "never",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "new",
           "kind": "keyword",
           "kindModifiers": "",
@@ -3363,18 +2968,6 @@
           "displayParts": [
             {
               "text": "null",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "number",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "number",
               "kind": "keyword"
             }
           ]
@@ -3434,18 +3027,6 @@
           ]
         },
         {
-          "name": "object",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "object",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "Object",
           "kind": "var",
           "kindModifiers": "declare",
@@ -3496,18 +3077,6 @@
             {
               "text": "Provides functionality common to all JavaScript objects.",
               "kind": "text"
-            }
-          ]
-        },
-        {
-          "name": "package",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "package",
-              "kind": "keyword"
             }
           ]
         },
@@ -3768,18 +3337,6 @@
           "documentation": []
         },
         {
-          "name": "readonly",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "ReferenceError",
           "kind": "var",
           "kindModifiers": "declare",
@@ -3878,18 +3435,6 @@
           "documentation": []
         },
         {
-          "name": "return",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "return",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "satisfies",
           "kind": "keyword",
           "kindModifiers": "",
@@ -3897,18 +3442,6 @@
           "displayParts": [
             {
               "text": "satisfies",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "string",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "string",
               "kind": "keyword"
             }
           ]
@@ -3980,30 +3513,6 @@
           ]
         },
         {
-          "name": "switch",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "switch",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "symbol",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "symbol",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "SyntaxError",
           "kind": "var",
           "kindModifiers": "declare",
@@ -4065,18 +3574,6 @@
           ]
         },
         {
-          "name": "throw",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "throw",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "true",
           "kind": "keyword",
           "kindModifiers": "",
@@ -4084,30 +3581,6 @@
           "displayParts": [
             {
               "text": "true",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "try",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "try",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "type",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "type",
               "kind": "keyword"
             }
           ]
@@ -4587,30 +4060,6 @@
           "documentation": []
         },
         {
-          "name": "unique",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "unique",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "unknown",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "unknown",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "URIError",
           "kind": "var",
           "kindModifiers": "declare",
@@ -4660,30 +4109,6 @@
           "documentation": []
         },
         {
-          "name": "using",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "using",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "var",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "var",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
           "name": "void",
           "kind": "keyword",
           "kindModifiers": "",
@@ -4691,42 +4116,6 @@
           "displayParts": [
             {
               "text": "void",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "while",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "while",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "with",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "with",
-              "kind": "keyword"
-            }
-          ]
-        },
-        {
-          "name": "yield",
-          "kind": "keyword",
-          "kindModifiers": "",
-          "sortText": "15",
-          "displayParts": [
-            {
-              "text": "yield",
               "kind": "keyword"
             }
           ]

--- a/tests/cases/fourslash/completionListAtEndOfWordInArrowFunction02.ts
+++ b/tests/cases/fourslash/completionListAtEndOfWordInArrowFunction02.ts
@@ -4,10 +4,9 @@
 
 verify.completions({
     marker: "1",
-    // TODO: should not include 'default' keyword at an expression location
     includes: [
         "d",
         "defaultIsAnInvalidParameterName",
-        { name: "default", sortText: completion.SortText.GlobalsOrKeywords }
-    ]
+    ],
+    excludes: ["default"],
 });

--- a/tests/cases/fourslash/completionListAtEndOfWordInArrowFunction03.ts
+++ b/tests/cases/fourslash/completionListAtEndOfWordInArrowFunction03.ts
@@ -6,7 +6,6 @@ verify.completions({
     marker: "1",
     includes: [
         "defaultIsAnInvalidParameterName",
-        // This should probably stop working in the future.
-        { name: "default", text: "default", kind: "keyword", sortText: completion.SortText.GlobalsOrKeywords },
     ],
+    excludes: ["default"],
 });

--- a/tests/cases/fourslash/completionsArrowFunctionExpressionBody.ts
+++ b/tests/cases/fourslash/completionsArrowFunctionExpressionBody.ts
@@ -1,0 +1,75 @@
+/// <reference path='fourslash.ts' />
+
+// Verify that statement-only keywords are excluded from completions in arrow function expression bodies,
+// while expression-valid keywords remain available.
+
+// @Filename: /a.ts
+////const f1 = (x: number) => /*expr1*/x;
+////const f2 = async (x: number) => /*expr2*/x;
+////const f3 = (x: number) => { return /*block1*/x; };
+
+goTo.marker("expr1");
+// Statement-only keywords must not appear in expression-body completions
+verify.completions({
+    excludes: [
+        "break",
+        "case",
+        "catch",
+        "continue",
+        "debugger",
+        "default",
+        "do",
+        "else",
+        "export",
+        "finally",
+        "for",
+        "if",
+        "return",
+        "switch",
+        "throw",
+        "try",
+        "var",
+        "while",
+        "with",
+        "yield",
+        "declare",
+        "using",
+        "type",
+    ],
+});
+// Expression-valid keywords must still appear
+verify.completions({
+    includes: [
+        { name: "new", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "typeof", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "void", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "false", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "true", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "null", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "function", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "class", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "delete", sortText: completion.SortText.GlobalsOrKeywords },
+    ],
+});
+
+goTo.marker("expr2");
+// async arrow function expression body: await should be available
+verify.completions({
+    includes: [{ name: "await", sortText: completion.SortText.GlobalsOrKeywords }],
+    excludes: [
+        "default",
+        "return",
+        "for",
+        "while",
+    ],
+});
+
+goTo.marker("block1");
+// In a block body, statement keywords ARE valid completions
+verify.completions({
+    includes: [
+        { name: "return", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "for", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "if", sortText: completion.SortText.GlobalsOrKeywords },
+    ],
+});


### PR DESCRIPTION
## Summary
This change narrows keyword completions only for concise arrow function expression bodies.

## Problem
Concise arrow expression bodies were using the broader function-like body keyword path, which allowed statement-oriented and other expression-invalid keywords in expression position.

## Approach
- Add a dedicated keyword filter for concise arrow expression bodies.
- Route only concise arrow expression-body contexts to that filter.
- Keep existing function/block-body filtering behavior unchanged.

## Scope
- Keyword-filtering only.
- Localized to completion logic in src/services/completions.ts.
- No parser/checker changes.

## Tests
- Updated existing nearby tests:
  - tests/cases/fourslash/completionListAtEndOfWordInArrowFunction02.ts
  - tests/cases/fourslash/completionListAtEndOfWordInArrowFunction03.ts
- Added focused regression coverage:
  - tests/cases/fourslash/completionsArrowFunctionExpressionBody.ts
- Included expected collateral baseline update:
  - tests/baselines/reference/completionsCommentsFunctionExpression.baseline

## Validation Notes
- Focused completion regressions pass.
- npx hereby lint passes.
- npx hereby format passes.
- npx hereby runtests-parallel had a timeout-only failure in tests/cases/compiler/relationComplexityError.ts.
- Isolated rerun of tests/cases/compiler/relationComplexityError.ts passed.

Related to #63463