### PR TITLE
fix: Deprecation error message reporting method type as deprecated instead...

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2626,6 +2626,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function addDeprecatedSuggestionWithSignature(location: Node, declaration: Node, deprecatedEntity: string | undefined, signatureString: string) {
         const diagnostic = deprecatedEntity
             ? createDiagnosticForNode(location, Diagnostics.The_signature_0_of_1_is_deprecated, signatureString, deprecatedEntity)
+            : isIdentifier(location)
+            ? createDiagnosticForNode(location, Diagnostics._0_is_deprecated, idText(location))
             : createDiagnosticForNode(location, Diagnostics._0_is_deprecated, signatureString);
         return addDeprecatedSuggestionWorker(declaration, diagnostic);
     }

--- a/tests/baselines/reference/deprecatedMethodOnChainedCall.errors.txt
+++ b/tests/baselines/reference/deprecatedMethodOnChainedCall.errors.txt
@@ -1,0 +1,22 @@
+deprecatedMethodOnChainedCall.ts(14,32): suggestion TS6385: 'oldMethod' is deprecated.
+
+
+==== deprecatedMethodOnChainedCall.ts (1 errors) ====
+    // Regression test for https://github.com/microsoft/TypeScript/issues/62396
+    // Deprecation message should show the method name, not the type signature
+    
+    interface Builder {
+        configure(value: string): Builder;
+        /** @deprecated use {@link Builder} instead */
+        oldMethod(): void;
+    }
+    
+    declare function createBuilder(): Builder;
+    
+    // When calling a deprecated method on the result of another call (chained call),
+    // the deprecation message should show the method name, not the type signature.
+    createBuilder().configure("x").oldMethod();
+                                   ~~~~~~~~~
+!!! suggestion TS6385: 'oldMethod' is deprecated.
+!!! related TS2798 deprecatedMethodOnChainedCall.ts:6:9: The declaration was marked as deprecated here.
+    

--- a/tests/baselines/reference/deprecatedMethodOnChainedCall.symbols
+++ b/tests/baselines/reference/deprecatedMethodOnChainedCall.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/deprecatedMethodOnChainedCall.ts] ////
+
+=== deprecatedMethodOnChainedCall.ts ===
+// Regression test for https://github.com/microsoft/TypeScript/issues/62396
+// Deprecation message should show the method name, not the type signature
+
+interface Builder {
+>Builder : Symbol(Builder, Decl(deprecatedMethodOnChainedCall.ts, 0, 0))
+
+    configure(value: string): Builder;
+>configure : Symbol(Builder.configure, Decl(deprecatedMethodOnChainedCall.ts, 3, 19))
+>value : Symbol(value, Decl(deprecatedMethodOnChainedCall.ts, 4, 14))
+>Builder : Symbol(Builder, Decl(deprecatedMethodOnChainedCall.ts, 0, 0))
+
+    /** @deprecated use {@link Builder} instead */
+    oldMethod(): void;
+>oldMethod : Symbol(Builder.oldMethod, Decl(deprecatedMethodOnChainedCall.ts, 4, 38))
+}
+
+declare function createBuilder(): Builder;
+>createBuilder : Symbol(createBuilder, Decl(deprecatedMethodOnChainedCall.ts, 7, 1))
+>Builder : Symbol(Builder, Decl(deprecatedMethodOnChainedCall.ts, 0, 0))
+
+// When calling a deprecated method on the result of another call (chained call),
+// the deprecation message should show the method name, not the type signature.
+createBuilder().configure("x").oldMethod();
+>createBuilder().configure("x").oldMethod : Symbol(Builder.oldMethod, Decl(deprecatedMethodOnChainedCall.ts, 4, 38))
+>createBuilder().configure : Symbol(Builder.configure, Decl(deprecatedMethodOnChainedCall.ts, 3, 19))
+>createBuilder : Symbol(createBuilder, Decl(deprecatedMethodOnChainedCall.ts, 7, 1))
+>configure : Symbol(Builder.configure, Decl(deprecatedMethodOnChainedCall.ts, 3, 19))
+>oldMethod : Symbol(Builder.oldMethod, Decl(deprecatedMethodOnChainedCall.ts, 4, 38))
+

--- a/tests/baselines/reference/deprecatedMethodOnChainedCall.types
+++ b/tests/baselines/reference/deprecatedMethodOnChainedCall.types
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/deprecatedMethodOnChainedCall.ts] ////
+
+=== deprecatedMethodOnChainedCall.ts ===
+// Regression test for https://github.com/microsoft/TypeScript/issues/62396
+// Deprecation message should show the method name, not the type signature
+
+interface Builder {
+    configure(value: string): Builder;
+>configure : (value: string) => Builder
+>          : ^     ^^      ^^^^^       
+>value : string
+>      : ^^^^^^
+
+    /** @deprecated use {@link Builder} instead */
+    oldMethod(): void;
+>oldMethod : () => void
+>          : ^^^^^^    
+}
+
+declare function createBuilder(): Builder;
+>createBuilder : () => Builder
+>              : ^^^^^^       
+
+// When calling a deprecated method on the result of another call (chained call),
+// the deprecation message should show the method name, not the type signature.
+createBuilder().configure("x").oldMethod();
+>createBuilder().configure("x").oldMethod() : void
+>                                           : ^^^^
+>createBuilder().configure("x").oldMethod : () => void
+>                                         : ^^^^^^    
+>createBuilder().configure("x") : Builder
+>                               : ^^^^^^^
+>createBuilder().configure : (value: string) => Builder
+>                          : ^     ^^      ^^^^^       
+>createBuilder() : Builder
+>                : ^^^^^^^
+>createBuilder : () => Builder
+>              : ^^^^^^       
+>configure : (value: string) => Builder
+>          : ^     ^^      ^^^^^       
+>"x" : "x"
+>    : ^^^
+>oldMethod : () => void
+>          : ^^^^^^    
+

--- a/tests/cases/compiler/deprecatedMethodOnChainedCall.ts
+++ b/tests/cases/compiler/deprecatedMethodOnChainedCall.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @captureSuggestions: true
+
+// Regression test for https://github.com/microsoft/TypeScript/issues/62396
+// Deprecation message should show the method name, not the type signature
+
+interface Builder {
+    configure(value: string): Builder;
+    /** @deprecated use {@link Builder} instead */
+    oldMethod(): void;
+}
+
+declare function createBuilder(): Builder;
+
+// When calling a deprecated method on the result of another call (chained call),
+// the deprecation message should show the method name, not the type signature.
+createBuilder().configure("x").oldMethod();


### PR DESCRIPTION
## Summary

## Root Cause

In `src/compiler/checker.ts`, the function `addDeprecatedSuggestionWithSignature` was missing a check for when `deprecatedEntity` is `undefined` but `location` is an `Identifier`. In that case, it fell through to use `signatureString` (the full function type like `(): ZodObject<...>`) as the deprecated entity name in the diagnostic message.

This happens when calling a deprecated method on the result of a chained call (e.g., `createBuilder().configure("x").oldMethod()`). In this pattern, `tryGetPropertyAccessOrIdentifierToString` returns `undefined` because the base of the property access is a `CallExpression` (not an identifier or simple property access). As a result, `name`/`deprecatedEntity` is `undefined`. Without the identifier check, the code would fall through and use `signatureString` in the message.

## Change Made

**`src/compiler/checker.ts`** — Added an `isIdentifier(location)` branch in `addDeprecatedSuggestionWithSignature`:

```ts
// Before:
const diagnostic = deprecatedEntity
    ? createDiagnosticForNode(location, Diagnostics.The_signature_0_of_1_is_deprecated, signatureString, deprecatedEntity)
    : createDiagnosticForNode(location, Diagnostics._0_is_deprecated, signatureString);

// After:
const diagnostic = deprecatedEntity
    ? createDiagnosticForNode(location, Diagnostics.The_signature_0_of_1_is_deprecated, signatureString, deprecatedEntity)
    : isIdentifier(location)
    ? createDiagnosticForNode(location, Diagnostics._0_is_deprecated, idText(location))
    : createDiagnosticForNode(location, Diagnostics._0_is_deprecated, signatureString);
```

When `deprecatedEntity` is `undefined` and the suggestion node is an identifier (e.g., the method name `oldMethod`), we now use `idText(location)` (the identifier text) instead of `signatureString` (the type signature). This produces `'oldMethod' is deprecated` instead of `'(): void' is deprecated`.



## Issue

Fixes #62396

**Issue URL:** https://github.com/microsoft/TypeScript/issues/62396


## Changes

```
src/compiler/checker.ts                            |  2 +
 .../deprecatedMethodOnChainedCall.errors.txt       | 22 +++++++++++
 .../deprecatedMethodOnChainedCall.symbols          | 32 +++++++++++++++
 .../reference/deprecatedMethodOnChainedCall.types  | 45 ++++++++++++++++++++++
 .../compiler/deprecatedMethodOnChainedCall.ts      | 17 ++++++++
 5 files changed, 118 insertions(+)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This PR was authored with the assistance of AI coding tools (GitHub Copilot). I have read and understand the change and will respond to review feedback myself.
