### PR TITLE
fix(parser): disallow optional chaining on import.defer

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -8555,5 +8555,9 @@
     "'{0}' is not a valid meta-property for keyword 'import'. Did you mean 'meta' or 'defer'?": {
         "category": "Error",
         "code": 18061
+    },
+    "'import.defer' does not support optional invocation.": {
+        "category": "Error",
+        "code": 18062
     }
 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5945,7 +5945,7 @@ namespace Parser {
                 expression = finishNode(factory.createMetaProperty(SyntaxKind.ImportKeyword, parseIdentifierName()), pos);
 
                 if ((expression as MetaProperty).name.escapedText === "defer") {
-                    if (token() === SyntaxKind.QuestionDotToken) {
+                    if (token() === SyntaxKind.QuestionDotToken && lookAhead(() => nextToken() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken)) {
                         parseErrorAtCurrentToken(Diagnostics.import_defer_does_not_support_optional_invocation);
                     }
                     if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5945,6 +5945,9 @@ namespace Parser {
                 expression = finishNode(factory.createMetaProperty(SyntaxKind.ImportKeyword, parseIdentifierName()), pos);
 
                 if ((expression as MetaProperty).name.escapedText === "defer") {
+                    if (token() === SyntaxKind.QuestionDotToken) {
+                        parseErrorAtCurrentToken(Diagnostics.import_defer_does_not_support_optional_invocation);
+                    }
                     if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {
                         sourceFlags |= NodeFlags.PossiblyContainsDynamicImport;
                     }

--- a/tests/baselines/reference/importDeferOptionalCall.errors.txt
+++ b/tests/baselines/reference/importDeferOptionalCall.errors.txt
@@ -1,11 +1,13 @@
 b.ts(1,13): error TS18062: 'import.defer' does not support optional invocation.
-b.ts(1,16): error TS2307: Cannot find module 'x' or its corresponding type declarations.
+b.ts(1,16): error TS2307: Cannot find module './x' or its corresponding type declarations.
 
 
+==== x.ts (0 errors) ====
+    export const x = 1;
 ==== b.ts (2 errors) ====
-    import.defer?.('x');
+    import.defer?.('./x');
                 ~~
 !!! error TS18062: 'import.defer' does not support optional invocation.
-                   ~~~
-!!! error TS2307: Cannot find module 'x' or its corresponding type declarations.
+                   ~~~~~
+!!! error TS2307: Cannot find module './x' or its corresponding type declarations.
     

--- a/tests/baselines/reference/importDeferOptionalCall.errors.txt
+++ b/tests/baselines/reference/importDeferOptionalCall.errors.txt
@@ -1,0 +1,11 @@
+b.ts(1,13): error TS18062: 'import.defer' does not support optional invocation.
+b.ts(1,16): error TS2307: Cannot find module 'x' or its corresponding type declarations.
+
+
+==== b.ts (2 errors) ====
+    import.defer?.('x');
+                ~~
+!!! error TS18062: 'import.defer' does not support optional invocation.
+                   ~~~
+!!! error TS2307: Cannot find module 'x' or its corresponding type declarations.
+    

--- a/tests/baselines/reference/importDeferOptionalCall.js
+++ b/tests/baselines/reference/importDeferOptionalCall.js
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+//// [b.ts]
+import.defer?.('x');
+
+
+//// [b.js]
+"use strict";
+var _a;
+(_a = import.defer) === null || _a === void 0 ? void 0 : _a('x');

--- a/tests/baselines/reference/importDeferOptionalCall.js
+++ b/tests/baselines/reference/importDeferOptionalCall.js
@@ -1,10 +1,14 @@
 //// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
 
+//// [x.ts]
+export const x = 1;
 //// [b.ts]
-import.defer?.('x');
+import.defer?.('./x');
 
 
+//// [x.js]
+export const x = 1;
 //// [b.js]
 "use strict";
 var _a;
-(_a = import.defer) === null || _a === void 0 ? void 0 : _a('x');
+(_a = import.defer) === null || _a === void 0 ? void 0 : _a('./x');

--- a/tests/baselines/reference/importDeferOptionalCall.symbols
+++ b/tests/baselines/reference/importDeferOptionalCall.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+=== b.ts ===
+
+import.defer?.('x');
+

--- a/tests/baselines/reference/importDeferOptionalCall.symbols
+++ b/tests/baselines/reference/importDeferOptionalCall.symbols
@@ -1,6 +1,10 @@
 //// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
 
+=== x.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(x.ts, 0, 12))
+
 === b.ts ===
 
-import.defer?.('x');
+import.defer?.('./x');
 

--- a/tests/baselines/reference/importDeferOptionalCall.types
+++ b/tests/baselines/reference/importDeferOptionalCall.types
@@ -1,11 +1,18 @@
 //// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
 
+=== x.ts ===
+export const x = 1;
+>x : 1
+>  : ^
+>1 : 1
+>  : ^
+
 === b.ts ===
-import.defer?.('x');
->import.defer?.('x') : Promise<any>
->                    : ^^^^^^^^^^^^
+import.defer?.('./x');
+>import.defer?.('./x') : Promise<any>
+>                      : ^^^^^^^^^^^^
 >defer : any
 >      : ^^^
->'x' : "x"
->    : ^^^
+>'./x' : "./x"
+>      : ^^^^^
 

--- a/tests/baselines/reference/importDeferOptionalCall.types
+++ b/tests/baselines/reference/importDeferOptionalCall.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+=== b.ts ===
+import.defer?.('x');
+>import.defer?.('x') : Promise<any>
+>                    : ^^^^^^^^^^^^
+>defer : any
+>      : ^^^
+>'x' : "x"
+>    : ^^^
+

--- a/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
+++ b/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
@@ -1,4 +1,6 @@
 // @target: es2015
 // @module: esnext
+// @filename: x.ts
+export const x = 1;
 // @filename: b.ts
-import.defer?.('x');
+import.defer?.('./x');

--- a/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
+++ b/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
@@ -1,0 +1,4 @@
+// @target: es2015
+// @module: esnext
+// @filename: b.ts
+import.defer?.('x');


### PR DESCRIPTION
Fixes #63679

## Problem
`import.defer?.('x')` was not producing an error in TypeScript, 
even though all major parsers (Oxc, SWC, Babel, Acorn) reject it.

## Fix
- Added diagnostic TS18062: `'import.defer' does not support optional invocation`
- Added check in `parser.ts` for `QuestionDotToken` immediately 
  after `import.defer` is parsed
- Added conformance test with baselines

## Test
Before fix:
import.defer?.('x'); // no error ❌

After fix:
import.defer?.('x');
// error TS18062: 'import.defer' does not support optional invocation ✅