### PR TITLE
docs: add JSDoc comments to ReadonlyMap interface

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -38,9 +38,22 @@ interface MapConstructor {
 declare var Map: MapConstructor;
 
 interface ReadonlyMap<K, V> {
+    /**
+     * Executes a provided function once per each key/value pair in the ReadonlyMap, in insertion order.
+     */
     forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+    /**
+     * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
+     * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
+     */
     get(key: K): V | undefined;
+    /**
+     * @returns boolean indicating whether an element with the specified key exists or not.
+     */
     has(key: K): boolean;
+    /**
+     * @returns the number of elements in the Map.
+     */
     readonly size: number;
 }
 


### PR DESCRIPTION
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch

Fixes #63710

Adds JSDoc comments to the four `ReadonlyMap<K, V>` members declared in `lib.es2015.collection.d.ts` (`forEach`, `get`, `has` and `size`), copied from the corresponding `Map<K, V>` members for consistency — the same approach #63483 took for `ReadonlySet<T>` (#63481). The `ReadonlyMap` members declared in `lib.es2015.iterable.d.ts` are already documented and are untouched.

(Note: the associated issue #63710 was filed alongside this PR and is awaiting triage into the `Backlog` milestone.)
