### PR TITLE
Allow lone ampersands in Unicode sets regex classes

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -3125,9 +3125,6 @@ export function createScanner(
                         mayContainStrings = !isCharacterComplement && expressionMayContainStrings;
                         return;
                     }
-                    else {
-                        error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos, 1, String.fromCharCode(ch));
-                    }
                     break;
                 default:
                     if (isCharacterComplement && mayContainStrings) {
@@ -3185,21 +3182,18 @@ export function createScanner(
                         }
                         break;
                     case CharacterCodes.ampersand:
-                        start = pos;
-                        pos++;
-                        if (charCodeChecked(pos) === CharacterCodes.ampersand) {
-                            pos++;
+                        if (charCodeChecked(pos + 1) === CharacterCodes.ampersand) {
+                            start = pos;
+                            pos += 2;
                             error(Diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, pos - 2, 2);
                             if (charCodeChecked(pos) === CharacterCodes.ampersand) {
                                 error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos, 1, String.fromCharCode(ch));
                                 pos++;
                             }
+                            operand = text.slice(start, pos);
+                            continue;
                         }
-                        else {
-                            error(Diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, pos - 1, 1, String.fromCharCode(ch));
-                        }
-                        operand = text.slice(start, pos);
-                        continue;
+                        break;
                 }
                 if (isClassContentExit(charCodeChecked(pos))) {
                     break;

--- a/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.js
+++ b/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+//// [regularExpressionUnicodeSetsLoneAmpersand.ts]
+const regexes: RegExp[] = [
+  /[?&]/v,
+  /[a&]/v,
+  /[&a]/v,
+];
+
+
+//// [regularExpressionUnicodeSetsLoneAmpersand.js]
+"use strict";
+const regexes = [
+    /[?&]/v,
+    /[a&]/v,
+    /[&a]/v,
+];

--- a/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.symbols
+++ b/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+=== regularExpressionUnicodeSetsLoneAmpersand.ts ===
+const regexes: RegExp[] = [
+>regexes : Symbol(regexes, Decl(regularExpressionUnicodeSetsLoneAmpersand.ts, 0, 5))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+  /[?&]/v,
+  /[a&]/v,
+  /[&a]/v,
+];
+

--- a/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.types
+++ b/tests/baselines/reference/regularExpressionUnicodeSetsLoneAmpersand.types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+=== regularExpressionUnicodeSetsLoneAmpersand.ts ===
+const regexes: RegExp[] = [
+>regexes : RegExp[]
+>        : ^^^^^^^^
+>[  /[?&]/v,  /[a&]/v,  /[&a]/v,] : RegExp[]
+>                                 : ^^^^^^^^
+
+  /[?&]/v,
+>/[?&]/v : RegExp
+>        : ^^^^^^
+
+  /[a&]/v,
+>/[a&]/v : RegExp
+>        : ^^^^^^
+
+  /[&a]/v,
+>/[&a]/v : RegExp
+>        : ^^^^^^
+
+];
+

--- a/tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts
+++ b/tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts
@@ -1,0 +1,7 @@
+// @target: esnext
+
+const regexes: RegExp[] = [
+  /[?&]/v,
+  /[a&]/v,
+  /[&a]/v,
+];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #62707

It allows a lone `&` in Unicode sets regular expression character classes while preserving `&&` handling as the class set intersection operator

The scanner now only enters the ampersand operator path when the current character and next character form `&&`. Lone `&` falls through to normal class set operand scanning

Tests:
- npx hereby lint
- npx hereby check-format
- npx hereby runtests --tests="regularExpression|scanner"
