### PR TITLE
Fix TypeScript package major-minor version

### DIFF
--- a/packages/typescript/lib/version.cjs
+++ b/packages/typescript/lib/version.cjs
@@ -1,3 +1,3 @@
 const { version } = require("../package.json");
 exports.version = version;
-exports.versionMajorMinor = "7.0";
+exports.versionMajorMinor = "7.1";

--- a/packages/typescript/lib/version.d.cts
+++ b/packages/typescript/lib/version.d.cts
@@ -1,2 +1,2 @@
 export declare const version: string;
-export declare const versionMajorMinor = "7.0";
+export declare const versionMajorMinor = "7.1";

--- a/packages/typescript/test/version.test.ts
+++ b/packages/typescript/test/version.test.ts
@@ -1,0 +1,14 @@
+import getExePath from "#getExePath";
+import { versionMajorMinor } from "@typescript/typescript";
+import assert from "node:assert";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+
+test("versionMajorMinor matches the compiler version", () => {
+    const compilerVersion = execFileSync(getExePath(), ["--version"], { encoding: "utf8" })
+        .trim()
+        .replace(/^Version /, "");
+    const majorMinor = compilerVersion.split(".", 2).join(".");
+
+    assert.strictEqual(versionMajorMinor, majorMinor);
+});

--- a/packages/typescript/test/version.test.ts
+++ b/packages/typescript/test/version.test.ts
@@ -2,13 +2,18 @@ import getExePath from "#getExePath";
 import { versionMajorMinor } from "@typescript/typescript";
 import assert from "node:assert";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
-test("versionMajorMinor matches the compiler version", () => {
+test("versionMajorMinor runtime and declaration match the compiler version", () => {
     const compilerVersion = execFileSync(getExePath(), ["--version"], { encoding: "utf8" })
         .trim()
         .replace(/^Version /, "");
     const majorMinor = compilerVersion.split(".", 2).join(".");
+    const declaration = readFileSync(new URL("../lib/version.d.cts", import.meta.url), "utf8");
+    const declarationMatch = declaration.match(/versionMajorMinor = "([^"]+)"/);
 
     assert.strictEqual(versionMajorMinor, majorMinor);
+    assert.ok(declarationMatch, "versionMajorMinor declaration not found");
+    assert.strictEqual(declarationMatch[1], majorMinor);
 });


### PR DESCRIPTION
This hardcoded version was wrong.

Perhaps instead of being hardcoded, we should derive it from something, but it has to be a literal in the `d.ts`, so, not bothering.

(Needed because dtslint needs this info for local TS versions)