### PR TITLE
lib: fix Atomics.waitAsync timeout parameter description

### DIFF
--- a/src/lib/es2024.sharedmemory.d.ts
+++ b/src/lib/es2024.sharedmemory.d.ts
@@ -7,7 +7,8 @@ interface Atomics {
      * @param typedArray A shared Int32Array or BigInt64Array.
      * @param index The position in the typedArray to wait on.
      * @param value The expected value to test.
-     * @param [timeout] The expected value to test.
+     * @param timeout The number of milliseconds to wait before the operation times out.
+     *        Defaults to `Infinity`.
      */
     waitAsync(typedArray: Int32Array, index: number, value: number, timeout?: number): { async: false; value: "not-equal" | "timed-out"; } | { async: true; value: Promise<"ok" | "timed-out">; };
 
@@ -17,7 +18,8 @@ interface Atomics {
      * @param typedArray A shared Int32Array or BigInt64Array.
      * @param index The position in the typedArray to wait on.
      * @param value The expected value to test.
-     * @param [timeout] The expected value to test.
+     * @param timeout The number of milliseconds to wait before the operation times out.
+     *        Defaults to `Infinity`.
      */
     waitAsync(typedArray: BigInt64Array, index: number, value: bigint, timeout?: number): { async: false; value: "not-equal" | "timed-out"; } | { async: true; value: Promise<"ok" | "timed-out">; };
 }


### PR DESCRIPTION
Both `Atomics.waitAsync` overloads document their `timeout` parameter as:

```
@param [timeout] The expected value to test.
```

That description belongs to the parameter above it — `value` is documented with exactly
the same sentence, so this reads as a copy/paste that was never adjusted. `timeout` is
not a value to test against; it is how long to wait before the operation gives up and
settles with `"timed-out"`.

The effect is visible in the editor: hovering the `timeout` argument of `Atomics.waitAsync`
describes it as the expected value to test, which is actively misleading rather than
merely missing.

Replaced with a description of what the parameter actually does, including the default,
in both the `Int32Array` and `BigInt64Array` overloads.

I also dropped the brackets from `@param [timeout]` to plain `@param timeout`. These two
lines are the only use of the optional-parameter bracket form in the whole of `src/lib`
(every other optional parameter is documented with a bare name), and the optionality is
already carried by `timeout?: number` in the signature.

## Testing

`npx hereby runtests-parallel` — 106,369 passing, no baseline changes from this PR.
(The full run was done with this change alongside three other lib JSDoc fixes I am
sending separately; the only baselines it moved belong to the `[Symbol.matchAll]`
parameter rename in that other PR, not to this one.)

## Disclosure

This patch was authored with AI assistance (Claude Code). I chose the change, reviewed the
diff, ran the tests locally, and will be the one responding to review feedback.
