### PR TITLE
Add missing JSDoc to ReadonlySet and ReadonlyMap members

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -38,9 +38,22 @@ interface MapConstructor {
 declare var Map: MapConstructor;
 
 interface ReadonlyMap<K, V> {
+    /**
+     * Executes a provided function once per each key/value pair in the Map, in insertion order.
+     */
     forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+    /**
+     * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
+     * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
+     */
     get(key: K): V | undefined;
+    /**
+     * @returns boolean indicating whether an element with the specified key exists or not.
+     */
     has(key: K): boolean;
+    /**
+     * @returns the number of elements in the Map.
+     */
     readonly size: number;
 }
 
@@ -106,8 +119,17 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface ReadonlySet<T> {
+    /**
+     * Executes a provided function once per each value in the Set object, in insertion order.
+     */
     forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+    /**
+     * @returns a boolean indicating whether an element with the specified value exists in the Set or not.
+     */
     has(value: T): boolean;
+    /**
+     * @returns the number of (unique) elements in the Set.
+     */
     readonly size: number;
 }
 


### PR DESCRIPTION
ReadonlySet and ReadonlyMap in es2015.collection.d.ts are missing JSDoc on their members. The mutable counterparts (Set, Map) have full documentation but the readonly versions have none.

This adds matching JSDoc to:
- `ReadonlySet<T>` · forEach, has, size
- `ReadonlyMap<K, V>` · forEach, get, has, size

Docs are consistent with the existing comments on `Set<T>` and `Map<K, V>`.

Fixes #63481