### PR TITLE
Don't depend on vfstest for transpile

### DIFF
--- a/tsc/internal/transpile/fs.go
+++ b/tsc/internal/transpile/fs.go
@@ -5,8 +5,8 @@ import (
 	"github.com/microsoft/TypeScript/tsc/internal/vfs"
 )
 
-// transpileFS embeds the unused operations so an unexpected filesystem access
-// panics. NoResolve limits transpilation to the synthesized files below.
+// transpileFS embeds unsupported operations so unexpected filesystem access
+// panics.
 type transpileFS struct {
 	vfs.FS
 	files map[string]string
@@ -30,9 +30,13 @@ func (fs *transpileFS) ReadFile(path string) (string, bool) {
 
 func (fs *transpileFS) DirectoryExists(path string) bool {
 	for file := range fs.files {
-		if tspath.ContainsPath(path, file, tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true}) {
+		if tspath.ContainsPath(path, tspath.GetDirectoryPath(file), tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true}) {
 			return true
 		}
 	}
 	return false
+}
+
+func (fs *transpileFS) Realpath(path string) string {
+	return path
 }

--- a/tsc/internal/transpile/fs.go
+++ b/tsc/internal/transpile/fs.go
@@ -1,0 +1,38 @@
+package transpile
+
+import (
+	"github.com/microsoft/TypeScript/tsc/internal/tspath"
+	"github.com/microsoft/TypeScript/tsc/internal/vfs"
+)
+
+// transpileFS embeds the unused operations so an unexpected filesystem access
+// panics. NoResolve limits transpilation to the synthesized files below.
+type transpileFS struct {
+	vfs.FS
+	files map[string]string
+}
+
+var _ vfs.FS = (*transpileFS)(nil)
+
+func (fs *transpileFS) UseCaseSensitiveFileNames() bool {
+	return true
+}
+
+func (fs *transpileFS) FileExists(path string) bool {
+	_, ok := fs.files[path]
+	return ok
+}
+
+func (fs *transpileFS) ReadFile(path string) (string, bool) {
+	content, ok := fs.files[path]
+	return content, ok
+}
+
+func (fs *transpileFS) DirectoryExists(path string) bool {
+	for file := range fs.files {
+		if tspath.ContainsPath(path, file, tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true}) {
+			return true
+		}
+	}
+	return false
+}

--- a/tsc/internal/transpile/fs_test.go
+++ b/tsc/internal/transpile/fs_test.go
@@ -1,0 +1,17 @@
+package transpile
+
+import (
+	"testing"
+)
+
+func TestTranspileFSDirectoryExists(t *testing.T) {
+	t.Parallel()
+
+	fs := &transpileFS{files: map[string]string{"/src/module.ts": ""}}
+	if fs.DirectoryExists("/src/module.ts") {
+		t.Fatal("file reported as directory")
+	}
+	if !fs.DirectoryExists("/src") {
+		t.Fatal("containing directory not found")
+	}
+}

--- a/tsc/internal/transpile/transpile.go
+++ b/tsc/internal/transpile/transpile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/TypeScript/tsc/internal/debug"
 	"github.com/microsoft/TypeScript/tsc/internal/tsoptions"
 	"github.com/microsoft/TypeScript/tsc/internal/tspath"
-	"github.com/microsoft/TypeScript/tsc/internal/vfs/vfstest"
 )
 
 // Options configures single-file transpilation.
@@ -195,8 +194,7 @@ func transpileWorker(ctx context.Context, input string, options Options, declara
 		files[tspath.CombinePaths(libDirectory, libFileName)] = barebonesLibContent
 	}
 
-	fs := vfstest.FromMap(files, true /*useCaseSensitiveFileNames*/)
-	host := compiler.NewCompilerHost(inputDirectory, fs, libDirectory, nil, nil, nil)
+	host := compiler.NewCompilerHost(inputDirectory, &transpileFS{files: files}, libDirectory, nil, nil, nil)
 
 	program := compiler.NewProgram(compiler.ProgramOptions{
 		Config: &tsoptions.ParsedCommandLine{

--- a/tsc/testdata/baselines/reference/transpile/nodeModulesSelfImport.js
+++ b/tsc/testdata/baselines/reference/transpile/nodeModulesSelfImport.js
@@ -1,0 +1,4 @@
+//// [node_modules/pkg/index.ts] ////
+import "pkg";
+//// [node_modules/pkg/index.js] ////
+import "pkg";

--- a/tsc/testdata/tests/cases/transpile/nodeModulesSelfImport.ts
+++ b/tsc/testdata/tests/cases/transpile/nodeModulesSelfImport.ts
@@ -1,0 +1,2 @@
+// @filename: node_modules/pkg/index.ts
+import "pkg";


### PR DESCRIPTION
The transpile package used the test FS as a VFS, but this brings in all of the testing code.

Use a local FS for this instead, which saves something like 100KB of binary.