### PR TITLE
Update README social links from Twitter to X

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/microsoft/TypeScript/badge)](https://securityscorecards.dev/viewer/?uri=github.com/microsoft/TypeScript)
 
 
-[TypeScript](https://www.typescriptlang.org/) is a language for application-scale JavaScript. TypeScript adds optional types to JavaScript that support tools for large-scale JavaScript applications for any browser, for any host, on any OS. TypeScript compiles to readable, standards-based JavaScript. Try it out at the [playground](https://www.typescriptlang.org/play/), and stay up to date via [our blog](https://blogs.msdn.microsoft.com/typescript) and [Twitter account](https://twitter.com/typescript).
+[TypeScript](https://www.typescriptlang.org/) is a language for application-scale JavaScript. TypeScript adds optional types to JavaScript that support tools for large-scale JavaScript applications for any browser, for any host, on any OS. TypeScript compiles to readable, standards-based JavaScript. Try it out at the [playground](https://www.typescriptlang.org/play/), and stay up to date via [our blog](https://blogs.msdn.microsoft.com/typescript) and [X account](https://x.com/typescript).
 
 Find others who are using TypeScript at [our community page](https://www.typescriptlang.org/community/).
 
@@ -32,7 +32,7 @@ There are many ways to [contribute](https://github.com/microsoft/TypeScript/blob
 * Review the [source code changes](https://github.com/microsoft/TypeScript/pulls).
 * Engage with other TypeScript users and developers on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript).
 * Help each other in the [TypeScript Community Discord](https://discord.gg/typescript).
-* Join the [#typescript](https://twitter.com/search?q=%23TypeScript) discussion on Twitter.
+* Join the [#typescript](https://x.com/search?q=%23TypeScript) discussion on X.
 * [Contribute bug fixes](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are many ways to [contribute](https://github.com/microsoft/TypeScript/blob
 * Review the [source code changes](https://github.com/microsoft/TypeScript/pulls).
 * Engage with other TypeScript users and developers on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript).
 * Help each other in the [TypeScript Community Discord](https://discord.gg/typescript).
-* Join the [#typescript](https://x.com/search?q=%23TypeScript) discussion on X.
+* Join the [#typescript](https://x.com/typescript) discussion on X.
 * [Contribute bug fixes](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are many ways to [contribute](https://github.com/microsoft/TypeScript/blob
 * Review the [source code changes](https://github.com/microsoft/TypeScript/pulls).
 * Engage with other TypeScript users and developers on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript).
 * Help each other in the [TypeScript Community Discord](https://discord.gg/typescript).
-* Join the [#typescript](https://x.com/typescript) discussion on X.
+* Join the [#typescript](https://x.com/search?q=%23TypeScript) discussion on X.
 * [Contribute bug fixes](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see


### PR DESCRIPTION
Fixes #56546 

Updates the two Twitter references in README.md to X, and leaves all other files unchanged.