### PR TITLE
Fix false-positive TS2354 for native private class field access with importHelpers at dated targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34889,11 +34889,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isAnyLike = isTypeAny(apparentType) || apparentType === silentNeverType;
         let prop: Symbol | undefined;
         if (isPrivateIdentifier(right)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 if (assignmentKind !== AssignmentKind.None) {
                     checkExternalEmitHelpers(node, ExternalEmitHelpers.ClassPrivateFieldSet);
                 }
@@ -40195,11 +40191,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return silentNeverType;
         }
         if (isPrivateIdentifier(left)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 checkExternalEmitHelpers(left, ExternalEmitHelpers.ClassPrivateFieldIn);
             }
             // Unlike in 'checkPrivateIdentifierExpression' we now have access to the RHS type
@@ -42465,11 +42457,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function setNodeLinksForPrivateIdentifierScope(node: PropertyDeclaration | PropertySignature | MethodDeclaration | MethodSignature | AccessorDeclaration) {
         if (isPrivateIdentifier(node.name)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 for (let lexicalScope = getEnclosingBlockScopeContainer(node); !!lexicalScope; lexicalScope = getEnclosingBlockScopeContainer(lexicalScope)) {
                     getNodeLinks(lexicalScope).flags |= NodeCheckFlags.ContainsClassWithPrivateIdentifiers;
                 }

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.js
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.js
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    get #accessor() { return this.#field; }
+    set #accessor(v) { this.#field = v; }
+    #autoAccessor_accessor_storage = true;
+    get #autoAccessor() { return this.#autoAccessor_accessor_storage; }
+    set #autoAccessor(value) { this.#autoAccessor_accessor_storage = value; }
+    static #staticAutoAccessor_accessor_storage = true;
+    static get #staticAutoAccessor() { return Foo.#staticAutoAccessor_accessor_storage; }
+    static set #staticAutoAccessor(value) { Foo.#staticAutoAccessor_accessor_storage = value; }
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
@@ -1,0 +1,88 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    get #accessor() { return this.#field; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+
+    accessor #autoAccessor = true;
+>#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 11, 5))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#accessor = this.#accessor;
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.types
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.types
@@ -1,0 +1,161 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+>    : ^^^
+
+    #field = true;
+>#field : boolean
+>       : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static #staticField = true;
+>#staticField : boolean
+>             : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    #method() {}
+>#method : () => void
+>        : ^^^^^^^^^^
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+>              : ^^^^^^^^^^
+
+    get #accessor() { return this.#field; }
+>#accessor : boolean
+>          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : boolean
+>          : ^^^^^^^
+>v : boolean
+>  : ^^^^^^^
+>this.#field = v : boolean
+>                : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>v : boolean
+>  : ^^^^^^^
+
+    accessor #autoAccessor = true;
+>#autoAccessor : boolean
+>              : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : boolean
+>                    : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField = true : true
+>                        : ^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>true : true
+>     : ^^^^
+    }
+    f() {
+>f : () => void
+>  : ^^^^^^^^^^
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>                          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#method();
+>this.#method() : void
+>               : ^^^^
+>this.#method : () => void
+>             : ^^^^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>                                    : ^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>                    : ^^^^
+>Foo.#staticMethod : () => void
+>                  : ^^^^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        this.#accessor = this.#accessor;
+>this.#accessor = this.#accessor : boolean
+>                                : ^^^^^^^
+>this.#accessor : boolean
+>               : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#accessor : boolean
+>               : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor = this.#autoAccessor : boolean
+>                                        : ^^^^^^^
+>this.#autoAccessor : boolean
+>                   : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#autoAccessor : boolean
+>                   : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor = Foo.#staticAutoAccessor : boolean
+>                                                  : ^^^^^^^
+>Foo.#staticAutoAccessor : boolean
+>                        : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticAutoAccessor : boolean
+>                        : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        #field in this;
+>#field in this : boolean
+>               : ^^^^^^^
+>#field : any
+>this : this
+>     : ^^^^
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
@@ -1,0 +1,47 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 4, 29))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
@@ -1,0 +1,80 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+>    : ^^^
+
+    #field = true;
+>#field : boolean
+>       : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static #staticField = true;
+>#staticField : boolean
+>             : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    #method() {}
+>#method : () => void
+>        : ^^^^^^^^^^
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+>              : ^^^^^^^^^^
+
+    f() {
+>f : () => void
+>  : ^^^^^^^^^^
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>                          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#method();
+>this.#method() : void
+>               : ^^^^
+>this.#method : () => void
+>             : ^^^^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>                                    : ^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>                    : ^^^^
+>Foo.#staticMethod : () => void
+>                  : ^^^^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        #field in this;
+>#field in this : boolean
+>               : ^^^^^^^
+>#field : any
+>this : this
+>     : ^^^^
+    }
+}
+

--- a/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
+++ b/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
@@ -1,0 +1,28 @@
+// @importHelpers: true
+// @target: es2022
+// @module: commonjs
+// @lib: esnext
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}

--- a/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
+++ b/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
@@ -1,0 +1,18 @@
+// @importHelpers: true
+// @target: es2022
+// @useDefineForClassFields: false
+// @module: commonjs
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}


### PR DESCRIPTION
Fixes #63728.

## The bug

With `importHelpers: true` and a dated `target` (e.g. `ES2022`–`ES2025`), `tsc` incorrectly reports `TS2354: This syntax requires an imported helper but module 'tslib' cannot be found` for plain, fully-native private field/method/accessor access (`this.#x`, `#x in obj`, static private fields/methods, private accessors, static blocks, private fields in generics/closures/class expressions/inheritance) — even though the emitted JS for all of these is 100% native ES2022+ syntax that never references `tslib`.

## Root cause

`checkPropertyAccessExpressionOrQualifiedName`, `checkInExpression`, and `setNodeLinksForPrivateIdentifierScope` gate the private-identifier helper-requirement check on:

```ts
languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
!useDefineForClassFields
```

- `ClassAndClassElementDecorators` is pinned to the `ESNext` sentinel because TC39 decorators have never been assigned to a dated ECMAScript edition. That makes `languageVersion < ClassAndClassElementDecorators` `true` for *every* dated target, forever — regardless of whether the file uses decorators at all. The actual emitter (`classFields.ts`'s `shouldTransformPrivateElementsOrClassStaticBlocks`) only checks `languageVersion < ES2022`, with no decorator-related gating, so this term in the checker never corresponded to real emit behavior.
- `!useDefineForClassFields` has the same problem: private fields are always emitted using "define" semantics regardless of `useDefineForClassFields` (that flag only affects public fields), so it also doesn't correspond to any real difference in whether `tslib` is needed for private-field access. Verified by emitting with `--useDefineForClassFields false --target es2022`: output is fully native with no `tslib` references, yet the checker still errored before this fix.

## The fix

Removes both spurious clauses from the 3 call sites above, leaving just `languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks`.

A 4th call site with the same `ClassAndClassElementDecorators` check, inside `getFirstTransformableStaticClassElement`, is intentionally **left unchanged**. That one only matters when a class is decorated, to decide if the decorator transform's hoisting of static private/static-block elements into an IIFE needs the `__setFunctionName` helper. I verified (by emitting `@dec class C { static #foo() {} }` at ES2022 with `--outDir`) that this really is required in the actual output, so removing this clause caused a real regression in `esDecorators-classDeclaration-missingEmitHelpers-classDecorator.3.ts`; that edit was reverted.

## Testing

- Added `tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts` — target ES2022, `importHelpers: true`, no `tslib` present, covering instance/static private fields, private methods, static private methods, private accessors, private auto-accessors (instance + static), static blocks, and `#x in obj`. Asserts zero errors; baseline `.js` confirms the emit never references `tslib`.
- Added `tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts` — same coverage with `useDefineForClassFields: false`, confirming that flag no longer triggers the false positive either.
- Ran the full test suite (`hereby runtests-parallel --light=false`, 106,383 tests) — all passing, no baseline regressions.
- `hereby lint` passes.
- Manually confirmed decorators and `using` declarations still correctly require `tslib` at dated targets (these are real transforms, not part of this bug).
- Manually reproduced and confirmed the fix against all 13 "confirmed bug" cases and both control cases from the original repro (https://github.com/astegmaier/typescript-private-field-tslib-repro), and confirmed the 4 "correctly required" cases (decorators, `using`) are unaffected.
