### PR TITLE
lib: fix misleading `maxLength` param on string pad* methods

### DIFF
--- a/src/lib/es2017.string.d.ts
+++ b/src/lib/es2017.string.d.ts
@@ -1,7 +1,7 @@
 interface String {
     /**
-     * Pads this string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
-     * The padding is applied from the start of this string.
+     * Pads the current string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
+     * The padding is applied from the start of the current string.
      *
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart)
      *
@@ -15,8 +15,8 @@ interface String {
     padStart(targetLength: number, padString?: string): string;
 
     /**
-     * Pads this string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
-     * The padding is applied from the end of this string.
+     * Pads the current string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
+     * The padding is applied from the end of the current string.
      *
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd)
      *

--- a/src/lib/es2017.string.d.ts
+++ b/src/lib/es2017.string.d.ts
@@ -1,27 +1,31 @@
 interface String {
     /**
-     * Pads the current string with a given string (possibly repeated) so that the resulting string reaches a given length.
-     * The padding is applied from the start (left) of the current string.
+     * Pads this string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
+     * The padding is applied from the start of this string.
      *
-     * @param maxLength The length of the resulting string once the current string has been padded.
-     *        If this parameter is smaller than the current string's length, the current string will be returned as it is.
+     * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart)
      *
-     * @param fillString The string to pad the current string with.
-     *        If this string is too long, it will be truncated and the left-most part will be applied.
-     *        The default value for this parameter is " " (U+0020).
+     * @param targetLength The length of the resulting string once the current `str` has been padded.
+     *        If the value is less than or equal to `str.length`, then `str` is returned as-is.
+     *
+     * @param padString The string to pad the current `str` with.
+     *        If `padString` is too long to stay within `targetLength`, it will be truncated from the end.
+     *        The default value is the space character (U+0020).
      */
-    padStart(maxLength: number, fillString?: string): string;
+    padStart(targetLength: number, padString?: string): string;
 
     /**
-     * Pads the current string with a given string (possibly repeated) so that the resulting string reaches a given length.
-     * The padding is applied from the end (right) of the current string.
+     * Pads this string with a given string (repeated and/or truncated, if needed) so that the resulting string has a given length.
+     * The padding is applied from the end of this string.
      *
-     * @param maxLength The length of the resulting string once the current string has been padded.
-     *        If this parameter is smaller than the current string's length, the current string will be returned as it is.
+     * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd)
      *
-     * @param fillString The string to pad the current string with.
-     *        If this string is too long, it will be truncated and the left-most part will be applied.
-     *        The default value for this parameter is " " (U+0020).
+     * @param targetLength The length of the resulting string once the current `str` has been padded.
+     *        If the value is less than or equal to `str.length`, then `str` is returned as-is.
+     *
+     * @param padString The string to pad the current `str` with.
+     *        If `padString` is too long to stay within `targetLength`, it will be truncated from the end.
+     *        The default value is the space character (U+0020).
      */
-    padEnd(maxLength: number, fillString?: string): string;
+    padEnd(targetLength: number, padString?: string): string;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #63503

- Rename the `maxLength` parameter for `String.padStart` and `String.padEnd` to `targetLength`, which matches the MDN documentation.
- Update the documentation on those methods to match the current wording from MDN and include a documentation link

**Note:** As of the time the PR was created, the related issue has not been triaged. Please let me know if I didn't follow the right procedure here.