### PR TITLE
fix: report error for private property access on generic intersection types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19656,6 +19656,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return wildcardType;
         }
         objectType = getReducedType(objectType);
+        // If the object type is an intersection with conflicting private properties,
+        // report an error — we shouldn't be able to access those properties via T["key"]
+        if (objectType.flags & TypeFlags.Intersection && !(objectType.flags & TypeFlags.Never)) {
+            const props = getPropertiesOfUnionOrIntersectionType(objectType as IntersectionType);
+            const conflictingPrivate = find(props, isConflictingPrivateProperty);
+            if (conflictingPrivate && accessNode) {
+                error(accessNode, Diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
+                      symbolToString(conflictingPrivate), typeToString(getDeclaringClass(conflictingPrivate)!));
+                return undefined;
+            }
+        }
         // If the object type has a string index signature and no other members we know that the result will
         // always be the type of that index signature and we can simplify accordingly.
         if (isStringIndexSignatureOnlyType(objectType) && !(indexType.flags & TypeFlags.Nullable) && isTypeAssignableToKind(indexType, TypeFlags.String | TypeFlags.Number)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19661,9 +19661,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (objectType.flags & TypeFlags.Intersection && !(objectType.flags & TypeFlags.Never)) {
             const props = getPropertiesOfUnionOrIntersectionType(objectType as IntersectionType);
             const conflictingPrivate = find(props, isConflictingPrivateProperty);
-            if (conflictingPrivate && accessNode) {
-                error(accessNode, Diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
-                      symbolToString(conflictingPrivate), typeToString(getDeclaringClass(conflictingPrivate)!));
+            if (conflictingPrivate) {
+                if (accessNode) {
+                    const declaringClass = getDeclaringClass(conflictingPrivate);
+                    if (declaringClass) {
+                        error(accessNode, Diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
+                              symbolToString(conflictingPrivate), typeToString(declaringClass));
+                    }
+                }
                 return undefined;
             }
         }


### PR DESCRIPTION
When two classes have conflicting private properties, accessing them 
via indexed access on their intersection should report an error, 
consistent with union behavior.

## Root Cause
`getIndexedAccessTypeOrUndefined` did not check for conflicting 
private properties in intersection types before resolving indexed access.

## Fix
Added check after `getReducedType()` using existing `isConflictingPrivateProperty` 
helper to detect private property conflicts and report 
`Property_0_is_private_and_only_accessible_within_class_1`.

## Before
```ts
type Z<T extends A & B> = T["a"];         // no error ❌
type Z3<T extends A, T2 extends B> = (T & T2)["a"];  // no error ❌
```

## After
```ts
type Z<T extends A & B> = T["a"];         // Error ✅
type Z3<T extends A, T2 extends B> = (T & T2)["a"];  // Error ✅
```

## Related
- PR #37762: Original intersection reduction logic
- Issue #62294

Closes #62294