### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
-      - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
+      - uses: microsoft/TypeScript-Twoslash-Repro-Action@896a8519c4a94659aae0e27c9c92d6115bfb6ad8 # master
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           issue: ${{ github.event.inputs.issue }}


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions