### PR TITLE
lib: document remaining ProxyHandler trap parameters

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -2,12 +2,15 @@ interface ProxyHandler<T extends object> {
     /**
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
+     * @param thisArg The `this` argument for the call.
+     * @param argArray The list of arguments for the call.
      */
     apply?(target: T, thisArg: any, argArray: any[]): any;
 
     /**
      * A trap for the `new` operator.
      * @param target The original object which is being proxied.
+     * @param argArray The list of arguments for the constructor.
      * @param newTarget The constructor that was originally called.
      */
     construct?(target: T, argArray: any[], newTarget: Function): object;
@@ -15,6 +18,8 @@ interface ProxyHandler<T extends object> {
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
+     * @param property The name or `Symbol` of the property to define.
+     * @param attributes The descriptor for the property being defined or modified.
      * @returns A `Boolean` indicating whether or not the property has been defined.
      */
     defineProperty?(target: T, property: string | symbol, attributes: PropertyDescriptor): boolean;
@@ -77,6 +82,7 @@ interface ProxyHandler<T extends object> {
      * A trap for setting a property value.
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to set.
+     * @param newValue The new value of the property to set.
      * @param receiver The object to which the assignment was originally directed.
      * @returns A `Boolean` indicating whether or not the property was set.
      */
@@ -87,7 +93,7 @@ interface ProxyHandler<T extends object> {
      * @param target The original object which is being proxied.
      * @param newPrototype The object's new prototype or `null`.
      */
-    setPrototypeOf?(target: T, v: object | null): boolean;
+    setPrototypeOf?(target: T, newPrototype: object | null): boolean;
 }
 
 interface ProxyConstructor {


### PR DESCRIPTION
`ProxyHandler` documents `target` on every trap, but several traps stop there and leave
their remaining parameters undocumented, so hovering them in an editor shows a parameter
list with no descriptions attached. One trap documents a parameter that does not exist.

| Trap | Problem |
|---|---|
| `apply` | `thisArg` and `argArray` undocumented |
| `construct` | `argArray` undocumented (`target` and `newTarget` are documented, so it is skipped in the middle) |
| `defineProperty` | `property` and `attributes` undocumented |
| `set` | `newValue` undocumented (`target`, `p` and `receiver` are documented) |
| `setPrototypeOf` | documents `@param newPrototype`, but the parameter is named `v` |

The `setPrototypeOf` one is the reason the others are worth fixing together: because the
JSDoc name does not match the parameter, the description is dropped on the floor and the
parameter shows up bare, exactly like the undocumented ones.

For that trap I renamed the parameter `v` → `newPrototype` rather than renaming the tag,
for two reasons. The neighbouring `set` trap already spells its value parameter
`newValue` instead of the spec's `V`, so `newPrototype` is what matches the surrounding
file; and the existing JSDoc shows `newPrototype` was the intended name. This follows
#63504, which renamed `maxLength`/`fillString` to `targetLength`/`padString` for the same
kind of mismatch. Parameter names in a `.d.ts` do not participate in assignability, so
this does not change what type-checks — it changes the name shown in completions and
signature help.

The added descriptions follow the wording already used by the sibling traps in this file
(`The name or `Symbol` of the property to ...`).

## Testing

`npx hereby runtests-parallel` — 106,369 passing, no baseline changes from this PR.
(The full run was done with this change alongside three other lib JSDoc fixes I am
sending separately; the only baselines it moved belong to the `[Symbol.matchAll]`
parameter rename in that other PR, not to this one.)

## Disclosure

This patch was authored with AI assistance (Claude Code). I chose the change, reviewed the
diff, ran the tests locally, and will be the one responding to review feedback.
