### PR TITLE
Update toFixed/toExponential/toPrecision digit range in docs to match the spec

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -547,19 +547,19 @@ interface Number {
 
     /**
      * Returns a string representing a number in fixed-point notation.
-     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 100, inclusive.
      */
     toFixed(fractionDigits?: number): string;
 
     /**
      * Returns a string containing a number represented in exponential notation.
-     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 100, inclusive.
      */
     toExponential(fractionDigits?: number): string;
 
     /**
      * Returns a string containing a number represented either in exponential or fixed-point notation with a specified number of digits.
-     * @param precision Number of significant digits. Must be in the range 1 - 21, inclusive.
+     * @param precision Number of significant digits. Must be in the range 1 - 100, inclusive.
      */
     toPrecision(precision?: number): string;
 


### PR DESCRIPTION
The doc comments for `Number.prototype.toFixed`, `toExponential` and `toPrecision` still list the old digit limits (`0 - 20`, and `1 - 21` for `toPrecision`). TC39 raised the maximum to 100 in tc39/ecma262#857, which shipped in ES2018, and engines follow that. Updated the three comments to `0 - 100` and `1 - 100`.

Fixes #59653
