### PR TITLE
Fix inconsistent `typeof this` when `this` parameter comes from a contextual signature (#63616)

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2859,10 +2859,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     break;
                 }
                 // falls through
-            case SyntaxKind.ThisKeyword:
-                if (node.kind === SyntaxKind.ThisKeyword || (node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "this")) {
-                    seenThisKeyword = true;
-                }
+            case SyntaxKind.ThisKeyword:
+                if (node.kind === SyntaxKind.ThisKeyword || (node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "this" && isPartOfTypeQuery(node))) {
+                    seenThisKeyword = true;
+                }
                 // TODO: Why use `isExpression` here? both Identifier and ThisKeyword are expressions.
                 if (currentFlow && (isExpression(node) || parent.kind === SyntaxKind.ShorthandPropertyAssignment)) {
                     (node as Identifier | ThisExpression).flowNode = currentFlow;

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2860,7 +2860,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 }
                 // falls through
             case SyntaxKind.ThisKeyword:
-                if (node.kind === SyntaxKind.ThisKeyword) {
+                if (node.kind === SyntaxKind.ThisKeyword || (node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "this")) {
                     seenThisKeyword = true;
                 }
                 // TODO: Why use `isExpression` here? both Identifier and ThisKeyword are expressions.

--- a/tests/baselines/reference/typeofThisWithContextualThisParameter.js
+++ b/tests/baselines/reference/typeofThisWithContextualThisParameter.js
@@ -1,0 +1,113 @@
+//// [tests/cases/compiler/typeofThisWithContextualThisParameter.ts] ////
+
+//// [typeofThisWithContextualThisParameter.ts]
+// Reproduces #63616: typeof this inconsistent when this parameter comes from a contextual signature
+
+interface A { a: string }
+
+// ---- Object-literal method case ----
+
+{
+    interface B { g: (this: A) => void }
+
+    function f(_: B): void {}
+
+    // Case 1: typeof this without explicit this usage — should resolve to A
+    f({
+        g() {
+            type X = typeof this;
+            //    ^ should be A
+        }
+    })
+
+    // Case 2: this used before typeof this — should resolve to A
+    f({
+        g() {
+            this;
+            type X = typeof this;
+            //    ^ should be A
+        }
+    })
+
+    // Case 3: this used after typeof this — should resolve to A
+    f({
+        g() {
+            type X = typeof this;
+            //    ^ should be A
+            this;
+        }
+    })
+}
+
+// ---- Function expression case ----
+
+{
+    function f(_: (this: A) => void): void {}
+
+    // Case 4: typeof this only — should resolve to A (not implicit any error for typeof this context)
+    f(function g() {
+        type X = typeof this;
+    })
+
+    // Case 5: this used before typeof this — should resolve to A
+    f(function g() {
+        this;
+        type X = typeof this;
+    })
+
+    // Case 6: this used after typeof this — should resolve to A
+    f(function g() {
+        type X = typeof this;
+        this;
+    })
+}
+
+
+//// [typeofThisWithContextualThisParameter.js]
+"use strict";
+// Reproduces #63616: typeof this inconsistent when this parameter comes from a contextual signature
+// ---- Object-literal method case ----
+{
+    function f(_) { }
+    // Case 1: typeof this without explicit this usage — should resolve to A
+    f({
+        g() {
+            //    ^ should be A
+        }
+    });
+    // Case 2: this used before typeof this — should resolve to A
+    f({
+        g() {
+            this;
+            //    ^ should be A
+        }
+    });
+    // Case 3: this used after typeof this — should resolve to A
+    f({
+        g() {
+            //    ^ should be A
+            this;
+        }
+    });
+}
+// ---- Function expression case ----
+{
+    function f(_) { }
+    // Case 4: typeof this only — should resolve to A (not implicit any error for typeof this context)
+    f(function g() {
+    });
+    // Case 5: this used before typeof this — should resolve to A
+    f(function g() {
+        this;
+    });
+    // Case 6: this used after typeof this — should resolve to A
+    f(function g() {
+        this;
+    });
+}
+
+
+//// [typeofThisWithContextualThisParameter.d.ts]
+interface A {
+    a: string;
+}

--- a/tests/baselines/reference/typeofThisWithContextualThisParameter.symbols
+++ b/tests/baselines/reference/typeofThisWithContextualThisParameter.symbols
@@ -1,0 +1,123 @@
+//// [tests/cases/compiler/typeofThisWithContextualThisParameter.ts] ////
+
+=== typeofThisWithContextualThisParameter.ts ===
+// Reproduces #63616: typeof this inconsistent when this parameter comes from a contextual signature
+
+interface A { a: string }
+>A : Symbol(A, Decl(typeofThisWithContextualThisParameter.ts, 0, 0))
+>a : Symbol(A.a, Decl(typeofThisWithContextualThisParameter.ts, 2, 13))
+
+// ---- Object-literal method case ----
+
+{
+    interface B { g: (this: A) => void }
+>B : Symbol(B, Decl(typeofThisWithContextualThisParameter.ts, 6, 1))
+>g : Symbol(B.g, Decl(typeofThisWithContextualThisParameter.ts, 7, 17))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+>A : Symbol(A, Decl(typeofThisWithContextualThisParameter.ts, 0, 0))
+
+    function f(_: B): void {}
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 7, 40))
+>_ : Symbol(_, Decl(typeofThisWithContextualThisParameter.ts, 9, 15))
+>B : Symbol(B, Decl(typeofThisWithContextualThisParameter.ts, 6, 1))
+
+    // Case 1: typeof this without explicit this usage — should resolve to A
+    f({
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 7, 40))
+
+        g() {
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 12, 7))
+
+            type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 13, 13))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+
+            //    ^ should be A
+        }
+    })
+
+    // Case 2: this used before typeof this — should resolve to A
+    f({
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 7, 40))
+
+        g() {
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 20, 7))
+
+            this;
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+
+            type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 22, 17))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+
+            //    ^ should be A
+        }
+    })
+
+    // Case 3: this used after typeof this — should resolve to A
+    f({
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 7, 40))
+
+        g() {
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 29, 7))
+
+            type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 30, 13))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+
+            //    ^ should be A
+            this;
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 7, 22))
+        }
+    })
+}
+
+// ---- Function expression case ----
+
+{
+    function f(_: (this: A) => void): void {}
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 40, 1))
+>_ : Symbol(_, Decl(typeofThisWithContextualThisParameter.ts, 41, 15))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+>A : Symbol(A, Decl(typeofThisWithContextualThisParameter.ts, 0, 0))
+
+    // Case 4: typeof this only — should resolve to A (not implicit any error for typeof this context)
+    f(function g() {
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 40, 1))
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 44, 6))
+
+        type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 44, 20))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+
+    })
+
+    // Case 5: this used before typeof this — should resolve to A
+    f(function g() {
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 40, 1))
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 49, 6))
+
+        this;
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+
+        type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 50, 13))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+
+    })
+
+    // Case 6: this used after typeof this — should resolve to A
+    f(function g() {
+>f : Symbol(f, Decl(typeofThisWithContextualThisParameter.ts, 40, 1))
+>g : Symbol(g, Decl(typeofThisWithContextualThisParameter.ts, 55, 6))
+
+        type X = typeof this;
+>X : Symbol(X, Decl(typeofThisWithContextualThisParameter.ts, 55, 20))
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+
+        this;
+>this : Symbol(this, Decl(typeofThisWithContextualThisParameter.ts, 41, 19))
+
+    })
+}
+

--- a/tests/baselines/reference/typeofThisWithContextualThisParameter.types
+++ b/tests/baselines/reference/typeofThisWithContextualThisParameter.types
@@ -1,0 +1,178 @@
+//// [tests/cases/compiler/typeofThisWithContextualThisParameter.ts] ////
+
+=== typeofThisWithContextualThisParameter.ts ===
+// Reproduces #63616: typeof this inconsistent when this parameter comes from a contextual signature
+
+interface A { a: string }
+>a : string
+>  : ^^^^^^
+
+// ---- Object-literal method case ----
+
+{
+    interface B { g: (this: A) => void }
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^    
+>this : A
+>     : ^
+
+    function f(_: B): void {}
+>f : (_: B) => void
+>  : ^ ^^^^^^^^    
+>_ : B
+>  : ^
+
+    // Case 1: typeof this without explicit this usage — should resolve to A
+    f({
+>f({        g() {            type X = typeof this;            //    ^ should be A        }    }) : void
+>                                                                                                : ^^^^
+>f : (_: B) => void
+>  : ^ ^^^^^^^^    
+>{        g() {            type X = typeof this;            //    ^ should be A        }    } : { g(this: A): void; }
+>                                                                                             : ^^^^    ^^ ^^^^^^^^^^
+
+        g() {
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+            type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+            //    ^ should be A
+        }
+    })
+
+    // Case 2: this used before typeof this — should resolve to A
+    f({
+>f({        g() {            this;            type X = typeof this;            //    ^ should be A        }    }) : void
+>                                                                                                                 : ^^^^
+>f : (_: B) => void
+>  : ^ ^^^^^^^^    
+>{        g() {            this;            type X = typeof this;            //    ^ should be A        }    } : { g(this: A): void; }
+>                                                                                                              : ^^^^    ^^ ^^^^^^^^^^
+
+        g() {
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+            this;
+>this : A
+>     : ^
+
+            type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+            //    ^ should be A
+        }
+    })
+
+    // Case 3: this used after typeof this — should resolve to A
+    f({
+>f({        g() {            type X = typeof this;            //    ^ should be A            this;        }    }) : void
+>                                                                                                                 : ^^^^
+>f : (_: B) => void
+>  : ^ ^^^^^^^^    
+>{        g() {            type X = typeof this;            //    ^ should be A            this;        }    } : { g(this: A): void; }
+>                                                                                                              : ^^^^    ^^ ^^^^^^^^^^
+
+        g() {
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+            type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+            //    ^ should be A
+            this;
+>this : A
+>     : ^
+        }
+    })
+}
+
+// ---- Function expression case ----
+
+{
+    function f(_: (this: A) => void): void {}
+>f : (_: (this: A) => void) => void
+>  : ^ ^^                 ^^^^^    
+>_ : (this: A) => void
+>  : ^    ^^ ^^^^^    
+>this : A
+>     : ^
+
+    // Case 4: typeof this only — should resolve to A (not implicit any error for typeof this context)
+    f(function g() {
+>f(function g() {        type X = typeof this;    }) : void
+>                                                    : ^^^^
+>f : (_: (this: A) => void) => void
+>  : ^ ^^                 ^^^^^    
+>function g() {        type X = typeof this;    } : (this: A) => void
+>                                                 : ^    ^^ ^^^^^^^^^
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+        type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+    })
+
+    // Case 5: this used before typeof this — should resolve to A
+    f(function g() {
+>f(function g() {        this;        type X = typeof this;    }) : void
+>                                                                 : ^^^^
+>f : (_: (this: A) => void) => void
+>  : ^ ^^                 ^^^^^    
+>function g() {        this;        type X = typeof this;    } : (this: A) => void
+>                                                              : ^    ^^ ^^^^^^^^^
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+        this;
+>this : A
+>     : ^
+
+        type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+    })
+
+    // Case 6: this used after typeof this — should resolve to A
+    f(function g() {
+>f(function g() {        type X = typeof this;        this;    }) : void
+>                                                                 : ^^^^
+>f : (_: (this: A) => void) => void
+>  : ^ ^^                 ^^^^^    
+>function g() {        type X = typeof this;        this;    } : (this: A) => void
+>                                                              : ^    ^^ ^^^^^^^^^
+>g : (this: A) => void
+>  : ^    ^^ ^^^^^^^^^
+
+        type X = typeof this;
+>X : A
+>  : ^
+>this : A
+>     : ^
+
+        this;
+>this : A
+>     : ^
+
+    })
+}
+

--- a/tests/cases/compiler/typeofThisWithContextualThisParameter.ts
+++ b/tests/cases/compiler/typeofThisWithContextualThisParameter.ts
@@ -1,0 +1,64 @@
+// @strict: true
+// @target: es2015
+// @declaration: true
+
+// Reproduces #63616: typeof this inconsistent when this parameter comes from a contextual signature
+
+interface A { a: string }
+
+// ---- Object-literal method case ----
+
+{
+    interface B { g: (this: A) => void }
+
+    function f(_: B): void {}
+
+    // Case 1: typeof this without explicit this usage — should resolve to A
+    f({
+        g() {
+            type X = typeof this;
+            //    ^ should be A
+        }
+    })
+
+    // Case 2: this used before typeof this — should resolve to A
+    f({
+        g() {
+            this;
+            type X = typeof this;
+            //    ^ should be A
+        }
+    })
+
+    // Case 3: this used after typeof this — should resolve to A
+    f({
+        g() {
+            type X = typeof this;
+            //    ^ should be A
+            this;
+        }
+    })
+}
+
+// ---- Function expression case ----
+
+{
+    function f(_: (this: A) => void): void {}
+
+    // Case 4: typeof this only — should resolve to A (not implicit any error for typeof this context)
+    f(function g() {
+        type X = typeof this;
+    })
+
+    // Case 5: this used before typeof this — should resolve to A
+    f(function g() {
+        this;
+        type X = typeof this;
+    })
+
+    // Case 6: this used after typeof this — should resolve to A
+    f(function g() {
+        type X = typeof this;
+        this;
+    })
+}


### PR DESCRIPTION

**Description:**

```markdown
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #63616

---

### i. What was the issue

When a function parameter's signature declares a `this` parameter (e.g. `interface B { g: (this: A) => void }`), the inferred `typeof this` in the function body was inconsistent. If `this` was used as an expression elsewhere in the body, `typeof this` correctly resolved to the contextual `this` type (`A`). If `this` was never used as an expression, `typeof this` incorrectly fell back to the enclosing type (`B`).

### ii. Where was the issue

The root cause is in `src/compiler/binder.ts` (line 2863). The binder tracked `seenThisKeyword` to set `NodeFlags.ContainsThis` on functions, but only recognized `ThisKeyword` AST nodes — not `Identifier` nodes with text `"this"`, which is how the parser represents `this` inside `typeof this` type queries. This flag feeds into `hasContextSensitiveParameters` (utilities.ts:10892), which determines whether `getContextualThisParameterType` considers the contextual signature's `this` parameter.

### iii. How it was fixed

Extended the `seenThisKeyword` check in the binder to also recognize `Identifier` nodes with `escapedText === "this"`:

```diff
- if (node.kind === SyntaxKind.ThisKeyword) {
+ if (node.kind === SyntaxKind.ThisKeyword || (node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "this")) {
```

This ensures `typeof this` correctly sets `NodeFlags.ContainsThis`, re-enabling contextual `this`-typing for functions that reference `this` only in type positions.

### iv. Why this method over others

The binder is the correct layer because `typeof this` IS a genuine reference to `this` — the `ContainsThis` flag should accurately reflect that. Alternative approaches (patching `hasContextSensitiveParameters` or `getContextualThisParameterType`) would either require re-scanning function bodies or would undo the intentional optimization from #62243. This fix also correctly affects `isThislessInterface`, which should similarly consider `typeof this` as a `this` reference.

### v. How to test locally

```bash
hereby runtests --tests=typeofThisWithContextualThisParameter
```

The test covers 6 scenarios across object-literal methods and function expressions, including cases where `this` is used before, after, or not at all alongside `typeof this`.

---

AI assistance disclosure: An AI coding agent co-authored this change under human supervision.