### PR TITLE
lib: fix JSDoc @param tags that document nothing

### DIFF
--- a/src/lib/es2020.symbol.wellknown.d.ts
+++ b/src/lib/es2020.symbol.wellknown.d.ts
@@ -19,5 +19,5 @@ interface RegExp {
      * containing the results of that search.
      * @param string A string to search within.
      */
-    [Symbol.matchAll](str: string): RegExpStringIterator<RegExpExecArray>;
+    [Symbol.matchAll](string: string): RegExpStringIterator<RegExpExecArray>;
 }

--- a/src/lib/scripthost.d.ts
+++ b/src/lib/scripthost.d.ts
@@ -172,7 +172,7 @@ declare var WScript: {
 
     /**
      * Creates a COM object.
-     * @param strProgiID
+     * @param strProgID The programmatic identifier (ProgID) of the COM object to create.
      * @param strPrefix Function names in the form prefix_event will be bound to this object's COM events.
      */
     CreateObject(strProgID: string, strPrefix?: string): any;
@@ -186,7 +186,7 @@ declare var WScript: {
      * Retrieves an existing object with the specified ProgID from memory, or creates a new one from a file.
      * @param strPathname Fully qualified path to the file containing the object persisted to disk.
      *                       For objects in memory, pass a zero-length string.
-     * @param strProgID
+     * @param strProgID The programmatic identifier (ProgID) of the object to retrieve or create.
      * @param strPrefix Function names in the form prefix_event will be bound to this object's COM events.
      */
     GetObject(strPathname: string, strProgID?: string, strPrefix?: string): any;

--- a/tests/baselines/reference/regexMatchAll-esnext.types
+++ b/tests/baselines/reference/regexMatchAll-esnext.types
@@ -6,8 +6,8 @@ const matches = /\w/g[Symbol.matchAll]("matchAll");
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >/\w/g[Symbol.matchAll]("matchAll") : RegExpStringIterator<RegExpExecArray>
 >                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->/\w/g[Symbol.matchAll] : (str: string) => RegExpStringIterator<RegExpExecArray>
->                       : ^   ^^      ^^^^^                                     
+>/\w/g[Symbol.matchAll] : (string: string) => RegExpStringIterator<RegExpExecArray>
+>                       : ^      ^^      ^^^^^                                     
 >/\w/g : RegExp
 >      : ^^^^^^
 >Symbol.matchAll : unique symbol

--- a/tests/baselines/reference/regexMatchAll.types
+++ b/tests/baselines/reference/regexMatchAll.types
@@ -6,8 +6,8 @@ const matches = /\w/g[Symbol.matchAll]("matchAll");
 >        : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >/\w/g[Symbol.matchAll]("matchAll") : RegExpStringIterator<RegExpExecArray>
 >                                   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->/\w/g[Symbol.matchAll] : (str: string) => RegExpStringIterator<RegExpExecArray>
->                       : ^   ^^      ^^^^^                                     
+>/\w/g[Symbol.matchAll] : (string: string) => RegExpStringIterator<RegExpExecArray>
+>                       : ^      ^^      ^^^^^                                     
 >/\w/g : RegExp
 >      : ^^^^^^
 >Symbol.matchAll : unique symbol


### PR DESCRIPTION
Two places in `src/lib` where a `@param` tag names a parameter that does not exist, so the
description is silently dropped and the parameter shows up with no documentation in hover
and signature help.

**`RegExp[Symbol.matchAll]`** — documented as `@param string`, but the parameter is `str`:

```ts
/**
 * @param string A string to search within.
 */
[Symbol.matchAll](str: string): RegExpStringIterator<RegExpExecArray>;
```

Here the parameter is the outlier rather than the tag. Every other well-known-symbol
method on `RegExp` names this parameter `string`:

```ts
[Symbol.match](string: string): RegExpMatchArray | null;
[Symbol.replace](string: string, replaceValue: string): string;
[Symbol.replace](string: string, replacer: (substring: string, ...args: any[]) => string): string;
[Symbol.search](string: string): number;
[Symbol.split](string: string, limit?: number): string[];
```

So `str` → `string` makes the JSDoc resolve and brings the method in line with its four
siblings. As with #63504, renaming a parameter in a `.d.ts` affects the name shown in
completions and signature help, not assignability.

**`WScript.CreateObject`** — documented as `@param strProgiID` (stray lowercase `i`) while
the parameter is `strProgID`. The tag also had no description at all, so I filled one in.
`WScript.GetObject`, a few declarations below, spells `strProgID` correctly but leaves it
equally undescribed — fixing one and leaving its neighbour looked arbitrary, so both are
filled in here.

Found these by comparing every `@param` name in the non-generated files under `src/lib`
against the actual parameter names of the signature that follows.

## Testing

`npx hereby runtests-parallel` — 106,369 passing. The only baselines affected are
`regexMatchAll.types` and `regexMatchAll-esnext.types`, which print the renamed parameter
in the signature of `[Symbol.matchAll]`; both are updated in this PR and re-verified with
`npx hereby runtests --tests=regexMatchAll` (12 passing).

## Disclosure

This patch was authored with AI assistance (Claude Code). I chose the change, reviewed the
diff and the baseline updates, ran the tests locally, and will be the one responding to
review feedback.
