### PR TITLE
Speed up CI with more jobs, less work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       TSGO_HEREBY_RACE: ${{ (matrix.config.race && 'true') || 'false' }}
       TSGO_HEREBY_NOEMBED: ${{ (matrix.config.noembed && 'true') || 'false' }}
       TSGO_HEREBY_CONCURRENT_TEST_PROGRAMS: ${{ (matrix.config.concurrent-test-programs && 'true') || 'false' }}
-      TSGO_HEREBY_COVERAGE: ${{ (matrix.config.coverage && 'true') || 'false' }}
+      TSGO_HEREBY_COVERAGE: ${{ (matrix.config.coverage && github.event_name != 'merge_group' && 'true') || 'false' }}
     steps:
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -138,13 +138,9 @@ jobs:
         if: ${{ matrix.config.os != 'windows' && !matrix.config.race }}
       - name: Tests
         id: test
-        run: npx hereby test
+        run: npx hereby test:tsc
       - name: Benchmarks
         run: npx hereby test:benchmarks
-      - name: Tools Tests
-        run: npx hereby test:tools
-      - name: API Tests
-        run: npx hereby test:api
       - run: git add .
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ always() && matrix.config.coverage && github.event_name != 'merge_group' }}
@@ -164,6 +160,70 @@ jobs:
         with:
           name: ${{ matrix.config.name || matrix.config.os }}-new-baselines
           path: tsc/testdata/baselines/local
+
+  test-extra:
+    strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+      matrix:
+        config:
+          - runner: ubuntu-latest
+            os: linux
+            coverage: true
+            main: true
+          - runner: windows-latest
+            os: windows
+            coverage: true
+            skip: ${{ github.event_name == 'merge_group' }}
+          - runner: macos-latest
+            os: macos
+            coverage: true
+            skip: ${{ github.event_name == 'merge_group' || github.event_name == 'pull_request' }}
+        exclude:
+          - config:
+              skip: true
+
+    name: test extra (${{ matrix.config.runner }})
+    runs-on: ${{ matrix.config.runner }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      TSGO_HEREBY_COVERAGE: ${{ (matrix.config.coverage && github.event_name != 'merge_group' && 'true') || 'false' }}
+    steps:
+      - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+          dotnet: false
+      - run: git config --system core.longpaths true
+        if: ${{ matrix.config.os == 'windows' }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 'lts/*'
+      - uses: ./.github/actions/setup-go
+      - if: ${{ !matrix.config.main }}
+        name: Disable PR annotations
+        run: |
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+          echo "::remove-matcher owner=tsc::"
+          echo "::remove-matcher owner=go::"
+      - run: npm ci
+      - run: go install gotest.tools/gotestsum@latest
+        if: ${{ matrix.config.os != 'windows' }}
+      - run: npx hereby test:extension
+      - run: npx hereby test:tools
+      - run: npx hereby test:api
+      - run: git add .
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ always() && matrix.config.coverage && github.event_name != 'merge_group' }}
+        with:
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+          name: extra-${{ matrix.config.runner }}
+          directory: ./coverage
+      - run: git diff --staged --exit-code --stat
 
   lint:
     strategy:
@@ -312,6 +372,7 @@ jobs:
       - package-feed-proxy
       - smoke
       - test
+      - test-extra
       - tidy
     steps:
       - name: Check required jobs

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -784,6 +784,12 @@ async function runTestExtension() {
     await $`npm test -w vscode-typescript`;
 }
 
+export const testTsc = task({
+    name: "test:tsc",
+    description: "Runs all tests in the tsc module.",
+    run: runTests,
+});
+
 export const test = task({
     name: "test",
     description: "Runs all tests. This is the most typical test task to need.",


### PR DESCRIPTION
I'm trying to get the merge queue time down; use more jobs and split apart the tests a bit. Also disable coverage for merge queues, which is a waste.

By my measure, this should reduce merge queue time by 40%.