### PR TITLE
Enhance jsonvalue_test.go with edge case tests

### DIFF
--- a/tsc/internal/api/jsonvalue_test.go
+++ b/tsc/internal/api/jsonvalue_test.go
@@ -32,4 +32,19 @@ func TestJSONValueToAny(t *testing.T) {
 	empty := root.GetOrZero("e").([]any)
 	assert.Assert(t, empty != nil)
 	assert.Equal(t, len(empty), 0)
+
+ 
+	var edgeValue packagejson.JSONValue
+	err = json.Unmarshal([]byte(`{"emptyObj":{},"boolVal":true,"floatVal":3.14}`), &edgeValue)
+	assert.NilError(t, err)
+
+	edgeRoot := jsonValueToAny(edgeValue).(*collections.OrderedMap[string, any])
+	
+ 
+	emptyObj := edgeRoot.GetOrZero("emptyObj").(*collections.OrderedMap[string, any])
+	assert.Equal(t, len(slices.Collect(emptyObj.Keys())), 0)
+
+ 
+	assert.Equal(t, edgeRoot.GetOrZero("boolVal"), true)
+	assert.Equal(t, edgeRoot.GetOrZero("floatVal"), float64(3.14))
 }

--- a/tsc/internal/api/jsonvalue_test.go
+++ b/tsc/internal/api/jsonvalue_test.go
@@ -33,18 +33,15 @@ func TestJSONValueToAny(t *testing.T) {
 	assert.Assert(t, empty != nil)
 	assert.Equal(t, len(empty), 0)
 
- 
 	var edgeValue packagejson.JSONValue
 	err = json.Unmarshal([]byte(`{"emptyObj":{},"boolVal":true,"floatVal":3.14}`), &edgeValue)
 	assert.NilError(t, err)
 
 	edgeRoot := jsonValueToAny(edgeValue).(*collections.OrderedMap[string, any])
-	
- 
+
 	emptyObj := edgeRoot.GetOrZero("emptyObj").(*collections.OrderedMap[string, any])
 	assert.Equal(t, len(slices.Collect(emptyObj.Keys())), 0)
 
- 
 	assert.Equal(t, edgeRoot.GetOrZero("boolVal"), true)
 	assert.Equal(t, edgeRoot.GetOrZero("floatVal"), float64(3.14))
 }


### PR DESCRIPTION
Add unit tests covering edge cases for `jsonvalueToAny`, including empty objects (`{}`), boolean types, and floating-point values to ensure robust parsing across various data structures.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `npx hereby test`
* [ ] You've successfully run `npx hereby lint`
* [ ] You've successfully run `npx hereby check:format`
* [x ] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

Fixes #
