### PR TITLE
fix(lib): remove callable signature without new from Intl.PluralRules…

### DIFF
--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -31,7 +31,6 @@ declare namespace Intl {
 
     interface PluralRulesConstructor {
         new (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
-        (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
         supportedLocalesOf(locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
     }
 

--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -449,7 +449,6 @@ declare namespace Intl {
 
     interface PluralRulesConstructor {
         new (locales?: LocalesArgument, options?: PluralRulesOptions): PluralRules;
-        (locales?: LocalesArgument, options?: PluralRulesOptions): PluralRules;
 
         supportedLocalesOf(locales: LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
     }


### PR DESCRIPTION
Fixes #63606

- [x] There is an associated issue in the `Backlog` milestone (**required**)
- [x] Code is up-to-date with the `main` branch
- [x] You've successfully run `hereby runtests` locally
- [x] There are new or updated unit tests validating the change

Per ECMA-402 section 18.1.1 (`Intl.PluralRules(...)`), if `NewTarget` is `undefined`, a `TypeError` exception is thrown. Unlike legacy constructors (`DateTimeFormat`, `NumberFormat`, `Collator`) which have legacy fallback call behavior, modern Intl constructors require `new`.

This PR removes the callable signature from `PluralRulesConstructor` in both `es2018.intl.d.ts` and `es2020.intl.d.ts`. Other ES2020+ constructors (such as `RelativeTimeFormat` and `Locale`) were audited and correctly only require `new`.
