### PR TITLE
Fix wildcard export target containment in auto-imports

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -2306,7 +2306,9 @@ function loadEntrypointsFromExportMap(
                 if (target.indexOf("*") !== target.lastIndexOf("*")) {
                     return false;
                 }
-
+                if (hasInvalidPackageJsonExportTargetSegments(target)) {
+                    return false;
+                }
                 state.host.readDirectory(
                     scope.packageDirectory,
                     extensionsToExtensionsArray(extensions),
@@ -2323,8 +2325,7 @@ function loadEntrypointsFromExportMap(
                 });
             }
             else {
-                const partsAfterFirst = getPathComponents(target).slice(2);
-                if (partsAfterFirst.includes("..") || partsAfterFirst.includes(".") || partsAfterFirst.includes("node_modules")) {
+                if (hasInvalidPackageJsonExportTargetSegments(target)) {
                     return false;
                 }
                 const resolvedTarget = combinePaths(scope.packageDirectory, target);
@@ -2354,6 +2355,13 @@ function loadEntrypointsFromExportMap(
             });
         }
     }
+}
+
+function hasInvalidPackageJsonExportTargetSegments(target: string): boolean {
+    // Package export targets are unrooted paths that begin with "./", so the
+    // first two components are the empty root marker and the leading ".".
+    const partsAfterFirst = getPathComponents(target).slice(2);
+    return partsAfterFirst.includes("..") || partsAfterFirst.includes(".") || partsAfterFirst.includes("node_modules");
 }
 
 /** @internal */

--- a/src/testRunner/unittests/tsserver/autoImportProvider.ts
+++ b/src/testRunner/unittests/tsserver/autoImportProvider.ts
@@ -333,6 +333,41 @@ describe("unittests:: tsserver:: autoImportProvider::", () => {
         assert.ok(seenSymbolNames.has("Volume"));
         baselineTsserverLogs("autoImportProvider", "Shared source files between AutoImportProvider and main program", session);
     });
+
+    it("Does not index wildcard export targets outside the package", () => {
+        const files = [
+            {
+                path: "/user/username/projects/project/node_modules/pkg/package.json",
+                content: jsonToReadableText({
+                    name: "pkg",
+                    version: "1.0.0",
+                    exports: {
+                        "./*": "./../../private/*.js",
+                    },
+                }),
+            },
+            { path: "/user/username/projects/project/private/leaked.d.ts", content: `export declare const leakedAutoImport: number;` },
+            { path: "/user/username/projects/project/package.json", content: jsonToReadableText({ dependencies: { pkg: "*" } }) },
+            {
+                path: "/user/username/projects/project/tsconfig.json",
+                content: jsonToReadableText({
+                    compilerOptions: {
+                        module: "nodenext",
+                        lib: ["es5"],
+                    },
+                    files: ["index.ts"],
+                }),
+            },
+            { path: "/user/username/projects/project/index.ts", content: "" },
+        ];
+
+        const { session } = setup(files);
+        openFilesForSession([files[4]], session);
+        const project = session.getProjectService().configuredProjects.get("/user/username/projects/project/tsconfig.json")!;
+        const completions = project.getLanguageService().getCompletionsAtPosition(files[4].path, 0, { includeCompletionsForModuleExports: true });
+        assert.isDefined(completions);
+        assert.isFalse(completions.entries.some(c => c.name === "leakedAutoImport"));
+    });
 });
 
 describe("unittests:: tsserver:: autoImportProvider:: monorepo", () => {


### PR DESCRIPTION
Fixes #63499.

## Summary

This applies the existing invalid package-json export target segment check before wildcard export targets enumerate files for auto-import entrypoint discovery.

The non-wildcard path already rejected target segments such as `..`, `.`, and `node_modules`. The wildcard path could call `readDirectory` before applying equivalent containment validation. This PR shares the existing check between those paths.

It also adds an auto-import provider regression test proving a wildcard export target that traverses outside the package does not surface an out-of-package declaration as a package auto-import completion.

## Contribution note

I saw the current contribution guidance that most code changes should go to `microsoft/typescript-go`. I am opening this as a draft against this repo because the issue is filed here and this code path is present here. If maintainers prefer, I can close this and port the same narrow fix/test to `microsoft/typescript-go`.

## Validation

- `npx hereby runtests --tests=autoImportProvider`
- `npx hereby local`
- `npx hereby lint`
- `git diff --check`

## AI assistance disclosure

This patch was prepared with Codex assistance for this specific issue and reviewed locally before submission.
