### PR TITLE
fix(formatting): recover from token spans outside property children

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -858,7 +858,7 @@ function formatSpanWorker(
                     return inheritedIndentation;
                 }
                 if (tokenInfo.token.end > childStartPos) {
-                    if (tokenInfo.token.pos > childStartPos) {
+                    if (tokenInfo.token.pos > childStartPos || tokenInfo.token.end > child.end) {
                         formattingScanner.skipToStartOf(child);
                     }
                     // stop when formatting scanner advances past the beginning of the child

--- a/tests/cases/fourslash/formattingTokenEndChildEnd.ts
+++ b/tests/cases/fourslash/formattingTokenEndChildEnd.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+/////*start*/type X = { prop: = `${abc}`xyz };
+format.document();
+
+goTo.marker("start");
+verify.currentLineContentIs("type X = { prop: = `${abc}`xyz };");


### PR DESCRIPTION
## Summary
- Fix formatting recursion guard in `processChildNode` to handle scanner tokens that overrun the current child node boundary in recovery scenarios.
- Add regression fourslash test for the invalid type-literal property syntax (`type X = { prop: = \`${abc}\`xyz }`) that triggered `Debug Failure. False expression: Token end is child end`.

## Validation
- `npx hereby runtests --tests formattingTokenEndChildEnd --light=false`
  - ✅ 1 passing (fourslash regression)

Fixes #63598.
