### PR TITLE
lib: fix two Reflect JSDoc defects

### DIFF
--- a/src/lib/es2015.reflect.d.ts
+++ b/src/lib/es2015.reflect.d.ts
@@ -105,6 +105,7 @@ declare namespace Reflect {
      * Sets the property of target, equivalent to `target[propertyKey] = value` when `receiver === target`.
      * @param target Object that contains the property on itself or in its prototype chain.
      * @param propertyKey Name of the property.
+     * @param value The value to assign to the property.
      * @param receiver The reference to use as the `this` value in the setter function,
      *        if `target[propertyKey]` is an accessor property.
      */
@@ -117,7 +118,7 @@ declare namespace Reflect {
     function set(target: object, propertyKey: PropertyKey, value: any, receiver?: any): boolean;
 
     /**
-     * Sets the prototype of a specified object o to object proto or null.
+     * Sets the prototype of a specified object `target` to object `proto` or null.
      * @param target The object to change its prototype.
      * @param proto The value of the new prototype or null.
      * @return Whether setting the prototype was successful.


### PR DESCRIPTION
Two small documentation defects in `lib.es2015.reflect.d.ts`:

**`Reflect.set` does not document `value`.** The block documents `target`, `propertyKey`
and `receiver` — everything except the value being assigned, which is skipped in the
middle of the list:

```ts
/**
 * @param target Object that contains the property on itself or in its prototype chain.
 * @param propertyKey Name of the property.
 * @param receiver The reference to use as the `this` value in the setter function, ...
 */
function set<T extends object, P extends PropertyKey>(
    target: T,
    propertyKey: P,
    value: P extends keyof T ? T[P] : any,   // <- undocumented
    receiver?: any,
): boolean;
```

**`Reflect.setPrototypeOf`'s summary refers to parameters that do not exist.** It reads
"Sets the prototype of a specified object o to object proto or null", but the parameters
are named `target` and `proto` — there is no `o`. The wording looks inherited from
`Object.setPrototypeOf(o, proto)` in `lib.es5.d.ts`, which does have an `o`. Renamed the
reference to `target` and put both parameter names in backticks so they read as
identifiers.

Documentation only; no signatures changed.

## Testing

`npx hereby runtests-parallel` — 106,369 passing, no baseline changes from this PR.
(The full run was done with this change alongside three other lib JSDoc fixes I am
sending separately; the only baselines it moved belong to the `[Symbol.matchAll]`
parameter rename in that other PR, not to this one.)

## Disclosure

This patch was authored with AI assistance (Claude Code). I chose the change, reviewed the
diff, ran the tests locally, and will be the one responding to review feedback.
