### PR TITLE
Fix extension launching

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -7,7 +7,9 @@
             "name": "Launch VS Code extension",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-typescript"
+                "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-typescript",
+                "--new-window",
+                "--disable-extension=TypeScriptTeam.native-preview"
             ],
             "outFiles": [
                 "${workspaceFolder}/packages/vscode-typescript/dist/**/*.js"

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -8,8 +8,7 @@
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-typescript",
-                "--new-window",
-                "--disable-extension=TypeScriptTeam.native-preview"
+                "--new-window"
             ],
             "outFiles": [
                 "${workspaceFolder}/packages/vscode-typescript/dist/**/*.js"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,7 +57,7 @@
             "type": "npm",
             "script": "extension:build",
             "group": "build",
-            "problemMatcher": ["$tsc"]
+            "problemMatcher": ["$esbuild"]
         },
         {
             "label": "Watch extension",
@@ -65,7 +65,7 @@
             "script": "extension:watch",
             "group": "build",
             "isBackground": true,
-            "problemMatcher": []
+            "problemMatcher": ["$esbuild-watch"]
         },
         {
             "label": "Watch for extension run",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,7 +57,30 @@
             "type": "npm",
             "script": "extension:build",
             "group": "build",
-            "problemMatcher": ["$esbuild"]
+            "problemMatcher": [
+                "$tsc",
+                // Copy-paste from https://github.com/connor4312/esbuild-problem-matchers to avoid the extension dependency
+                {
+                    "owner": "esbuild",
+                    "severity": "error",
+                    "applyTo": "closedDocuments",
+                    "source": "esbuild",
+                    "fileLocation": "relative",
+                    "pattern": [
+                        {
+                            "regexp": "^[✘▲] \\[([A-Z]+)\\] (.+)",
+                            "severity": 1,
+                            "message": 2
+                        },
+                        {
+                            "regexp": "^(?:\\t| {4})(?!\\s)([^:]+)(?::([0-9]+))?(?::([0-9]+))?:$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3
+                        }
+                    ]
+                }
+            ]
         },
         {
             "label": "Watch extension",
@@ -65,7 +88,38 @@
             "script": "extension:watch",
             "group": "build",
             "isBackground": true,
-            "problemMatcher": ["$esbuild-watch"]
+            "problemMatcher": [
+                // Copy-paste from https://github.com/connor4312/esbuild-problem-matchers to avoid the extension dependency
+                {
+                    "owner": "esbuild-watch",
+                    "severity": "error",
+                    "applyTo": "closedDocuments",
+                    "source": "esbuild",
+                    "fileLocation": "relative",
+                    "pattern": [
+                        {
+                            "regexp": "^[✘▲] \\[([A-Z]+)\\] (.+)",
+                            "severity": 1,
+                            "message": 2
+                        },
+                        {
+                            "regexp": "^(?:\\t| {4})(?!\\s)([^:]+)(?::([0-9]+))?(?::([0-9]+))?:$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3
+                        }
+                    ],
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": {
+                            "regexp": "\\[watch\\] build started"
+                        },
+                        "endsPattern": {
+                            "regexp": "\\[watch\\] build finished"
+                        }
+                    }
+                }
+            ]
         },
         {
             "label": "Watch for extension run",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Package-specific commands:
 ```bash
 npm run -w @typescript/typescript build
 npm run -w @typescript/typescript test
-npm run -w vscode-typescript build
+npm run -w native-preview build
 ```
 
 ## Compiler tests
@@ -143,7 +143,7 @@ npx hereby format
 npx hereby check:format
 npm run -w @typescript/typescript build
 npm run -w @typescript/typescript test
-npm run -w vscode-typescript build
+npm run -w native-preview build
 go -C ./tsc mod tidy -diff
 go -C ./tools mod tidy -diff
 go work sync

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -287,7 +287,7 @@ export const generateExtension = task({
     name: "generate:extension",
     description: "Generates files in the extension",
     run: async () => {
-        await $`npm run -w vscode-typescript generateLocBundle`;
+        await $`npm run -w native-preview generateLocBundle`;
     },
 });
 
@@ -781,7 +781,7 @@ async function runTests() {
 }
 
 async function runTestExtension() {
-    await $`npm test -w vscode-typescript`;
+    await $`npm test -w native-preview`;
 }
 
 export const test = task({

--- a/package-lock.json
+++ b/package-lock.json
@@ -4211,6 +4211,10 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/native-preview": {
+            "resolved": "packages/vscode-typescript",
+            "link": true
+        },
         "node_modules/node-abi": {
             "version": "3.94.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
@@ -5675,10 +5679,6 @@
                 "vscode": "^1.85.0"
             }
         },
-        "node_modules/vscode-typescript": {
-            "resolved": "packages/vscode-typescript",
-            "link": true
-        },
         "node_modules/vscode-typescript-nightly": {
             "resolved": "packages/vscode-typescript-nightly",
             "link": true
@@ -5864,6 +5864,7 @@
             "license": "MIT"
         },
         "packages/vscode-typescript": {
+            "name": "native-preview",
             "version": "0.0.0",
             "dependencies": {
                 "@vscode/extension-telemetry": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "check:format": "hereby check:format",
         "generate": "hereby generate",
         "tidy": "hereby tidy",
-        "extension:build": "npm run -w vscode-typescript build",
-        "extension:watch": "npm run -w vscode-typescript watch",
+        "extension:build": "npm run -w native-preview build",
+        "extension:watch": "npm run -w native-preview watch",
         "setup-hooks": "node tools/scripts/link-hooks.mjs"
     },
     "devDependencies": {

--- a/packages/vscode-typescript/package.json
+++ b/packages/vscode-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "vscode-typescript",
+    "name": "native-preview",
     "displayName": "TypeScript 7",
     "publisher": "TypeScriptTeam",
     "author": "Microsoft Corp.",

--- a/packages/vscode-typescript/src/util.ts
+++ b/packages/vscode-typescript/src/util.ts
@@ -49,11 +49,11 @@ const packagedExeBaseNames = ["tsc", "tsgo"];
 
 export async function getBuiltinExePath(context: vscode.ExtensionContext): Promise<ExeInfo> {
     if (context.extensionMode === vscode.ExtensionMode.Development) {
-        const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
-        const exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
+        const exeName = `tsc${process.platform === "win32" ? ".exe" : ""}`;
+        const exe = context.asAbsolutePath(path.join("../../", "built", "local", exeName));
         try {
             await vscode.workspace.fs.stat(vscode.Uri.file(exe));
-            return { path: exe, version: "(local)", name: "tsgo", isLocal: true };
+            return { path: exe, version: "(local)", name: "tsc", isLocal: true };
         }
         catch {}
     }

--- a/packages/vscode-typescript/src/util.ts
+++ b/packages/vscode-typescript/src/util.ts
@@ -41,7 +41,6 @@ export function isJsConfigOrTsConfigFileName(fileName: string): boolean {
 export interface ExeInfo {
     path: string;
     version: string;
-    name: string;
     isLocal?: boolean;
 }
 
@@ -53,7 +52,7 @@ export async function getBuiltinExePath(context: vscode.ExtensionContext): Promi
         const exe = context.asAbsolutePath(path.join("../../", "built", "local", exeName));
         try {
             await vscode.workspace.fs.stat(vscode.Uri.file(exe));
-            return { path: exe, version: "(local)", name: "tsc", isLocal: true };
+            return { path: exe, version: "(local)", isLocal: true };
         }
         catch {}
     }
@@ -106,7 +105,6 @@ async function tryGetPackagedExePath(extensionUri: vscode.Uri, version: unknown)
             return {
                 path: withLongPathPrefix(exePath.fsPath),
                 version: typeof version === "string" ? version : "unknown",
-                name: baseName,
             };
         }
         catch {}
@@ -340,7 +338,7 @@ export async function resolveTsdkPathToExe(tsdkPath: string): Promise<ExeInfo | 
             const platformPackage = `${baseName}-${process.platform}-${process.arch}`;
             const exePath = vscode.Uri.file(resolvePackageExecutable(packageJsonPath.fsPath, platformPackage, exeName));
             await vscode.workspace.fs.stat(exePath);
-            return { path: withLongPathPrefix(exePath.fsPath), version: typeof packageJson.version === "string" ? packageJson.version : "unknown", name: expectedBinName };
+            return { path: withLongPathPrefix(exePath.fsPath), version: typeof packageJson.version === "string" ? packageJson.version : "unknown" };
         }
         catch {}
     }
@@ -348,7 +346,7 @@ export async function resolveTsdkPathToExe(tsdkPath: string): Promise<ExeInfo | 
         try {
             const exePath = vscode.Uri.joinPath(resolved, `${baseName}${process.platform === "win32" ? ".exe" : ""}`);
             await vscode.workspace.fs.stat(exePath);
-            return { path: withLongPathPrefix(exePath.fsPath), version: "(local)", name: baseName, isLocal: true };
+            return { path: withLongPathPrefix(exePath.fsPath), version: "(local)", isLocal: true };
         }
         catch {}
     }


### PR DESCRIPTION
Extension launching was a little bit broken. Here's a few fixes and cleanups that get it into shape:

1. Use the inlined esbuild problem matchers so that we can register that the builds succeed.
2. Add `--new-window` to `launch.template.json` - otherwise, VS Code weirdly complains with

   ```
   The debugger needs to open a new tab or window for the debuggee but the browser prevented this. You must give permission to continue.
   ```
3. ~Disable `TypeScriptTeam.native-preview`~ Rename the extension to `native-preview` so that the new extension takes over on top of the old one. Otherwise, the two would have conflicted in their commands and settings:

   ```
   Cannot register 'js/ts.trace.server'. This property is already registered.
   Activating extension 'TypeScriptTeam.vscode-typescript' failed: command 'typescript.native-preview.enable' already exists.
   ```
   
4. The executable is now named `tsc`, so lookup needs to use that instead of `tsgo`.
5. Resolve the executable with an extra `../` since the extension is now one level deeper, since it was moved within `packages`.
6. A minor cleanup: I deleted an unused `name` property from `ExeInfo`.