### PR TITLE
fix(lib): rectify docs error for Array.prototype.at

### DIFF
--- a/src/lib/es2022.array.d.ts
+++ b/src/lib/es2022.array.d.ts
@@ -1,7 +1,7 @@
 interface Array<T> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): T | undefined;
 }
@@ -9,7 +9,7 @@ interface Array<T> {
 interface ReadonlyArray<T> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): T | undefined;
 }
@@ -17,7 +17,7 @@ interface ReadonlyArray<T> {
 interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -25,7 +25,7 @@ interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
 interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -33,7 +33,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
 interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -41,7 +41,7 @@ interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
 interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -49,7 +49,7 @@ interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
 interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -57,7 +57,7 @@ interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
 interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -65,7 +65,7 @@ interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
 interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -73,7 +73,7 @@ interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
 interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -81,7 +81,7 @@ interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
 interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): number | undefined;
 }
@@ -89,7 +89,7 @@ interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
 interface BigInt64Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): bigint | undefined;
 }
@@ -97,7 +97,7 @@ interface BigInt64Array<TArrayBuffer extends ArrayBufferLike> {
 interface BigUint64Array<TArrayBuffer extends ArrayBufferLike> {
     /**
      * Returns the item located at the specified index.
-     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
      */
     at(index: number): bigint | undefined;
 }


### PR DESCRIPTION
Replace the term _code unit_ with _item_ in the TSDoc comment for the `index` parameter to `Array.prototype.at`.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #63722
