### PR TITLE
fix catastrophic backtracking in jquery typesMap rule

### DIFF
--- a/src/server/typesMap.json
+++ b/src/server/typesMap.json
@@ -1,7 +1,7 @@
 {
     "typesMap": {
         "jquery": {
-            "match": "jquery(-(\\.?\\d+)+)?(\\.intellisense)?(\\.min)?\\.js$",
+            "match": "jquery(-[\\d.]+)?(\\.intellisense)?(\\.min)?\\.js$",
             "types": ["jquery"]
         },
         "WinJS": {


### PR DESCRIPTION
reading through the safelist matching i noticed the jquery rule in typesMap.json compiles to a regex with a nested quantifier, jquery(-(\.?\d+)+)?..., so the inner (\.?\d+)+ can partition a run of digits ambiguously. applySafeListWorker tests it against every project file name, and a name like jquery-0000000000000000000000000000000000.jsx (long digit run, no .js tail) forces exponential backtracking - roughly 10s at 32 digits locally, growing fast from there, which stalls the language service.

the in-code defaultTypeSafeList already uses the linear (-[\d.]+)? form for the same rule, so this just brings the shipped map in line with it. matches the same jquery file names, no behaviour change.