### PR TITLE
Add missing JSDoc parameter and return type tags to esnext lib files

### DIFF
--- a/src/lib/esnext.array.d.ts
+++ b/src/lib/esnext.array.d.ts
@@ -2,6 +2,7 @@ interface ArrayConstructor {
     /**
      * Creates an array from an async iterator or iterable object.
      * @param iterableOrArrayLike An async iterator or array-like object to convert to an array.
+     * @returns A Promise that resolves to an array of the values from the async iterable.
      */
     fromAsync<T>(iterableOrArrayLike: AsyncIterable<T> | Iterable<T | PromiseLike<T>> | ArrayLike<T | PromiseLike<T>>): Promise<T[]>;
 
@@ -12,6 +13,7 @@ interface ArrayConstructor {
      * @param mapfn A mapping function to call on every element of itarableOrArrayLike.
      *      Each return value is awaited before being added to result array.
      * @param thisArg Value of 'this' used when executing mapfn.
+     * @returns A Promise that resolves to an array of mapped values from the async iterable.
      */
     fromAsync<T, U>(iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Awaited<U>[]>;
 }

--- a/src/lib/esnext.collection.d.ts
+++ b/src/lib/esnext.collection.d.ts
@@ -4,12 +4,16 @@ interface Map<K, V> {
     /**
      * Returns a specified element from the Map object.
      * If no element is associated with the specified key, a new element with the value `defaultValue` will be inserted into the Map and returned.
+     * @param key The key of the element to return.
+     * @param defaultValue The value to insert if no element exists for the given key.
      * @returns The element associated with the specified key, which will be `defaultValue` if no element previously existed.
      */
     getOrInsert(key: K, defaultValue: V): V;
     /**
      * Returns a specified element from the Map object.
      * If no element is associated with the specified key, the result of passing the specified key to the `callback` function will be inserted into the Map and returned.
+     * @param key The key of the element to return.
+     * @param callback A function that produces the value to insert if no element exists for the given key.
      * @returns The element associated with the specific key, which will be the newly computed value if no element previously existed.
      */
     getOrInsertComputed(key: K, callback: (key: K) => V): V;
@@ -19,12 +23,16 @@ interface WeakMap<K extends WeakKey, V> {
     /**
      * Returns a specified element from the WeakMap object.
      * If no element is associated with the specified key, a new element with the value `defaultValue` will be inserted into the WeakMap and returned.
+     * @param key The key of the element to return.
+     * @param defaultValue The value to insert if no element exists for the given key.
      * @returns The element associated with the specified key, which will be `defaultValue` if no element previously existed.
      */
     getOrInsert(key: K, defaultValue: V): V;
     /**
      * Returns a specified element from the WeakMap object.
      * If no element is associated with the specified key, the result of passing the specified key to the `callback` function will be inserted into the WeakMap and returned.
+     * @param key The key of the element to return.
+     * @param callback A function that produces the value to insert if no element exists for the given key.
      * @returns The element associated with the specific key, which will be the newly computed value if no element previously existed.
      */
     getOrInsertComputed(key: K, callback: (key: K) => V): V;

--- a/src/lib/esnext.date.d.ts
+++ b/src/lib/esnext.date.d.ts
@@ -1,5 +1,9 @@
 /// <reference lib="esnext.temporal" />
 
 interface Date {
+    /**
+     * Converts a Date object to a Temporal.Instant object.
+     * @returns A Temporal.Instant representing the same instant as this Date.
+     */
     toTemporalInstant(): Temporal.Instant;
 }

--- a/src/lib/esnext.error.d.ts
+++ b/src/lib/esnext.error.d.ts
@@ -1,6 +1,8 @@
 interface ErrorConstructor {
     /**
      * Indicates whether the argument provided is a built-in Error instance or not.
+     * @param error The value to check.
+     * @returns `true` if the argument is a built-in Error instance, otherwise `false`.
      */
     isError(error: unknown): error is Error;
 }

--- a/src/lib/esnext.sharedmemory.d.ts
+++ b/src/lib/esnext.sharedmemory.d.ts
@@ -2,6 +2,7 @@ interface Atomics {
     /**
      * Performs a finite-time microwait by signaling to the operating system or
      * CPU that the current executing code is in a spin-wait loop.
+     * @param n The number of times the pause hint should be issued. If omitted, a platform-defined default is used.
      */
     pause(n?: number): void;
 }

--- a/src/lib/esnext.typedarrays.d.ts
+++ b/src/lib/esnext.typedarrays.d.ts
@@ -66,6 +66,7 @@ interface Uint8ArrayConstructor {
 
     /**
      * Creates a new `Uint8Array` from a base16-encoded string.
+     * @param string The base16-encoded string.
      * @returns A new `Uint8Array` instance.
      */
     fromHex(


### PR DESCRIPTION
## Summary

Adds missing JSDoc `@param` and `@returns` annotations across several `esnext` lib declaration files.

Changes include:

- `Error.isError` — added `@param error` and `@returns`
- `Date.toTemporalInstant` — added full JSDoc (previously undocumented)
- `Atomics.pause` — added `@param n`
- `Map`/`WeakMap` `getOrInsert*` methods — added missing parameter annotations
- `Array.fromAsync` — added `@returns` to both overloads
- `Uint8Array.fromHex` — added `@param string`

## Testing

- `npx dprint fmt`
- `npx eslint`
- `npx hereby local`