### PR TITLE
Gate ES2025 regex syntax (duplicate named groups, pattern modifiers) behind target

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1724,6 +1724,14 @@
         "category": "Error",
         "code": 1515
     },
+    "Regular expression pattern modifiers are only available when targeting '{0}' or later.": {
+        "category": "Error",
+        "code": 18062
+    },
+    "Duplicate named capturing groups are only available when targeting '{0}' or later.": {
+        "category": "Error",
+        "code": 18063
+    },
     "A character class range must not be bounded by another character class.": {
         "category": "Error",
         "code": 1516

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2750,6 +2750,9 @@ export function createScanner(
                                             error(Diagnostics.Subpattern_flags_must_be_present_when_there_is_a_minus_sign, start, pos - start);
                                         }
                                     }
+                                    if (pos !== start && languageVersion < ScriptTarget.ES2025) {
+                                        error(Diagnostics.Regular_expression_pattern_modifiers_are_only_available_when_targeting_0_or_later, start, pos - start, getNameOfScriptTarget(ScriptTarget.ES2025));
+                                    }
                                     scanExpectedChar(CharacterCodes.colon);
                                     isPreviousTermQuantifiable = true;
                                     break;
@@ -3008,6 +3011,9 @@ export function createScanner(
                 error(Diagnostics.Named_capturing_groups_with_the_same_name_must_be_mutually_exclusive_to_each_other, tokenStart, pos - tokenStart);
             }
             else {
+                if (groupSpecifiers?.has(tokenValue) && languageVersion < ScriptTarget.ES2025) {
+                    error(Diagnostics.Duplicate_named_capturing_groups_are_only_available_when_targeting_0_or_later, tokenStart, pos - tokenStart, getNameOfScriptTarget(ScriptTarget.ES2025));
+                }
                 topNamedCapturingGroupsScope ??= new Set();
                 topNamedCapturingGroupsScope.add(tokenValue);
                 groupSpecifiers ??= new Set();

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).errors.txt
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).errors.txt
@@ -1,0 +1,11 @@
+regexPatternModifiersAndDuplicateNamedGroups.ts(1,47): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
+regexPatternModifiersAndDuplicateNamedGroups.ts(2,22): error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.
+
+
+==== regexPatternModifiersAndDuplicateNamedGroups.ts (2 errors) ====
+    const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+                                                  ~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
+    const modifiers = /(?i:abc)/;
+                         ~
+!!! error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).js
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).js
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+//// [regexPatternModifiersAndDuplicateNamedGroups.ts]
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+const modifiers = /(?i:abc)/;
+
+//// [regexPatternModifiersAndDuplicateNamedGroups.js]
+"use strict";
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+const modifiers = /(?i:abc)/;

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).symbols
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).symbols
@@ -1,0 +1,9 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+=== regexPatternModifiersAndDuplicateNamedGroups.ts ===
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+>dupNames : Symbol(dupNames, Decl(regexPatternModifiersAndDuplicateNamedGroups.ts, 0, 5))
+
+const modifiers = /(?i:abc)/;
+>modifiers : Symbol(modifiers, Decl(regexPatternModifiersAndDuplicateNamedGroups.ts, 1, 5))
+

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).types
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2022).types
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+=== regexPatternModifiersAndDuplicateNamedGroups.ts ===
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+>dupNames : RegExp
+>         : ^^^^^^
+>/(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/ : RegExp
+>                                       : ^^^^^^
+
+const modifiers = /(?i:abc)/;
+>modifiers : RegExp
+>          : ^^^^^^
+>/(?i:abc)/ : RegExp
+>           : ^^^^^^
+

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).js
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).js
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+//// [regexPatternModifiersAndDuplicateNamedGroups.ts]
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+const modifiers = /(?i:abc)/;
+
+//// [regexPatternModifiersAndDuplicateNamedGroups.js]
+"use strict";
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+const modifiers = /(?i:abc)/;

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).symbols
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).symbols
@@ -1,0 +1,9 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+=== regexPatternModifiersAndDuplicateNamedGroups.ts ===
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+>dupNames : Symbol(dupNames, Decl(regexPatternModifiersAndDuplicateNamedGroups.ts, 0, 5))
+
+const modifiers = /(?i:abc)/;
+>modifiers : Symbol(modifiers, Decl(regexPatternModifiersAndDuplicateNamedGroups.ts, 1, 5))
+

--- a/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).types
+++ b/tests/baselines/reference/regexPatternModifiersAndDuplicateNamedGroups(target=es2025).types
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts] ////
+
+=== regexPatternModifiersAndDuplicateNamedGroups.ts ===
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+>dupNames : RegExp
+>         : ^^^^^^
+>/(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/ : RegExp
+>                                       : ^^^^^^
+
+const modifiers = /(?i:abc)/;
+>modifiers : RegExp
+>          : ^^^^^^
+>/(?i:abc)/ : RegExp
+>           : ^^^^^^
+

--- a/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
@@ -13,6 +13,7 @@ regularExpressionScanning.ts(3,19): error TS1499: Unknown regular expression fla
 regularExpressionScanning.ts(3,20): error TS1499: Unknown regular expression flag.
 regularExpressionScanning.ts(3,21): error TS1500: Duplicate regular expression flag.
 regularExpressionScanning.ts(3,22): error TS1499: Unknown regular expression flag.
+regularExpressionScanning.ts(5,5): error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(5,6): error TS1499: Unknown regular expression flag.
 regularExpressionScanning.ts(5,7): error TS1509: This regular expression flag cannot be toggled within a subpattern.
 regularExpressionScanning.ts(5,10): error TS1509: This regular expression flag cannot be toggled within a subpattern.
@@ -45,11 +46,14 @@ regularExpressionScanning.ts(14,5): error TS1503: Named capturing groups are onl
 regularExpressionScanning.ts(14,14): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,29): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,45): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(14,46): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(14,57): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(14,58): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(15,15): error TS1532: There is no capturing group named 'absent' in this regular expression.
 regularExpressionScanning.ts(15,24): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,36): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,45): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(15,46): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(15,58): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,59): error TS1515: Named capturing groups with the same name must be mutually exclusive to each other.
 regularExpressionScanning.ts(17,31): error TS1507: There is nothing available for repetition.
@@ -219,7 +223,7 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
 regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 
 
-==== regularExpressionScanning.ts (219 errors) ====
+==== regularExpressionScanning.ts (223 errors) ====
     const regexes: RegExp[] = [
     	// Flags
     	/foo/visualstudiocode,
@@ -255,6 +259,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1499: Unknown regular expression flag.
     	// Pattern modifiers
     	/(?med-ium:bar)/,
+    	   ~~~~~~~
+!!! error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.
     	    ~
 !!! error TS1499: Unknown regular expression flag.
     	     ~
@@ -328,8 +334,12 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                           ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                            ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	                                                       ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                                        ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	/(\k<bar>)\k<absent>(?<foo>foo)|(?<bar>)((?<foo>)|(bar(?<bar>bar)))/,
     	             ~~~~~~
 !!! error TS1532: There is no capturing group named 'absent' in this regular expression.
@@ -339,6 +349,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                           ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                            ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	                                                        ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                                         ~~~

--- a/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
@@ -14,6 +14,7 @@ regularExpressionScanning.ts(3,19): error TS1499: Unknown regular expression fla
 regularExpressionScanning.ts(3,20): error TS1499: Unknown regular expression flag.
 regularExpressionScanning.ts(3,21): error TS1500: Duplicate regular expression flag.
 regularExpressionScanning.ts(3,22): error TS1499: Unknown regular expression flag.
+regularExpressionScanning.ts(5,5): error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(5,6): error TS1499: Unknown regular expression flag.
 regularExpressionScanning.ts(5,7): error TS1509: This regular expression flag cannot be toggled within a subpattern.
 regularExpressionScanning.ts(5,10): error TS1509: This regular expression flag cannot be toggled within a subpattern.
@@ -47,11 +48,14 @@ regularExpressionScanning.ts(14,5): error TS1503: Named capturing groups are onl
 regularExpressionScanning.ts(14,14): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,29): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(14,45): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(14,46): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(14,57): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(14,58): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(15,15): error TS1532: There is no capturing group named 'absent' in this regular expression.
 regularExpressionScanning.ts(15,24): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,36): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,45): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+regularExpressionScanning.ts(15,46): error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
 regularExpressionScanning.ts(15,58): error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
 regularExpressionScanning.ts(15,59): error TS1515: Named capturing groups with the same name must be mutually exclusive to each other.
 regularExpressionScanning.ts(17,31): error TS1507: There is nothing available for repetition.
@@ -228,7 +232,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 
 
 !!! error TS5107: Option 'target=ES5' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
-==== regularExpressionScanning.ts (226 errors) ====
+==== regularExpressionScanning.ts (230 errors) ====
     const regexes: RegExp[] = [
     	// Flags
     	/foo/visualstudiocode,
@@ -264,6 +268,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1499: Unknown regular expression flag.
     	// Pattern modifiers
     	/(?med-ium:bar)/,
+    	   ~~~~~~~
+!!! error TS18062: Regular expression pattern modifiers are only available when targeting 'es2025' or later.
     	    ~
 !!! error TS1499: Unknown regular expression flag.
     	     ~
@@ -339,8 +345,12 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                           ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                            ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	                                                       ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                                        ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	/(\k<bar>)\k<absent>(?<foo>foo)|(?<bar>)((?<foo>)|(bar(?<bar>bar)))/,
     	             ~~~~~~
 !!! error TS1532: There is no capturing group named 'absent' in this regular expression.
@@ -350,6 +360,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                           ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+    	                                            ~~~
+!!! error TS18063: Duplicate named capturing groups are only available when targeting 'es2025' or later.
     	                                                        ~~~~~
 !!! error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
     	                                                         ~~~

--- a/tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts
+++ b/tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts
@@ -1,0 +1,4 @@
+// @target: es2022,es2025
+
+const dupNames = /(?<y>\d{4})-\d{2}|\d{2}\/(?<y>\d{4})/;
+const modifiers = /(?i:abc)/;


### PR DESCRIPTION
Fixes #63682

Both duplicate named capturing groups and pattern modifier syntax
(`(?i:...)`) were being parsed and validated correctly, but weren't
gated to ES2025+ the way named capturing groups are gated to ES2018
and the `v` flag is gated to ES2024.

- `scanGroupName` now errors (TS18063) when a capturing group name
  is reused across mutually-exclusive alternatives and the target
  is below ES2025 — this sits alongside the existing mutual-exclusivity
  check (TS1515) rather than replacing it.
- The pattern-modifier scan site in the `(?` switch now errors
  (TS18062) when modifier text is present and the target is below
  ES2025 — bare non-capturing groups (`(?:...)`) are unaffected since
  no modifier characters are scanned in that case.

Added a new conformance test
(`tests/cases/conformance/es2025/regexPatternModifiersAndDuplicateNamedGroups.ts`)
targeting es2022 and es2025 to show the gate firing/not firing.
Also updated the existing `regularExpressionScanning.ts` baselines
(es5, es2015), which already had test cases for both features and
now correctly produce the new errors.

I used AI assistance while working through this fix and
reviewed/tested the result myself before opening this PR.