### PR TITLE
Delete browser-integration job from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,24 +209,6 @@ jobs:
       - name: Check formatting
         run: npx dprint check
 
-  browser-integration:
-    if: ${{ github.event_name != 'merge_group' }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 'lts/*'
-      - run: npm ci
-
-      - name: Installing browsers
-        run: npx playwright install --with-deps
-
-      - name: Validate the browser can import TypeScript
-        run: npx hereby test-browser-integration
-
   typecheck:
     runs-on: ubuntu-latest
 
@@ -422,7 +404,6 @@ jobs:
       - lint
       - knip
       - format
-      - browser-integration
       - typecheck
       - smoke
       - package-size


### PR DESCRIPTION
Removed the browser-integration job from CI workflow

This is failing for some external reason and we're not going to mess with this ever again anyway