### PR TITLE
Fix release pipeline

### DIFF
--- a/tools/pipelines/typescript-build.yml
+++ b/tools/pipelines/typescript-build.yml
@@ -46,8 +46,6 @@ extends:
         fetchTags: false
         retryCount: 3
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
-      sourceRepositoriesToScan:
-        include:
     featureFlags:
       golang:
         internalModuleProxy:


### PR DESCRIPTION
This was a bad port from the old repo. This can't be empty.