### PR TITLE
fix: remove false tslib requirement for native #private fields at ES2022+

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34889,11 +34889,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isAnyLike = isTypeAny(apparentType) || apparentType === silentNeverType;
         let prop: Symbol | undefined;
         if (isPrivateIdentifier(right)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 if (assignmentKind !== AssignmentKind.None) {
                     checkExternalEmitHelpers(node, ExternalEmitHelpers.ClassPrivateFieldSet);
                 }
@@ -40195,11 +40191,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return silentNeverType;
         }
         if (isPrivateIdentifier(left)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 checkExternalEmitHelpers(left, ExternalEmitHelpers.ClassPrivateFieldIn);
             }
             // Unlike in 'checkPrivateIdentifierExpression' we now have access to the RHS type
@@ -42465,11 +42457,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function setNodeLinksForPrivateIdentifierScope(node: PropertyDeclaration | PropertySignature | MethodDeclaration | MethodSignature | AccessorDeclaration) {
         if (isPrivateIdentifier(node.name)) {
-            if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
-            ) {
+            if (languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks) {
                 for (let lexicalScope = getEnclosingBlockScopeContainer(node); !!lexicalScope; lexicalScope = getEnclosingBlockScopeContainer(lexicalScope)) {
                     getNodeLinks(lexicalScope).flags |= NodeCheckFlags.ContainsClassWithPrivateIdentifiers;
                 }

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.js
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.js
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    get #accessor() { return this.#field; }
+    set #accessor(v) { this.#field = v; }
+    #autoAccessor_accessor_storage = true;
+    get #autoAccessor() { return this.#autoAccessor_accessor_storage; }
+    set #autoAccessor(value) { this.#autoAccessor_accessor_storage = value; }
+    static #staticAutoAccessor_accessor_storage = true;
+    static get #staticAutoAccessor() { return Foo.#staticAutoAccessor_accessor_storage; }
+    static set #staticAutoAccessor(value) { Foo.#staticAutoAccessor_accessor_storage = value; }
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
@@ -1,0 +1,88 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    get #accessor() { return this.#field; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+
+    accessor #autoAccessor = true;
+>#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 11, 5))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#accessor = this.#accessor;
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.types
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022.types
@@ -1,0 +1,161 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+>    : ^^^
+
+    #field = true;
+>#field : boolean
+>       : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static #staticField = true;
+>#staticField : boolean
+>             : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    #method() {}
+>#method : () => void
+>        : ^^^^^^^^^^
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+>              : ^^^^^^^^^^
+
+    get #accessor() { return this.#field; }
+>#accessor : boolean
+>          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : boolean
+>          : ^^^^^^^
+>v : boolean
+>  : ^^^^^^^
+>this.#field = v : boolean
+>                : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>v : boolean
+>  : ^^^^^^^
+
+    accessor #autoAccessor = true;
+>#autoAccessor : boolean
+>              : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : boolean
+>                    : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField = true : true
+>                        : ^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>true : true
+>     : ^^^^
+    }
+    f() {
+>f : () => void
+>  : ^^^^^^^^^^
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>                          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#method();
+>this.#method() : void
+>               : ^^^^
+>this.#method : () => void
+>             : ^^^^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>                                    : ^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>                    : ^^^^
+>Foo.#staticMethod : () => void
+>                  : ^^^^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        this.#accessor = this.#accessor;
+>this.#accessor = this.#accessor : boolean
+>                                : ^^^^^^^
+>this.#accessor : boolean
+>               : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#accessor : boolean
+>               : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor = this.#autoAccessor : boolean
+>                                        : ^^^^^^^
+>this.#autoAccessor : boolean
+>                   : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#autoAccessor : boolean
+>                   : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor = Foo.#staticAutoAccessor : boolean
+>                                                  : ^^^^^^^
+>Foo.#staticAutoAccessor : boolean
+>                        : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticAutoAccessor : boolean
+>                        : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        #field in this;
+>#field in this : boolean
+>               : ^^^^^^^
+>#field : any
+>this : this
+>     : ^^^^
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
@@ -1,0 +1,47 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 4, 29))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
+++ b/tests/baselines/reference/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
@@ -1,0 +1,80 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+>    : ^^^
+
+    #field = true;
+>#field : boolean
+>       : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    static #staticField = true;
+>#staticField : boolean
+>             : ^^^^^^^
+>true : true
+>     : ^^^^
+
+    #method() {}
+>#method : () => void
+>        : ^^^^^^^^^^
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+>              : ^^^^^^^^^^
+
+    f() {
+>f : () => void
+>  : ^^^^^^^^^^
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>                          : ^^^^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+>this.#field : boolean
+>            : ^^^^^^^
+>this : this
+>     : ^^^^
+
+        this.#method();
+>this.#method() : void
+>               : ^^^^
+>this.#method : () => void
+>             : ^^^^^^^^^^
+>this : this
+>     : ^^^^
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>                                    : ^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+>Foo.#staticField : boolean
+>                 : ^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>                    : ^^^^
+>Foo.#staticMethod : () => void
+>                  : ^^^^^^^^^^
+>Foo : typeof Foo
+>    : ^^^^^^^^^^
+
+        #field in this;
+>#field in this : boolean
+>               : ^^^^^^^
+>#field : any
+>this : this
+>     : ^^^^
+    }
+}
+

--- a/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
+++ b/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
@@ -1,0 +1,28 @@
+// @importHelpers: true
+// @target: es2022
+// @module: commonjs
+// @lib: esnext
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}

--- a/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
+++ b/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
@@ -1,0 +1,18 @@
+// @importHelpers: true
+// @target: es2022
+// @useDefineForClassFields: false
+// @module: commonjs
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}


### PR DESCRIPTION
## Closed

This PR targets the JavaScript-based TypeScript codebase, which is in maintenance mode. The fix has been ported to `microsoft/typescript-go` in [PR #4841](https://github.com/microsoft/typescript-go/pull/4841) by astegmaier.

Closing in favor of the Go-based fix.