### PR TITLE
fix: allow destructured require under module preserve + verbatimModuleSyntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -48526,6 +48526,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     moduleKind === ModuleKind.Preserve &&
                     node.kind !== SyntaxKind.ImportEqualsDeclaration &&
                     node.kind !== SyntaxKind.VariableDeclaration &&
+                    // `const { x } = require(...)` is CommonJS alias syntax (BindingElement), not ESM.
+                    node.kind !== SyntaxKind.BindingElement &&
                     host.getEmitModuleFormatOfFile(getSourceFileOfNode(node)) === ModuleKind.CommonJS
                 ) {
                     // In `--module preserve`, ESM input syntax emits ESM output syntax, but there will be times

--- a/tests/baselines/reference/modulePreserveDestructuredRequire.errors.txt
+++ b/tests/baselines/reference/modulePreserveDestructuredRequire.errors.txt
@@ -1,0 +1,22 @@
+/file.cjs(11,10): error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+
+
+==== /file.cjs (1 errors) ====
+    // Destructured and whole-module require are valid CommonJS and must not error under
+    // --module preserve + --verbatimModuleSyntax (https://github.com/microsoft/TypeScript/issues/63696).
+    const { x } = require("./mod");
+    const { y: renamed } = require("./mod");
+    const whole = require("./mod");
+    x;
+    renamed;
+    whole.y;
+    
+    // True ESM syntax in a .cjs file remains an error.
+    import { x as x2 } from "./mod";
+             ~~~~~~~
+!!! error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+    
+==== /mod.js (0 errors) ====
+    exports.x = 1;
+    exports.y = 2;
+    

--- a/tests/baselines/reference/modulePreserveDestructuredRequire.symbols
+++ b/tests/baselines/reference/modulePreserveDestructuredRequire.symbols
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/modulePreserveDestructuredRequire.ts] ////
+
+=== /file.cjs ===
+// Destructured and whole-module require are valid CommonJS and must not error under
+// --module preserve + --verbatimModuleSyntax (https://github.com/microsoft/TypeScript/issues/63696).
+const { x } = require("./mod");
+>x : Symbol(x, Decl(file.cjs, 2, 7))
+>require : Symbol(require)
+>"./mod" : Symbol(whole, Decl(mod.js, 0, 0))
+
+const { y: renamed } = require("./mod");
+>y : Symbol(renamed, Decl(mod.js, 0, 14))
+>renamed : Symbol(renamed, Decl(file.cjs, 3, 7))
+>require : Symbol(require)
+>"./mod" : Symbol(whole, Decl(mod.js, 0, 0))
+
+const whole = require("./mod");
+>whole : Symbol(whole, Decl(file.cjs, 4, 5))
+>require : Symbol(require)
+>"./mod" : Symbol(whole, Decl(mod.js, 0, 0))
+
+x;
+>x : Symbol(x, Decl(file.cjs, 2, 7))
+
+renamed;
+>renamed : Symbol(renamed, Decl(file.cjs, 3, 7))
+
+whole.y;
+>whole.y : Symbol(renamed, Decl(mod.js, 0, 14))
+>whole : Symbol(whole, Decl(file.cjs, 4, 5))
+>y : Symbol(renamed, Decl(mod.js, 0, 14))
+
+// True ESM syntax in a .cjs file remains an error.
+import { x as x2 } from "./mod";
+>x : Symbol(x, Decl(mod.js, 0, 0))
+>x2 : Symbol(x2, Decl(file.cjs, 10, 8))
+
+=== /mod.js ===
+exports.x = 1;
+>exports.x : Symbol(x, Decl(mod.js, 0, 0))
+>exports : Symbol(x, Decl(mod.js, 0, 0))
+>x : Symbol(x, Decl(mod.js, 0, 0))
+
+exports.y = 2;
+>exports.y : Symbol(y, Decl(mod.js, 0, 14))
+>exports : Symbol(y, Decl(mod.js, 0, 14))
+>y : Symbol(y, Decl(mod.js, 0, 14))
+

--- a/tests/baselines/reference/modulePreserveDestructuredRequire.types
+++ b/tests/baselines/reference/modulePreserveDestructuredRequire.types
@@ -1,0 +1,85 @@
+//// [tests/cases/compiler/modulePreserveDestructuredRequire.ts] ////
+
+=== /file.cjs ===
+// Destructured and whole-module require are valid CommonJS and must not error under
+// --module preserve + --verbatimModuleSyntax (https://github.com/microsoft/TypeScript/issues/63696).
+const { x } = require("./mod");
+>x : 1
+>  : ^
+>require("./mod") : typeof whole
+>                 : ^^^^^^^^^^^^
+>require : any
+>        : ^^^
+>"./mod" : "./mod"
+>        : ^^^^^^^
+
+const { y: renamed } = require("./mod");
+>y : any
+>  : ^^^
+>renamed : 2
+>        : ^
+>require("./mod") : typeof whole
+>                 : ^^^^^^^^^^^^
+>require : any
+>        : ^^^
+>"./mod" : "./mod"
+>        : ^^^^^^^
+
+const whole = require("./mod");
+>whole : typeof whole
+>      : ^^^^^^^^^^^^
+>require("./mod") : typeof whole
+>                 : ^^^^^^^^^^^^
+>require : any
+>        : ^^^
+>"./mod" : "./mod"
+>        : ^^^^^^^
+
+x;
+>x : 1
+>  : ^
+
+renamed;
+>renamed : 2
+>        : ^
+
+whole.y;
+>whole.y : 2
+>        : ^
+>whole : typeof whole
+>      : ^^^^^^^^^^^^
+>y : 2
+>  : ^
+
+// True ESM syntax in a .cjs file remains an error.
+import { x as x2 } from "./mod";
+>x : 1
+>  : ^
+>x2 : 1
+>   : ^
+
+=== /mod.js ===
+exports.x = 1;
+>exports.x = 1 : 1
+>              : ^
+>exports.x : 1
+>          : ^
+>exports : typeof import("./mod")
+>        : ^^^^^^^^^^^^^^^^^^^^^^
+>x : 1
+>  : ^
+>1 : 1
+>  : ^
+
+exports.y = 2;
+>exports.y = 2 : 2
+>              : ^
+>exports.y : 2
+>          : ^
+>exports : typeof import("./mod")
+>        : ^^^^^^^^^^^^^^^^^^^^^^
+>y : 2
+>  : ^
+>2 : 2
+>  : ^
+

--- a/tests/cases/compiler/modulePreserveDestructuredRequire.ts
+++ b/tests/cases/compiler/modulePreserveDestructuredRequire.ts
@@ -1,0 +1,23 @@
+// @module: preserve
+// @target: esnext
+// @verbatimModuleSyntax: true
+// @checkJs: true
+// @noEmit: true
+// @strict: true
+
+// @Filename: /mod.js
+exports.x = 1;
+exports.y = 2;
+
+// @Filename: /file.cjs
+// Destructured and whole-module require are valid CommonJS and must not error under
+// --module preserve + --verbatimModuleSyntax (https://github.com/microsoft/TypeScript/issues/63696).
+const { x } = require("./mod");
+const { y: renamed } = require("./mod");
+const whole = require("./mod");
+x;
+renamed;
+whole.y;
+
+// True ESM syntax in a .cjs file remains an error.
+import { x as x2 } from "./mod";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #63696

Under `--module preserve` with `--verbatimModuleSyntax`, CommonJS files (e.g. `.cjs`) correctly allow bare `require` assignments:

```js
const whole = require("./mod"); // ok
```

but incorrectly reported **TS1293** on destructured `require`:

```js
const { x } = require("./mod"); // was false-positive TS1293
```

### Cause

In `checkAliasSymbol`, the preserve-mode CommonJS check excludes `ImportEqualsDeclaration` and `VariableDeclaration` (the latter covers `const x = require(...)`), but object-destructuring aliases are modeled as `BindingElement` nodes (`const { x } = require(...)`) and fell through to the ESM-syntax error.

### Fix

Also exclude `SyntaxKind.BindingElement` from that check so CJS require destructuring is treated like whole-module `require`. Real ESM import/export syntax in unambiguously CommonJS files still errors.

### Test

New compiler test `modulePreserveDestructuredRequire.ts`:

- `const { x } = require("./mod")` — no error
- `const { y: renamed } = require("./mod")` — no error
- `const whole = require("./mod")` — no error
- `import { x as x2 } from "./mod"` in `.cjs` — still TS1293

Locally: `hereby runtests --tests=modulePreserveDestructuredRequire` and `modulePreserve4` (both pass).

### AI disclosure

This change was developed with assistance from an LLM (coding agent). I reviewed the root cause, the patch, and the test baselines before submitting.