### PR TITLE
fix(2814): correct misleading error message for functions without bodies

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3790,7 +3790,7 @@
         "category": "Error",
         "code": 2813
     },
-    "Function with bodies can only merge with classes that are ambient.": {
+    "Functions can only merge with classes that are ambient.": {
         "category": "Error",
         "code": 2814
     },


### PR DESCRIPTION
Closes #63628

The TS2814 error currently says 'Function with bodies can only merge with classes that are ambient.' but the function in question (an overload declaration like unction Foo();) doesn't have a body. This makes the message confusing.

The fix removes the incorrect 'with bodies' qualifier since the error can fire for any function declaration regardless of whether it has a body.