### PR TITLE
Avoid wrapping the queued function in an extra closure in parallelWorkGroup

### DIFF
--- a/tsc/internal/core/workgroup.go
+++ b/tsc/internal/core/workgroup.go
@@ -36,9 +36,7 @@ func (w *parallelWorkGroup) Queue(fn func()) {
 		panic("Queue called after RunAndWait returned")
 	}
 
-	w.wg.Go(func() {
-		fn()
-	})
+	w.wg.Go(fn)
 }
 
 func (w *parallelWorkGroup) RunAndWait() {


### PR DESCRIPTION
Part of a series reducing allocation churn on hot paths (see #63895).

`parallelWorkGroup.Queue` wrapped each queued function in an extra
closure before handing it to the WaitGroup. `sync.WaitGroup.Go`
(Go 1.25+) already does the Add/Done bookkeeping, so pass `fn` through
directly — one less closure allocation per queued task.

Output on a full vscode/src check is byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
