### PR TITLE
Don't reuse emit resolvers cross-file

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -884,8 +884,6 @@ type Checker struct {
 	isStringIndexSignatureOnlyType              func(*Type) bool
 	markNodeAssignments                         func(*ast.Node) bool
 	compareTypesAssignable                      TypeComparer
-	emitResolver                                *EmitResolver
-	emitResolverOnce                            sync.Once
 	_jsxNamespace                               string
 	_jsxFactoryEntity                           *ast.Node
 	skipDirectInferenceNodes                    collections.Set[*ast.Node]
@@ -32285,12 +32283,8 @@ func (c *Checker) GetTypeAtLocation(node *ast.Node) *Type {
 	return c.getTypeOfNode(ast.GetReparsedNodeForNode(node))
 }
 
-func (c *Checker) GetEmitResolver() *EmitResolver {
-	c.emitResolverOnce.Do(func() {
-		c.emitResolver = newEmitResolver(c)
-	})
-
-	return c.emitResolver
+func (c *Checker) NewEmitResolver() *EmitResolver {
+	return newEmitResolver(c)
 }
 
 func (c *Checker) GetAliasedSymbol(symbol *ast.Symbol) *ast.Symbol {

--- a/tsc/internal/checker/emitresolver.go
+++ b/tsc/internal/checker/emitresolver.go
@@ -50,10 +50,6 @@ func newEmitResolver(checker *Checker) *EmitResolver {
 	return e
 }
 
-func (c *Checker) NewEmitResolver() *EmitResolver {
-	return newEmitResolver(c)
-}
-
 func (r *EmitResolver) GetJsxFactoryEntity(location *ast.Node) *ast.Node {
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()

--- a/tsc/internal/checker/emitresolver.go
+++ b/tsc/internal/checker/emitresolver.go
@@ -50,6 +50,10 @@ func newEmitResolver(checker *Checker) *EmitResolver {
 	return e
 }
 
+func (c *Checker) NewEmitResolver() *EmitResolver {
+	return newEmitResolver(c)
+}
+
 func (r *EmitResolver) GetJsxFactoryEntity(location *ast.Node) *ast.Node {
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
@@ -679,7 +683,7 @@ func (r *EmitResolver) IsExpandoFunctionDeclaration(node *ast.Node) bool {
 }
 
 func (r *EmitResolver) isSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasToMarkVisible bool) printer.SymbolAccessibilityResult {
-	return r.checker.IsSymbolAccessible(symbol, enclosingDeclaration, meaning, shouldComputeAliasToMarkVisible)
+	return r.checker.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, shouldComputeAliasToMarkVisible, true /*allowModules*/, r)
 }
 
 func (r *EmitResolver) IsSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasToMarkVisible bool) printer.SymbolAccessibilityResult {
@@ -955,7 +959,7 @@ func (r *EmitResolver) CreateReturnTypeOfSignatureDeclaration(emitContext *print
 
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 	return requestNodeBuilder.SerializeReturnTypeForSignature(original, enclosingDeclaration, flags, internalFlags, tracker)
 }
 
@@ -967,7 +971,7 @@ func (r *EmitResolver) CreateTypeParametersOfSignatureDeclaration(emitContext *p
 
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 	return requestNodeBuilder.SerializeTypeParametersForSignature(original, enclosingDeclaration, flags, internalFlags, tracker)
 }
 
@@ -979,7 +983,7 @@ func (r *EmitResolver) CreateTypeOfDeclaration(emitContext *printer.EmitContext,
 
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 	// // Get type of the symbol if this is the valid symbol otherwise get type at location
 	symbol := r.checker.getSymbolOfDeclaration(declaration)
 	return requestNodeBuilder.SerializeTypeForDeclaration(declaration, symbol, enclosingDeclaration, flags|nodebuilder.FlagsMultilineObjectLiterals, internalFlags, tracker)
@@ -998,7 +1002,7 @@ func (r *EmitResolver) CreateLiteralConstValue(emitContext *printer.EmitContext,
 	if t.flags&TypeFlagsEnumLike != 0 {
 		r.checkerMu.Lock()
 		defer r.checkerMu.Unlock()
-		requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+		requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 		enumResult = requestNodeBuilder.SymbolToExpression(t.symbol, ast.SymbolFlagsValue, node, nodebuilder.FlagsNone, nodebuilder.InternalFlagsNone, tracker)
 		// What about regularTrueType/regularFalseType - since those aren't fresh, we never make initializers from them
 		// TODO: handle those if this function is ever used for more than initializers in declaration emit
@@ -1054,7 +1058,7 @@ func (r *EmitResolver) CreateTypeOfExpression(emitContext *printer.EmitContext, 
 
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 	return requestNodeBuilder.SerializeTypeForExpression(expression, enclosingDeclaration, flags|nodebuilder.FlagsMultilineObjectLiterals, internalFlags, tracker)
 }
 
@@ -1072,7 +1076,7 @@ func (r *EmitResolver) CreateLateBoundIndexSignatures(emitContext *printer.EmitC
 		instanceInfos = r.checker.getIndexInfosOfIndexSymbol(instanceIndexSymbol, siblingSymbols)
 	}
 
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 
 	var result []*ast.Node
 	for i, infoList := range [][]*IndexInfo{staticInfos, instanceInfos} {
@@ -1281,7 +1285,7 @@ func (r *EmitResolver) TryJSTypeNodeToTypeNode(emitContext *printer.EmitContext,
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
 
-	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	requestNodeBuilder := newNodeBuilder(r.checker, emitContext, r) // TODO: cache per-context
 	return requestNodeBuilder.TryJSTypeNodeToTypeNode(typeNode, enclosingDeclaration, flags, internalFlags, tracker)
 }
 

--- a/tsc/internal/checker/exports.go
+++ b/tsc/internal/checker/exports.go
@@ -361,7 +361,7 @@ func (c *Checker) RequiresAddingImplicitUndefined(node *ast.Node) bool {
 	if symbol == nil {
 		return false
 	}
-	return c.GetEmitResolver().RequiresAddingImplicitUndefined(node, symbol, enclosingDeclaration)
+	return c.NewEmitResolver().RequiresAddingImplicitUndefined(node, symbol, enclosingDeclaration)
 }
 
 func (c *Checker) RemoveMissingOrUndefinedType(t *Type) *Type {

--- a/tsc/internal/checker/nodebuilder.go
+++ b/tsc/internal/checker/nodebuilder.go
@@ -281,7 +281,15 @@ func NewNodeBuilder(ch *Checker, e *printer.EmitContext) *NodeBuilder {
 }
 
 func NewNodeBuilderEx(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast.IdentifierNode]*ast.Symbol) *NodeBuilder {
-	impl := newNodeBuilderImpl(ch, e, idToSymbol)
+	return newNodeBuilderEx(ch, e, idToSymbol, ch.GetEmitResolver())
+}
+
+func newNodeBuilder(ch *Checker, e *printer.EmitContext, emitResolver *EmitResolver) *NodeBuilder {
+	return newNodeBuilderEx(ch, e, nil /*idToSymbol*/, emitResolver)
+}
+
+func newNodeBuilderEx(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast.IdentifierNode]*ast.Symbol, emitResolver *EmitResolver) *NodeBuilder {
+	impl := newNodeBuilderImpl(ch, e, idToSymbol, emitResolver)
 	return &NodeBuilder{impl: impl, ctxStack: make([]*NodeBuilderContext, 0, 1), host: ch.program}
 }
 

--- a/tsc/internal/checker/nodebuilder.go
+++ b/tsc/internal/checker/nodebuilder.go
@@ -281,7 +281,7 @@ func NewNodeBuilder(ch *Checker, e *printer.EmitContext) *NodeBuilder {
 }
 
 func NewNodeBuilderEx(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast.IdentifierNode]*ast.Symbol) *NodeBuilder {
-	return newNodeBuilderEx(ch, e, idToSymbol, ch.GetEmitResolver())
+	return newNodeBuilderEx(ch, e, idToSymbol, ch.NewEmitResolver())
 }
 
 func newNodeBuilder(ch *Checker, e *printer.EmitContext, emitResolver *EmitResolver) *NodeBuilder {

--- a/tsc/internal/checker/nodebuilderimpl.go
+++ b/tsc/internal/checker/nodebuilderimpl.go
@@ -100,7 +100,8 @@ type NodeBuilderImpl struct {
 	symbolLinks core.LinkStore[*ast.Symbol, NodeBuilderSymbolLinks]
 
 	// state
-	ctx *NodeBuilderContext
+	ctx          *NodeBuilderContext
+	emitResolver *EmitResolver
 
 	// reusable visitor
 	cloneBindingNameVisitor *ast.NodeVisitor
@@ -116,13 +117,17 @@ const (
 
 // Node builder utility functions
 
-func newNodeBuilderImpl(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast.IdentifierNode]*ast.Symbol) *NodeBuilderImpl {
+func newNodeBuilderImpl(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast.IdentifierNode]*ast.Symbol, emitResolver *EmitResolver) *NodeBuilderImpl {
 	if idToSymbol == nil {
 		idToSymbol = make(map[*ast.IdentifierNode]*ast.Symbol)
 	}
-	b := &NodeBuilderImpl{f: e.Factory.AsNodeFactory(), ch: ch, e: e, idToSymbol: idToSymbol, pc: pseudochecker.NewPseudoChecker(ch.strictNullChecks, ch.exactOptionalPropertyTypes)}
+	b := &NodeBuilderImpl{f: e.Factory.AsNodeFactory(), ch: ch, e: e, idToSymbol: idToSymbol, pc: pseudochecker.NewPseudoChecker(ch.strictNullChecks, ch.exactOptionalPropertyTypes), emitResolver: emitResolver}
 	b.cloneBindingNameVisitor = ast.NewNodeVisitor(b.cloneBindingName, b.f, ast.NodeVisitorHooks{})
 	return b
+}
+
+func (b *NodeBuilderImpl) isSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, allowModules bool) bool {
+	return b.ch.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, false /*shouldComputeAliasesToMakeVisible*/, allowModules, b.emitResolver).Accessibility == printer.SymbolAccessibilityAccessible
 }
 
 func (b *NodeBuilderImpl) saveRestoreFlags() func() {
@@ -448,7 +453,7 @@ func (b *NodeBuilderImpl) serializeTypeName(node *ast.Node, isTypeOf bool, typeA
 		resolvedSymbol = b.ch.resolveAlias(symbol)
 	}
 
-	if b.ch.IsSymbolAccessible(symbol, b.ctx.enclosingDeclaration, meaning, false).Accessibility != printer.SymbolAccessibilityAccessible {
+	if !b.isSymbolAccessible(symbol, b.ctx.enclosingDeclaration, meaning, true /*allowModules*/) {
 		return nil
 	}
 	return b.symbolToTypeNode(resolvedSymbol, meaning, typeArguments)
@@ -2081,7 +2086,7 @@ func (b *NodeBuilderImpl) isTriviallySerializableComputedName(e *ast.Node) bool 
 		return false
 	}
 	// TODO: going through emit resolver here is weird. Relayer these APIs.
-	return b.ch.GetEmitResolver().isEntityNameVisible(e.Name().Expression(), b.ctx.enclosingDeclaration, false).Accessibility == printer.SymbolAccessibilityAccessible
+	return b.emitResolver.isEntityNameVisible(e.Name().Expression(), b.ctx.enclosingDeclaration, false).Accessibility == printer.SymbolAccessibilityAccessible
 }
 
 func (b *NodeBuilderImpl) indexInfoToObjectComputedNamesOrSignatureDeclaration(indexInfo *IndexInfo, typeNode *ast.TypeNode) []*ast.Node {
@@ -2213,7 +2218,7 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 	}
 
 	// !!! TODO: JSDoc, getEmitResolver call is unfortunate layering for the helper - hoist it into checker
-	requiresAddingUndefined := declaration != nil && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && b.ch.GetEmitResolver().requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
+	requiresAddingUndefined := declaration != nil && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && b.emitResolver.requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
 	addUndefinedForParameter := requiresAddingUndefined && (ast.IsParameterDeclaration(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/)
 	if addUndefinedForParameter {
 		t = b.ch.getOptionalType(t, false)
@@ -2470,7 +2475,7 @@ func (b *NodeBuilderImpl) getPropertyNameNodeForSymbolFromNameType(symbol *ast.S
 			enumSymbol = nameType.symbol
 		}
 		if enumEnclosingDeclaration != nil &&
-			b.ch.IsSymbolAccessibleByFlags(enumSymbol, enumEnclosingDeclaration, ast.SymbolFlagsValue) {
+			b.isSymbolAccessible(enumSymbol, enumEnclosingDeclaration, ast.SymbolFlagsValue, false /*allowModules*/) {
 			saveEnclosingDeclaration := b.ctx.enclosingDeclaration
 			b.ctx.enclosingDeclaration = enumEnclosingDeclaration
 			result := b.f.NewComputedPropertyName(b.symbolToExpression(nameType.symbol, ast.SymbolFlagsValue))
@@ -2807,7 +2812,7 @@ func (b *NodeBuilderImpl) shouldWriteTypeOfFunctionSymbol(symbol *ast.Symbol, ty
 		}
 		// typeof is allowed only for static/non local functions
 		return (b.ctx.flags&nodebuilder.FlagsUseTypeOfFunction != 0 || b.ctx.visitedTypes.Has(typeId)) && // it is type of the symbol uses itself recursively
-			(b.ctx.flags&nodebuilder.FlagsUseStructuralFallback == 0 || b.ch.IsValueSymbolAccessible(symbol, b.ctx.enclosingDeclaration)), symbol // And the build is going to succeed without visibility error or there is no structural fallback allowed
+			(b.ctx.flags&nodebuilder.FlagsUseStructuralFallback == 0 || b.isSymbolAccessible(symbol, b.ctx.enclosingDeclaration, ast.SymbolFlagsValue, true /*allowModules*/)), symbol // And the build is going to succeed without visibility error or there is no structural fallback allowed
 	}
 	return false, symbol
 }
@@ -2820,7 +2825,7 @@ func (b *NodeBuilderImpl) shouldEmitTypeOfSymbol(forceExpansion bool, forceClass
 	if forceExpansion {
 		return false, symbol
 	}
-	nonFunctionResult := symbol.Flags&ast.SymbolFlagsClass != 0 && !forceClassExpansion && b.ch.getBaseTypeVariableOfClass(symbol) == nil && !(symbol.ValueDeclaration != nil && ast.IsClassLike(symbol.ValueDeclaration) && b.ctx.flags&nodebuilder.FlagsWriteClassExpressionAsTypeLiteral != 0 && (!ast.IsClassDeclaration(symbol.ValueDeclaration) || b.ch.IsSymbolAccessible(symbol, b.ctx.enclosingDeclaration, isInstanceType, false /*shouldComputeAliasesToMakeVisible*/).Accessibility != printer.SymbolAccessibilityAccessible)) || symbol.Flags&(ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0
+	nonFunctionResult := symbol.Flags&ast.SymbolFlagsClass != 0 && !forceClassExpansion && b.ch.getBaseTypeVariableOfClass(symbol) == nil && !(symbol.ValueDeclaration != nil && ast.IsClassLike(symbol.ValueDeclaration) && b.ctx.flags&nodebuilder.FlagsWriteClassExpressionAsTypeLiteral != 0 && (!ast.IsClassDeclaration(symbol.ValueDeclaration) || !b.isSymbolAccessible(symbol, b.ctx.enclosingDeclaration, isInstanceType, true /*allowModules*/))) || symbol.Flags&(ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0
 	if nonFunctionResult {
 		return true, symbol
 	}
@@ -3062,7 +3067,7 @@ func (b *NodeBuilderImpl) typeReferenceToTypeNode(t *Type) *ast.TypeNode {
 		b.ctx.encounteredError = true
 		return nil
 		// TODO: GH#18217
-	} else if b.ctx.flags&nodebuilder.FlagsWriteClassExpressionAsTypeLiteral != 0 && t.symbol.ValueDeclaration != nil && ast.IsClassLike(t.symbol.ValueDeclaration) && !b.ch.IsValueSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration) {
+	} else if b.ctx.flags&nodebuilder.FlagsWriteClassExpressionAsTypeLiteral != 0 && t.symbol.ValueDeclaration != nil && ast.IsClassLike(t.symbol.ValueDeclaration) && !b.isSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration, ast.SymbolFlagsValue, true /*allowModules*/) {
 		return b.createAnonymousTypeNode(t)
 	} else {
 		outerTypeParameters := t.Target().AsInterfaceType().OuterTypeParameters()
@@ -3333,7 +3338,7 @@ func (b *NodeBuilderImpl) typeToTypeNode(t *Type) *ast.TypeNode {
 	}
 	if t.flags&TypeFlagsUniqueESSymbol != 0 {
 		if b.ctx.flags&nodebuilder.FlagsAllowUniqueESSymbolType == 0 {
-			if b.ch.IsValueSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration) {
+			if b.isSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration, ast.SymbolFlagsValue, true /*allowModules*/) {
 				b.ctx.approximateLength += 6
 				return b.symbolToTypeNode(t.symbol, ast.SymbolFlagsValue, nil)
 			}
@@ -3377,7 +3382,7 @@ func (b *NodeBuilderImpl) typeToTypeNode(t *Type) *ast.TypeNode {
 		return b.f.NewThisTypeNode()
 	}
 
-	if inTypeAlias == 0 && t.alias != nil && (b.ctx.flags&nodebuilder.FlagsUseAliasDefinedOutsideCurrentScope != 0 || b.ch.IsTypeSymbolAccessible(t.alias.Symbol(), b.ctx.enclosingDeclaration)) {
+	if inTypeAlias == 0 && t.alias != nil && (b.ctx.flags&nodebuilder.FlagsUseAliasDefinedOutsideCurrentScope != 0 || b.isSymbolAccessible(t.alias.Symbol(), b.ctx.enclosingDeclaration, ast.SymbolFlagsType, true /*allowModules*/)) {
 		// If we should expand this type alias, skip the alias and fall through to expand the underlying type
 		if !b.shouldExpandType(t, true /*isAlias*/) {
 			sym := t.alias.Symbol()

--- a/tsc/internal/checker/nodecopy.go
+++ b/tsc/internal/checker/nodecopy.go
@@ -245,7 +245,7 @@ func (b *NodeBuilderImpl) getModuleSpecifierOverride(parent *ast.Node, lit *ast.
 			meaning = ast.SymbolFlagsValue
 		}
 		var parentSymbol *ast.Symbol
-		if nodeSymbol != nil && b.ch.IsSymbolAccessible(nodeSymbol, b.ctx.enclosingDeclaration, meaning, false).Accessibility == printer.SymbolAccessibilityAccessible {
+		if nodeSymbol != nil && b.isSymbolAccessible(nodeSymbol, b.ctx.enclosingDeclaration, meaning, true /*allowModules*/) {
 			parentSymbol = b.lookupSymbolChain(nodeSymbol, meaning, true)[0]
 		}
 		if parentSymbol != nil && IsExternalModuleSymbol(parentSymbol) {
@@ -330,7 +330,7 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 		if ast.IsThisIdentifier(leftmost) {
 			// `this` isn't a bindable identifier - skip resolution, find a relevant `this` symbol directly and avoid exhaustive scope traversal
 			sym = b.ch.getSymbolOfDeclaration(b.ch.getThisContainer(leftmost, false, false))
-			if b.ch.IsSymbolAccessible(sym, leftmost, meaning, false).Accessibility != printer.SymbolAccessibilityAccessible {
+			if !b.isSymbolAccessible(sym, leftmost, meaning, true /*allowModules*/) {
 				introducesError = true
 				b.ctx.tracker.ReportInaccessibleThisError()
 			}
@@ -371,7 +371,7 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 				}
 			}
 			if sym.Flags&ast.SymbolFlagsTypeParameter == 0 /* Type parameters are visible in the current context if they are are resolvable */ && !ast.IsDeclarationName(node) &&
-				b.ch.IsSymbolAccessible(sym, enclosingDeclaration, meaning, false).Accessibility != printer.SymbolAccessibilityAccessible {
+				!b.isSymbolAccessible(sym, enclosingDeclaration, meaning, true /*allowModules*/) {
 				b.ctx.tracker.ReportInferenceFallback(node)
 				introducesError = true
 			} else {

--- a/tsc/internal/checker/symbolaccessibility.go
+++ b/tsc/internal/checker/symbolaccessibility.go
@@ -8,25 +8,6 @@ import (
 	"github.com/microsoft/TypeScript/tsc/internal/printer"
 )
 
-func (c *Checker) IsTypeSymbolAccessible(typeSymbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
-	access := c.isSymbolAccessibleWorkerWithResolver(typeSymbol, enclosingDeclaration, ast.SymbolFlagsType /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true, c.GetEmitResolver())
-	return access.Accessibility == printer.SymbolAccessibilityAccessible
-}
-
-func (c *Checker) IsValueSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
-	access := c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, ast.SymbolFlagsValue /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true, c.GetEmitResolver())
-	return access.Accessibility == printer.SymbolAccessibilityAccessible
-}
-
-func (c *Checker) IsSymbolAccessibleByFlags(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags ast.SymbolFlags) bool {
-	access := c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, flags /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, false, c.GetEmitResolver()) // TODO: Strada bug? Why is this allowModules: false?
-	return access.Accessibility == printer.SymbolAccessibilityAccessible
-}
-
-func (c *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclaration *ast.Node, initialSymbol *ast.Symbol, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool) *printer.SymbolAccessibilityResult {
-	return c.isAnySymbolAccessible(symbols, enclosingDeclaration, initialSymbol, meaning, shouldComputeAliasesToMakeVisible, allowModules, c.GetEmitResolver())
-}
-
 func (c *Checker) isAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclaration *ast.Node, initialSymbol *ast.Symbol, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool, emitResolver *EmitResolver) *printer.SymbolAccessibilityResult {
 	if len(symbols) == 0 {
 		return nil
@@ -838,14 +819,6 @@ func (c *Checker) getClassExpressionNameTable(location *ast.Node) ast.SymbolTabl
  * @param meaning a SymbolFlags to check if such meaning of the symbol is accessible
  * @param shouldComputeAliasToMakeVisible a boolean value to indicate whether to return aliases to be mark visible in case the symbol is accessible
  */
-
-func (c *Checker) IsSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool) printer.SymbolAccessibilityResult {
-	return c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, true /*allowModules*/, c.GetEmitResolver())
-}
-
-func (c *Checker) isSymbolAccessibleWorker(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool) printer.SymbolAccessibilityResult {
-	return c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, allowModules, c.GetEmitResolver())
-}
 
 func (c *Checker) isSymbolAccessibleWorkerWithResolver(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool, emitResolver *EmitResolver) printer.SymbolAccessibilityResult {
 	if symbol != nil && enclosingDeclaration != nil {

--- a/tsc/internal/checker/symbolaccessibility.go
+++ b/tsc/internal/checker/symbolaccessibility.go
@@ -9,21 +9,25 @@ import (
 )
 
 func (c *Checker) IsTypeSymbolAccessible(typeSymbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
-	access := c.isSymbolAccessibleWorker(typeSymbol, enclosingDeclaration, ast.SymbolFlagsType /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true)
+	access := c.isSymbolAccessibleWorkerWithResolver(typeSymbol, enclosingDeclaration, ast.SymbolFlagsType /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true, c.GetEmitResolver())
 	return access.Accessibility == printer.SymbolAccessibilityAccessible
 }
 
 func (c *Checker) IsValueSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
-	access := c.isSymbolAccessibleWorker(symbol, enclosingDeclaration, ast.SymbolFlagsValue /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true)
+	access := c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, ast.SymbolFlagsValue /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, true, c.GetEmitResolver())
 	return access.Accessibility == printer.SymbolAccessibilityAccessible
 }
 
 func (c *Checker) IsSymbolAccessibleByFlags(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags ast.SymbolFlags) bool {
-	access := c.isSymbolAccessibleWorker(symbol, enclosingDeclaration, flags /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, false) // TODO: Strada bug? Why is this allowModules: false?
+	access := c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, flags /*shouldComputeAliasesToMakeVisible*/, false /*allowModules*/, false, c.GetEmitResolver()) // TODO: Strada bug? Why is this allowModules: false?
 	return access.Accessibility == printer.SymbolAccessibilityAccessible
 }
 
 func (c *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclaration *ast.Node, initialSymbol *ast.Symbol, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool) *printer.SymbolAccessibilityResult {
+	return c.isAnySymbolAccessible(symbols, enclosingDeclaration, initialSymbol, meaning, shouldComputeAliasesToMakeVisible, allowModules, c.GetEmitResolver())
+}
+
+func (c *Checker) isAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclaration *ast.Node, initialSymbol *ast.Symbol, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool, emitResolver *EmitResolver) *printer.SymbolAccessibilityResult {
 	if len(symbols) == 0 {
 		return nil
 	}
@@ -35,8 +39,7 @@ func (c *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclarat
 		accessibleSymbolChain := c.getAccessibleSymbolChain(symbol, enclosingDeclaration, meaning /*useOnlyExternalAliasing*/, false)
 		if len(accessibleSymbolChain) > 0 {
 			hadAccessibleChain = symbol
-			// TODO: going through emit resolver here is weird. Relayer these APIs.
-			hasAccessibleDeclarations := c.GetEmitResolver().hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
+			hasAccessibleDeclarations := emitResolver.hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
 			if hasAccessibleDeclarations != nil {
 				return hasAccessibleDeclarations
 			}
@@ -76,7 +79,7 @@ func (c *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclarat
 		if initialSymbol == symbol {
 			nextMeaning = getQualifiedLeftMeaning(meaning)
 		}
-		parentResult := c.IsAnySymbolAccessible(containers, enclosingDeclaration, initialSymbol, nextMeaning, shouldComputeAliasesToMakeVisible, allowModules)
+		parentResult := c.isAnySymbolAccessible(containers, enclosingDeclaration, initialSymbol, nextMeaning, shouldComputeAliasesToMakeVisible, allowModules, emitResolver)
 		if parentResult != nil {
 			return parentResult
 		}
@@ -837,12 +840,16 @@ func (c *Checker) getClassExpressionNameTable(location *ast.Node) ast.SymbolTabl
  */
 
 func (c *Checker) IsSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool) printer.SymbolAccessibilityResult {
-	return c.isSymbolAccessibleWorker(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, true /*allowModules*/)
+	return c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, true /*allowModules*/, c.GetEmitResolver())
 }
 
 func (c *Checker) isSymbolAccessibleWorker(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool) printer.SymbolAccessibilityResult {
+	return c.isSymbolAccessibleWorkerWithResolver(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, allowModules, c.GetEmitResolver())
+}
+
+func (c *Checker) isSymbolAccessibleWorkerWithResolver(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool, emitResolver *EmitResolver) printer.SymbolAccessibilityResult {
 	if symbol != nil && enclosingDeclaration != nil {
-		result := c.IsAnySymbolAccessible([]*ast.Symbol{symbol}, enclosingDeclaration, symbol, meaning, shouldComputeAliasesToMakeVisible, allowModules)
+		result := c.isAnySymbolAccessible([]*ast.Symbol{symbol}, enclosingDeclaration, symbol, meaning, shouldComputeAliasesToMakeVisible, allowModules, emitResolver)
 		if result != nil {
 			return *result
 		}

--- a/tsc/internal/checker/symbolaccessibility.go
+++ b/tsc/internal/checker/symbolaccessibility.go
@@ -20,6 +20,7 @@ func (c *Checker) isAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclarat
 		accessibleSymbolChain := c.getAccessibleSymbolChain(symbol, enclosingDeclaration, meaning /*useOnlyExternalAliasing*/, false)
 		if len(accessibleSymbolChain) > 0 {
 			hadAccessibleChain = symbol
+			// TODO: going through emit resolver here is weird. Relayer these APIs.
 			hasAccessibleDeclarations := emitResolver.hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
 			if hasAccessibleDeclarations != nil {
 				return hasAccessibleDeclarations

--- a/tsc/internal/compiler/emitHost.go
+++ b/tsc/internal/compiler/emitHost.go
@@ -39,7 +39,7 @@ func newEmitHost(ctx context.Context, program *Program, file *ast.SourceFile) (*
 	checker, done := program.GetTypeCheckerForFile(ctx, file)
 	return &emitHost{
 		program:      program,
-		emitResolver: checker.GetEmitResolver(),
+		emitResolver: checker.NewEmitResolver(),
 	}, done
 }
 

--- a/tsc/internal/ls/findallreferences.go
+++ b/tsc/internal/ls/findallreferences.go
@@ -510,7 +510,7 @@ func (l *LanguageService) getNonLocalDefinition(ctx context.Context, entry *Symb
 	program := l.GetProgram()
 	checker, done := program.GetTypeChecker(ctx)
 	defer done()
-	emitResolver := checker.GetEmitResolver()
+	emitResolver := checker.NewEmitResolver()
 	for _, d := range entry.definition.symbol.Declarations {
 		if isDefinitionVisible(emitResolver, d) {
 			file, startPos := getFileAndStartPosFromDeclaration(d)

--- a/tsc/internal/transformers/tstransforms/importelision_test.go
+++ b/tsc/internal/transformers/tstransforms/importelision_test.go
@@ -263,7 +263,7 @@ func TestImportElision(t *testing.T) {
 				},
 			}, nil)
 
-			emitResolver := c.GetEmitResolver()
+			emitResolver := c.NewEmitResolver()
 
 			opts := &transformers.TransformOptions{CompilerOptions: compilerOptions, Context: printer.NewEmitContext(), EmitResolver: emitResolver, Resolver: emitResolver}
 			file = tstransforms.NewTypeEraserTransformer(opts).TransformSourceFile(file)


### PR DESCRIPTION
Reusing resolvers appears to cause races, like:

```diff
diff --git a/tsc/testdata/baselines/reference/compiler/declarationEmitComputedPropertyNameSymbol2.js b/tsc/testdata/baselines/reference/compiler/declarationEmitComputedPropertyNameSymbol2.js
index dfd39246..fabe2d77 100644
--- a/tsc/testdata/baselines/reference/compiler/declarationEmitComputedPropertyNameSymbol2.js
+++ b/tsc/testdata/baselines/reference/compiler/declarationEmitComputedPropertyNameSymbol2.js
@@ -15,12 +15,24 @@ export const foo = { ...({} as Type) };
 
 
 //// [type.d.ts]
-declare namespace Foo {
-    const sym: unique symbol;
-}
 export type Type = {
     x?: {
         [Foo.sym]: 0;
     };
 };
-export {};
+
+
+!!!! File type.d.ts differs from original emit in noCheck emit
+//// [type.d.ts]
+--- Expected	The full check baseline
++++ Actual	with noCheck set
+@@ -1,5 +1,9 @@
++declare namespace Foo {
++    const sym: unique symbol;
++}
+ export type Type = {
+     x?: {
+         [Foo.sym]: 0;
+     };
+ };
++export {};
\ No newline at end of file
```

As far as I can tell, there's no perf impact for flipping this around to just make a new one and refactor things a bit.