### PR TITLE
ci: name version-bump workflow steps for readability

### DIFF
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -67,7 +67,8 @@ jobs:
           # corepack enable npm
           npm install -g $(jq -r '.packageManager' < package.json)
           npm --version
-      - env:
+      - name: Bump version, LKG, and create release branch
+        env:
           BRANCH_NAME: ${{ inputs.branch_name }}
           PACKAGE_VERSION: ${{ inputs.package_version }}
           CORE_MAJOR_MINOR: ${{ inputs.core_major_minor }}

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -72,7 +72,8 @@ jobs:
       # branch_name - the target branch
       # package_version - the full version string (eg, `3.9.1-rc` or `3.9.2`)
       # core_major_minor - the major.minor pair associated with the desired package_version (eg, `3.9` for `3.9.3`)
-      - env:
+      - name: Bump version and LKG
+        env:
           PACKAGE_VERSION: ${{ inputs.package_version }}
           CORE_MAJOR_MINOR: ${{ inputs.core_major_minor }}
         run: |


### PR DESCRIPTION
## Problem

In `.github/workflows/new-release-branch.yaml` and `.github/workflows/set-version.yaml`, the version-bump / LKG `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when release automation fails.

## Changes

Semantics are unchanged: same env vars, same sed / npm / LKG / git commands.

- Add `name: Bump version, LKG, and create release branch` in `new-release-branch.yaml`
- Add `name: Bump version and LKG` in `set-version.yaml`

## Test plan
- [ ] Confirm both workflows still bump versions, run LKG, and commit the same files
- [ ] Confirm the steps show the new names in the Actions UI
