### PR TITLE
Downgrade too-new npm deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,22 +194,22 @@
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.19.0.tgz",
-            "integrity": "sha512-DHe9iRcyByGJuLPkl0K31a1JjOdRY2zX38Q07mQpSbR8zOj1EIgsWfTXhSQVyyijUxlcofVy/br7qWJbrMwVXQ==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+            "integrity": "sha512-SPTeHYZghdEdRddJzNjhH+CI5MSQtquNYwGJnYXfOHIBRXCmrWimBS85OhwXpXFIlrCtNTbBPm5mPAWRNEoktA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.13.0"
+                "@azure/msal-common": "16.12.0"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "16.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.13.0.tgz",
-            "integrity": "sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==",
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.12.0.tgz",
+            "integrity": "sha512-hgLgfRdbG2AmhXPygebf1KYJEvse86+ZZLWufdiTKaGRYEUqOzHdlf6AS1IiuUCHWbynkgbHc451jSNkbfhWlg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -217,13 +217,13 @@
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.6.0.tgz",
-            "integrity": "sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.5.0.tgz",
+            "integrity": "sha512-A/2WIsuH0vsC6JVkkafjS4kHpi2LDR4AzDT0kJ+oIRtXYeYtvGQ2pwN2X88thQPhSek+82ela3MprsKXWQRrhQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.13.0",
+                "@azure/msal-common": "16.12.0",
                 "jsonwebtoken": "^9.0.0"
             },
             "engines": {
@@ -2719,9 +2719,9 @@
             }
         },
         "node_modules/default-browser": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
-            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
The repo migration caused a relock, somehow. Downgrade some deps so CI unblocks with delayed feeds.