### PR TITLE
Fix string detection across regex class union operands

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -3214,6 +3214,10 @@ export function createScanner(
                         break;
                     default:
                         operand = scanClassSetOperand();
+                        if (isCharacterComplement && mayContainStrings) {
+                            error(Diagnostics.Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class, start, pos - start);
+                        }
+                        expressionMayContainStrings ||= mayContainStrings;
                         break;
                 }
             }

--- a/tests/baselines/reference/regularExpressionClassUnionMayContainStrings.errors.txt
+++ b/tests/baselines/reference/regularExpressionClassUnionMayContainStrings.errors.txt
@@ -1,0 +1,22 @@
+regularExpressionClassUnionMayContainStrings.ts(2,8): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionClassUnionMayContainStrings.ts(3,9): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionClassUnionMayContainStrings.ts(4,11): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionClassUnionMayContainStrings.ts(5,9): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+
+
+==== regularExpressionClassUnionMayContainStrings.ts (4 errors) ====
+    const regexes: RegExp[] = [
+        /[^\q{xy}b]/v,
+           ~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+        /[^b\q{xy}]/v,
+            ~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+        /[^a-c\q{xy}]/v,
+              ~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+        /[^b[b\q{xy}]]/v,
+            ~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    ];
+    

--- a/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es2015).errors.txt
@@ -195,19 +195,23 @@ regularExpressionScanning.ts(38,87): error TS1501: This regular expression flag 
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
 regularExpressionScanning.ts(39,77): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
+regularExpressionScanning.ts(40,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(40,83): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(41,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,30): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,83): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(42,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(42,18): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,28): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,53): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,77): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
+regularExpressionScanning.ts(43,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(43,95): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(44,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,34): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,95): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(45,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(45,22): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,32): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,61): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,89): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
@@ -219,7 +223,7 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
 regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 
 
-==== regularExpressionScanning.ts (219 errors) ====
+==== regularExpressionScanning.ts (223 errors) ====
     const regexes: RegExp[] = [
     	// Flags
     	/foo/visualstudiocode,
@@ -654,6 +658,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                           ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{Emoji}\p{RGI_Emoji}][^\p{Emoji}--\p{RGI_Emoji}][^\p{Emoji}&&\p{RGI_Emoji}]/v,
+    	            ~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                                                 ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{RGI_Emoji}\p{Emoji}][^\p{RGI_Emoji}--\p{Emoji}][^\p{RGI_Emoji}&&\p{Emoji}]/v,
@@ -666,6 +672,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	/[^\p{RGI_Emoji}\q{foo}][^\p{RGI_Emoji}--\q{foo}][^\p{RGI_Emoji}&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                ~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                          ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                   ~~~~~~~~~~~~~~~~~~~~~~
@@ -673,6 +681,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                           ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{Emoji}[[\p{RGI_Emoji}]]][^\p{Emoji}--[[\p{RGI_Emoji}]]][^\p{Emoji}&&[[\p{RGI_Emoji}]]]/v,
+    	            ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                                                             ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^[[\p{RGI_Emoji}]]\p{Emoji}][^[[\p{RGI_Emoji}]]--\p{Emoji}][^[[\p{RGI_Emoji}]]&&\p{Emoji}]/v,
@@ -684,6 +694,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^[[\p{RGI_Emoji}]]\q{foo}][^[[\p{RGI_Emoji}]]--\q{foo}][^[[\p{RGI_Emoji}]]&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                    ~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                              ~~~~~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.

--- a/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=es5).errors.txt
@@ -203,19 +203,23 @@ regularExpressionScanning.ts(38,87): error TS1501: This regular expression flag 
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
 regularExpressionScanning.ts(39,77): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
+regularExpressionScanning.ts(40,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(40,83): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(41,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,30): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,83): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(42,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(42,18): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,28): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,53): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,77): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
+regularExpressionScanning.ts(43,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(43,95): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(44,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,34): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,95): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
 regularExpressionScanning.ts(45,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(45,22): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,32): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,61): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,89): error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
@@ -228,7 +232,7 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 
 
 !!! error TS5107: Option 'target=ES5' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
-==== regularExpressionScanning.ts (226 errors) ====
+==== regularExpressionScanning.ts (230 errors) ====
     const regexes: RegExp[] = [
     	// Flags
     	/foo/visualstudiocode,
@@ -677,6 +681,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                           ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{Emoji}\p{RGI_Emoji}][^\p{Emoji}--\p{RGI_Emoji}][^\p{Emoji}&&\p{RGI_Emoji}]/v,
+    	            ~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                                                 ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{RGI_Emoji}\p{Emoji}][^\p{RGI_Emoji}--\p{Emoji}][^\p{RGI_Emoji}&&\p{Emoji}]/v,
@@ -689,6 +695,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	/[^\p{RGI_Emoji}\q{foo}][^\p{RGI_Emoji}--\q{foo}][^\p{RGI_Emoji}&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                ~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                          ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                   ~~~~~~~~~~~~~~~~~~~~~~
@@ -696,6 +704,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
     	                                                                           ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^\p{Emoji}[[\p{RGI_Emoji}]]][^\p{Emoji}--[[\p{RGI_Emoji}]]][^\p{Emoji}&&[[\p{RGI_Emoji}]]]/v,
+    	            ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                                                             ~
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^[[\p{RGI_Emoji}]]\p{Emoji}][^[[\p{RGI_Emoji}]]--\p{Emoji}][^[[\p{RGI_Emoji}]]&&\p{Emoji}]/v,
@@ -707,6 +717,8 @@ regularExpressionScanning.ts(47,101): error TS1501: This regular expression flag
 !!! error TS1501: This regular expression flag is only available when targeting 'es2024' or later.
     	/[^[[\p{RGI_Emoji}]]\q{foo}][^[[\p{RGI_Emoji}]]--\q{foo}][^[[\p{RGI_Emoji}]]&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                    ~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                              ~~~~~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.

--- a/tests/baselines/reference/regularExpressionScanning(target=esnext).errors.txt
+++ b/tests/baselines/reference/regularExpressionScanning(target=esnext).errors.txt
@@ -177,14 +177,18 @@ regularExpressionScanning.ts(38,75): error TS1508: Unexpected '&'. Did you mean 
 regularExpressionScanning.ts(38,85): error TS1520: Expected a class set operand.
 regularExpressionScanning.ts(39,56): error TS1519: Operators must not be mixed within a character class. Wrap it in a nested class instead.
 regularExpressionScanning.ts(39,67): error TS1005: '&&' expected.
+regularExpressionScanning.ts(40,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(41,30): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(42,18): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,28): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(42,53): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(43,14): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(44,34): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+regularExpressionScanning.ts(45,22): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,32): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(45,61): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 regularExpressionScanning.ts(46,5): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -193,7 +197,7 @@ regularExpressionScanning.ts(47,5): error TS1518: Anything that would possibly m
 regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
 
 
-==== regularExpressionScanning.ts (193 errors) ====
+==== regularExpressionScanning.ts (197 errors) ====
     const regexes: RegExp[] = [
     	// Flags
     	/foo/visualstudiocode,
@@ -592,6 +596,8 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
     	                                                                 
 !!! error TS1005: '&&' expected.
     	/[^\p{Emoji}\p{RGI_Emoji}][^\p{Emoji}--\p{RGI_Emoji}][^\p{Emoji}&&\p{RGI_Emoji}]/v,
+    	            ~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	/[^\p{RGI_Emoji}\p{Emoji}][^\p{RGI_Emoji}--\p{Emoji}][^\p{RGI_Emoji}&&\p{Emoji}]/v,
     	   ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -600,11 +606,15 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
     	/[^\p{RGI_Emoji}\q{foo}][^\p{RGI_Emoji}--\q{foo}][^\p{RGI_Emoji}&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                ~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                          ~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                                                   ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	/[^\p{Emoji}[[\p{RGI_Emoji}]]][^\p{Emoji}--[[\p{RGI_Emoji}]]][^\p{Emoji}&&[[\p{RGI_Emoji}]]]/v,
+    	            ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	/[^[[\p{RGI_Emoji}]]\p{Emoji}][^[[\p{RGI_Emoji}]]--\p{Emoji}][^[[\p{RGI_Emoji}]]&&\p{Emoji}]/v,
     	   ~~~~~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
@@ -612,6 +622,8 @@ regularExpressionScanning.ts(47,89): error TS1518: Anything that would possibly 
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	/[^[[\p{RGI_Emoji}]]\q{foo}][^[[\p{RGI_Emoji}]]--\q{foo}][^[[\p{RGI_Emoji}]]&&\q{foo}]/v,
     	   ~~~~~~~~~~~~~~~~~
+!!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
+    	                    ~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.
     	                              ~~~~~~~~~~~~~~~~~
 !!! error TS1518: Anything that would possibly match more than a single character is invalid inside a negated character class.

--- a/tests/cases/compiler/regularExpressionClassUnionMayContainStrings.ts
+++ b/tests/cases/compiler/regularExpressionClassUnionMayContainStrings.ts
@@ -1,0 +1,10 @@
+// @target: esnext
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+const regexes: RegExp[] = [
+    /[^\q{xy}b]/v,
+    /[^b\q{xy}]/v,
+    /[^a-c\q{xy}]/v,
+    /[^b[b\q{xy}]]/v,
+];


### PR DESCRIPTION
Fixes #63718

## Summary

- accumulate `MayContainStrings` across every `ClassUnion` operand
- report TS1518 when a later operand in a negated Unicode set may match strings
- add focused operand-order and nested-union coverage and update the existing regex scanning baselines

## Test plan

- `npx hereby lint`
- `npx hereby runtests --tests='regularExpression(ClassUnionMayContainStrings|Scanning)'`
- `npx hereby runtests` completed with 106,373 passing tests; eight macOS `fsEvents` symlink-watching tests failed with `EMFILE: too many open files, watch` and reproduce when the watcher suite is run independently

## AI assistance disclosure

AI was used to review the code and understand existing codebase. 