### PR TITLE
feat(lib): add Math.sumPrecise type definition (ES2026)

### DIFF
--- a/src/lib/esnext.d.ts
+++ b/src/lib/esnext.d.ts
@@ -5,6 +5,7 @@
 /// <reference lib="esnext.disposable" />
 /// <reference lib="esnext.array" />
 /// <reference lib="esnext.error" />
+/// <reference lib="esnext.math" />
 /// <reference lib="esnext.sharedmemory" />
 /// <reference lib="esnext.typedarrays" />
 /// <reference lib="esnext.temporal" />

--- a/src/lib/esnext.math.d.ts
+++ b/src/lib/esnext.math.d.ts
@@ -1,0 +1,15 @@
+/** TypeScript Definition File
+ * Created: ES2026
+ */
+
+interface Math {
+    /**
+     * Returns the sum of the values in the iterable using a more precise
+     * summation algorithm than naive floating-point addition.
+     * Returns `-0` if the iterable is empty.
+     * @param numbers An iterable (such as an Array) of numbers.
+     * @throws {TypeError} If `numbers` is not iterable, or if any value in the iterable is not of type `number`.
+     * @throws {RangeError} If the iterable yields 2^53 or more values.
+     */
+    sumPrecise(numbers: Iterable<number>): number;
+}


### PR DESCRIPTION
Fixes #63427

Adds `Math.sumPrecise` type definition for the ES2026 `Math.sumPrecise` API (TC39 proposal-math-sum, Stage 4).

## Changes
- Created `src/lib/esnext.math.d.ts` with the `Math.sumPrecise` declaration
- Added `/// <reference lib="esnext.math" />` to `src/lib/esnext.d.ts`

## Note
Additional build system changes (libs.json, commandLineParser.ts, utilities.ts) may be needed for proper integration. Feedback welcome on whether these are required.

## References
- TC39 Proposal: https://github.com/tc39/proposal-math-sum
- MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise
- Already shipped in Bun, Firefox 137+, Safari 18.4