### PR TITLE
Fix normalizePath rooting a relative path that begins with ./ followed by a slash

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -736,7 +736,10 @@ function simpleNormalizePath(path: string): string | undefined {
     }
     // Some paths only require cleanup of `/./` or leading `./`
     let simplified = path.replace(/\/\.\//g, "/");
-    if (simplified.startsWith("./")) {
+    // Only strip a leading `./` when it is an actual `.` segment, not the
+    // start of a `.//` sequence where the second slash is a redundant
+    // separator (stripping there would turn a relative path into a rooted one).
+    if (simplified.startsWith("./") && simplified.charCodeAt(2) !== CharacterCodes.slash) {
         simplified = simplified.slice(2);
     }
     if (simplified !== path) {

--- a/src/testRunner/unittests/paths.ts
+++ b/src/testRunner/unittests/paths.ts
@@ -318,6 +318,10 @@ describe("unittests:: core paths", () => {
         assert.strictEqual(ts.getNormalizedAbsolutePath(".", ""), "");
         assert.strictEqual(ts.getNormalizedAbsolutePath("./", ""), "");
         assert.strictEqual(ts.getNormalizedAbsolutePath("./a", ""), "a");
+        // A `./` followed by a redundant separator must stay relative, not become rooted.
+        assert.strictEqual(ts.getNormalizedAbsolutePath(".//a", ""), "a");
+        assert.strictEqual(ts.getNormalizedAbsolutePath(".//a/b", ""), "a/b");
+        assert.strictEqual(ts.getNormalizedAbsolutePath("././/a", ""), "a");
         // Strangely, these do not normalize to the empty string.
         assert.strictEqual(ts.getNormalizedAbsolutePath("..", ""), "..");
         assert.strictEqual(ts.getNormalizedAbsolutePath("../", ""), "..");


### PR DESCRIPTION
Fixes #63588

## Problem

`simpleNormalizePath` (the allocation-free fast path added in #60812) strips a leading `./` before checking whether the next character is itself a separator:

```ts
let simplified = path.replace(/\/\.\//g, "/");
if (simplified.startsWith("./")) {
    simplified = simplified.slice(2);
}
```

For an input like `.//a`, the `/./` cleanup is a no-op, then `startsWith("./")` is true and `slice(2)` removes `./` and leaves `/a` — but that second `/` was a **redundant separator**, not a root. `/a` then re-tests clean and is returned, so a **relative** path is silently turned into a **rooted** one:

| input | before | expected |
|---|---|---|
| `.//a` | `/a` | `a` |
| `.//a/b` | `/a/b` | `a/b` |
| `././/a` | `/a` | `a` |

This affects both `normalizePath` and `getNormalizedAbsolutePath`. The slow-path component walker (the documented oracle) returns the correct relative result; only the fast path is wrong.

## Reproduction (real compiler, esbuild-bundled)

```
getNormalizedAbsolutePath(".//a", "")  ->  "/a"    (expected "a")
normalizePath(".//a")                  ->  "/a"    (expected "a")
```

## Fix

Only strip the leading `./` when it is an actual `.` segment — i.e. when the character after it is not another separator; otherwise fall through to the slow path, which normalizes correctly:

```ts
if (simplified.startsWith("./") && simplified.charCodeAt(2) !== CharacterCodes.slash) {
    simplified = simplified.slice(2);
}
```

## Verification

- RED→GREEN confirmed on the bundled compiler for the cases above.
- Exhaustive differential over all strings up to length 8 from `{'.', '/', 'a'}` (9,840 inputs), original vs patched: **172 differing results, every one a `./`-followed-by-separator case where the patched output drops the spurious leading `/` to match the slow path; zero changes elsewhere.**

## Test

Adds `.//a`, `.//a/b`, `././/a` assertions to the `getNormalizedAbsolutePath` unit test in `src/testRunner/unittests/paths.ts`.