### PR TITLE
Avoid allocations when checking project reference declaration directories

### DIFF
--- a/tsc/internal/compiler/projectreferencedtsfakinghost.go
+++ b/tsc/internal/compiler/projectreferencedtsfakinghost.go
@@ -223,13 +223,8 @@ func (fs *projectReferenceDtsFakingVfs) fileExistsIfProjectReferenceDts(file str
 
 func (fs *projectReferenceDtsFakingVfs) directoryExistsIfProjectReferenceDeclDir(dir string) core.Tristate {
 	dirPath := fs.toPath(dir)
-	dirPathWithTrailingDirectorySeparator := dirPath + "/"
 	for declDirPath := range fs.dtsDirectories.Keys() {
-		if dirPath == declDirPath ||
-			// Any parent directory of declaration dir
-			strings.HasPrefix(string(declDirPath), string(dirPathWithTrailingDirectorySeparator)) ||
-			// Any directory inside declaration dir
-			strings.HasPrefix(string(dirPath), string(declDirPath)+"/") {
+		if dirPath.ContainsPath(declDirPath) || declDirPath.ContainsPath(dirPath) {
 			return core.TSTrue
 		}
 	}


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `npx hereby test`
* [ ] You've successfully run `npx hereby lint`
* [ ] You've successfully run `npx hereby check:format`
* [ ] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

Fixes #63976

`ContainsPath` does the same check without extra allocations

https://github.com/microsoft/TypeScript/blob/e9e477458d7b975ed5e43117fb85f6bc87363a6a/tsc/internal/tspath/path.go#L1085-L1093

---

Before: `handled method 'textDocument/references' (32) in 3.071585458s`

<img width="3456" height="2066" alt="image" src="https://github.com/user-attachments/assets/7c0bf53f-1be8-422b-9293-2ab7e4e7accd" />

After: `handled method 'textDocument/references' (20) in 2.692099625s`

<img width="1728" height="991" alt="image" src="https://github.com/user-attachments/assets/cd755c6f-441a-4dd5-be9e-a1127c3c6c9a" />
