### PR TITLE
Fix go-to-type-definition for tuple aliases

### DIFF
--- a/tsc/internal/fourslash/tests/goToTypeWithTupleTypes_test.go
+++ b/tsc/internal/fourslash/tests/goToTypeWithTupleTypes_test.go
@@ -17,6 +17,15 @@ export let x/*1*/: [number, number] = [1, 2];
 type DoubleTupleTrouble<T> = [T, T];
 
 export let y/*2*/: DoubleTupleTrouble<number> = [1, 2];
+
+type SpanMapping = [
+    virtualStart: number,
+    virtualLength: number,
+    originalStart: number,
+    originalLength: number,
+];
+
+export let mapping/*3*/: SpanMapping;
 `
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()

--- a/tsc/internal/ls/definition.go
+++ b/tsc/internal/ls/definition.go
@@ -522,8 +522,12 @@ func getTypeOfSymbolAtLocation(c *checker.Checker, symbol *ast.Symbol, node *ast
 func getDeclarationsFromType(t *checker.Type) []*ast.Node {
 	var result []*ast.Node
 	for _, t := range t.Distributed() {
-		if t.Symbol() != nil {
-			for _, decl := range t.Symbol().Declarations {
+		symbol := t.Symbol()
+		if symbol == nil {
+			symbol = t.Alias().Symbol()
+		}
+		if symbol != nil {
+			for _, decl := range symbol.Declarations {
 				result = core.AppendIfUnique(result, decl)
 			}
 		}

--- a/tsc/testdata/baselines/reference/fourslash/goToType/goToTypeWithTupleTypes1.baseline.jsonc
+++ b/tsc/testdata/baselines/reference/fourslash/goToType/goToTypeWithTupleTypes1.baseline.jsonc
@@ -5,8 +5,7 @@
 // 
 // type DoubleTupleTrouble<T> = [T, T];
 // 
-// export let y: DoubleTupleTrouble<number> = [1, 2];
-// 
+// --- (line: 6) skipped ---
 
 
 
@@ -15,7 +14,28 @@
 // 
 // export let x: [number, number] = [1, 2];
 // 
-// type DoubleTupleTrouble<T> = [T, T];
+// <|type [|DoubleTupleTrouble|]<T> = [T, T];|>
 // 
 // export let y/*GOTO TYPE*/: DoubleTupleTrouble<number> = [1, 2];
+// 
+// type SpanMapping = [
+//     virtualStart: number,
+// --- (line: 10) skipped ---
+
+
+
+// === goToType ===
+// === /goToTypeWithTupleTypes1.ts ===
+// --- (line: 4) skipped ---
+// 
+// export let y: DoubleTupleTrouble<number> = [1, 2];
+// 
+// <|type [|SpanMapping|] = [
+//     virtualStart: number,
+//     virtualLength: number,
+//     originalStart: number,
+//     originalLength: number,
+// ];|>
+// 
+// export let mapping/*GOTO TYPE*/: SpanMapping;
 // 


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/63762