### PR TITLE
Content mapper auto import formatting panic

### DIFF
--- a/tsc/internal/fourslash/tests/contentMapperAutoImports_test.go
+++ b/tsc/internal/fourslash/tests/contentMapperAutoImports_test.go
@@ -250,3 +250,68 @@ profileTi/**/
 	})
 	f.BaselineAutoImportsCompletions(t, []string{""})
 }
+
+// TestContentMapperAutoImportAtHoistedImportBoundary covers a mapper that hoists the imports of a
+// component's script above the generated render function, the way svelte2tsx does. Hoisting places the
+// script text preceding the first import *after* that import in the virtual file:
+//
+//	///<reference types="svelte" />
+//	;
+//	import { existing } from "./dep";   <- original [21, 54)
+//	function $$render() {
+//	<whitespace preceding the first import>   <- original [18, 21)
+//	  const value = help;                     <- original [54, 77)
+//
+// Original position 21 therefore has two exact virtual projections: the start of the hoisted import and
+// the end of the preceding whitespace segment. A new import sorts ahead of "./dep" and is inserted at
+// exactly that position, so the change tracker formats the same new import node once per projection.
+// Printing assigns source positions to the node, so the second print reads the module specifier back out
+// of the virtual file at those stale offsets and yields text like `import { helper } from om "./de;`,
+// which then trips a formatter assertion.
+func TestContentMapperAutoImportAtHoistedImportBoundary(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	f, done := newContentMapperFourslash(t, `// @Filename: /aaa.ts
+export const helper = 1;
+
+// @Filename: /dep.ts
+export const existing = 2;
+
+// @Filename: /App.svelte
+<script lang="ts">
+  import { existing } from "./dep";
+  const value = help/**/;
+</script>
+`, contentmappertest.HoistingMapper, ".svelte")
+	defer done()
+
+	f.VerifyCompletions(t, "", &fourslash.CompletionsExpectedList{
+		UserPreferences: &lsutil.UserPreferences{
+			IncludeCompletionsForModuleExports:    core.TSTrue,
+			IncludeCompletionsForImportStatements: core.TSTrue,
+		},
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &DefaultCommitCharacters,
+			EditRange:        Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{Includes: []fourslash.CompletionsExpectedItem{
+			&lsproto.CompletionItem{
+				Label:               "helper",
+				SortText:            new(string(ls.SortTextAutoImportSuggestions)),
+				Data:                &lsproto.CompletionItemData{AutoImport: &lsproto.AutoImportFix{ModuleSpecifier: "./aaa"}},
+				AdditionalTextEdits: fourslash.AnyTextEdits,
+			},
+		}},
+	})
+	f.VerifyApplyCodeActionFromCompletion(t, new(""), &fourslash.ApplyCodeActionFromCompletionOptions{
+		Name:        "helper",
+		Source:      "./aaa",
+		Description: `Add import from "./aaa"`,
+		NewFileContent: new(`<script lang="ts">
+  import { helper } from "./aaa";
+  import { existing } from "./dep";
+  const value = help;
+</script>
+`),
+	})
+}

--- a/tsc/internal/fourslash/tests/contentMapperDuplicateProjections_test.go
+++ b/tsc/internal/fourslash/tests/contentMapperDuplicateProjections_test.go
@@ -1,0 +1,31 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/internal/testutil"
+	"github.com/microsoft/TypeScript/tsc/internal/testutil/contentmappertest"
+)
+
+// A mapper may emit the same original text in more than one virtual output. Each output is a separate
+// source file to the change tracker, but they share an original file, so an edit to a span present in
+// both is recorded twice. The two edits describe the same change to the same original range, and applying
+// it more than once would corrupt the file, so only one may reach the client.
+func TestContentMapperFileRenameAcrossDuplicateProjections(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	f, done := newContentMapperFourslash(t, `// @Filename: /dep.ts
+export const helper = 1;
+
+// @Filename: /app.astro
+import { helper } from "./dep";
+helper;
+`, contentmappertest.DuplicateProjectionMapper, ".astro")
+	defer done()
+
+	f.VerifyWillRenameFilesEdits(t, "/dep.ts", "/renamed.ts", map[string]string{
+		"/app.astro": `import { helper } from "./renamed";
+helper;
+`,
+	}, nil)
+}

--- a/tsc/internal/fourslash/tests/importFixIndentedStatements_test.go
+++ b/tsc/internal/fourslash/tests/importFixIndentedStatements_test.go
@@ -1,0 +1,75 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/internal/fourslash"
+	"github.com/microsoft/TypeScript/tsc/internal/testutil"
+)
+
+// An added import has to line up with the imports already in the file. The formatter indents a new
+// top-level statement to column zero, since that is where a top-level statement canonically belongs, so
+// the surrounding indentation has to be reapplied when the file does something else. Statements are only
+// indented like this in hand-written TypeScript by accident, but it is the normal shape of the virtual
+// file a content mapper produces for an indented `<script>` block.
+//
+// The two tests below cover the two sides of the insertion point: the indentation can sit before it or
+// after it, and it has to end up on both lines either way.
+
+// The new import sorts first, so it is inserted directly after the existing import's indentation.
+func TestImportFixBeforeIndentedImport(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	f, done := fourslash.NewFourslashWithOptions(t, `// @Filename: /aaa.ts
+export const helper = 1;
+
+// @Filename: /dep.ts
+export const existing = 2;
+
+// @Filename: /main.ts
+// header
+  import { existing } from "./dep";
+  const value = help/**/;
+`, &fourslash.FourslashOptions{})
+	defer done()
+
+	f.VerifyApplyCodeActionFromCompletion(t, new(""), &fourslash.ApplyCodeActionFromCompletionOptions{
+		Name:        "helper",
+		Source:      "./aaa",
+		Description: `Add import from "./aaa"`,
+		NewFileContent: new(`// header
+  import { helper } from "./aaa";
+  import { existing } from "./dep";
+  const value = help;
+`),
+	})
+}
+
+// The new import sorts last, so it is inserted at the start of the line following the existing import.
+func TestImportFixAfterIndentedImport(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	f, done := fourslash.NewFourslashWithOptions(t, `// @Filename: /aaa.ts
+export const existing = 2;
+
+// @Filename: /zzz.ts
+export const helper = 1;
+
+// @Filename: /main.ts
+// header
+  import { existing } from "./aaa";
+  const value = help/**/;
+`, &fourslash.FourslashOptions{})
+	defer done()
+
+	f.VerifyApplyCodeActionFromCompletion(t, new(""), &fourslash.ApplyCodeActionFromCompletionOptions{
+		Name:        "helper",
+		Source:      "./zzz",
+		Description: `Add import from "./zzz"`,
+		NewFileContent: new(`// header
+  import { existing } from "./aaa";
+  import { helper } from "./zzz";
+  const value = help;
+`),
+	})
+}

--- a/tsc/internal/fourslash/tests/importFixIndentedStatements_test.go
+++ b/tsc/internal/fourslash/tests/importFixIndentedStatements_test.go
@@ -73,3 +73,29 @@ export const helper = 1;
 `),
 	})
 }
+
+// The scanner treats a lone carriage return as a line terminator, so a file that uses CR endings has real
+// lines and real indentation, and an inserted import has to respect them.
+func TestImportFixBeforeIndentedImportWithCarriageReturns(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	f, done := fourslash.NewFourslashWithOptions(t, `// @Filename: /aaa.ts
+export const helper = 1;
+
+// @Filename: /dep.ts
+export const existing = 2;
+
+// @Filename: /main.ts
+`+"// header\r  import { existing } from \"./dep\";\r  const value = help/**/;\r",
+		&fourslash.FourslashOptions{})
+	defer done()
+
+	// The inserted line is separated with the tracker's newline rather than the file's, which is a
+	// pre-existing behavior unrelated to indentation; what matters here is that both imports stay indented.
+	f.VerifyApplyCodeActionFromCompletion(t, new(""), &fourslash.ApplyCodeActionFromCompletionOptions{
+		Name:           "helper",
+		Source:         "./aaa",
+		Description:    `Add import from "./aaa"`,
+		NewFileContent: new("// header\r  import { helper } from \"./aaa\";\n  import { existing } from \"./dep\";\r  const value = help;\r"),
+	})
+}

--- a/tsc/internal/ls/change/delete.go
+++ b/tsc/internal/ls/change/delete.go
@@ -24,7 +24,7 @@ func deleteDeclaration(t *Tracker, deletedNodesInLists map[*ast.Node]bool, sourc
 			// Lambdas with exactly one parameter are special because, after removal, there
 			// must be an empty parameter list (i.e. `()`) and this won't necessarily be the
 			// case if the parameter is simply removed (e.g. in `x => 1`).
-			t.ReplaceRangeWithText(sourceFile, t.GetAdjustedRange(sourceFile, node, node, LeadingTriviaOptionIncludeAll, TrailingTriviaOptionInclude), "()")
+			t.ReplaceTextRangeWithText(sourceFile, t.GetAdjustedRange(sourceFile, node, node, LeadingTriviaOptionIncludeAll, TrailingTriviaOptionInclude), "()")
 		} else {
 			deleteNodeInList(t, deletedNodesInLists, sourceFile, node)
 		}
@@ -114,7 +114,7 @@ func deleteDefaultImport(t *Tracker, sourceFile *ast.SourceFile, importClause *a
 		if nextToken != nil && nextToken.Kind == ast.KindCommaToken {
 			// shift first non-whitespace position after comma to the start position of the node
 			end := scanner.SkipTriviaEx(sourceFile.Text(), nextToken.End(), &scanner.SkipTriviaOptions{StopAfterLineBreak: false, StopAtComments: true})
-			t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(start, end)), "")
+			t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(start, end), "")
 		} else {
 			deleteNode(t, sourceFile, name, LeadingTriviaOptionIncludeAll, TrailingTriviaOptionInclude)
 		}
@@ -130,7 +130,7 @@ func deleteImportBinding(t *Tracker, sourceFile *ast.SourceFile, node *ast.Node)
 		previousToken := astnav.GetTokenAtPosition(sourceFile, node.Pos()-1)
 		debug.Assert(previousToken != nil, "previousToken should not be nil")
 		start := astnav.GetStartOfNode(previousToken, sourceFile, false)
-		t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(start, node.End())), "")
+		t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(start, node.End()), "")
 	} else {
 		// Delete the entire import declaration
 		// |import * as ns from './file'|
@@ -183,7 +183,7 @@ func deleteVariableDeclaration(t *Tracker, deletedNodesInLists map[*ast.Node]boo
 func deleteNode(t *Tracker, sourceFile *ast.SourceFile, node *ast.Node, leadingTrivia LeadingTriviaOption, trailingTrivia TrailingTriviaOption) {
 	startPosition := t.getAdjustedStartPosition(sourceFile, node, leadingTrivia, false)
 	endPosition := t.getAdjustedEndPosition(sourceFile, node, trailingTrivia)
-	t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(startPosition, endPosition)), "")
+	t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(startPosition, endPosition), "")
 }
 
 func deleteNodeInList(t *Tracker, deletedNodesInLists map[*ast.Node]bool, sourceFile *ast.SourceFile, node *ast.Node) {
@@ -214,7 +214,7 @@ func deleteNodeInList(t *Tracker, deletedNodesInLists map[*ast.Node]bool, source
 		endPos = t.endPositionToDeleteNodeInList(sourceFile, node, prevNode, containingList.Nodes[index+1])
 	}
 
-	t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(startPos, endPos)), "")
+	t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(startPos, endPos), "")
 }
 
 // startPositionToDeleteNodeInList finds the first non-whitespace position in the leading trivia of the node

--- a/tsc/internal/ls/change/tracker.go
+++ b/tsc/internal/ls/change/tracker.go
@@ -66,11 +66,7 @@ const (
 
 type trackerEdit struct {
 	kind trackerEditKind
-	// virtual is the edit's range in the transformed text the nodes and formatter work in. It is converted
-	// to the original text once, by GetChanges. Converting earlier would discard which projection the edit
-	// was computed against, and one original position can have several virtual counterparts, so that
-	// choice cannot be recovered afterwards.
-	virtual core.TextRange
+	core.TextRange
 
 	NewText string // kind == text
 
@@ -152,10 +148,9 @@ func (t *Tracker) GetChanges() (map[string][]*lsproto.TextEdit, []string) {
 	return changes, unmappable
 }
 
-// fromLSPEditRange converts an LSP range in the original document to transformed-text (virtual)
-// coordinates. Original-to-virtual is one-to-many when a mapper copies a span, but every exact projection
-// maps back to the range we started from, so any of them represents the same edit; a range with no exact
-// projection cannot be written back at all, and marks the file unmappable.
+// fromLSPEditRange converts an LSP range to a source file range. For a content-mapped file, an original
+// range may have several projections; this selects the one belonging to sourceFile. A range with no exact
+// projection cannot be written back and marks the file unmappable.
 func (t *Tracker) fromLSPEditRange(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range) core.TextRange {
 	spans := lsconv.FromLSPRangeForSourceFile(t.converters, sourceFile, lsprotoRange, spanmap.FeatureAll)
 	for _, span := range spans {
@@ -170,10 +165,10 @@ func (t *Tracker) fromLSPEditRange(sourceFile *ast.SourceFile, lsprotoRange lspr
 	return core.NewTextRange(0, 0)
 }
 
-// toLSPEditRange converts a transformed-text range to an LSP range for an edit, mapping through the
-// content mapper's span map when the file is content-mapped. If the range does not fall entirely within a
-// single verbatim span the edit cannot be represented safely in the original text: the file is recorded so
-// GetChanges drops its edits, and a best-effort range is returned so the accumulated edits stay well-formed.
+// toLSPEditRange converts a source file range to an LSP range. For a content-mapped file, the range is
+// mapped back to the original document. If it does not fall entirely within a single verbatim span, the
+// edit cannot be represented safely: the file is recorded so GetChanges drops its edits, and a best-effort
+// range is returned so the accumulated edits stay well-formed.
 func (t *Tracker) toLSPEditRange(sourceFile *ast.SourceFile, textRange core.TextRange) lsproto.Range {
 	r, fidelity := t.converters.ToLSPRange(sourceFile, textRange)
 	if !fidelity.IsExact() {
@@ -206,40 +201,38 @@ func (t *Tracker) ReplaceNodeWithNodes(sourceFile *ast.SourceFile, oldNode *ast.
 	t.ReplaceRangeWithNodes(sourceFile, t.GetAdjustedRange(sourceFile, oldNode, oldNode, options.LeadingTriviaOption, options.TrailingTriviaOption), newNodes, *options)
 }
 
-// ReplaceRange replaces textRange, in transformed-text (virtual) coordinates, with newNode.
+// ReplaceRange replaces textRange in sourceFile with newNode.
 func (t *Tracker) ReplaceRange(sourceFile *ast.SourceFile, textRange core.TextRange, newNode *ast.Node, options NodeOptions) {
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithSingleNode, virtual: textRange, options: options, Node: newNode})
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithSingleNode, TextRange: textRange, options: options, Node: newNode})
 }
 
-// ReplaceRangeWithText replaces an LSP range given in the coordinates of the original document. Only text
-// edits may be expressed this way: an edit that has to be formatted needs the virtual context the nodes
-// live in, whereas text is inserted verbatim and so does not care which projection it is placed at.
+// ReplaceRangeWithText replaces an LSP range with text. For a content-mapped file, the LSP range is in the
+// original document; text may be placed at any exact projection because it does not need formatting context.
 func (t *Tracker) ReplaceRangeWithText(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range, text string) {
 	t.ReplaceTextRangeWithText(sourceFile, t.fromLSPEditRange(sourceFile, lsprotoRange), text)
 }
 
-// ReplaceTextRangeWithText replaces textRange (in transformed-text coordinates) with text. The range is
-// mapped to the original text by GetChanges, and an edit that cannot be represented there marks the file
-// unmappable and is dropped.
+// ReplaceTextRangeWithText replaces textRange in sourceFile with text. For a content-mapped file, GetChanges
+// maps the range back to the original document and drops the file if the edit cannot be represented there.
 func (t *Tracker) ReplaceTextRangeWithText(sourceFile *ast.SourceFile, textRange core.TextRange, text string) {
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindText, virtual: textRange, NewText: text})
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindText, TextRange: textRange, NewText: text})
 }
 
-// ReplaceRangeWithNodes replaces textRange, in transformed-text (virtual) coordinates, with newNodes.
+// ReplaceRangeWithNodes replaces textRange in sourceFile with newNodes.
 func (t *Tracker) ReplaceRangeWithNodes(sourceFile *ast.SourceFile, textRange core.TextRange, newNodes []*ast.Node, options NodeOptions) {
 	if len(newNodes) == 1 {
 		t.ReplaceRange(sourceFile, textRange, newNodes[0], options)
 		return
 	}
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithMultipleNodes, virtual: textRange, nodes: newNodes, options: options})
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithMultipleNodes, TextRange: textRange, nodes: newNodes, options: options})
 }
 
-// insertTextAt inserts text at a transformed-text (virtual) offset.
+// insertTextAt inserts text at an offset in sourceFile.
 func (t *Tracker) insertTextAt(sourceFile *ast.SourceFile, pos core.TextPos, text string) {
 	t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(int(pos), int(pos)), text)
 }
 
-// InsertText inserts text at an LSP position given in the coordinates of the original document.
+// InsertText inserts text at an LSP position.
 func (t *Tracker) InsertText(sourceFile *ast.SourceFile, pos lsproto.Position, text string) {
 	t.ReplaceRangeWithText(sourceFile, lsproto.Range{Start: pos, End: pos}, text)
 }

--- a/tsc/internal/ls/change/tracker.go
+++ b/tsc/internal/ls/change/tracker.go
@@ -66,7 +66,11 @@ const (
 
 type trackerEdit struct {
 	kind trackerEditKind
-	lsproto.Range
+	// virtual is the edit's range in the transformed text the nodes and formatter work in. It is converted
+	// to the original text once, by GetChanges. Converting earlier would discard which projection the edit
+	// was computed against, and one original position can have several virtual counterparts, so that
+	// choice cannot be recovered afterwards.
+	virtual core.TextRange
 
 	NewText string // kind == text
 
@@ -148,6 +152,24 @@ func (t *Tracker) GetChanges() (map[string][]*lsproto.TextEdit, []string) {
 	return changes, unmappable
 }
 
+// fromLSPEditRange converts an LSP range in the original document to transformed-text (virtual)
+// coordinates. Original-to-virtual is one-to-many when a mapper copies a span, but every exact projection
+// maps back to the range we started from, so any of them represents the same edit; a range with no exact
+// projection cannot be written back at all, and marks the file unmappable.
+func (t *Tracker) fromLSPEditRange(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range) core.TextRange {
+	spans := lsconv.FromLSPRangeForSourceFile(t.converters, sourceFile, lsprotoRange, spanmap.FeatureAll)
+	for _, span := range spans {
+		if span.Fidelity.IsExact() && span.Script == sourceFile {
+			return span.Span
+		}
+	}
+	t.unmappableFiles.Add(sourceFile.OriginalFileName())
+	if len(spans) > 0 {
+		return spans[0].Span
+	}
+	return core.NewTextRange(0, 0)
+}
+
 // toLSPEditRange converts a transformed-text range to an LSP range for an edit, mapping through the
 // content mapper's span map when the file is content-mapped. If the range does not fall entirely within a
 // single verbatim span the edit cannot be represented safely in the original text: the file is recorded so
@@ -161,12 +183,6 @@ func (t *Tracker) toLSPEditRange(sourceFile *ast.SourceFile, textRange core.Text
 		t.unmappableFiles.Add(sourceFile.OriginalFileName())
 	}
 	return r
-}
-
-// toLSPEditPos converts a transformed-text offset to an LSP position for a zero-length edit (an insertion),
-// applying the same content-mapping safety check as toLSPEditRange.
-func (t *Tracker) toLSPEditPos(sourceFile *ast.SourceFile, pos core.TextPos) lsproto.Position {
-	return t.toLSPEditRange(sourceFile, core.NewTextRange(int(pos), int(pos))).Start
 }
 
 func (t *Tracker) ReplaceNode(sourceFile *ast.SourceFile, oldNode *ast.Node, newNode *ast.Node, options *NodeOptions) {
@@ -190,41 +206,50 @@ func (t *Tracker) ReplaceNodeWithNodes(sourceFile *ast.SourceFile, oldNode *ast.
 	t.ReplaceRangeWithNodes(sourceFile, t.GetAdjustedRange(sourceFile, oldNode, oldNode, options.LeadingTriviaOption, options.TrailingTriviaOption), newNodes, *options)
 }
 
-func (t *Tracker) ReplaceRange(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range, newNode *ast.Node, options NodeOptions) {
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithSingleNode, Range: lsprotoRange, options: options, Node: newNode})
+// ReplaceRange replaces textRange, in transformed-text (virtual) coordinates, with newNode.
+func (t *Tracker) ReplaceRange(sourceFile *ast.SourceFile, textRange core.TextRange, newNode *ast.Node, options NodeOptions) {
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithSingleNode, virtual: textRange, options: options, Node: newNode})
 }
 
+// ReplaceRangeWithText replaces an LSP range given in the coordinates of the original document. Only text
+// edits may be expressed this way: an edit that has to be formatted needs the virtual context the nodes
+// live in, whereas text is inserted verbatim and so does not care which projection it is placed at.
 func (t *Tracker) ReplaceRangeWithText(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range, text string) {
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindText, Range: lsprotoRange, NewText: text})
+	t.ReplaceTextRangeWithText(sourceFile, t.fromLSPEditRange(sourceFile, lsprotoRange), text)
 }
 
-// ReplaceTextRangeWithText replaces textRange (in transformed-text coordinates) with text, mapping the
-// range through the content-mapping guard so an edit that cannot be represented in the original text marks
-// the file unmappable and is dropped by GetChanges.
+// ReplaceTextRangeWithText replaces textRange (in transformed-text coordinates) with text. The range is
+// mapped to the original text by GetChanges, and an edit that cannot be represented there marks the file
+// unmappable and is dropped.
 func (t *Tracker) ReplaceTextRangeWithText(sourceFile *ast.SourceFile, textRange core.TextRange, text string) {
-	t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, textRange), text)
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindText, virtual: textRange, NewText: text})
 }
 
-func (t *Tracker) ReplaceRangeWithNodes(sourceFile *ast.SourceFile, lsprotoRange lsproto.Range, newNodes []*ast.Node, options NodeOptions) {
+// ReplaceRangeWithNodes replaces textRange, in transformed-text (virtual) coordinates, with newNodes.
+func (t *Tracker) ReplaceRangeWithNodes(sourceFile *ast.SourceFile, textRange core.TextRange, newNodes []*ast.Node, options NodeOptions) {
 	if len(newNodes) == 1 {
-		t.ReplaceRange(sourceFile, lsprotoRange, newNodes[0], options)
+		t.ReplaceRange(sourceFile, textRange, newNodes[0], options)
 		return
 	}
-	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithMultipleNodes, Range: lsprotoRange, nodes: newNodes, options: options})
+	t.changes.Add(sourceFile, &trackerEdit{kind: trackerEditKindReplaceWithMultipleNodes, virtual: textRange, nodes: newNodes, options: options})
 }
 
+// insertTextAt inserts text at a transformed-text (virtual) offset.
+func (t *Tracker) insertTextAt(sourceFile *ast.SourceFile, pos core.TextPos, text string) {
+	t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(int(pos), int(pos)), text)
+}
+
+// InsertText inserts text at an LSP position given in the coordinates of the original document.
 func (t *Tracker) InsertText(sourceFile *ast.SourceFile, pos lsproto.Position, text string) {
 	t.ReplaceRangeWithText(sourceFile, lsproto.Range{Start: pos, End: pos}, text)
 }
 
 func (t *Tracker) InsertNodeAt(sourceFile *ast.SourceFile, pos core.TextPos, newNode *ast.Node, options NodeOptions) {
-	lsPos := t.toLSPEditPos(sourceFile, pos)
-	t.ReplaceRange(sourceFile, lsproto.Range{Start: lsPos, End: lsPos}, newNode, options)
+	t.ReplaceRange(sourceFile, core.NewTextRange(int(pos), int(pos)), newNode, options)
 }
 
 func (t *Tracker) InsertNodesAt(sourceFile *ast.SourceFile, pos core.TextPos, newNodes []*ast.Node, options NodeOptions) {
-	lsPos := t.toLSPEditPos(sourceFile, pos)
-	t.ReplaceRangeWithNodes(sourceFile, lsproto.Range{Start: lsPos, End: lsPos}, newNodes, options)
+	t.ReplaceRangeWithNodes(sourceFile, core.NewTextRange(int(pos), int(pos)), newNodes, options)
 }
 
 func (t *Tracker) InsertNodeAfter(sourceFile *ast.SourceFile, after *ast.Node, newNode *ast.Node) {
@@ -294,8 +319,8 @@ func (t *Tracker) ParenthesizeArrowParameters(sourceFile *ast.SourceFile, arrowF
 	firstParam := params[0]
 	lastParam := params[len(params)-1]
 	startPos := astnav.GetStartOfNode(firstParam, sourceFile, false)
-	t.InsertText(sourceFile, t.toLSPEditPos(sourceFile, core.TextPos(startPos)), "(")
-	t.InsertText(sourceFile, t.toLSPEditPos(sourceFile, core.TextPos(lastParam.End())), ")")
+	t.insertTextAt(sourceFile, core.TextPos(startPos), "(")
+	t.insertTextAt(sourceFile, core.TextPos(lastParam.End()), ")")
 }
 
 // InsertModifierBefore inserts a modifier token (like 'type') before a node with a trailing space.
@@ -315,22 +340,20 @@ func (t *Tracker) Delete(sourceFile *ast.SourceFile, node *ast.Node) {
 
 // DeleteRange deletes a text range from the source file.
 func (t *Tracker) DeleteRange(sourceFile *ast.SourceFile, textRange core.TextRange) {
-	lspRange := t.toLSPEditRange(sourceFile, textRange)
-	t.ReplaceRangeWithText(sourceFile, lspRange, "")
+	t.ReplaceTextRangeWithText(sourceFile, textRange, "")
 }
 
 // DeleteNode deletes a node immediately with specified trivia options.
 // Stop! Consider using Delete instead, which has logic for deleting nodes from delimited lists.
 func (t *Tracker) DeleteNode(sourceFile *ast.SourceFile, node *ast.Node, leadingTrivia LeadingTriviaOption, trailingTrivia TrailingTriviaOption) {
-	rng := t.GetAdjustedRange(sourceFile, node, node, leadingTrivia, trailingTrivia)
-	t.ReplaceRangeWithText(sourceFile, rng, "")
+	t.ReplaceTextRangeWithText(sourceFile, t.GetAdjustedRange(sourceFile, node, node, leadingTrivia, trailingTrivia), "")
 }
 
 // DeleteNodeRange deletes a range of nodes with specified trivia options.
 func (t *Tracker) DeleteNodeRange(sourceFile *ast.SourceFile, startNode *ast.Node, endNode *ast.Node, leadingTrivia LeadingTriviaOption, trailingTrivia TrailingTriviaOption) {
 	startPosition := t.getAdjustedStartPosition(sourceFile, startNode, leadingTrivia, false)
 	endPosition := t.getAdjustedEndPosition(sourceFile, endNode, trailingTrivia)
-	t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(startPosition, endPosition)), "")
+	t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(startPosition, endPosition), "")
 }
 
 // finishDeleteDeclarations processes all queued deletions with smart handling for lists and trailing commas.
@@ -373,7 +396,7 @@ func (t *Tracker) finishDeleteDeclarations() {
 		if lastNonDeletedIndex != -1 {
 			start := list.Nodes[lastNonDeletedIndex].End()
 			end := t.startPositionToDeleteNodeInList(sourceFile, list.Nodes[lastNonDeletedIndex+1])
-			t.ReplaceRangeWithText(sourceFile, t.toLSPEditRange(sourceFile, core.NewTextRange(start, end)), "")
+			t.ReplaceTextRangeWithText(sourceFile, core.NewTextRange(start, end), "")
 		}
 	}
 }
@@ -382,13 +405,13 @@ func (t *Tracker) endPosForInsertNodeAfter(sourceFile *ast.SourceFile, after *as
 	if needSemicolonBetween(after, newNode) && (rune(sourceFile.Text()[after.End()-1]) != ';') {
 		// check if previous statement ends with semicolon
 		// if not - insert semicolon to preserve the code from changing the meaning due to ASI
-		endPos := t.toLSPEditPos(sourceFile, core.TextPos(after.End()))
+		endPos := core.TextPos(after.End())
 		semicolon := t.NewToken(ast.KindSemicolonToken)
 		semicolon.Loc = core.NewTextRange(after.End(), after.End())
 		semicolon.Parent = after.Parent
 		t.ReplaceRange(
 			sourceFile,
-			lsproto.Range{Start: endPos, End: endPos},
+			core.NewTextRange(int(endPos), int(endPos)),
 			semicolon,
 			NodeOptions{},
 		)
@@ -475,8 +498,8 @@ func (t *Tracker) InsertNodeInListAfter(sourceFile *ast.SourceFile, after *ast.N
 		separatorString := scanner.TokenToString(separator)
 		separatorToken.Loc = core.NewTextRange(end, end+len(separatorString))
 		separatorToken.Parent = after.Parent
-		endPos := t.toLSPEditPos(sourceFile, core.TextPos(end))
-		t.ReplaceRange(sourceFile, lsproto.Range{Start: endPos, End: endPos}, separatorToken, NodeOptions{})
+		endPos := core.TextPos(end)
+		t.ReplaceRange(sourceFile, core.NewTextRange(int(endPos), int(endPos)), separatorToken, NodeOptions{})
 		// use the same indentation as 'after' item
 		indentation := format.FindFirstNonWhitespaceColumn(afterStartLinePosition, afterStart, sourceFile, t.formatSettings)
 		// insert element before the line break on the line that contains 'after' element
@@ -485,10 +508,10 @@ func (t *Tracker) InsertNodeInListAfter(sourceFile *ast.SourceFile, after *ast.N
 		for insertPos != end && stringutil.IsLineBreak(rune(sourceFile.Text()[insertPos-1])) {
 			insertPos--
 		}
-		insertLSPos := t.toLSPEditPos(sourceFile, core.TextPos(insertPos))
+		insertLSPos := core.TextPos(insertPos)
 		t.ReplaceRange(
 			sourceFile,
-			lsproto.Range{Start: insertLSPos, End: insertLSPos},
+			core.NewTextRange(int(insertLSPos), int(insertLSPos)),
 			newNode,
 			NodeOptions{
 				indentation: &indentation,
@@ -497,8 +520,8 @@ func (t *Tracker) InsertNodeInListAfter(sourceFile *ast.SourceFile, after *ast.N
 		)
 	} else {
 		separatorString := scanner.TokenToString(separator)
-		endPos := t.toLSPEditPos(sourceFile, core.TextPos(end))
-		t.ReplaceRange(sourceFile, lsproto.Range{Start: endPos, End: endPos}, newNode, NodeOptions{Prefix: separatorString + " "})
+		endPos := core.TextPos(end)
+		t.ReplaceRange(sourceFile, core.NewTextRange(int(endPos), int(endPos)), newNode, NodeOptions{Prefix: separatorString + " "})
 	}
 }
 
@@ -764,7 +787,7 @@ func (t *Tracker) finishNodesWithInsertionsAtStart() {
 		}
 
 		if isSingleLine {
-			t.InsertText(state.sourceFile, t.toLSPEditPos(state.sourceFile, core.TextPos(closeBrace.End()-1)), t.newLine)
+			t.insertTextAt(state.sourceFile, core.TextPos(closeBrace.End()-1), t.newLine)
 		}
 	}
 }

--- a/tsc/internal/ls/change/trackerimpl.go
+++ b/tsc/internal/ls/change/trackerimpl.go
@@ -20,7 +20,7 @@ import (
 
 func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 	changes := map[string][]*lsproto.TextEdit{}
-	// A content-mapped file can have several virtual projections, each keyed separately in t.changes but
+	// A content-mapped file can have several projections, each keyed separately in t.changes but
 	// all sharing one original file. Their edits are collected together before being ordered and checked,
 	// so duplicate edits are emitted once and conflicting edits are rejected regardless of map iteration
 	// order.
@@ -30,9 +30,8 @@ func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 		if t.unmappableFiles.Has(fileName) {
 			continue
 		}
-		// Edits are computed and stored in virtual coordinates but applied to the original document, and a
-		// mapper is free to reorder text, so virtual order does not imply original order. Convert first,
-		// then sort and check for overlap in the space the edits are actually applied in.
+		// For a content-mapped file, a mapper may reorder source text relative to the original document.
+		// Convert first, then sort and check for overlap in the space where edits are actually applied.
 		textChanges := core.MapNonNil(changesInFile, func(change *trackerEdit) *lsproto.TextEdit {
 			// !!! targetSourceFile
 
@@ -44,7 +43,7 @@ func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 
 			return &lsproto.TextEdit{
 				NewText: newText,
-				Range:   t.toLSPEditRange(sourceFile, change.virtual),
+				Range:   t.toLSPEditRange(sourceFile, change.TextRange),
 			}
 		})
 
@@ -118,7 +117,7 @@ func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.Sour
 		return change.NewText
 	}
 
-	pos := change.virtual.Pos()
+	pos := change.TextRange.Pos()
 	formatNode := func(n *ast.Node) string {
 		return t.getFormattedTextOfNode(n, targetSourceFile, sourceFile, pos, change.options)
 	}
@@ -156,17 +155,17 @@ func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.Sour
 //     column zero, so the indentation is emitted before the text.
 //
 // The indentation is read from the original text at the edit's original position, so it holds for a
-// content-mapped file whose virtual copy is indented differently from the document the edit is applied to.
+// content-mapped file whose projection is indented differently from the document the edit is applied to.
 // Edits carrying an explicit indentation option are left alone.
 func (t *Tracker) reindentInsertedLines(sourceFile *ast.SourceFile, change *trackerEdit, text string) string {
-	if text == "" || change.virtual.Pos() != change.virtual.End() || change.options.indentation != nil {
+	if text == "" || change.TextRange.Pos() != change.TextRange.End() || change.options.indentation != nil {
 		return text
 	}
 	if !strings.HasSuffix(text, t.newLine) {
 		return text
 	}
 	original := sourceFile.OriginalText()
-	pos := change.virtual.Pos()
+	pos := change.TextRange.Pos()
 	if spans := sourceFile.SpanMap(); spans != nil {
 		mapped, fidelity := spans.VirtualToOriginalPosition(core.TextPos(pos))
 		if !fidelity.IsExact() {

--- a/tsc/internal/ls/change/trackerimpl.go
+++ b/tsc/internal/ls/change/trackerimpl.go
@@ -10,13 +10,11 @@ import (
 	"github.com/microsoft/TypeScript/tsc/internal/astnav"
 	"github.com/microsoft/TypeScript/tsc/internal/core"
 	"github.com/microsoft/TypeScript/tsc/internal/format"
-	"github.com/microsoft/TypeScript/tsc/internal/ls/lsconv"
 	"github.com/microsoft/TypeScript/tsc/internal/ls/lsutil"
 	"github.com/microsoft/TypeScript/tsc/internal/lsp/lsproto"
 	"github.com/microsoft/TypeScript/tsc/internal/parser"
 	"github.com/microsoft/TypeScript/tsc/internal/printer"
 	"github.com/microsoft/TypeScript/tsc/internal/scanner"
-	"github.com/microsoft/TypeScript/tsc/internal/spanmap"
 	"github.com/microsoft/TypeScript/tsc/internal/stringutil"
 )
 
@@ -26,17 +24,9 @@ func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 		if t.unmappableFiles.Has(sourceFile.OriginalFileName()) {
 			continue
 		}
-		// order changes by start position
-		// If the start position is the same, put the shorter range first, since an empty range (x, x) may precede (x, y) but not vice-versa.
-		slices.SortStableFunc(changesInFile, func(a, b *trackerEdit) int { return lsproto.CompareRanges(a.Range, b.Range) })
-		// verify that change intervals do not overlap, except possibly at end points.
-		for i := range len(changesInFile) - 1 {
-			if lsproto.ComparePositions(changesInFile[i].Range.End, changesInFile[i+1].Range.Start) > 0 {
-				// assert change[i].End <= change[i + 1].Start
-				panic(fmt.Sprintf("changes overlap: %v and %v", changesInFile[i].Range, changesInFile[i+1].Range))
-			}
-		}
-
+		// Edits are computed and stored in virtual coordinates but applied to the original document, and a
+		// mapper is free to reorder text, so virtual order does not imply original order. Convert first,
+		// then sort and check for overlap in the space the edits are actually applied in.
 		textChanges := core.MapNonNil(changesInFile, func(change *trackerEdit) *lsproto.TextEdit {
 			// !!! targetSourceFile
 
@@ -48,9 +38,20 @@ func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 
 			return &lsproto.TextEdit{
 				NewText: newText,
-				Range:   change.Range,
+				Range:   t.toLSPEditRange(sourceFile, change.virtual),
 			}
 		})
+
+		// order changes by start position
+		// If the start position is the same, put the shorter range first, since an empty range (x, x) may precede (x, y) but not vice-versa.
+		slices.SortStableFunc(textChanges, func(a, b *lsproto.TextEdit) int { return lsproto.CompareRanges(a.Range, b.Range) })
+		// verify that change intervals do not overlap, except possibly at end points.
+		for i := range len(textChanges) - 1 {
+			if lsproto.ComparePositions(textChanges[i].Range.End, textChanges[i+1].Range.Start) > 0 {
+				// assert change[i].End <= change[i + 1].Start
+				panic(fmt.Sprintf("changes overlap: %v and %v", textChanges[i].Range, textChanges[i+1].Range))
+			}
+		}
 
 		if len(textChanges) > 0 {
 			fileName := sourceFile.OriginalFileName()
@@ -71,51 +72,30 @@ func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.Sour
 		return change.NewText
 	}
 
-	positions := lsconv.FromLSPPositionForSourceFile(t.converters, sourceFile, change.Range.Start, spanmap.FeatureAll)
-	var result string
-	found := false
-	// The original range may have multiple verbatim copies; it is safe to lose their identity only when
-	// formatting at every exact projection produces the same edit.
-	for _, mapped := range positions {
-		if !mapped.Fidelity.IsExact() {
-			continue
-		}
-		projection := mapped.Script
-		pos := int(mapped.Position)
-		formatNode := func(n *ast.Node) string {
-			return t.getFormattedTextOfNode(n, targetSourceFile, projection, pos, change.options)
-		}
+	pos := change.virtual.Pos()
+	formatNode := func(n *ast.Node) string {
+		return t.getFormattedTextOfNode(n, targetSourceFile, sourceFile, pos, change.options)
+	}
 
-		var text string
-		switch change.kind {
-		case trackerEditKindReplaceWithMultipleNodes:
-			joiner := change.options.joiner
-			if joiner == "" {
-				joiner = t.newLine
-			}
-			text = strings.Join(core.Map(change.nodes, func(n *ast.Node) string { return strings.TrimSuffix(formatNode(n), t.newLine) }), joiner)
-		case trackerEditKindReplaceWithSingleNode:
-			text = formatNode(change.Node)
-		default:
-			panic(fmt.Sprintf("change kind %d should have been handled earlier", change.kind))
+	var text string
+	switch change.kind {
+	case trackerEditKindReplaceWithMultipleNodes:
+		joiner := change.options.joiner
+		if joiner == "" {
+			joiner = t.newLine
 		}
-		// Strip initial indentation if text will be inserted in the middle of the line.
-		noIndent := text
-		if !(change.options.indentation != nil || format.GetLineStartPositionForPosition(pos, projection) == pos) {
-			noIndent = strings.TrimLeftFunc(text, unicode.IsSpace)
-		}
-		candidate := change.options.Prefix + noIndent + core.IfElse(strings.HasSuffix(noIndent, change.options.Suffix), "", change.options.Suffix)
-		if found && candidate != result {
-			t.unmappableFiles.Add(sourceFile.OriginalFileName())
-			return ""
-		}
-		result = candidate
-		found = true
+		text = strings.Join(core.Map(change.nodes, func(n *ast.Node) string { return strings.TrimSuffix(formatNode(n), t.newLine) }), joiner)
+	case trackerEditKindReplaceWithSingleNode:
+		text = formatNode(change.Node)
+	default:
+		panic(fmt.Sprintf("change kind %d should have been handled earlier", change.kind))
 	}
-	if !found {
-		t.unmappableFiles.Add(sourceFile.OriginalFileName())
-		return ""
+	// Strip initial indentation if text will be inserted in the middle of the line.
+	noIndent := text
+	if !(change.options.indentation != nil || format.GetLineStartPositionForPosition(pos, sourceFile) == pos) {
+		noIndent = strings.TrimLeftFunc(text, unicode.IsSpace)
 	}
+	result := change.options.Prefix + noIndent + core.IfElse(strings.HasSuffix(noIndent, change.options.Suffix), "", change.options.Suffix)
 	return t.reindentInsertedLines(sourceFile, change, result)
 }
 
@@ -129,18 +109,25 @@ func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.Sour
 //   - Inserting at the very start of a line leaves the existing text indented but puts the inserted text at
 //     column zero, so the indentation is emitted before the text.
 //
-// This works from the original text and the edit's original range, so it holds for a content-mapped file
-// whose virtual copy is indented differently from the document the edit is applied to, and it produces the
-// same result for every projection. Edits carrying an explicit indentation option are left alone.
+// The indentation is read from the original text at the edit's original position, so it holds for a
+// content-mapped file whose virtual copy is indented differently from the document the edit is applied to.
+// Edits carrying an explicit indentation option are left alone.
 func (t *Tracker) reindentInsertedLines(sourceFile *ast.SourceFile, change *trackerEdit, text string) string {
-	if text == "" || change.Range.Start != change.Range.End || change.options.indentation != nil {
+	if text == "" || change.virtual.Pos() != change.virtual.End() || change.options.indentation != nil {
 		return text
 	}
 	if !strings.HasSuffix(text, t.newLine) {
 		return text
 	}
 	original := sourceFile.OriginalText()
-	pos := lsconv.FromLSPRangeToOriginal(t.converters, sourceFile, change.Range).Pos()
+	pos := change.virtual.Pos()
+	if spans := sourceFile.SpanMap(); spans != nil {
+		mapped, fidelity := spans.VirtualToOriginalPosition(core.TextPos(pos))
+		if !fidelity.IsExact() {
+			return text
+		}
+		pos = int(mapped)
+	}
 	if pos < 0 || pos > len(original) {
 		return text
 	}
@@ -215,13 +202,10 @@ func (t *Tracker) getNonformattedText(node *ast.Node, sourceFile *ast.SourceFile
 
 // method on the changeTracker because use of converters
 // GetAdjustedRange computes the adjusted range for a node in a source file, accounting for trivia.
-func (t *Tracker) GetAdjustedRange(sourceFile *ast.SourceFile, startNode *ast.Node, endNode *ast.Node, leadingOption LeadingTriviaOption, trailingOption TrailingTriviaOption) lsproto.Range {
-	return t.toLSPEditRange(
-		sourceFile,
-		core.NewTextRange(
-			t.getAdjustedStartPosition(sourceFile, startNode, leadingOption, false),
-			t.getAdjustedEndPosition(sourceFile, endNode, trailingOption),
-		),
+func (t *Tracker) GetAdjustedRange(sourceFile *ast.SourceFile, startNode *ast.Node, endNode *ast.Node, leadingOption LeadingTriviaOption, trailingOption TrailingTriviaOption) core.TextRange {
+	return core.NewTextRange(
+		t.getAdjustedStartPosition(sourceFile, startNode, leadingOption, false),
+		t.getAdjustedEndPosition(sourceFile, endNode, trailingOption),
 	)
 }
 

--- a/tsc/internal/ls/change/trackerimpl.go
+++ b/tsc/internal/ls/change/trackerimpl.go
@@ -114,8 +114,60 @@ func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.Sour
 	}
 	if !found {
 		t.unmappableFiles.Add(sourceFile.OriginalFileName())
+		return ""
 	}
-	return result
+	return t.reindentInsertedLines(sourceFile, change, result)
+}
+
+// reindentInsertedLines fixes the indentation of a line an insertion introduces into the document the
+// edit is applied to. The inserted text forms its own line when it ends in a newline, and that line has to
+// pick up the indentation of the line it is being spliced into. Where the indentation goes depends on
+// which side of the insertion point it already sits on:
+//
+//   - Inserting after a line's indentation (`\t\tfoo` with the point before `foo`) leaves the inserted text
+//     indented but pushes the rest of the line down bare, so the indentation is repeated after the text.
+//   - Inserting at the very start of a line leaves the existing text indented but puts the inserted text at
+//     column zero, so the indentation is emitted before the text.
+//
+// This works from the original text and the edit's original range, so it holds for a content-mapped file
+// whose virtual copy is indented differently from the document the edit is applied to, and it produces the
+// same result for every projection. Edits carrying an explicit indentation option are left alone.
+func (t *Tracker) reindentInsertedLines(sourceFile *ast.SourceFile, change *trackerEdit, text string) string {
+	if text == "" || change.Range.Start != change.Range.End || change.options.indentation != nil {
+		return text
+	}
+	if !strings.HasSuffix(text, t.newLine) {
+		return text
+	}
+	original := sourceFile.OriginalText()
+	pos := lsconv.FromLSPRangeToOriginal(t.converters, sourceFile, change.Range).Pos()
+	if pos < 0 || pos > len(original) {
+		return text
+	}
+	lineStart := strings.LastIndexByte(original[:pos], '\n') + 1
+	beforePoint := original[lineStart:pos]
+	if beforePoint == "" {
+		// At the start of a line: the existing text keeps its indentation, and the inserted line needs it —
+		// but only when the formatter left the text at column zero. Where the formatter already indented it
+		// (inserting into a multi-line list, say), that indentation is the correct one.
+		if leadingIndentation(text) != "" {
+			return text
+		}
+		return leadingIndentation(original[lineStart:]) + text
+	}
+	if leadingIndentation(beforePoint) != beforePoint {
+		return text
+	}
+	// Just past the indentation: the inserted line already has it, the text pushed down needs it back.
+	return text + beforePoint
+}
+
+func leadingIndentation(text string) string {
+	end := 0
+	for end < len(text) && (text[end] == ' ' || text[end] == '\t') {
+		end++
+	}
+	return text[:end]
 }
 
 /** Note: this may mutate `nodeIn`. */

--- a/tsc/internal/ls/change/trackerimpl.go
+++ b/tsc/internal/ls/change/trackerimpl.go
@@ -20,8 +20,14 @@ import (
 
 func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 	changes := map[string][]*lsproto.TextEdit{}
+	// A content-mapped file can have several virtual projections, each keyed separately in t.changes but
+	// all sharing one original file. Their edits are collected together before being ordered and checked,
+	// so duplicate edits are emitted once and conflicting edits are rejected regardless of map iteration
+	// order.
+	projections := map[string]int{}
 	for sourceFile, changesInFile := range t.changes.M {
-		if t.unmappableFiles.Has(sourceFile.OriginalFileName()) {
+		fileName := sourceFile.OriginalFileName()
+		if t.unmappableFiles.Has(fileName) {
 			continue
 		}
 		// Edits are computed and stored in virtual coordinates but applied to the original document, and a
@@ -42,26 +48,66 @@ func (t *Tracker) getTextChangesFromChanges() map[string][]*lsproto.TextEdit {
 			}
 		})
 
+		if len(textChanges) > 0 {
+			changes[fileName] = append(changes[fileName], textChanges...)
+			projections[fileName]++
+		}
+	}
+
+	for fileName, textChanges := range changes {
+		// Converting the edits above may have found that this file cannot be represented in its original
+		// text. GetChanges drops it, so its order does not matter, and the best-effort ranges left behind
+		// may overlap in ways the check below would refuse.
+		if t.unmappableFiles.Has(fileName) {
+			continue
+		}
 		// order changes by start position
 		// If the start position is the same, put the shorter range first, since an empty range (x, x) may precede (x, y) but not vice-versa.
 		slices.SortStableFunc(textChanges, func(a, b *lsproto.TextEdit) int { return lsproto.CompareRanges(a.Range, b.Range) })
+		if projections[fileName] > 1 {
+			textChanges = dedupeIdenticalEdits(textChanges)
+			changes[fileName] = textChanges
+		}
 		// verify that change intervals do not overlap, except possibly at end points.
 		for i := range len(textChanges) - 1 {
-			if lsproto.ComparePositions(textChanges[i].Range.End, textChanges[i+1].Range.Start) > 0 {
+			if textEditsConflict(textChanges[i], textChanges[i+1], projections[fileName] > 1) {
+				if projections[fileName] > 1 {
+					// Projections of one original range disagree about how to edit it. That is a property of
+					// the mapper's output rather than a bug here, so drop the file instead of failing.
+					t.unmappableFiles.Add(fileName)
+					break
+				}
 				// assert change[i].End <= change[i + 1].Start
 				panic(fmt.Sprintf("changes overlap: %v and %v", textChanges[i].Range, textChanges[i+1].Range))
 			}
 		}
-
-		if len(textChanges) > 0 {
-			fileName := sourceFile.OriginalFileName()
-			if t.unmappableFiles.Has(fileName) {
-				continue
-			}
-			changes[fileName] = append(changes[fileName], textChanges...)
-		}
 	}
 	return changes
+}
+
+// dedupeIdenticalEdits drops exact duplicates from a sorted slice of edits. When a mapper copies one span
+// of the original into more than one projection, an edit computed against each projection describes the
+// same change to the same original range; emitting it once per projection would apply it repeatedly.
+func dedupeIdenticalEdits(edits []*lsproto.TextEdit) []*lsproto.TextEdit {
+	deduped := edits[:0]
+	for _, edit := range edits {
+		if n := len(deduped); n > 0 && deduped[n-1].Range == edit.Range && deduped[n-1].NewText == edit.NewText {
+			continue
+		}
+		deduped = append(deduped, edit)
+	}
+	return deduped
+}
+
+func textEditsConflict(a, b *lsproto.TextEdit, multipleProjections bool) bool {
+	if lsproto.ComparePositions(a.Range.End, b.Range.Start) > 0 {
+		return true
+	}
+	// Different insertions at the same position are ambiguous when they may come from different projections.
+	return multipleProjections &&
+		a.Range.Start == a.Range.End &&
+		a.Range == b.Range &&
+		a.NewText != b.NewText
 }
 
 func (t *Tracker) computeNewText(change *trackerEdit, targetSourceFile *ast.SourceFile, sourceFile *ast.SourceFile) string {
@@ -131,7 +177,7 @@ func (t *Tracker) reindentInsertedLines(sourceFile *ast.SourceFile, change *trac
 	if pos < 0 || pos > len(original) {
 		return text
 	}
-	lineStart := strings.LastIndexByte(original[:pos], '\n') + 1
+	lineStart := strings.LastIndexAny(original[:pos], "\r\n") + 1
 	beforePoint := original[lineStart:pos]
 	if beforePoint == "" {
 		// At the start of a line: the existing text keeps its indentation, and the inserted line needs it —

--- a/tsc/internal/ls/change/trackerimpl.go
+++ b/tsc/internal/ls/change/trackerimpl.go
@@ -170,7 +170,6 @@ func leadingIndentation(text string) string {
 	return text[:end]
 }
 
-/** Note: this may mutate `nodeIn`. */
 func (t *Tracker) getFormattedTextOfNode(nodeIn *ast.Node, targetSourceFile *ast.SourceFile, sourceFile *ast.SourceFile, pos int, options NodeOptions) string {
 	text, sourceFileLike := t.getNonformattedText(nodeIn, targetSourceFile)
 	// !!! if (validate) validate(node, text);

--- a/tsc/internal/ls/change/trackerimpl_test.go
+++ b/tsc/internal/ls/change/trackerimpl_test.go
@@ -1,0 +1,22 @@
+package change
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/internal/lsp/lsproto"
+)
+
+func TestTextEditsConflictAtSameInsertionPointAcrossProjections(t *testing.T) {
+	t.Parallel()
+
+	position := lsproto.Position{Line: 1, Character: 2}
+	a := &lsproto.TextEdit{Range: lsproto.Range{Start: position, End: position}, NewText: "a"}
+	b := &lsproto.TextEdit{Range: lsproto.Range{Start: position, End: position}, NewText: "b"}
+
+	if !textEditsConflict(a, b, true) {
+		t.Fatal("different insertions at the same position across projections should conflict")
+	}
+	if textEditsConflict(a, b, false) {
+		t.Fatal("insertions at the same position within one projection should retain their existing ordering")
+	}
+}

--- a/tsc/internal/printer/changetrackerwriter.go
+++ b/tsc/internal/printer/changetrackerwriter.go
@@ -135,9 +135,12 @@ func (ct *ChangeTrackerWriter) assignPositionsToNodeWorker(
 		return node
 	}
 	visited := node.VisitEachChild(v)
-	// create proxy node for non synthesized nodes
+	// Assigning positions must not mutate the caller's node: it may be printed again (a change in a
+	// content-mapped file is formatted once per virtual projection of its insertion point), and a node
+	// that has acquired positions is printed by reading text back out of the source file. VisitEachChild
+	// returns a fresh node only when a child changed, so clone whenever it hands back the input.
 	newNode := visited
-	if !ast.NodeIsSynthesized(visited) {
+	if visited == node {
 		newNode = visited.Clone(v.Factory)
 	}
 	newNode.ForEachChild(func(child *ast.Node) bool {

--- a/tsc/internal/testutil/contentmappertest/duplicate_projection.go
+++ b/tsc/internal/testutil/contentmappertest/duplicate_projection.go
@@ -1,0 +1,40 @@
+package contentmappertest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoft/TypeScript/tsc/internal/contentmapper"
+	"github.com/microsoft/TypeScript/tsc/internal/json"
+)
+
+// duplicateProjectionHandler emits the original content as both the canonical output and a supplemental
+// one, so a single original span has an identical counterpart in two distinct virtual source files that
+// share an OriginalFileName. An edit to that span is therefore recorded once per projection.
+type duplicateProjectionHandler struct{ noNotifications }
+
+func (duplicateProjectionHandler) HandleRequest(ctx context.Context, method string, params json.Value) (any, error) {
+	switch method {
+	case contentmapper.MethodInitialize:
+		return initializeResult("mapper"), nil
+	case contentmapper.MethodTransform:
+		var p contentmapper.TransformParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, err
+		}
+		canonical, err := identityMappedOutput(p.Content)
+		if err != nil {
+			return nil, err
+		}
+		supplemental, err := identityMappedOutput(p.Content)
+		if err != nil {
+			return nil, err
+		}
+		return contentmapper.TransformResult{
+			MappedOutput: canonical,
+			Supplemental: []contentmapper.SupplementalOutput{{MappedOutput: supplemental}},
+		}, nil
+	default:
+		return nil, fmt.Errorf("contentmappertest: unexpected method %q", method)
+	}
+}

--- a/tsc/internal/testutil/contentmappertest/hoisting.go
+++ b/tsc/internal/testutil/contentmappertest/hoisting.go
@@ -1,0 +1,132 @@
+package contentmappertest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/internal/contentmapper"
+	"github.com/microsoft/TypeScript/tsc/internal/core"
+	"github.com/microsoft/TypeScript/tsc/internal/json"
+	"github.com/microsoft/TypeScript/tsc/internal/spanmap"
+)
+
+type hoistingHandler struct{ noNotifications }
+
+func (hoistingHandler) HandleRequest(ctx context.Context, method string, params json.Value) (any, error) {
+	switch method {
+	case contentmapper.MethodInitialize:
+		return initializeResult("mapper"), nil
+	case contentmapper.MethodTransform:
+		var p contentmapper.TransformParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, err
+		}
+		text, mappings, err := transformHoisting(p.Content)
+		if err != nil {
+			return nil, err
+		}
+		return contentmapper.TransformResult{MappedOutput: contentmapper.MappedOutput{Text: text, Extension: ".ts", Mappings: mappings}}, nil
+	default:
+		return nil, fmt.Errorf("contentmappertest: unexpected method %q", method)
+	}
+}
+
+// transformHoisting emits the script body inside a render function, but lifts the leading run of import
+// declarations above it, so the virtual text is laid out as:
+//
+//	///<reference types="svelte" />
+//	;
+//	import { existing } from "./dep";      <- original [importsStart, importsEnd)
+//	function $$render() {
+//	<whitespace before the first import>   <- original [scriptStart, importsStart)
+//	<script body after the last import>    <- original [importsEnd, scriptEnd)
+//	}
+//
+// This mirrors the layout svelte2tsx produces for a component. Hoisting splits the script into segments
+// that are contiguous in the original but disjoint in the virtual text, so the original position at a
+// splice point (importsStart) lies on the boundary of two verbatim segments and projects to two distinct
+// exact virtual positions.
+func transformHoisting(content string) (string, json.Value, error) {
+	var virtual strings.Builder
+	var segments []spanmap.Segment
+
+	writeMapped := func(originalStart, originalEnd int) {
+		virtualStart := core.TextPos(virtual.Len())
+		virtual.WriteString(content[originalStart:originalEnd])
+		segments = append(segments, spanmap.Segment{
+			VirtualStart:  virtualStart,
+			VirtualEnd:    core.TextPos(virtual.Len()),
+			OriginalStart: core.TextPos(originalStart),
+			OriginalEnd:   core.TextPos(originalEnd),
+			Kind:          spanmap.KindVerbatim,
+			Features:      spanmap.FeatureAll,
+		})
+	}
+
+	scriptStart, scriptEnd, err := scriptRange(content)
+	if err != nil {
+		return "", nil, err
+	}
+	importsStart, importsEnd := leadingImportRange(content, scriptStart, scriptEnd)
+
+	virtual.WriteString("///<reference types=\"svelte\" />\n;\n")
+	writeMapped(importsStart, importsEnd)
+	virtual.WriteString("\nfunction $$render() {")
+	writeMapped(scriptStart, importsStart)
+	writeMapped(importsEnd, scriptEnd)
+	virtual.WriteString("\n;\nreturn { props: {} as Record<string, never> }}\n")
+
+	mappings, err := spanmap.New(segments).Marshal()
+	if err != nil {
+		return "", nil, err
+	}
+	return virtual.String(), json.Value(mappings), nil
+}
+
+func scriptRange(content string) (start, end int, err error) {
+	scriptOpen := strings.Index(content, "<script")
+	if scriptOpen < 0 {
+		return 0, 0, errors.New("contentmappertest: missing <script> tag")
+	}
+	openEndRel := strings.IndexByte(content[scriptOpen:], '>')
+	if openEndRel < 0 {
+		return 0, 0, errors.New("contentmappertest: unclosed <script> tag")
+	}
+	start = scriptOpen + openEndRel + 1
+	closeRel := strings.Index(content[start:], "</script>")
+	if closeRel < 0 {
+		return 0, 0, errors.New("contentmappertest: missing </script> tag")
+	}
+	return start, start + closeRel, nil
+}
+
+// leadingImportRange returns the range covering the run of import declarations at the top of the script
+// body, skipping the whitespace that precedes them.
+func leadingImportRange(content string, scriptStart, scriptEnd int) (start, end int) {
+	start = scriptStart
+	for start < scriptEnd && isSpaceByte(content[start]) {
+		start++
+	}
+	end = start
+	for end < scriptEnd && strings.HasPrefix(content[end:scriptEnd], "import ") {
+		lineEnd := strings.IndexByte(content[end:scriptEnd], '\n')
+		if lineEnd < 0 {
+			end = scriptEnd
+			break
+		}
+		end += lineEnd
+		for end < scriptEnd && isSpaceByte(content[end]) {
+			end++
+		}
+	}
+	for end > start && isSpaceByte(content[end-1]) {
+		end--
+	}
+	return start, end
+}
+
+func isSpaceByte(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'
+}

--- a/tsc/internal/testutil/contentmappertest/registry.go
+++ b/tsc/internal/testutil/contentmappertest/registry.go
@@ -24,6 +24,7 @@ const (
 	SupplementalModuleMapper      = "supplemental-module-mapper"
 	PrefixedSupplementalMapper    = "prefixed-supplemental-mapper"
 	UnmappedFoldingMapper         = "unmapped-folding-mapper"
+	HoistingMapper                = "hoisting-mapper"
 )
 
 type handlerConstructor func(*ProjectLifecycle) ipc.Handler
@@ -45,6 +46,7 @@ var mapperHandlers = map[string]handlerConstructor{
 	SupplementalModuleMapper:      func(*ProjectLifecycle) ipc.Handler { return supplementalModuleHandler{} },
 	PrefixedSupplementalMapper:    func(*ProjectLifecycle) ipc.Handler { return prefixedSupplementalHandler{} },
 	UnmappedFoldingMapper:         func(*ProjectLifecycle) ipc.Handler { return unmappedFoldingHandler{} },
+	HoistingMapper:                func(*ProjectLifecycle) ipc.Handler { return hoistingHandler{} },
 }
 
 func handlerForMapper(command []string, lifecycle *ProjectLifecycle) (ipc.Handler, error) {

--- a/tsc/internal/testutil/contentmappertest/registry.go
+++ b/tsc/internal/testutil/contentmappertest/registry.go
@@ -25,6 +25,7 @@ const (
 	PrefixedSupplementalMapper    = "prefixed-supplemental-mapper"
 	UnmappedFoldingMapper         = "unmapped-folding-mapper"
 	HoistingMapper                = "hoisting-mapper"
+	DuplicateProjectionMapper     = "duplicate-projection-mapper"
 )
 
 type handlerConstructor func(*ProjectLifecycle) ipc.Handler
@@ -47,6 +48,7 @@ var mapperHandlers = map[string]handlerConstructor{
 	PrefixedSupplementalMapper:    func(*ProjectLifecycle) ipc.Handler { return prefixedSupplementalHandler{} },
 	UnmappedFoldingMapper:         func(*ProjectLifecycle) ipc.Handler { return unmappedFoldingHandler{} },
 	HoistingMapper:                func(*ProjectLifecycle) ipc.Handler { return hoistingHandler{} },
+	DuplicateProjectionMapper:     func(*ProjectLifecycle) ipc.Handler { return duplicateProjectionHandler{} },
 }
 
 func handlerForMapper(command []string, lifecycle *ProjectLifecycle) (ipc.Handler, error) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `npx hereby test`
* [ ] You've successfully run `npx hereby lint`
* [ ] You've successfully run `npx hereby check:format`
* [ ] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

Fixes https://github.com/sveltejs/language-tools/pull/3111#issuecomment-5421236091

The crash was a consequence of the very sketchy comment (inherited from Strada)

```go
/** Note: this may mutate `nodeIn`. */
func (t *Tracker) getFormattedTextOfNode(nodeIn *ast.Node, targetSourceFile *ast.SourceFile, sourceFile *ast.SourceFile, pos int, options NodeOptions) string {
```

This was ok-ish before because `nodeIn` was freshly synthesized and only used once. But with content mappers, when a node was inserted into an original text position that maps to more than one verbatim location in the virtual text, we formatted the same synthesized node in both virtual locations to make sure it formats the same way. During this process, the assignment of node positions during the first pass messes up state for the second pass. The crash is fixed just by cloning the node instead of mutating it.

However, this made me realize that the change tracker was modeling this poorly. Edits were being computed in virtual source files, then converted into original text coordinates for storage, and then converting _back_ into virtual text coordinates for formatting, which is a lossy/ambiguous operation: original to virtual position is potentially a one-to-many. So this PR applies a refactor to keep change tracker edits in virtual coordinates until the very end when retrieving the final LSP edits.