### PR TITLE
Fix using declarations when Symbol is shadowed

### DIFF
--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -1385,13 +1385,13 @@ const addDisposableResourceHelper: UnscopedEmitHelper = {
         var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
             if (value !== null && value !== void 0) {
                 if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-                var dispose, inner;
+                var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
                 if (async) {
-                    if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+                    if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
                     dispose = value[Symbol.asyncDispose];
                 }
                 if (dispose === void 0) {
-                    if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+                    if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
                     dispose = value[Symbol.dispose];
                     if (async) inner = dispose;
                 }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2015).js
@@ -123,13 +123,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2017).js
@@ -114,13 +114,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es2022).js
@@ -114,13 +114,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.1(target=es5).js
@@ -150,13 +150,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.2(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.2(target=es2015).js
@@ -21,13 +21,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.2(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.2(target=es2017).js
@@ -12,13 +12,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.2(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.2(target=es2022).js
@@ -12,13 +12,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.2(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.2(target=es5).js
@@ -48,13 +48,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.3(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.3(target=es2015).js
@@ -23,13 +23,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.3(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.3(target=es2017).js
@@ -14,13 +14,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.3(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.3(target=es2022).js
@@ -14,13 +14,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarations.3(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarations.3(target=es5).js
@@ -50,13 +50,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2015).js
@@ -23,13 +23,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2017).js
@@ -14,13 +14,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es2022).js
@@ -14,13 +14,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInFor(target=es5).js
@@ -50,13 +50,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2015).js
@@ -20,13 +20,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2017).js
@@ -11,13 +11,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es2022).js
@@ -11,13 +11,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf(target=es5).js
@@ -47,13 +47,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf.3(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForAwaitOf.3(target=es5).js
@@ -53,13 +53,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2015).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2015).js
@@ -21,13 +21,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2017).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2017).js
@@ -12,13 +12,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2022).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es2022).js
@@ -12,13 +12,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForOf.1(target=es5).js
@@ -48,13 +48,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/awaitUsingDeclarationsInForOf.5(target=es5).js
+++ b/tests/baselines/reference/awaitUsingDeclarationsInForOf.5(target=es5).js
@@ -53,13 +53,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/declarationBasicSyntax(declarationMap=false).js
+++ b/tests/baselines/reference/transpile/declarationBasicSyntax(declarationMap=false).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/declarationBasicSyntax(declarationMap=true).js
+++ b/tests/baselines/reference/transpile/declarationBasicSyntax(declarationMap=true).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/jsWithInlineSourceMapBasic(inlineSourceMap=false).js
+++ b/tests/baselines/reference/transpile/jsWithInlineSourceMapBasic(inlineSourceMap=false).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/jsWithInlineSourceMapBasic(inlineSourceMap=true).js
+++ b/tests/baselines/reference/transpile/jsWithInlineSourceMapBasic(inlineSourceMap=true).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/jsWithSourceMapBasic(sourceMap=false).js
+++ b/tests/baselines/reference/transpile/jsWithSourceMapBasic(sourceMap=false).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/transpile/jsWithSourceMapBasic(sourceMap=true).js
+++ b/tests/baselines/reference/transpile/jsWithSourceMapBasic(sourceMap=true).js
@@ -45,13 +45,13 @@ export type A<T> = { x: T };
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.1(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2015).js
@@ -177,13 +177,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.1(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2017).js
@@ -168,13 +168,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.1(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es2022).js
@@ -168,13 +168,13 @@ export {};
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.1(target=es5).js
+++ b/tests/baselines/reference/usingDeclarations.1(target=es5).js
@@ -219,13 +219,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.11(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarations.11(target=es2015).js
@@ -41,13 +41,13 @@ class C5 extends A {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.11(target=es5).js
+++ b/tests/baselines/reference/usingDeclarations.11(target=es5).js
@@ -56,13 +56,13 @@ var __extends = (this && this.__extends) || (function () {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.12(usedefineforclassfields=false).js
+++ b/tests/baselines/reference/usingDeclarations.12(usedefineforclassfields=false).js
@@ -18,13 +18,13 @@ class C2 extends C1 {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.12(usedefineforclassfields=true).js
+++ b/tests/baselines/reference/usingDeclarations.12(usedefineforclassfields=true).js
@@ -18,13 +18,13 @@ class C2 extends C1 {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.2(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarations.2(target=es2015).js
@@ -12,13 +12,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.2(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarations.2(target=es2017).js
@@ -12,13 +12,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.2(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarations.2(target=es2022).js
@@ -12,13 +12,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.2(target=es5).js
+++ b/tests/baselines/reference/usingDeclarations.2(target=es5).js
@@ -12,13 +12,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.3(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarations.3(target=es2015).js
@@ -14,13 +14,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.3(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarations.3(target=es2017).js
@@ -14,13 +14,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.3(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarations.3(target=es2022).js
@@ -14,13 +14,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarations.3(target=es5).js
+++ b/tests/baselines/reference/usingDeclarations.3(target=es5).js
@@ -14,13 +14,13 @@
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInFor(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarationsInFor(target=es2015).js
@@ -10,13 +10,13 @@ for (using d1 = { [Symbol.dispose]() {} }, d2 = null, d3 = undefined;;) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInFor(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarationsInFor(target=es2017).js
@@ -10,13 +10,13 @@ for (using d1 = { [Symbol.dispose]() {} }, d2 = null, d3 = undefined;;) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInFor(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarationsInFor(target=es2022).js
@@ -10,13 +10,13 @@ for (using d1 = { [Symbol.dispose]() {} }, d2 = null, d3 = undefined;;) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInFor(target=es5).js
+++ b/tests/baselines/reference/usingDeclarationsInFor(target=es5).js
@@ -10,13 +10,13 @@ for (using d1 = { [Symbol.dispose]() {} }, d2 = null, d3 = undefined;;) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es2015).js
@@ -21,13 +21,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es2017).js
@@ -12,13 +12,13 @@ async function main() {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es5).js
+++ b/tests/baselines/reference/usingDeclarationsInForAwaitOf(target=es5).js
@@ -48,13 +48,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2015).js
+++ b/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2015).js
@@ -10,13 +10,13 @@ for (using d1 of [{ [Symbol.dispose]() {} }, null, undefined]) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2017).js
+++ b/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2017).js
@@ -10,13 +10,13 @@ for (using d1 of [{ [Symbol.dispose]() {} }, null, undefined]) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2022).js
+++ b/tests/baselines/reference/usingDeclarationsInForOf.1(target=es2022).js
@@ -10,13 +10,13 @@ for (using d1 of [{ [Symbol.dispose]() {} }, null, undefined]) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsInForOf.1(target=es5).js
+++ b/tests/baselines/reference/usingDeclarationsInForOf.1(target=es5).js
@@ -10,13 +10,13 @@ for (using d1 of [{ [Symbol.dispose]() {} }, null, undefined]) {
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.js
+++ b/tests/baselines/reference/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.js
@@ -66,13 +66,13 @@ var __setFunctionName = (this && this.__setFunctionName) || function (f, name, p
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-        var dispose, inner;
+        var dispose, inner, Symbol = typeof globalThis === "object" ? globalThis.Symbol : void 0;
         if (async) {
-            if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+            if (!Symbol || !Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
             dispose = value[Symbol.asyncDispose];
         }
         if (dispose === void 0) {
-            if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+            if (!Symbol || !Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
             dispose = value[Symbol.dispose];
             if (async) inner = dispose;
         }

--- a/tests/baselines/reference/usingDeclarationsShadowedGlobalSymbol.js
+++ b/tests/baselines/reference/usingDeclarationsShadowedGlobalSymbol.js
@@ -1,14 +1,31 @@
-//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsInForAwaitOf.ts] ////
+//// [tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsShadowedGlobalSymbol.ts] ////
 
-//// [usingDeclarationsInForAwaitOf.ts]
-async function main() {
-    for await (using d1 of [{ [Symbol.dispose]() {} }, null, undefined]) {
-    }
+//// [usingDeclarationsShadowedGlobalSymbol.ts]
+export class Symbol {
 }
 
+export const output: string[] = [];
 
-//// [usingDeclarationsInForAwaitOf.js]
-"use strict";
+{
+    using _ = {
+        [globalThis.Symbol.dispose]() {
+            output.push("disposed");
+        },
+    };
+}
+
+async function disposeAsync() {
+    await using _ = {
+        async [globalThis.Symbol.asyncDispose]() {
+            output.push("async disposed");
+        },
+    };
+}
+
+disposeAsync();
+
+
+//// [usingDeclarationsShadowedGlobalSymbol.js]
 var __addDisposableResource = (this && this.__addDisposableResource) || function (env, value, async) {
     if (value !== null && value !== void 0) {
         if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
@@ -61,18 +78,43 @@ var __disposeResources = (this && this.__disposeResources) || (function (Suppres
     var e = new Error(message);
     return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
 });
-async function main() {
-    for await (const d1_1 of [{ [Symbol.dispose]() { } }, null, undefined]) {
-        const env_1 = { stack: [], error: void 0, hasError: false };
-        try {
-            const d1 = __addDisposableResource(env_1, d1_1, false);
-        }
-        catch (e_1) {
-            env_1.error = e_1;
-            env_1.hasError = true;
-        }
-        finally {
-            __disposeResources(env_1);
-        }
+export class Symbol {
+}
+export const output = [];
+{
+    const env_1 = { stack: [], error: void 0, hasError: false };
+    try {
+        const _ = __addDisposableResource(env_1, {
+            [globalThis.Symbol.dispose]() {
+                output.push("disposed");
+            },
+        }, false);
+    }
+    catch (e_1) {
+        env_1.error = e_1;
+        env_1.hasError = true;
+    }
+    finally {
+        __disposeResources(env_1);
     }
 }
+async function disposeAsync() {
+    const env_2 = { stack: [], error: void 0, hasError: false };
+    try {
+        const _ = __addDisposableResource(env_2, {
+            async [globalThis.Symbol.asyncDispose]() {
+                output.push("async disposed");
+            },
+        }, true);
+    }
+    catch (e_2) {
+        env_2.error = e_2;
+        env_2.hasError = true;
+    }
+    finally {
+        const result_1 = __disposeResources(env_2);
+        if (result_1)
+            await result_1;
+    }
+}
+disposeAsync();

--- a/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsShadowedGlobalSymbol.ts
+++ b/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsShadowedGlobalSymbol.ts
@@ -1,0 +1,28 @@
+// @strict: false
+// @target: es2024
+// @module: esnext
+// @lib: esnext
+// @noTypesAndSymbols: true
+
+export class Symbol {
+}
+
+export const output: string[] = [];
+
+{
+    using _ = {
+        [globalThis.Symbol.dispose]() {
+            output.push("disposed");
+        },
+    };
+}
+
+async function disposeAsync() {
+    await using _ = {
+        async [globalThis.Symbol.asyncDispose]() {
+            output.push("async disposed");
+        },
+    };
+}
+
+disposeAsync();


### PR DESCRIPTION
Fixes #63522

This updates the disposable resource emit helper to resolve disposable symbols through `globalThis.Symbol`, so local declarations named `Symbol` do not shadow the global `Symbol` constructor used by `using` and `await using` emit.

A regression test covers both `using` and `await using` when a module exports a class named `Symbol`.

Tests run:
- `npx hereby runtests --tests=usingDeclarationsShadowedGlobalSymbol`
- `npx hereby runtests --tests=usingDeclarations`
- `npx hereby runtests-parallel`