### PR TITLE
Fixed mapped types not being considered as homomorphic with substitution constraints

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -22636,7 +22636,7 @@ func (c *Checker) cloneTypeParameter(tp *Type) *Type {
 }
 
 func (c *Checker) getHomomorphicTypeVariable(t *Type) *Type {
-	constraintType := c.getConstraintTypeFromMappedType(t)
+	constraintType := c.getActualTypeVariable(c.getConstraintTypeFromMappedType(t))
 	if constraintType.flags&TypeFlagsIndex != 0 {
 		typeVariable := c.getActualTypeVariable(constraintType.AsIndexType().target)
 		if typeVariable.flags&TypeFlagsTypeParameter != 0 {

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.js
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.js
@@ -1,0 +1,65 @@
+//// [tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts] ////
+
+//// [mappedTypeHomomorphismWithPriorKeyofTChecks1.ts]
+type SharedUnionFieldsDeep1<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? {
+        [Key in keyof T]: SharedUnionFieldsDeep1<T[Key]>;
+      }
+    : {}
+  : T;
+
+// distributes
+declare const actual1: SharedUnionFieldsDeep1<
+  { tuple: [number] } | { tuple: [number, string] }
+>;
+
+type SharedUnionFieldsDeep2<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? keyof T extends infer Keys extends PropertyKey
+      ? {
+          [Key in Keys]: SharedUnionFieldsDeep2<T[Key & keyof T]>;
+        }
+      : never
+    : {}
+  : T;
+
+// doesn't distribute
+declare const actual2: SharedUnionFieldsDeep2<
+  { tuple: [number] } | { tuple: [number, string] }
+>;
+
+// `& unknown` used here just to avoid printing type alias printing at actual3
+type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
+  [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
+} & unknown;
+
+type SharedUnionFieldsDeep3<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? SharedUnionFieldsDeepMappedType3<T>
+    : {}
+  : T;
+
+// doesn't distribute either
+declare const actual3: SharedUnionFieldsDeep3<
+  { tuple: [number] } | { tuple: [number, string] }
+>;
+
+
+//// [mappedTypeHomomorphismWithPriorKeyofTChecks1.js]
+"use strict";

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.js
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.js
@@ -39,7 +39,7 @@ declare const actual2: SharedUnionFieldsDeep2<
   { tuple: [number] } | { tuple: [number, string] }
 >;
 
-// `& unknown` used here just to avoid printing type alias printing at actual3
+// `& unknown` used here just to avoid printing type alias at actual3
 type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
   [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
 } & unknown;

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.symbols
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.symbols
@@ -1,0 +1,158 @@
+//// [tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts] ////
+
+=== mappedTypeHomomorphismWithPriorKeyofTChecks1.ts ===
+type SharedUnionFieldsDeep1<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep1 : Symbol(SharedUnionFieldsDeep1, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+
+    ? [T[0]]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+
+    : T
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+
+  : keyof T extends infer CommonKeys
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 5, 25))
+
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 5, 25))
+
+    ? {
+        [Key in keyof T]: SharedUnionFieldsDeep1<T[Key]>;
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 8, 9))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+>SharedUnionFieldsDeep1 : Symbol(SharedUnionFieldsDeep1, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 8, 9))
+      }
+    : {}
+  : T;
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 28))
+
+// distributes
+declare const actual1: SharedUnionFieldsDeep1<
+>actual1 : Symbol(actual1, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 14, 13))
+>SharedUnionFieldsDeep1 : Symbol(SharedUnionFieldsDeep1, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 0, 0))
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 15, 3))
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 15, 25))
+
+>;
+
+type SharedUnionFieldsDeep2<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep2 : Symbol(SharedUnionFieldsDeep2, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 16, 2))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+
+    ? [T[0]]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+
+    : T
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+
+  : keyof T extends infer CommonKeys
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 23, 25))
+
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 23, 25))
+
+    ? keyof T extends infer Keys extends PropertyKey
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+>Keys : Symbol(Keys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 25, 27))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
+
+      ? {
+          [Key in Keys]: SharedUnionFieldsDeep2<T[Key & keyof T]>;
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 27, 11))
+>Keys : Symbol(Keys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 25, 27))
+>SharedUnionFieldsDeep2 : Symbol(SharedUnionFieldsDeep2, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 16, 2))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 27, 11))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+        }
+      : never
+    : {}
+  : T;
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 18, 28))
+
+// doesn't distribute
+declare const actual2: SharedUnionFieldsDeep2<
+>actual2 : Symbol(actual2, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 34, 13))
+>SharedUnionFieldsDeep2 : Symbol(SharedUnionFieldsDeep2, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 16, 2))
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 35, 3))
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 35, 25))
+
+>;
+
+// `& unknown` used here just to avoid printing type alias printing at actual3
+type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
+>SharedUnionFieldsDeepMappedType3 : Symbol(SharedUnionFieldsDeepMappedType3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 36, 2))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 38))
+>K : Symbol(K, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 40))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 38))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 38))
+
+  [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 40, 3))
+>K : Symbol(K, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 40))
+>SharedUnionFieldsDeep3 : Symbol(SharedUnionFieldsDeep3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 41, 12))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 38))
+>Key : Symbol(Key, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 40, 3))
+
+} & unknown;
+
+type SharedUnionFieldsDeep3<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep3 : Symbol(SharedUnionFieldsDeep3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 41, 12))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+    ? [T[0]]
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+    : T
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+  : keyof T extends infer CommonKeys
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 48, 25))
+
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>CommonKeys : Symbol(CommonKeys, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 48, 25))
+
+    ? SharedUnionFieldsDeepMappedType3<T>
+>SharedUnionFieldsDeepMappedType3 : Symbol(SharedUnionFieldsDeepMappedType3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 36, 2))
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+    : {}
+  : T;
+>T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 43, 28))
+
+// doesn't distribute either
+declare const actual3: SharedUnionFieldsDeep3<
+>actual3 : Symbol(actual3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 55, 13))
+>SharedUnionFieldsDeep3 : Symbol(SharedUnionFieldsDeep3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 41, 12))
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 56, 3))
+>tuple : Symbol(tuple, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 56, 25))
+
+>;
+

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.symbols
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.symbols
@@ -98,7 +98,7 @@ declare const actual2: SharedUnionFieldsDeep2<
 
 >;
 
-// `& unknown` used here just to avoid printing type alias printing at actual3
+// `& unknown` used here just to avoid printing type alias at actual3
 type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
 >SharedUnionFieldsDeepMappedType3 : Symbol(SharedUnionFieldsDeepMappedType3, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 36, 2))
 >T : Symbol(T, Decl(mappedTypeHomomorphismWithPriorKeyofTChecks1.ts, 39, 38))

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.types
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.types
@@ -1,0 +1,97 @@
+//// [tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts] ////
+
+=== mappedTypeHomomorphismWithPriorKeyofTChecks1.ts ===
+type SharedUnionFieldsDeep1<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep1 : SharedUnionFieldsDeep1<T>
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>true : true
+>false : false
+>false : false
+
+    ? {
+        [Key in keyof T]: SharedUnionFieldsDeep1<T[Key]>;
+      }
+    : {}
+  : T;
+
+// distributes
+declare const actual1: SharedUnionFieldsDeep1<
+>actual1 : { tuple: [number]; } | { tuple: [number, string]; }
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : [number]
+>tuple : [number, string]
+
+>;
+
+type SharedUnionFieldsDeep2<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep2 : SharedUnionFieldsDeep2<T>
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>true : true
+>false : false
+>false : false
+
+    ? keyof T extends infer Keys extends PropertyKey
+      ? {
+          [Key in Keys]: SharedUnionFieldsDeep2<T[Key & keyof T]>;
+        }
+      : never
+    : {}
+  : T;
+
+// doesn't distribute
+declare const actual2: SharedUnionFieldsDeep2<
+>actual2 : { tuple: [number]; }
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : [number]
+>tuple : [number, string]
+
+>;
+
+// `& unknown` used here just to avoid printing type alias printing at actual3
+type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
+>SharedUnionFieldsDeepMappedType3 : { [Key in K]: SharedUnionFieldsDeep3<T[Key]>; }
+
+  [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
+} & unknown;
+
+type SharedUnionFieldsDeep3<T> = [T] extends [unknown[]]
+>SharedUnionFieldsDeep3 : SharedUnionFieldsDeep3<T>
+
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+>true : true
+>false : false
+>false : false
+
+    ? SharedUnionFieldsDeepMappedType3<T>
+    : {}
+  : T;
+
+// doesn't distribute either
+declare const actual3: SharedUnionFieldsDeep3<
+>actual3 : { tuple: [number]; }
+
+  { tuple: [number] } | { tuple: [number, string] }
+>tuple : [number]
+>tuple : [number, string]
+
+>;
+

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.types
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.types
@@ -61,7 +61,7 @@ declare const actual2: SharedUnionFieldsDeep2<
 
 >;
 
-// `& unknown` used here just to avoid printing type alias printing at actual3
+// `& unknown` used here just to avoid printing type alias at actual3
 type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
 >SharedUnionFieldsDeepMappedType3 : { [Key in K]: SharedUnionFieldsDeep3<T[Key]>; }
 

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeNotMistakenlyHomomorphic2.symbols
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeNotMistakenlyHomomorphic2.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic2.ts] ////
+
+=== mappedTypeNotMistakenlyHomomorphic2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63132
+
+type KeyMap<T> = keyof T extends PropertyKey ? { [K in keyof T]: K } : never;
+>KeyMap : Symbol(KeyMap, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 12))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 12))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
+>K : Symbol(K, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 50))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 12))
+>K : Symbol(K, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 50))
+
+type X = KeyMap<number>;
+>X : Symbol(X, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 2, 77))
+>KeyMap : Symbol(KeyMap, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 0, 0))
+
+type U = { a?: number; b: string } | { b: string; readonly c: boolean };
+>U : Symbol(U, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 3, 24))
+>a : Symbol(a, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 10))
+>b : Symbol(b, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 22))
+>b : Symbol(b, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 38))
+>c : Symbol(c, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 49))
+
+type MapStringOnly<T> = keyof T extends string ? { [K in keyof T]: [T[K]] } : never;
+>MapStringOnly : Symbol(MapStringOnly, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 72))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 19))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 19))
+>K : Symbol(K, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 52))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 19))
+>T : Symbol(T, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 19))
+>K : Symbol(K, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 52))
+
+type Y = MapStringOnly<U>;
+>Y : Symbol(Y, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 6, 84))
+>MapStringOnly : Symbol(MapStringOnly, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 5, 72))
+>U : Symbol(U, Decl(mappedTypeNotMistakenlyHomomorphic2.ts, 3, 24))
+

--- a/tsc/testdata/baselines/reference/compiler/mappedTypeNotMistakenlyHomomorphic2.types
+++ b/tsc/testdata/baselines/reference/compiler/mappedTypeNotMistakenlyHomomorphic2.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic2.ts] ////
+
+=== mappedTypeNotMistakenlyHomomorphic2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63132
+
+type KeyMap<T> = keyof T extends PropertyKey ? { [K in keyof T]: K } : never;
+>KeyMap : KeyMap<T>
+
+type X = KeyMap<number>;
+>X : number
+
+type U = { a?: number; b: string } | { b: string; readonly c: boolean };
+>U : U
+>a : number | undefined
+>b : string
+>b : string
+>c : boolean
+
+type MapStringOnly<T> = keyof T extends string ? { [K in keyof T]: [T[K]] } : never;
+>MapStringOnly : MapStringOnly<T>
+
+type Y = MapStringOnly<U>;
+>Y : { a?: [number | undefined] | undefined; b: [string]; } | { b: [string]; readonly c: [boolean]; }
+

--- a/tsc/testdata/tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts
+++ b/tsc/testdata/tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts
@@ -1,0 +1,58 @@
+type SharedUnionFieldsDeep1<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? {
+        [Key in keyof T]: SharedUnionFieldsDeep1<T[Key]>;
+      }
+    : {}
+  : T;
+
+// distributes
+declare const actual1: SharedUnionFieldsDeep1<
+  { tuple: [number] } | { tuple: [number, string] }
+>;
+
+type SharedUnionFieldsDeep2<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? keyof T extends infer Keys extends PropertyKey
+      ? {
+          [Key in Keys]: SharedUnionFieldsDeep2<T[Key & keyof T]>;
+        }
+      : never
+    : {}
+  : T;
+
+// doesn't distribute
+declare const actual2: SharedUnionFieldsDeep2<
+  { tuple: [number] } | { tuple: [number, string] }
+>;
+
+// `& unknown` used here just to avoid printing type alias printing at actual3
+type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
+  [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
+} & unknown;
+
+type SharedUnionFieldsDeep3<T> = [T] extends [unknown[]]
+  ? // Keep only tuple positions guaranteed across the union.
+    1 extends T["length"]
+    ? [T[0]]
+    : T
+  : keyof T extends infer CommonKeys
+  ? ([CommonKeys] extends [never] ? true : false) extends false
+    ? SharedUnionFieldsDeepMappedType3<T>
+    : {}
+  : T;
+
+// doesn't distribute either
+declare const actual3: SharedUnionFieldsDeep3<
+  { tuple: [number] } | { tuple: [number, string] }
+>;

--- a/tsc/testdata/tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts
+++ b/tsc/testdata/tests/cases/compiler/mappedTypeHomomorphismWithPriorKeyofTChecks1.ts
@@ -36,7 +36,7 @@ declare const actual2: SharedUnionFieldsDeep2<
   { tuple: [number] } | { tuple: [number, string] }
 >;
 
-// `& unknown` used here just to avoid printing type alias printing at actual3
+// `& unknown` used here just to avoid printing type alias at actual3
 type SharedUnionFieldsDeepMappedType3<T, K extends keyof T = keyof T> = {
   [Key in K]: SharedUnionFieldsDeep3<T[Key]>;
 } & unknown;

--- a/tsc/testdata/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic2.ts
+++ b/tsc/testdata/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic2.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/63132
+
+type KeyMap<T> = keyof T extends PropertyKey ? { [K in keyof T]: K } : never;
+type X = KeyMap<number>;
+
+type U = { a?: number; b: string } | { b: string; readonly c: boolean };
+type MapStringOnly<T> = keyof T extends string ? { [K in keyof T]: [T[K]] } : never;
+type Y = MapStringOnly<U>;


### PR DESCRIPTION
ports https://github.com/microsoft/typescript-go/pull/4596
fixes https://github.com/microsoft/TypeScript/issues/63132

## What

This PR fixes the issue where conditionals like this `keyof T extends X ? Truthy : Falsy` would make `{ [K in keyof T: T[K] }` not being recognized as homomorphic within the `Truthy` branch of the conditional type.

## Extra

This PR comes with a `type-fest` break. I already looked through it... so I'll just quote my original answer here:

> A distributive homomorphic type requires to be written in this form (roughly):
> 
> ```ts
> type M<T> = {
>   [K in keyof T]: T[K]
> }
> ```
> 
> A type-fest-based repro case can be seen [here](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAygFgQwE4QCYFUB2BLA9pgMWwgBtUBnAEQgjAB4AVAPigF4oBtBgXSggA9gETBU4BXTAGtMuAO6YO3bgCgoUAPxQA9FqgBpGmCj4SIKMDFgS0MLnLZgeTOSgBzMcgSYhaKAgDGSHYuwHDQEk4AdKpqUACMfILCogwcAETWmK6haSqxGpypAAxKMWoAXFAMMZWSECC4AGZViUIiLtiYjRBIUADCuAC2g-gGIOQxmgAUHAPDo-XkvAJtohyYEABuPbyawEhi0JWNCCTkEACUrckuJ2cQZQUA3o-5HHpQnVB1Dc08lfBkGgsE4iKQKNRaIx3twmABuV5QAC+j0qTxRFSqCOUqAg-hIQKg-nw5GAfn8FlOAMQKAwOHwYLIVEMdBiT3MlmslXWYkGACMdsioAAfKDsixWCDczC8gVIAA0UFJSE6rl4KPhyhxeIJKCgjQkFKciUgFIY4AgjCYU02p0OlQYF0qm1w2FQCIEpuA5sgdHFnKlnBl-MFSOtAUpJAu2J05gtUAAghSPCQACwAVgAnAA2Nhi5Sx-ISrlB2U7BGxpEi-OF2LFwM8kMKpX7VXcCu6JEIoA). As we can see, that exact form (`[K in keyof T]: ...`) is used there. Therefore, I think the expectation should be that this would be treated as a distributive homomorphic type.
> 
> But because of the issue fixed by this PR, that mapped type was not recognized as homomorphic and distributive. That happened because `keyof T` in `[K in keyof T]` became (invisibly!) a substitution type internally. With the fix here, it gets recognized properly~ so it started to distribute and thus it broke `type-fest`'s implementation as it was accidentally leveraging the incorrect behavior.
> 
> It's common to change the code a little bit to enable/disable distributivity of conditional types and I think the same principle kinda applied to mapped types, given the distributivity (or the lack of it) is also an implied trait of any mapped type.
> 
> I just pushed out a test documenting this and showcasing 2 possible workarounds for the `type-fest`'s case, see [this commit](https://github.com/microsoft/typescript-go/pull/4596/changes/5e28359cf473d37b859ec46e8675a42770ae875f). If this PR lands then I will go to `type-fest` and PR a fix for them.