### PR TITLE
fix(lib): add missing article in Set#size JSDoc

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -94,7 +94,7 @@ interface Set<T> {
      */
     has(value: T): boolean;
     /**
-     * @returns the number of (unique) elements in Set.
+     * @returns the number of (unique) elements in the Set.
      */
     readonly size: number;
 }


### PR DESCRIPTION
This is an independent contribution made in good faith by an individual contributor.

## Summary

Fixes a minor grammar issue in `lib.es2015.collection.d.ts` where the JSDoc comment for `Set#size` is missing the definite article, producing ungrammatical text.

## Root Cause

The `@returns` annotation for `Set#size` reads:
> the number of (unique) elements in Set.

This is missing "the" before "Set", making it grammatically incorrect.

## Fix

Added the missing definite article:
> the number of (unique) elements in the Set.

## Testing

This is a comment-only change to a type definition file. No runtime behavior is affected. The change aligns with the existing style used in other `@returns` tags within the same interface.

Closes #63480