### PR TITLE
fix(lib): add missing JSDoc to ReadonlySet and fix Set#size grammar

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -94,7 +94,7 @@ interface Set<T> {
      */
     has(value: T): boolean;
     /**
-     * @returns the number of (unique) elements in Set.
+     * @returns the number of (unique) elements in the Set.
      */
     readonly size: number;
 }
@@ -106,8 +106,17 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface ReadonlySet<T> {
+    /**
+     * Executes a provided function once per each value in the Set object, in insertion order.
+     */
     forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+    /**
+     * @returns a boolean indicating whether an element with the specified value exists in the Set or not.
+     */
     has(value: T): boolean;
+    /**
+     * @returns the number of (unique) elements in the Set.
+     */
     readonly size: number;
 }
 


### PR DESCRIPTION
Closes #63480, closes #63481.

Two small documentation fixes in `src/lib/es2015.collection.d.ts`, both tagged Help Wanted.

**Grammar fix (#63480):** `Set#size` JSDoc said "the number of (unique) elements in Set" — missing "the" before "Set". Changed to match `Map#size` and the rest of the file.

**Missing JSDoc (#63481):** `ReadonlySet` had no documentation on `forEach`, `has`, or `size`, while `Set<T>` has full JSDoc on every member. Added the three missing blocks using the same text as `Set<T>`. The callback type reference changes from `Set<T>` to `ReadonlySet<T>`.

`ReadonlyMap` has the same gap, but that's a separate issue. Stayed minimal here.

**Checklist:**
- [x] There is an associated issue in the `Backlog` milestone
- [x] Code is up-to-date with the `main` branch
- [x] ~~`hereby runtests`~~ — doc-only change (JSDoc comments only); no types or signatures changed, no baselines affected
- [ ] New or updated unit tests — not applicable for JSDoc-only changes