### PR TITLE
fix: panic on nil point on name check

### DIFF
--- a/tsc/internal/parser/parser_test.go
+++ b/tsc/internal/parser/parser_test.go
@@ -329,32 +329,3 @@ namespace N {
 	assert.Equal(t, positionMap.UTF8ToUTF16(afterBoxDrawingCharacter), afterBoxDrawingCharacter-2)
 	assert.Equal(t, positionMap.UTF8ToUTF16(len(sourceText)), len(sourceText)-2)
 }
-
-func TestJSDocOverloadAnonDefaultExport(t *testing.T) {
-	t.Parallel()
-	sourceText := `/** @overload */
-export default function () {}
-`
-	opts := ast.SourceFileParseOptions{FileName: "/index.js", Path: "/index.js"}
-
-	file := parser.ParseSourceFile(opts, sourceText, core.ScriptKindJS)
-
-	function := file.Statements.Nodes[0]
-	assert.Assert(t, ast.IsFunctionDeclaration(function))
-	assert.Assert(t, function.Name() == nil)
-}
-
-func TestJSDocOverloadNamedDefaultExport(t *testing.T) {
-	t.Parallel()
-	sourceText := `/** @overload */
-export default function foo() {}
-`
-	opts := ast.SourceFileParseOptions{FileName: "/index.js", Path: "/index.js"}
-
-	file := parser.ParseSourceFile(opts, sourceText, core.ScriptKindJS)
-
-	function := file.Statements.Nodes[0]
-	assert.Assert(t, ast.IsFunctionDeclaration(function))
-	assert.Assert(t, function.Name() != nil)
-	assert.Equal(t, function.Name().Text(), "foo")
-}

--- a/tsc/internal/parser/parser_test.go
+++ b/tsc/internal/parser/parser_test.go
@@ -329,3 +329,32 @@ namespace N {
 	assert.Equal(t, positionMap.UTF8ToUTF16(afterBoxDrawingCharacter), afterBoxDrawingCharacter-2)
 	assert.Equal(t, positionMap.UTF8ToUTF16(len(sourceText)), len(sourceText)-2)
 }
+
+func TestJSDocOverloadAnonDefaultExport(t *testing.T) {
+	t.Parallel()
+	sourceText := `/** @overload */
+export default function () {}
+`
+	opts := ast.SourceFileParseOptions{FileName: "/index.js", Path: "/index.js"}
+
+	file := parser.ParseSourceFile(opts, sourceText, core.ScriptKindJS)
+
+	function := file.Statements.Nodes[0]
+	assert.Assert(t, ast.IsFunctionDeclaration(function))
+	assert.Assert(t, function.Name() == nil)
+}
+
+func TestJSDocOverloadNamedDefaultExport(t *testing.T) {
+	t.Parallel()
+	sourceText := `/** @overload */
+export default function foo() {}
+`
+	opts := ast.SourceFileParseOptions{FileName: "/index.js", Path: "/index.js"}
+
+	file := parser.ParseSourceFile(opts, sourceText, core.ScriptKindJS)
+
+	function := file.Statements.Nodes[0]
+	assert.Assert(t, ast.IsFunctionDeclaration(function))
+	assert.Assert(t, function.Name() != nil)
+	assert.Equal(t, function.Name().Text(), "foo")
+}

--- a/tsc/internal/parser/reparser.go
+++ b/tsc/internal/parser/reparser.go
@@ -39,6 +39,10 @@ func (p *Parser) addTransformedReparse(newNode *ast.Node, old *ast.Node) *ast.No
 }
 
 func (p *Parser) checkNonIdentifierName(name *ast.Node) *ast.Node {
+	// Handles the case of anonymous functions
+	if name == nil {
+		return nil
+	}
 	if ast.IsIdentifier(name) && !scanner.IsValidIdentifier(name.AsIdentifier().Text) {
 		errLoc := name.Loc
 		if errLoc.Len() == 0 { // missing name, emit error on the character before the missing name node

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.js
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/jsDocOverloadAnonDefaultExport.ts] ////
+
+//// [jsDocOverloadAnonDefaultExport.js]
+/** @overload */
+export default function () {}
+
+
+//// [jsDocOverloadAnonDefaultExport.js]
+/** @overload */
+export default function () { }
+
+
+//// [jsDocOverloadAnonDefaultExport.d.ts]
+/** @overload */
+export default function (): any;

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.symbols
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/compiler/jsDocOverloadAnonDefaultExport.ts] ////
+
+=== jsDocOverloadAnonDefaultExport.js ===
+
+/** @overload */
+export default function () {}
+

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.types
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadAnonDefaultExport.types
@@ -1,0 +1,7 @@
+//// [tests/cases/compiler/jsDocOverloadAnonDefaultExport.ts] ////
+
+=== jsDocOverloadAnonDefaultExport.js ===
+
+/** @overload */
+export default function () {}
+

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.js
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/jsDocOverloadNamedDefaultExport.ts] ////
+
+//// [jsDocOverloadNamedDefaultExport.js]
+/** @overload */
+export default function foo() {}
+
+
+//// [jsDocOverloadNamedDefaultExport.js]
+/** @overload */
+export default function foo() { }
+
+
+//// [jsDocOverloadNamedDefaultExport.d.ts]
+/** @overload */
+export default function foo(): any;

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.symbols
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.symbols
@@ -1,0 +1,7 @@
+//// [tests/cases/compiler/jsDocOverloadNamedDefaultExport.ts] ////
+
+=== jsDocOverloadNamedDefaultExport.js ===
+/** @overload */
+export default function foo() {}
+>foo : Symbol(foo, Decl(jsDocOverloadNamedDefaultExport.js, 0, 5), Decl(jsDocOverloadNamedDefaultExport.js, 0, 0))
+

--- a/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.types
+++ b/tsc/testdata/baselines/reference/compiler/jsDocOverloadNamedDefaultExport.types
@@ -1,0 +1,7 @@
+//// [tests/cases/compiler/jsDocOverloadNamedDefaultExport.ts] ////
+
+=== jsDocOverloadNamedDefaultExport.js ===
+/** @overload */
+export default function foo() {}
+>foo : () => any
+

--- a/tsc/testdata/tests/cases/compiler/jsDocOverloadAnonDefaultExport.ts
+++ b/tsc/testdata/tests/cases/compiler/jsDocOverloadAnonDefaultExport.ts
@@ -1,0 +1,8 @@
+// @target: es2015
+// @allowJs: true
+// @outDir: dist/
+// @declaration: true
+// @filename: jsDocOverloadAnonDefaultExport.js
+
+/** @overload */
+export default function () {}

--- a/tsc/testdata/tests/cases/compiler/jsDocOverloadNamedDefaultExport.ts
+++ b/tsc/testdata/tests/cases/compiler/jsDocOverloadNamedDefaultExport.ts
@@ -1,0 +1,8 @@
+// @target: es2015
+// @allowJs: true
+// @outDir: dist/
+// @declaration: true
+// @filename: jsDocOverloadNamedDefaultExport.js
+
+/** @overload */
+export default function foo() {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `npx hereby test`
* [x] You've successfully run `npx hereby lint`
* [x] You've successfully run `npx hereby check:format`
* [x] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

# Why
In `checkNonIdentifierName`, when name is `nil`, a panic occurs due to a nil pointer reference.

Fixes #63750

# How
Adds a check on the name, instead of passing it to `IsIdentifier`. This prevents the panic when passing a nil pointer to `IsIdentifier`.
Returns an early `nil` if name is already  `nil`.

# Tests
- Add a test to cover anonymous and non-anonymous default function declarations

# Verification
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `npx hereby test`
* [x] You've successfully run `npx hereby lint`
* [x] You've successfully run `npx hereby check:format`
* [x] There are new or updated tests validating the change