### PR TITLE
Add fast paths to CombinePaths and defer path canonicalization in checkSourceFilesBelongToPath

### DIFF
--- a/tsc/internal/compiler/program.go
+++ b/tsc/internal/compiler/program.go
@@ -1746,8 +1746,8 @@ func (p *Program) CommonSourceDirectory() string {
 func (p *Program) checkSourceFilesBelongToPath(sourceFiles []string, rootDirectory string) bool {
 	allFilesBelongToPath := true
 	for _, file := range sourceFiles {
-		absoluteSourceFilePath := tspath.GetCanonicalFileName(tspath.GetNormalizedAbsolutePath(file, p.GetCurrentDirectory()), p.UseCaseSensitiveFileNames())
 		if !tspath.ContainsPath(rootDirectory, file, p.comparePathsOptions) {
+			absoluteSourceFilePath := tspath.GetCanonicalFileName(tspath.GetNormalizedAbsolutePath(file, p.GetCurrentDirectory()), p.UseCaseSensitiveFileNames())
 			p.includeProcessor.addProcessingDiagnostic(&processingDiagnostic{
 				kind: processingDiagnosticKindExplainingFileInclude,
 				data: &includeExplainingDiagnostic{

--- a/tsc/internal/tspath/combinepaths_diff_test.go
+++ b/tsc/internal/tspath/combinepaths_diff_test.go
@@ -1,0 +1,38 @@
+package tspath
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// CombinePaths' fast paths must be pure shortcuts of combinePathsSlow, which is
+// the unmodified pre-fast-path implementation. This test compares the two
+// directly over all combinations of representative path pieces.
+
+var combinePathsPieces = []string{
+	"", "/", "a", "a/b", "/abs", "/abs/child", "c:/drive", "c:relative",
+	"..", "../up", ".", "./same", "file:///url", "with\\backslash", "\\\\server\\share",
+	"trailing/", "/trailing/", "//",
+}
+
+func TestCombinePathsMatchesSlowPath(t *testing.T) {
+	t.Parallel()
+
+	// All (first), (first, p1), and (first, p1, p2) combinations.
+	for _, first := range combinePathsPieces {
+		got := CombinePaths(first)
+		want := combinePathsSlow(first, nil)
+		assert.Equal(t, got, want, "CombinePaths(%q)", first)
+		for _, p1 := range combinePathsPieces {
+			got := CombinePaths(first, p1)
+			want := combinePathsSlow(first, []string{p1})
+			assert.Equal(t, got, want, "CombinePaths(%q, %q)", first, p1)
+			for _, p2 := range combinePathsPieces {
+				got := CombinePaths(first, p1, p2)
+				want := combinePathsSlow(first, []string{p1, p2})
+				assert.Equal(t, got, want, "CombinePaths(%q, %q, %q)", first, p1, p2)
+			}
+		}
+	}
+}

--- a/tsc/internal/tspath/path.go
+++ b/tsc/internal/tspath/path.go
@@ -89,8 +89,23 @@ func HasTrailingDirectorySeparator(path string) bool {
 //	CombinePaths("file:///path", "file:///to", "file.ext") === "file:///to/file.ext"
 //	```
 func CombinePaths(firstPath string, paths ...string) string {
-	// TODO (drosen): There is potential for a fast path here.
-	// In the case where we find the last absolute path and just path.Join from there.
+	// Fast paths: no trailing paths, or the last trailing path is slash-rooted
+	// and supersedes everything before it. NormalizeSlashes does not allocate unless
+	// the path contains backslashes.
+	if len(paths) == 0 {
+		return NormalizeSlashes(firstPath)
+	}
+	// Only recognize slash-rooted paths here to keep the check cheap;
+	// drive-letter and URL-rooted paths take the general path below.
+	if p := paths[len(paths)-1]; p != "" && p[0] == '/' && strings.IndexByte(p, '\\') < 0 {
+		return p
+	}
+	// The general case is kept byte-for-byte unchanged as combinePathsSlow,
+	// which also serves as the differential-test oracle for the fast paths.
+	return combinePathsSlow(firstPath, paths)
+}
+
+func combinePathsSlow(firstPath string, paths []string) string {
 	firstPath = NormalizeSlashes(firstPath)
 
 	var b strings.Builder

--- a/tsc/internal/tspath/path_test.go
+++ b/tsc/internal/tspath/path_test.go
@@ -265,6 +265,8 @@ func BenchmarkCombinePaths(b *testing.B) {
 		{"/path", "/to", "file.ext"},
 		{"c:/path", "to", "file.ext"},
 		{"file:///path", "to", "file.ext"},
+		{"/path", "/abs/to/file.ext"},
+		{"/lone/path/to/file.ext"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Part of a series reducing allocation churn on hot paths (see #63895 for
motivation and series-wide measurements).

## This PR

`CombinePaths` built its result through a `strings.Builder` even when
the last argument is already an absolute path — the common case for
`ContainsPath` and module resolution callers, where the trailing path
supersedes everything before it. Return it directly instead. Only
slash-rooted paths (without backslashes) take the fast path;
drive-letter and URL-rooted arguments still go through the general
case, which is kept byte-for-byte unchanged as `combinePathsSlow` and
doubles as the differential oracle for the test.

`checkSourceFilesBelongToPath` computed the canonical absolute path for
every source file even though it is only used when emitting the error
diagnostic; compute it in the error branch instead.

## Results

Two cases covering the fast paths are added to the existing
`BenchmarkCombinePaths` (benchstat, 8 alternated runs):

| Case | Before | After |
|---|---:|---:|
| last argument absolute | 44.6 ns, 24 B/op | 4.7 ns, 0 B/op (**−89%**) |
| single argument, already normalized | 33.4 ns, 24 B/op | 15.0 ns, 0 B/op (**−55%**) |
| six existing relative-path cases | — | no significant change (p ≥ 0.44) |

An isolated microbenchmark of the miss path showed ≈+1 ns per call;
at ~125k relative-path calls per full vscode/src check that is ~0.1 ms
total. End-to-end, `CombinePaths` allocations drop from 185k–207k to
125k per full check.

## Verification

- Full vscode/src output is byte-identical to main (43 errors).
- `TestCombinePathsMatchesSlowPath` exhaustively compares `CombinePaths`
  against `combinePathsSlow` (the unmodified pre-fast-path
  implementation) over ~5,800 combinations of representative path
  pieces, including backslashes, UNC, drive letters, URLs, and empties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
