### PR TITLE
Use ".ts" suffixed code action kinds

### DIFF
--- a/tsc/internal/fourslash/fourslash.go
+++ b/tsc/internal/fourslash/fourslash.go
@@ -1990,7 +1990,7 @@ func (f *FourslashTest) VerifySourceFixAll(t *testing.T, expectedContent string)
 
 	var selected *lsproto.CodeAction
 	for _, item := range *result.CommandOrCodeActionArray {
-		if item.CodeAction == nil || item.CodeAction.Kind == nil || *item.CodeAction.Kind != lsproto.CodeActionKindSourceFixAll {
+		if item.CodeAction == nil || item.CodeAction.Kind == nil || *item.CodeAction.Kind != lsproto.CodeActionKindSourceFixAllTs {
 			continue
 		}
 		selected = item.CodeAction
@@ -2155,8 +2155,17 @@ func (f *FourslashTest) VerifyOrganizeImports(t *testing.T, expectedContent stri
 	}
 
 	var organizeAction *lsproto.CodeAction
+	expectedKind := codeActionKind
+	switch codeActionKind {
+	case lsproto.CodeActionKindSourceOrganizeImports:
+		expectedKind = lsproto.CodeActionKindSourceOrganizeImportsTs
+	case lsproto.CodeActionKindSourceRemoveUnusedImports:
+		expectedKind = lsproto.CodeActionKindSourceRemoveUnusedImportsTs
+	case lsproto.CodeActionKindSourceSortImports:
+		expectedKind = lsproto.CodeActionKindSourceSortImportsTs
+	}
 	for _, item := range *result.CommandOrCodeActionArray {
-		if item.CodeAction != nil && item.CodeAction.Kind != nil && *item.CodeAction.Kind == codeActionKind {
+		if item.CodeAction != nil && item.CodeAction.Kind != nil && *item.CodeAction.Kind == expectedKind {
 			organizeAction = item.CodeAction
 			break
 		}

--- a/tsc/internal/fourslash/fourslash.go
+++ b/tsc/internal/fourslash/fourslash.go
@@ -2129,6 +2129,28 @@ func (f *FourslashTest) applyEditsToContent(content string, edits []*lsproto.Tex
 
 func (f *FourslashTest) VerifyOrganizeImports(t *testing.T, expectedContent string, codeActionKind lsproto.CodeActionKind, preferences *lsutil.UserPreferences) {
 	t.Helper()
+	f.verifyOrganizeImports(t, expectedContent, codeActionKind, codeActionKind, preferences)
+}
+
+func (f *FourslashTest) VerifyOrganizeImportsWithRequestKind(
+	t *testing.T,
+	expectedContent string,
+	requestedKind lsproto.CodeActionKind,
+	expectedKind lsproto.CodeActionKind,
+	preferences *lsutil.UserPreferences,
+) {
+	t.Helper()
+	f.verifyOrganizeImports(t, expectedContent, requestedKind, expectedKind, preferences)
+}
+
+func (f *FourslashTest) verifyOrganizeImports(
+	t *testing.T,
+	expectedContent string,
+	requestedKind lsproto.CodeActionKind,
+	expectedKind lsproto.CodeActionKind,
+	preferences *lsutil.UserPreferences,
+) {
+	t.Helper()
 
 	if preferences != nil {
 		reset := f.ConfigureWithReset(t, *preferences)
@@ -2144,7 +2166,7 @@ func (f *FourslashTest) VerifyOrganizeImports(t *testing.T, expectedContent stri
 			End:   f.converters.PositionToLineAndCharacter(f.getScriptInfo(f.activeFilename), core.TextPos(len(f.getScriptInfo(f.activeFilename).content))),
 		},
 		Context: &lsproto.CodeActionContext{
-			Only: &[]lsproto.CodeActionKind{codeActionKind},
+			Only: &[]lsproto.CodeActionKind{requestedKind},
 		},
 	}
 
@@ -2155,15 +2177,6 @@ func (f *FourslashTest) VerifyOrganizeImports(t *testing.T, expectedContent stri
 	}
 
 	var organizeAction *lsproto.CodeAction
-	expectedKind := codeActionKind
-	switch codeActionKind {
-	case lsproto.CodeActionKindSourceOrganizeImports:
-		expectedKind = lsproto.CodeActionKindSourceOrganizeImportsTs
-	case lsproto.CodeActionKindSourceRemoveUnusedImports:
-		expectedKind = lsproto.CodeActionKindSourceRemoveUnusedImportsTs
-	case lsproto.CodeActionKindSourceSortImports:
-		expectedKind = lsproto.CodeActionKindSourceSortImportsTs
-	}
 	for _, item := range *result.CommandOrCodeActionArray {
 		if item.CodeAction != nil && item.CodeAction.Kind != nil && *item.CodeAction.Kind == expectedKind {
 			organizeAction = item.CodeAction

--- a/tsc/internal/fourslash/tests/organizeImports10_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports10_test.go
@@ -26,7 +26,7 @@ export function fun() { /* ... */ }
 
 /** Intended to be used in combination with {@link ZodType} */
 export function fun() { /* ... */ }`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports11_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports11_test.go
@@ -71,7 +71,7 @@ export class MyClass {
     someFunction();
   }
 }`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports12_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports12_test.go
@@ -23,7 +23,7 @@ declare export * from "foo";`
 declare export * from "foo";
 declare export { a, b };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports13_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports13_test.go
@@ -60,7 +60,7 @@ console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`
 } from "foo";
 interface Use extends Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9 {}
 console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.VerifyOrganizeImports(t,
@@ -86,7 +86,7 @@ console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`,
 } from "foo";
 interface Use extends Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9 {}
 console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},

--- a/tsc/internal/fourslash/tests/organizeImports14_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports14_test.go
@@ -42,7 +42,7 @@ import { foo } from "./a";`
 // comment 2
 
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports15_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports15_test.go
@@ -40,7 +40,7 @@ import { foo } from "./a";`
 // comment 2
 
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports16_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports16_test.go
@@ -22,7 +22,7 @@ console.log(a, b);`
 		`import { a, A, b } from "foo";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.ReplaceLine(t, 0, "import { a, A, b } from \"foo1\";")
@@ -30,7 +30,7 @@ console.log(a, b);`,
 		`import { a, A, b } from "foo1";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 		},
@@ -40,7 +40,7 @@ console.log(a, b);`,
 		`import { a, A, b } from "foo2";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},
@@ -50,7 +50,7 @@ console.log(a, b);`,
 		`import { A, a, b } from "foo3";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 		},

--- a/tsc/internal/fourslash/tests/organizeImports17_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports17_test.go
@@ -21,7 +21,7 @@ import { aa, CaseInsensitively, sorted } from "aardvark";`
 		`import { aa, CaseInsensitively, sorted } from "aardvark";
 import { Both } from "module-specifiers-unsorted";
 `,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 		},

--- a/tsc/internal/fourslash/tests/organizeImports18_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports18_test.go
@@ -40,7 +40,7 @@ export { bFuncA } from "./A";
 export { bFuncB } from "./B";
 export { bFuncC } from "./C";
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports19_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports19_test.go
@@ -31,7 +31,7 @@ export { b };
 const c = 1;
 export { c };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports1_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports1_test.go
@@ -30,7 +30,7 @@ console.log(a, B, b, c, C, d, D);
 console.log(e, f, F, g, G, H, h);`
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()
-	f.VerifyOrganizeImports(t,
+	f.VerifyOrganizeImportsWithRequestKind(t,
 		`import {
     a,
     b,
@@ -49,6 +49,7 @@ console.log(e, f, F, g, G, H, h);`
 console.log(a, B, b, c, C, d, D);
 console.log(e, f, F, g, G, H, h);`,
 		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},
@@ -73,7 +74,7 @@ console.log(e, f, F, g, G, H, h);`,
 
 console.log(a, B, b, c, C, d, D);
 console.log(e, f, F, g, G, H, h);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 		},

--- a/tsc/internal/fourslash/tests/organizeImports20_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports20_test.go
@@ -22,7 +22,7 @@ export { b };`
 const b = 1;
 export { a, b };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports21_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports21_test.go
@@ -36,7 +36,7 @@ export {
     PersonDefinitions
 } from './a';
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports22_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports22_test.go
@@ -28,7 +28,7 @@ console.log(abc, Abc, bc, Bc, I, R, M);`
 } from 'a';
 import { abc, Abc, bc, Bc } from 'b';
 console.log(abc, Abc, bc, Bc, I, R, M);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.VerifyOrganizeImports(t,
@@ -39,7 +39,7 @@ console.log(abc, Abc, bc, Bc, I, R, M);`,
 } from 'a';
 import { abc, Abc, bc, Bc } from 'b';
 console.log(abc, Abc, bc, Bc, I, R, M);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports23_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports23_test.go
@@ -30,7 +30,7 @@ console.log(abc, Abc, I, R, M);`
 import { abc, Abc, type bc, type Bc } from 'b';
 type x = bc | Bc;
 console.log(abc, Abc, I, R, M);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.VerifyOrganizeImports(t,
@@ -42,7 +42,7 @@ console.log(abc, Abc, I, R, M);`,
 import { abc, Abc, type bc, type Bc } from 'b';
 type x = bc | Bc;
 console.log(abc, Abc, I, R, M);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports2_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports2_test.go
@@ -26,7 +26,7 @@ console.log(Foo, Bar);`
 } from "foo";
 
 console.log(Foo, Bar);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports3_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports3_test.go
@@ -26,7 +26,7 @@ console.log(Foo, Bar);`
 } from "foo";
 
 console.log(Foo, Bar);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports4_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports4_test.go
@@ -25,7 +25,7 @@ import * as AnotherThingElse from "someotherpath";`
 	defer done()
 	f.VerifyOrganizeImports(t,
 		``,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports5_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports5_test.go
@@ -25,7 +25,7 @@ import * as AnotherThingElse from "someotherpath";`
 	defer done()
 	f.VerifyOrganizeImports(t,
 		``,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports6_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports6_test.go
@@ -35,7 +35,7 @@ import * as anotherThing from "someopath"; /* small comment */ // single line on
 */
 
 anotherThing;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports7_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports7_test.go
@@ -30,7 +30,7 @@ import * as something from "path"; /**
 
 something;
 somethingElse;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports8_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports8_test.go
@@ -18,7 +18,7 @@ foo;`
 	f.VerifyOrganizeImports(t,
 		`import { foo } from "foo";
 foo;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports9_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports9_test.go
@@ -18,7 +18,7 @@ a(b, d);`
 	f.VerifyOrganizeImports(t,
 		`import { a, b, d } from "foo";
 a(b, d);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsAttributes2_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsAttributes2_test.go
@@ -29,7 +29,7 @@ import { A as D } from "./a" with { type: "b" };
 import { Z } from "./z";
 
 export type G = A | B | C | D | E | F | Z;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsAttributes3_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsAttributes3_test.go
@@ -30,7 +30,7 @@ import { A as D, Y } from "./a" with { type: "b" };
 import { Z } from "./z";
 
 export type G = A | B | C | D | E | F | Y | Z;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsAttributes4_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsAttributes4_test.go
@@ -30,7 +30,7 @@ import { F, Z } from "./a" with { foo: "42" };
 import { Y } from "./a" with { foo: 42 };
 
 export type G = A | B | C | D | E | F | Y | Z;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsAttributes_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsAttributes_test.go
@@ -27,7 +27,7 @@ import { C, E } from "./file" with { type: "a" };
 import { A as D, A as F } from "./file" with { type: "b" };
 
 type G = A | B | C | D | E | F;`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsGroup_CommentInNewline_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsGroup_CommentInNewline_test.go
@@ -30,7 +30,7 @@ import b from "B";
 import d from "D";
 
 console.log(a, b, c, d)`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsGroup_MultiNewlines_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsGroup_MultiNewlines_test.go
@@ -30,7 +30,7 @@ import b from "B";
 import d from "D";
 
 console.log(a, b, c, d)`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsGroup_MultilineCommentInNewline_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsGroup_MultilineCommentInNewline_test.go
@@ -34,7 +34,7 @@ import b from "B";
 import d from "D";
 
 console.log(a, b, c, d)`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsGroup_Newline_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsGroup_Newline_test.go
@@ -28,7 +28,7 @@ import b from "B";
 import d from "D";
 
 console.log(a, b, c, d)`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsPathsUnicode1_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsPathsUnicode1_test.go
@@ -28,7 +28,7 @@ import * as _aB from "./_aB";
 import * as aB from "./aB";
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationOrdinal,
@@ -41,7 +41,7 @@ import * as aB from "./aB";
 import * as Ab from "./Ab";
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsPathsUnicode2_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsPathsUnicode2_test.go
@@ -26,7 +26,7 @@ import * as a100 from "./a100";
 import * as a2 from "./a2";
 
 console.log(a1, a2, a100);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:       core.TSFalse,
 			OrganizeImportsCollation:        lsutil.OrganizeImportsCollationUnicode,
@@ -39,7 +39,7 @@ import * as a2 from "./a2";
 import * as a100 from "./a100";
 
 console.log(a1, a2, a100);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:       core.TSFalse,
 			OrganizeImportsCollation:        lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsPathsUnicode3_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsPathsUnicode3_test.go
@@ -26,7 +26,7 @@ import * as À from "./À";
 import * as B from "./B";
 
 console.log(A, À, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:      core.TSFalse,
 			OrganizeImportsCollation:       lsutil.OrganizeImportsCollationUnicode,
@@ -39,7 +39,7 @@ import * as À from "./À";
 import * as B from "./B";
 
 console.log(A, À, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:      core.TSFalse,
 			OrganizeImportsCollation:       lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsPathsUnicode4_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsPathsUnicode4_test.go
@@ -28,7 +28,7 @@ import * as Ab from "./Ab";
 import * as aB from "./aB";
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,
@@ -42,7 +42,7 @@ import * as aB from "./aB";
 import * as Ab from "./Ab";
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsReactJsxDev_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsReactJsxDev_test.go
@@ -39,7 +39,7 @@ import './';`
 	f.GoToFile(t, "test.tsx")
 	f.VerifyOrganizeImports(t,
 		`export default () => <div></div>`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsReactJsx_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsReactJsx_test.go
@@ -39,7 +39,7 @@ import './';`
 	f.GoToFile(t, "test.tsx")
 	f.VerifyOrganizeImports(t,
 		`export default () => <div></div>`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsShebang_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsShebang_test.go
@@ -32,7 +32,7 @@ import Foo from "foo";
 import Foobar from "foobar";
 
 console.log(Foo, Bar, Foobar);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsType10_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType10_test.go
@@ -60,7 +60,7 @@ console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`
 } from "foo";
 interface Use extends Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9 {}
 console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},

--- a/tsc/internal/fourslash/tests/organizeImportsType11_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType11_test.go
@@ -58,7 +58,7 @@ console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`
 } from "foo";
 interface Use extends Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9 {}
 console.log(func1, func2, func3, func4, func5, func6, func7, func8, func9);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImportsType1_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType1_test.go
@@ -29,14 +29,14 @@ console.log(A, B, C, D, E);`
 		`import { A, C, D, type B, type E } from "foo";
 
 console.log(A, B, C, D, E);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.VerifyOrganizeImports(t,
 		`import { A, type B, C, D, type E } from "foo";
 
 console.log(A, B, C, D, E);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderInline,
 		},
@@ -45,7 +45,7 @@ console.log(A, B, C, D, E);`,
 		`import { type B, type E, A, C, D } from "foo";
 
 console.log(A, B, C, D, E);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderFirst,
 		},
@@ -54,7 +54,7 @@ console.log(A, B, C, D, E);`,
 		`import { A, C, D, type B, type E } from "foo";
 
 console.log(A, B, C, D, E);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderLast,
 		},

--- a/tsc/internal/fourslash/tests/organizeImportsType2_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType2_test.go
@@ -28,7 +28,7 @@ type B = string;
 const C = "hello";
 export { A, C, type B };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 	f.VerifyOrganizeImports(t,
@@ -37,7 +37,7 @@ type B = string;
 const C = "hello";
 export { A, type B, C };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderInline,
 		},
@@ -48,7 +48,7 @@ type B = string;
 const C = "hello";
 export { type B, A, C };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderFirst,
 		},
@@ -59,7 +59,7 @@ type B = string;
 const C = "hello";
 export { A, C, type B };
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderLast,
 		},

--- a/tsc/internal/fourslash/tests/organizeImportsType3_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType3_test.go
@@ -38,7 +38,7 @@ console.log(A, a, B, b, c, C, d, D);`
     d
 } from './foo';
 console.log(A, a, B, b, c, C, d, D);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImportsType4_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType4_test.go
@@ -38,7 +38,7 @@ console.log(A, a, B, b, c, C, d, D);`
     type d as D
 } from './foo';
 console.log(A, a, B, b, c, C, d, D);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImportsType5_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType5_test.go
@@ -38,7 +38,7 @@ console.log(A, a, B, b, c, C, d, D);`
     type d as D
 } from './foo';
 console.log(A, a, B, b, c, C, d, D);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -56,7 +56,7 @@ console.log(A, a, B, b, c, C, d, D);`,
     type d as D
 } from './foo';
 console.log(A, a, B, b, c, C, d, D);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImportsType6_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType6_test.go
@@ -22,7 +22,7 @@ console.log(a, b);`
 		`import { type a, A, b } from "foo";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderInline,
 		},
@@ -32,7 +32,7 @@ console.log(a, b);`,
 		`import { type a, A, b } from "foo1";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -43,7 +43,7 @@ console.log(a, b);`,
 		`import { type a, A, b } from "foo2";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -54,7 +54,7 @@ console.log(a, b);`,
 		`import { A, type a, b } from "foo3";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImportsType7_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType7_test.go
@@ -22,7 +22,7 @@ console.log(a, b);`
 		`import { a, type A, b } from "foo";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderInline,
 		},
@@ -32,7 +32,7 @@ console.log(a, b);`,
 		`import { a, type A, b } from "foo1";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -43,7 +43,7 @@ console.log(a, b);`,
 		`import { a, type A, b } from "foo2";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -54,7 +54,7 @@ console.log(a, b);`,
 		`import { type A, a, b } from "foo3";
 interface Use extends A {}
 console.log(a, b);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImportsType8_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType8_test.go
@@ -20,7 +20,7 @@ console.log(a, b, A, B);`
 	f.VerifyOrganizeImports(t,
 		`import { type A, type a, b, B } from "foo";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -30,7 +30,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type A, type a, b, B } from "foo1";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderFirst,
@@ -40,7 +40,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { b, B, type A, type a } from "foo2";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderLast,
@@ -50,7 +50,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type A, type a, b, B } from "foo3";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 		},
@@ -59,7 +59,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type A, type a, b, B } from "foo4";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},
@@ -68,7 +68,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type A, B, type a, b } from "foo5";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 		},

--- a/tsc/internal/fourslash/tests/organizeImportsType9_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsType9_test.go
@@ -20,7 +20,7 @@ console.log(a, b, A, B);`
 	f.VerifyOrganizeImports(t,
 		`import { type a, type A, b, B } from "foo";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderInline,
@@ -30,7 +30,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type a, type A, b, B } from "foo1";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderFirst,
@@ -40,7 +40,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { b, B, type a, type A } from "foo2";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 			OrganizeImportsTypeOrder:  lsutil.OrganizeImportsTypeOrderLast,
@@ -50,7 +50,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type a, type A, b, B } from "foo3";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSUnknown,
 		},
@@ -59,7 +59,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type a, type A, b, B } from "foo4";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSTrue,
 		},
@@ -68,7 +68,7 @@ console.log(a, b, A, B);`,
 	f.VerifyOrganizeImports(t,
 		`import { type A, B, type a, b } from "foo5";
 console.log(a, b, A, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 		},

--- a/tsc/internal/fourslash/tests/organizeImportsUnicode1_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsUnicode1_test.go
@@ -32,7 +32,7 @@ console.log(_aB, _Ab, aB, Ab);`
 } from './foo';
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationOrdinal,
@@ -47,7 +47,7 @@ console.log(_aB, _Ab, aB, Ab);`,
 } from './foo';
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsUnicode2_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsUnicode2_test.go
@@ -30,7 +30,7 @@ console.log(a1, a2, a100);`
 } from './foo';
 
 console.log(a1, a2, a100);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:       core.TSFalse,
 			OrganizeImportsCollation:        lsutil.OrganizeImportsCollationUnicode,
@@ -45,7 +45,7 @@ console.log(a1, a2, a100);`,
 } from './foo';
 
 console.log(a1, a2, a100);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:       core.TSFalse,
 			OrganizeImportsCollation:        lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsUnicode3_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsUnicode3_test.go
@@ -30,7 +30,7 @@ console.log(A, À, B);`
 } from './foo';
 
 console.log(A, À, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:      core.TSFalse,
 			OrganizeImportsCollation:       lsutil.OrganizeImportsCollationUnicode,
@@ -45,7 +45,7 @@ console.log(A, À, B);`,
 } from './foo';
 
 console.log(A, À, B);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase:      core.TSFalse,
 			OrganizeImportsCollation:       lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsUnicode4_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsUnicode4_test.go
@@ -32,7 +32,7 @@ console.log(_aB, _Ab, aB, Ab);`
 } from './foo';
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,
@@ -48,7 +48,7 @@ console.log(_aB, _Ab, aB, Ab);`,
 } from './foo';
 
 console.log(_aB, _Ab, aB, Ab);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsIgnoreCase: core.TSFalse,
 			OrganizeImportsCollation:  lsutil.OrganizeImportsCollationUnicode,

--- a/tsc/internal/fourslash/tests/organizeImportsWithTraceResolution1_test.go
+++ b/tsc/internal/fourslash/tests/organizeImportsWithTraceResolution1_test.go
@@ -30,7 +30,7 @@ import "./dep.js";
 		t,
 		`import "./dep.js";
 `,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_coalesceExports_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_coalesceExports_test.go
@@ -20,7 +20,7 @@ void 0;`
 		t,
 		`export { B, default as M, a as n, Z as O, y } from "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -37,7 +37,7 @@ void 0;`
 		t,
 		`export * from "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -56,7 +56,7 @@ void 0;`
 		`const x = 1, z = 2;
 export { x, z as y };
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -73,7 +73,7 @@ void 0;`
 		t,
 		`export { x, y as z } from "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -94,7 +94,7 @@ void 0;`
 export * from "lib";
 export { y } from "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -114,7 +114,7 @@ void 0;`
 		`const x = 1, w = 2, z = 3, q = 4;
 export { z as default, q as w, x, w as y };
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -133,7 +133,7 @@ void 0;`
 		`export * from "lib";
 export { x as a, z as b, y } from "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -158,7 +158,7 @@ export { z } from "aaa";
 export { x };
 export type { y };
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -179,7 +179,7 @@ void 0;`
 type y = number;
 export type { x, y };
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_coalesceImports_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_coalesceImports_test.go
@@ -20,7 +20,7 @@ M; n; B; y; O;`
 		t,
 		`import { B, default as M, a as n, Z as O, y } from "lib";
 M; n; B; y; O;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -37,7 +37,7 @@ void 0;`
 		t,
 		`import "lib";
 void 0;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -58,7 +58,7 @@ x; y; z;`
 import * as x from "lib";
 import * as y from "lib";
 x; y; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -75,7 +75,7 @@ x; y;`
 		t,
 		`import { default as x, default as y } from "lib";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -92,7 +92,7 @@ x; z;`
 		t,
 		`import { x, y as z } from "lib";
 x; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -113,7 +113,7 @@ x; z;`
 import "lib";
 import * as x from "lib";
 x; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -134,7 +134,7 @@ x; z;`
 import "lib";
 import x from "lib";
 x; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -155,7 +155,7 @@ x; z;`
 import "lib";
 import { x } from "lib";
 x; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -173,7 +173,7 @@ x; y;`
 		t,
 		`import y, * as x from "lib";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -194,7 +194,7 @@ x; y; z;`
 import * as x from "lib";
 import { y } from "lib";
 x; y; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -212,7 +212,7 @@ x; y;`
 		t,
 		`import x, { y } from "lib";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -238,7 +238,7 @@ import * as x from "lib";
 import * as y from "lib";
 import { a, b, default as w, default as z } from "lib";
 w; x; y; z; a; b;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -261,7 +261,7 @@ import * as x from "lib";
 import * as y from "lib";
 import z from "lib";
 x; y; z; w;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -281,7 +281,7 @@ x; y; z;`
 		`import type { x, y } from "lib";
 import { z } from "lib";
 x; y; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -302,7 +302,7 @@ x; y; z;`
 import type z from "lib";
 import type { x } from "lib";
 x; y; z;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -318,7 +318,7 @@ z; y; x; c; b; a;`
 		t,
 		`import { a, type b, c, type x, y, type z } from "lib";
 z; y; x; c; b; a;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{
 			OrganizeImportsSort:      lsutil.OrganizeImportsSortOrdinalIgnoreCase,
 			OrganizeImportsTypeOrder: lsutil.OrganizeImportsTypeOrderInline,

--- a/tsc/internal/fourslash/tests/organizeImports_dtsUnusedImportWithAugmentation_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_dtsUnusedImportWithAugmentation_test.go
@@ -33,7 +33,7 @@ declare module 'styled-components' {
         keyframes(): Keyframes;
     }
 }`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_exportLeadingComment_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_exportLeadingComment_test.go
@@ -58,7 +58,7 @@ console.log(a);`,
 			defer testutil.RecoverAndFail(t, "Panic on fourslash test")
 			f, done := fourslash.NewFourslash(t, nil /*capabilities*/, tc.content)
 			defer done()
-			f.VerifyOrganizeImports(t, tc.content, lsproto.CodeActionKindSourceSortImports, nil)
+			f.VerifyOrganizeImports(t, tc.content, lsproto.CodeActionKindSourceSortImportsTs, nil)
 		})
 	}
 }

--- a/tsc/internal/fourslash/tests/organizeImports_removeOnly_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_removeOnly_test.go
@@ -25,7 +25,7 @@ import { e } from "bar";
 import { g } from "foo";
 
 export { g, e, b, c };`,
-		lsproto.CodeActionKindSourceRemoveUnusedImports,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_removeUnused_preservesMultiline_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_removeUnused_preservesMultiline_test.go
@@ -30,7 +30,7 @@ export { a, b, c };`
 } from "module";
 
 export { a, b, c };`,
-		lsproto.CodeActionKindSourceRemoveUnusedImports,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
 		nil,
 	)
 }
@@ -55,7 +55,7 @@ export { a, c };`
 } from "module";
 
 export { a, c };`,
-		lsproto.CodeActionKindSourceRemoveUnusedImports,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
 		nil,
 	)
 }
@@ -81,7 +81,7 @@ export { a, c };`
 	f.VerifyOrganizeImports(
 		t,
 		"import {\n\ta,\n\tc\n} from \"module\";\n\nexport { a, c };",
-		lsproto.CodeActionKindSourceRemoveUnusedImports,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
 		&preferences,
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_sortModuleSpecifiers_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_sortModuleSpecifiers_test.go
@@ -22,7 +22,7 @@ x; y;`
 		`import y from "lib1";
 import x from "lib2";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -40,7 +40,7 @@ x; y;`
 		`import y from "./lib1";
 import x from "./lib2";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -58,7 +58,7 @@ x; y;`
 		`import y from "lib";
 import x from "./lib";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -77,7 +77,7 @@ x; y;`
 		`import y from "a";
 import x from "Z";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }
@@ -96,7 +96,7 @@ x; y;`
 		`import y from "A";
 import x from "z";
 x; y;`,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceSortImportsTs,
 		&lsutil.UserPreferences{OrganizeImportsSort: lsutil.OrganizeImportsSortOrdinalIgnoreCase},
 	)
 }

--- a/tsc/internal/fourslash/tests/organizeImports_typeOrderSameModule_test.go
+++ b/tsc/internal/fourslash/tests/organizeImports_typeOrderSameModule_test.go
@@ -38,7 +38,7 @@ import Default, { foo } from './package';
 
 const x: Foo = foo;
 console.log(x, Default, ns);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }
@@ -78,7 +78,7 @@ import { b } from './b';
 const x: TypeA = a;
 const y: TypeB = b;
 console.log(x, y);`,
-		lsproto.CodeActionKindSourceOrganizeImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
 		nil,
 	)
 }

--- a/tsc/internal/ls/codeactions.go
+++ b/tsc/internal/ls/codeactions.go
@@ -240,18 +240,9 @@ func isFixableDiagnostic(diagnostic *ast.Diagnostic, errorCodes []int32) bool {
 	return diagnostic.Source() == "" && containsErrorCode(errorCodes, diagnostic.Code())
 }
 
-// codeActionKindContains returns true if the requested kind equals or is a
-// hierarchical parent of actionKind, using '.' as the separator. This matches
-// the semantics of VS Code's HierarchicalKind.contains.
-func codeActionKindContains(requestedKind, actionKind lsproto.CodeActionKind) bool {
-	return requestedKind == actionKind ||
-		requestedKind == "" ||
-		strings.HasPrefix(string(actionKind), string(requestedKind)+".")
-}
-
 // isFixAllKind returns true if the requested kind matches source.fixAll
 func isFixAllKind(kind lsproto.CodeActionKind) bool {
-	return codeActionKindContains(kind, lsproto.CodeActionKindSourceFixAll)
+	return kind.Contains(lsproto.CodeActionKindSourceFixAllTs)
 }
 
 // wantsQuickFixes returns true if the Only filter is nil/empty (meaning all kinds are wanted)
@@ -261,7 +252,7 @@ func wantsQuickFixes(only *[]lsproto.CodeActionKind) bool {
 		return true
 	}
 	for _, kind := range *only {
-		if codeActionKindContains(kind, lsproto.CodeActionKindQuickFix) {
+		if kind.Contains(lsproto.CodeActionKindQuickFix) {
 			return true
 		}
 	}
@@ -276,7 +267,7 @@ func (l *LanguageService) createFixAllAction(
 	file *ast.SourceFile,
 	uri lsproto.DocumentUri,
 ) (*lsproto.CommandOrCodeAction, error) {
-	kind := lsproto.CodeActionKindSourceFixAll
+	kind := lsproto.CodeActionKindSourceFixAllTs
 	lspChanges := make(map[lsproto.DocumentUri][]*lsproto.TextEdit)
 
 	for _, provider := range codeFixProviders {
@@ -316,9 +307,9 @@ func (l *LanguageService) createFixAllAction(
 func getOrganizeImportsActionTitle(ctx context.Context, kind lsproto.CodeActionKind) string {
 	loc := locale.FromContext(ctx)
 	switch kind {
-	case lsproto.CodeActionKindSourceRemoveUnusedImports:
+	case lsproto.CodeActionKindSourceRemoveUnusedImportsTs:
 		return diagnostics.Remove_Unused_Imports.Localize(loc)
-	case lsproto.CodeActionKindSourceSortImports:
+	case lsproto.CodeActionKindSourceSortImportsTs:
 		return diagnostics.Sort_Imports.Localize(loc)
 	default:
 		return diagnostics.Organize_Imports.Localize(loc)
@@ -329,14 +320,14 @@ func getOrganizeImportsActionTitle(ctx context.Context, kind lsproto.CodeActionK
 // returned for the given requested kind.
 func getOrganizeImportsActionsForKind(requestedKind lsproto.CodeActionKind) []lsproto.CodeActionKind {
 	organizeImportsKinds := []lsproto.CodeActionKind{
-		lsproto.CodeActionKindSourceOrganizeImports,
-		lsproto.CodeActionKindSourceRemoveUnusedImports,
-		lsproto.CodeActionKindSourceSortImports,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
+		lsproto.CodeActionKindSourceSortImportsTs,
 	}
 
 	var result []lsproto.CodeActionKind
 	for _, organizeKind := range organizeImportsKinds {
-		if codeActionKindContains(requestedKind, organizeKind) {
+		if requestedKind.Contains(organizeKind) {
 			result = append(result, organizeKind)
 		}
 	}

--- a/tsc/internal/ls/organizeimports.go
+++ b/tsc/internal/ls/organizeimports.go
@@ -28,9 +28,9 @@ func (l *LanguageService) OrganizeImports(
 	kind lsproto.CodeActionKind,
 ) map[string][]*lsproto.TextEdit {
 	changeTracker := change.NewTracker(ctx, program.Options(), l.FormatOptions(), l.converters)
-	shouldSort := kind == lsproto.CodeActionKindSourceSortImports || kind == lsproto.CodeActionKindSourceOrganizeImports
+	shouldSort := kind == lsproto.CodeActionKindSourceSortImportsTs || kind == lsproto.CodeActionKindSourceOrganizeImportsTs
 	shouldCombine := shouldSort
-	shouldRemove := kind == lsproto.CodeActionKindSourceRemoveUnusedImports || kind == lsproto.CodeActionKindSourceOrganizeImports
+	shouldRemove := kind == lsproto.CodeActionKindSourceRemoveUnusedImportsTs || kind == lsproto.CodeActionKindSourceOrganizeImportsTs
 	topLevelImportDecls := lsutil.FilterImportDeclarations(sourceFile.Statements.Nodes)
 	topLevelImportGroupDecls := groupByNewlineContiguous(sourceFile, topLevelImportDecls)
 
@@ -74,7 +74,7 @@ func (l *LanguageService) OrganizeImports(
 		organizeImportsWorker(importGroupDecl, comparer, shouldSort, shouldCombine, shouldRemove, sourceFile, program, changeTracker, ctx)
 	}
 
-	if kind != lsproto.CodeActionKindSourceRemoveUnusedImports {
+	if kind != lsproto.CodeActionKindSourceRemoveUnusedImportsTs {
 		topLevelExportGroupDecls := getTopLevelExportGroups(sourceFile)
 		for _, exportGroupDecl := range topLevelExportGroupDecls {
 			organizeExportsWorker(exportGroupDecl, comparer, sourceFile, changeTracker)
@@ -100,7 +100,7 @@ func (l *LanguageService) OrganizeImports(
 			organizeImportsWorker(importGroupDecl, comparer, shouldSort, shouldCombine, shouldRemove, sourceFile, program, changeTracker, ctx)
 		}
 
-		if kind != lsproto.CodeActionKindSourceRemoveUnusedImports {
+		if kind != lsproto.CodeActionKindSourceRemoveUnusedImportsTs {
 			var ambientModuleExportDecls []*ast.Statement
 			for _, s := range moduleBody.Statements.Nodes {
 				if s.Kind == ast.KindExportDeclaration {

--- a/tsc/internal/lsp/lsproto/lsp.go
+++ b/tsc/internal/lsp/lsproto/lsp.go
@@ -306,7 +306,19 @@ func PreferredMarkupKind(formats []MarkupKind) MarkupKind {
 	return MarkupKindPlainText
 }
 
+// Contains reports whether other is this code action kind or one of its children.
+func (kind CodeActionKind) Contains(other CodeActionKind) bool {
+	return kind == other ||
+		kind == CodeActionKindEmpty ||
+		strings.HasPrefix(string(other), string(kind)+".")
+}
+
 const (
 	CodeActionKindSourceRemoveUnusedImports CodeActionKind = "source.removeUnusedImports"
 	CodeActionKindSourceSortImports         CodeActionKind = "source.sortImports"
+
+	CodeActionKindSourceFixAllTs              CodeActionKind = CodeActionKindSourceFixAll + ".ts"
+	CodeActionKindSourceOrganizeImportsTs     CodeActionKind = CodeActionKindSourceOrganizeImports + ".ts"
+	CodeActionKindSourceRemoveUnusedImportsTs CodeActionKind = CodeActionKindSourceRemoveUnusedImports + ".ts"
+	CodeActionKindSourceSortImportsTs         CodeActionKind = CodeActionKindSourceSortImports + ".ts"
 )

--- a/tsc/internal/lsp/lsproto/lsp.go
+++ b/tsc/internal/lsp/lsproto/lsp.go
@@ -314,11 +314,8 @@ func (kind CodeActionKind) Contains(other CodeActionKind) bool {
 }
 
 const (
-	CodeActionKindSourceRemoveUnusedImports CodeActionKind = "source.removeUnusedImports"
-	CodeActionKindSourceSortImports         CodeActionKind = "source.sortImports"
-
 	CodeActionKindSourceFixAllTs              CodeActionKind = CodeActionKindSourceFixAll + ".ts"
 	CodeActionKindSourceOrganizeImportsTs     CodeActionKind = CodeActionKindSourceOrganizeImports + ".ts"
-	CodeActionKindSourceRemoveUnusedImportsTs CodeActionKind = CodeActionKindSourceRemoveUnusedImports + ".ts"
-	CodeActionKindSourceSortImportsTs         CodeActionKind = CodeActionKindSourceSortImports + ".ts"
+	CodeActionKindSourceRemoveUnusedImportsTs CodeActionKind = CodeActionKindSource + ".removeUnusedImports.ts"
+	CodeActionKindSourceSortImportsTs         CodeActionKind = CodeActionKindSource + ".sortImports.ts"
 )

--- a/tsc/internal/lsp/server.go
+++ b/tsc/internal/lsp/server.go
@@ -349,6 +349,16 @@ const (
 	contentMapperWillRenameFilesRegistrationID   = "content-mapper-will-rename-files"
 )
 
+func supportedCodeActionKinds() []lsproto.CodeActionKind {
+	return []lsproto.CodeActionKind{
+		lsproto.CodeActionKindQuickFix,
+		lsproto.CodeActionKindSourceOrganizeImportsTs,
+		lsproto.CodeActionKindSourceRemoveUnusedImportsTs,
+		lsproto.CodeActionKindSourceSortImportsTs,
+		lsproto.CodeActionKindSourceFixAllTs,
+	}
+}
+
 func (s *Server) supportsContentMapperRegistration(id string) bool {
 	switch id {
 	case contentMapperDidOpenRegistrationID, contentMapperDidChangeRegistrationID, contentMapperDidCloseRegistrationID:
@@ -633,13 +643,7 @@ func (s *Server) RegisterContentMapperExtensions(ctx context.Context, extensions
 			RegisterOptions: &lsproto.RegisterOptions{
 				TextDocumentCodeAction: &lsproto.CodeActionRegistrationOptions{
 					DocumentSelector: selector,
-					CodeActionKinds: &[]lsproto.CodeActionKind{
-						lsproto.CodeActionKindQuickFix,
-						lsproto.CodeActionKindSourceOrganizeImports,
-						lsproto.CodeActionKindSourceRemoveUnusedImports,
-						lsproto.CodeActionKindSourceSortImports,
-						lsproto.CodeActionKindSourceFixAll,
-					},
+					CodeActionKinds:  new(supportedCodeActionKinds()),
 				},
 			},
 		},
@@ -1634,13 +1638,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 			},
 			CodeActionProvider: &lsproto.BooleanOrCodeActionOptions{
 				CodeActionOptions: &lsproto.CodeActionOptions{
-					CodeActionKinds: &[]lsproto.CodeActionKind{
-						lsproto.CodeActionKindQuickFix,
-						lsproto.CodeActionKindSourceOrganizeImports,
-						lsproto.CodeActionKindSourceRemoveUnusedImports,
-						lsproto.CodeActionKindSourceSortImports,
-						lsproto.CodeActionKindSourceFixAll,
-					},
+					CodeActionKinds: new(supportedCodeActionKinds()),
 				},
 			},
 			CallHierarchyProvider: &lsproto.BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions{

--- a/tsc/internal/lsp/server_contentmapper_test.go
+++ b/tsc/internal/lsp/server_contentmapper_test.go
@@ -165,6 +165,10 @@ export const title = "Profile";
 			assert.Assert(t, selector != nil && len(*selector) == 1)
 			assert.Equal(t, *(*selector)[0].Pattern.Pattern.Pattern, "**/*.vue")
 		}
+		if registration.Id == "content-mapper-code-action" {
+			assert.Assert(t, registration.RegisterOptions != nil && registration.RegisterOptions.TextDocumentCodeAction != nil)
+			assert.DeepEqual(t, *registration.RegisterOptions.TextDocumentCodeAction.CodeActionKinds, expectedCodeActionKinds())
+		}
 	}
 	for id, found := range expectedMapperRegistrations {
 		assert.Assert(t, found, "expected %s registration for .vue", id)

--- a/tsc/internal/lsp/server_projectinfo_test.go
+++ b/tsc/internal/lsp/server_projectinfo_test.go
@@ -13,6 +13,16 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func expectedCodeActionKinds() []lsproto.CodeActionKind {
+	return []lsproto.CodeActionKind{
+		lsproto.CodeActionKindQuickFix,
+		"source.organizeImports.ts",
+		"source.removeUnusedImports.ts",
+		"source.sortImports.ts",
+		"source.fixAll.ts",
+	}
+}
+
 func initProjectInfoClient(t *testing.T, files map[string]string) *lsptestutil.LSPClient {
 	t.Helper()
 
@@ -47,6 +57,24 @@ func initProjectInfoClient(t *testing.T, files map[string]string) *lsptestutil.L
 	<-client.Server.InitComplete()
 
 	return client
+}
+
+func TestInitializeCodeActionKinds(t *testing.T) {
+	t.Parallel()
+
+	client, closeClient := lsptestutil.NewLSPClient(t, lsp.ServerOptions{
+		Err:                io.Discard,
+		Cwd:                "/home/projects",
+		FS:                 bundled.WrapFS(vfstest.FromMap(map[string]string{}, false)),
+		DefaultLibraryPath: bundled.LibPath(),
+	}, nil)
+	t.Cleanup(func() { _ = closeClient() })
+
+	message, result, ok := lsptestutil.SendRequest(t, client, lsproto.InitializeInfo, &lsproto.InitializeParams{
+		Capabilities: &lsproto.ClientCapabilities{},
+	})
+	assert.Assert(t, ok && message.AsResponse().Error == nil, "Initialize failed")
+	assert.DeepEqual(t, *result.Capabilities.CodeActionProvider.CodeActionOptions.CodeActionKinds, expectedCodeActionKinds())
 }
 
 func TestProjectInfoConfiguredProject(t *testing.T) {


### PR DESCRIPTION
Fixes #63823

Advertise `source.fixAll.ts` etc instead of just `source.fixAll`. This matches `typescript-language-server` allowing scoped fixing.

We don't need to actually keep and declare `source.fixAll` etc (without `.ts` suffix), because the fix naming system is hierarchical; we in fact copied a helper from VS Code that does this matching, which I've moved into the method.

For consistency, I've changed all of the testing to just use the defined one, which works.

(A previous PR for this was more complicated, but it turns out we don't need much. Most changes are test churn.)