### PR TITLE
Fix binder race

### DIFF
--- a/tsc/internal/project/compilerhost.go
+++ b/tsc/internal/project/compilerhost.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/microsoft/TypeScript/tsc/internal/ast"
+	"github.com/microsoft/TypeScript/tsc/internal/binder"
 	"github.com/microsoft/TypeScript/tsc/internal/compiler"
 	"github.com/microsoft/TypeScript/tsc/internal/contentmapper"
 	"github.com/microsoft/TypeScript/tsc/internal/diagnostics"
@@ -135,8 +136,10 @@ func (c *compilerHost) GetContentMappedSourceFiles(parseOptions ast.SourceFilePa
 			return contentmapper.SourceFiles{}, transformErr
 		}
 		files.Canonical.Hash = key.Hash
+		binder.BindSourceFile(files.Canonical)
 		for _, supplemental := range files.Supplemental {
 			supplemental.Hash = key.Hash
+			binder.BindSourceFile(supplemental)
 		}
 		return files, nil
 	})

--- a/tsc/internal/project/parsecache.go
+++ b/tsc/internal/project/parsecache.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/microsoft/TypeScript/tsc/internal/ast"
+	"github.com/microsoft/TypeScript/tsc/internal/binder"
 	"github.com/microsoft/TypeScript/tsc/internal/compiler"
 	"github.com/microsoft/TypeScript/tsc/internal/contentmapper"
 	"github.com/microsoft/TypeScript/tsc/internal/core"
@@ -76,6 +77,7 @@ func NewParseCache(options RefCountCacheOptions) *ParseCache {
 		func(key ParseCacheKey, fh FileHandle) *ast.SourceFile {
 			file := parser.ParseSourceFile(key.SourceFileParseOptions, fh.Content(), key.ScriptKind)
 			file.Hash = fh.Hash()
+			binder.BindSourceFile(file)
 			return file
 		},
 	)

--- a/tsc/internal/project/refcountcache_test.go
+++ b/tsc/internal/project/refcountcache_test.go
@@ -69,6 +69,25 @@ func TestContentMappedParseCacheKeyReconstruction(t *testing.T) {
 	assert.DeepEqual(t, contentMappedParseCacheKeyForDuplicate(duplicate), expected)
 }
 
+func TestParseCacheBindsBeforePublishing(t *testing.T) {
+	t.Parallel()
+
+	const fileName = "/index.js"
+	fileHandle := newOverlay(fileName, "module.exports = 0;", 1, core.ScriptKindJS)
+	parseOptions := ast.SourceFileParseOptions{
+		FileName: fileName,
+		Path:     tspath.Path(fileName),
+	}
+	key := NewParseCacheKey(parseOptions, fileHandle.Hash(), fileHandle.Kind())
+	cache := NewParseCache(RefCountCacheOptions{})
+
+	file := cache.Acquire(key, fileHandle)
+	defer cache.Deref(key)
+
+	assert.Assert(t, file.IsBound())
+	assert.Assert(t, file.CommonJSModuleIndicator != nil)
+}
+
 func TestRefCountingCaches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Saw this race in CI: https://github.com/microsoft/TypeScript/actions/runs/32524317879/job/96903027702

```
==================
WARNING: DATA RACE
Write at 0x00c038130250 by goroutine 243459:
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).setCommonJSModuleIndicator()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:932 +0x109
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindCallExpression()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:923 +0x78
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:690 +0x95d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind-fm()
      <autogenerated>:1 +0x34
  github.com/microsoft/TypeScript/tsc/internal/ast.visit()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast.go:32 +0x112
  github.com/microsoft/TypeScript/tsc/internal/ast.(*VariableDeclaration).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:1729 +0xd8
  github.com/microsoft/TypeScript/tsc/internal/ast.(*Node).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:8733 +0x2808
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1738 +0x49
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindVariableDeclarationFlow()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:2329 +0x31
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindChildren()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1711 +0x5d6
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:731 +0x141d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind-fm()
      <autogenerated>:1 +0x34
  github.com/microsoft/TypeScript/tsc/internal/ast.visitNodes()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast.go:39 +0x55bc
  github.com/microsoft/TypeScript/tsc/internal/ast.visitNodeList()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast.go:48 +0x2885
  github.com/microsoft/TypeScript/tsc/internal/ast.(*VariableDeclarationList).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:1774 +0x2855
  github.com/microsoft/TypeScript/tsc/internal/ast.(*Node).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:8735 +0x2821
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1738 +0x68c
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindChildren()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1732 +0x68d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:731 +0x141d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind-fm()
      <autogenerated>:1 +0x34
  github.com/microsoft/TypeScript/tsc/internal/ast.visit()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast.go:32 +0xf7
  github.com/microsoft/TypeScript/tsc/internal/ast.(*VariableStatement).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:1679 +0x26
  github.com/microsoft/TypeScript/tsc/internal/ast.(*Node).ForEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast_generated.go:8731 +0x204a
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindEachChild()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1738 +0x68c
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindChildren()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1732 +0x68d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:731 +0x141d
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindEachStatementFunctionsFirst()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1767 +0x13a
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindChildren()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1720 +0x6dd
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bindContainer()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:1545 +0xbb4
  github.com/microsoft/TypeScript/tsc/internal/binder.(*Binder).bind()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:733 +0x1438
  github.com/microsoft/TypeScript/tsc/internal/binder.bindSourceFile.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:126 +0x191
  github.com/microsoft/TypeScript/tsc/internal/binder.bindSourceFile.(*SourceFile).BindOnce.func2()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/ast.go:2910 +0x33
  sync.(*Once).doSlow()
      /usr/local/vss-agent/2.336.0/_work/_tool/go-87ee608c/1.26.7/x64/src/sync/once.go:78 +0xa1
  github.com/microsoft/TypeScript/tsc/internal/binder.BindSourceFile()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/binder/binder.go:99 +0x3c
  github.com/microsoft/TypeScript/tsc/internal/compiler.(*Program).BindSourceFiles.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/compiler/program.go:562 +0x168
  github.com/microsoft/TypeScript/tsc/internal/core.(*parallelWorkGroup).Queue.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/core/workgroup.go:40 +0x2e

Previous read at 0x00c038130250 by goroutine 232414:
  github.com/microsoft/TypeScript/tsc/internal/ast.IsExternalOrCommonJSModule()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/ast/utilities.go:1671 +0x228
  github.com/microsoft/TypeScript/tsc/internal/compiler.(*Program).canReplaceFileInProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/compiler/program.go:438 +0x1eb
  github.com/microsoft/TypeScript/tsc/internal/compiler.(*Program).ReuseProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/compiler/program.go:357 +0x53a
  github.com/microsoft/TypeScript/tsc/internal/compiler.(*Program).UpdateProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/compiler/program.go:302 +0x8b
  github.com/microsoft/TypeScript/tsc/internal/project.(*Project).CreateProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/project.go:386 +0x1ee
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram.func2.1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1214 +0x6fe
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[go.shape.*uint8]).Change()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:41 +0xe9
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[*github.com/microsoft/TypeScript/tsc/internal/project.Project]).Change()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:36 +0x3a
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram.func2()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1209 +0x12f
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[go.shape.*uint8]).Locked()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:57 +0x46
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[*github.com/microsoft/TypeScript/tsc/internal/project.Project]).Locked()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:56 +0xe
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1208 +0x655
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).DidRequestFile()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:524 +0x25a
  github.com/microsoft/TypeScript/tsc/internal/project.(*Snapshot).Clone()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/snapshot.go:423 +0x1eee
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).updateSnapshot()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1444 +0x228
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).getSnapshot()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1105 +0x3b5
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).getSnapshotAndDefaultProject()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1163 +0x164
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).GetLanguageService()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1182 +0x55
  github.com/microsoft/TypeScript/tsc/internal/lsp.init.func1.registerLanguageServiceDocumentRequestHandler[go.shape.*uint8,go.shape.struct { TextEdits *[]*github.com/microsoft/TypeScript/tsc/internal/lsp/lsproto.TextEdit }].22()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1344 +0xd8
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).handleRequestOrNotification()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1145 +0x161
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).dispatchLoop()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1009 +0x704
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).Run.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:858 +0x46
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/cloudtest/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x86

Goroutine 243459 (running) created at:
  sync.(*WaitGroup).Go()
      /usr/local/vss-agent/2.336.0/_work/_tool/go-87ee608c/1.26.7/x64/src/sync/waitgroup.go:238 +0x72
  github.com/microsoft/TypeScript/tsc/internal/compiler.(*Program).BindSourceFiles()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/compiler/program.go:558 +0x2a7
  github.com/microsoft/TypeScript/tsc/internal/project.(*Project).CreateProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/project.go:440 +0xa57
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram.func2.1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1214 +0x6fe
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[go.shape.*uint8]).Change()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:41 +0xe9
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[*github.com/microsoft/TypeScript/tsc/internal/project.Project]).Change()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:36 +0x3a
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram.func2()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1209 +0x12f
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[go.shape.*uint8]).Locked()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:57 +0x46
  github.com/microsoft/TypeScript/tsc/internal/project/dirty.(*Box[*github.com/microsoft/TypeScript/tsc/internal/project.Project]).Locked()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/dirty/box.go:56 +0xe
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).updateProgram()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:1208 +0x655
  github.com/microsoft/TypeScript/tsc/internal/project.(*ProjectCollectionBuilder).DidRequestFile()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/projectcollectionbuilder.go:524 +0x25a
  github.com/microsoft/TypeScript/tsc/internal/project.(*Snapshot).Clone()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/snapshot.go:423 +0x1eee
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).updateSnapshot()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1444 +0x228
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).getSnapshot()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1105 +0x3b5
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).getSnapshotAndDefaultProject()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1163 +0x164
  github.com/microsoft/TypeScript/tsc/internal/project.(*Session).GetLanguageService()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/project/session.go:1182 +0x55
  github.com/microsoft/TypeScript/tsc/internal/lsp.init.func1.registerLanguageServiceDocumentRequestHandler[go.shape.*uint8,go.shape.struct { TextEdits *[]*github.com/microsoft/TypeScript/tsc/internal/lsp/lsproto.TextEdit }].22()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1344 +0xd8
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).handleRequestOrNotification()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1145 +0x161
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).dispatchLoop()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:1009 +0x704
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).Run.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:858 +0x46
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/cloudtest/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x86

Goroutine 232414 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /home/cloudtest/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:78 +0x11c
  github.com/microsoft/TypeScript/tsc/internal/lsp.(*Server).Run()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/lsp/server.go:858 +0x1e5
  github.com/microsoft/TypeScript/tsc/internal/testutil/lsptestutil.NewLSPClient.func1()
      /usr/local/vss-agent/2.336.0/_work/TypeScript/TypeScript/tsc/internal/testutil/lsptestutil/lspclient.go:112 +0x78
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/cloudtest/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x86
==================
```

A "fix" is to just ensure everything's bound, since the LS et al is surely going to need that info.