### PR TITLE
Disable concurrent test programs job in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
             name: 'concurrent test programs'
             concurrent-test-programs: true
             coverage: true
+            skip: ${{ github.event_name == 'merge_group' }}
         exclude:
           - config:
               skip: true


### PR DESCRIPTION
My original intent was that this would catch people adding two pieces of code that together caused data races, but I think we're more likely to hit test flakes that need to be fixed separately, and then the general slower merge time. So, remove it, and we can track flakes through failing main or PR builds.