### PR TITLE
Disallow optional calls on import.defer

### DIFF
--- a/tsc/internal/parser/parser.go
+++ b/tsc/internal/parser/parser.go
@@ -5241,6 +5241,9 @@ func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
 			p.nextToken() // advance past the dot
 			expression = p.finishNode(p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName()), pos)
 			if expression.Text() == "defer" {
+				if p.token == ast.KindQuestionDotToken && p.lookAhead((*Parser).nextTokenIsOpenParenOrLessThan) {
+					p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(ast.KindOpenParenToken))
+				}
 				if p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken {
 					p.sourceFlags |= ast.NodeFlagsPossiblyContainsDynamicImport
 				}

--- a/tsc/internal/parser/parser.go
+++ b/tsc/internal/parser/parser.go
@@ -5242,6 +5242,7 @@ func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
 			expression = p.finishNode(p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName()), pos)
 			if expression.Text() == "defer" {
 				if p.token == ast.KindQuestionDotToken && p.lookAhead((*Parser).nextTokenIsOpenParenOrLessThan) {
+					p.sourceFlags |= ast.NodeFlagsPossiblyContainsDynamicImport
 					p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(ast.KindOpenParenToken))
 				}
 				if p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken {

--- a/tsc/internal/parser/parser_test.go
+++ b/tsc/internal/parser/parser_test.go
@@ -186,6 +186,31 @@ class MissingImplements implements B. {}
 	assert.Equal(t, missingImplementsDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindExpressionWithTypeArguments)
 }
 
+func TestImportDeferOptionalCallsCollectExternalModuleReferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sourceText string
+	}{
+		{"optional call", `import.defer?.("./x");`},
+		{"generic optional call", `import.defer?.<string>("./x");`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			file := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/index.ts",
+				Path:     "/index.ts",
+			}, test.sourceText, core.ScriptKindTS)
+
+			assert.Equal(t, len(file.Imports()), 1)
+			assert.Equal(t, file.Imports()[0].Text(), "./x")
+		})
+	}
+}
+
 func TestJSDocImportTypeParentChain(t *testing.T) {
 	t.Parallel()
 	sourceText := `test("", async function () {

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.errors.txt
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.errors.txt
@@ -1,0 +1,16 @@
+b.ts(1,13): error TS1005: '(' expected.
+b.ts(2,13): error TS1005: '(' expected.
+
+
+==== x.ts (0 errors) ====
+    export const x = 1;
+    
+==== b.ts (2 errors) ====
+    import.defer?.("./x");
+                ~~
+!!! error TS1005: '(' expected.
+    import.defer?.<string>("./x");
+                ~~
+!!! error TS1005: '(' expected.
+    import.defer("./x");
+    

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.errors.txt
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.errors.txt
@@ -1,16 +1,20 @@
 b.ts(1,13): error TS1005: '(' expected.
-b.ts(2,13): error TS1005: '(' expected.
+c.ts(1,13): error TS1005: '(' expected.
 
 
 ==== x.ts (0 errors) ====
     export const x = 1;
     
-==== b.ts (2 errors) ====
+==== b.ts (1 errors) ====
     import.defer?.("./x");
                 ~~
 !!! error TS1005: '(' expected.
+    
+==== c.ts (1 errors) ====
     import.defer?.<string>("./x");
                 ~~
 !!! error TS1005: '(' expected.
+    
+==== d.ts (0 errors) ====
     import.defer("./x");
     

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.js
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.js
@@ -5,7 +5,11 @@ export const x = 1;
 
 //// [b.ts]
 import.defer?.("./x");
+
+//// [c.ts]
 import.defer?.<string>("./x");
+
+//// [d.ts]
 import.defer("./x");
 
 
@@ -14,5 +18,9 @@ export const x = 1;
 //// [b.js]
 "use strict";
 import.defer?.("./x");
+//// [c.js]
+"use strict";
 import.defer?.("./x");
+//// [d.js]
+"use strict";
 import.defer("./x");

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.js
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.js
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+//// [x.ts]
+export const x = 1;
+
+//// [b.ts]
+import.defer?.("./x");
+import.defer?.<string>("./x");
+import.defer("./x");
+
+
+//// [x.js]
+export const x = 1;
+//// [b.js]
+"use strict";
+import.defer?.("./x");
+import.defer?.("./x");
+import.defer("./x");

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.symbols
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.symbols
@@ -8,9 +8,11 @@ export const x = 1;
 import.defer?.("./x");
 >"./x" : Symbol("./x", Decl(x.ts, 0, 0))
 
+=== c.ts ===
 import.defer?.<string>("./x");
 >"./x" : Symbol("./x", Decl(x.ts, 0, 0))
 
+=== d.ts ===
 import.defer("./x");
 >"./x" : Symbol("./x", Decl(x.ts, 0, 0))
 

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.symbols
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.symbols
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+=== x.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(x.ts, 0, 12))
+
+=== b.ts ===
+import.defer?.("./x");
+>"./x" : Symbol("./x", Decl(x.ts, 0, 0))
+
+import.defer?.<string>("./x");
+>"./x" : Symbol("./x", Decl(x.ts, 0, 0))
+
+import.defer("./x");
+>"./x" : Symbol("./x", Decl(x.ts, 0, 0))
+

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.types
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.types
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalCall.ts] ////
+
+=== x.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+=== b.ts ===
+import.defer?.("./x");
+>import.defer?.("./x") : Promise<typeof import("./x")>
+>defer : any
+>"./x" : "./x"
+
+import.defer?.<string>("./x");
+>import.defer?.<string>("./x") : Promise<typeof import("./x")>
+>defer : any
+>"./x" : "./x"
+
+import.defer("./x");
+>import.defer("./x") : Promise<typeof import("./x")>
+>defer : any
+>"./x" : "./x"
+

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.types
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalCall.types
@@ -11,11 +11,13 @@ import.defer?.("./x");
 >defer : any
 >"./x" : "./x"
 
+=== c.ts ===
 import.defer?.<string>("./x");
 >import.defer?.<string>("./x") : Promise<typeof import("./x")>
 >defer : any
 >"./x" : "./x"
 
+=== d.ts ===
 import.defer("./x");
 >import.defer("./x") : Promise<typeof import("./x")>
 >defer : any

--- a/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
+++ b/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
@@ -5,5 +5,9 @@ export const x = 1;
 
 // @filename: b.ts
 import.defer?.("./x");
+
+// @filename: c.ts
 import.defer?.<string>("./x");
+
+// @filename: d.ts
 import.defer("./x");

--- a/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
+++ b/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalCall.ts
@@ -1,0 +1,9 @@
+// @module: esnext
+
+// @filename: x.ts
+export const x = 1;
+
+// @filename: b.ts
+import.defer?.("./x");
+import.defer?.<string>("./x");
+import.defer("./x");


### PR DESCRIPTION
Fixes #63679

## Summary

- Report a parse error for `import.defer?.(...)`.
- Cover the TypeScript generic optional-call form `import.defer?.<T>(...)` as well.
- Preserve normal `import.defer(...)` calls and add conformance baselines for all three cases.

The parser reuses the existing `TS1005: '(' expected` diagnostic. This matches the current diagnostics for other invalid standalone uses of `import.defer` and avoids adding a new public diagnostic for the same grammar requirement.

## Tests

- `go -C ./tsc test -count=1 -run='TestLocal/importDeferOptionalCall' ./internal/testrunner`
- `npx hereby generate`
- `npx hereby build`
- `npx hereby test`
- `npx hereby test:all`
- `npx hereby lint`
- `npx hereby check:format`
- `npm run -w @typescript/typescript build`
- `npm run -w @typescript/typescript test`
- `npm run -w native-preview build`
- `go -C ./tsc mod tidy -diff`
- `go -C ./tools mod tidy -diff`
- `go work sync`

The full suite was also rerun with Node.js 24 LTS.

## Prior work

This incorporates the syntax coverage identified in microsoft/TypeScript#63690 and microsoft/typescript-go#4794. Those PRs were closed during the TypeScript/Go repository transition rather than because the parser direction was rejected.

## AI assistance disclosure

I used Codex to help implement and validate this patch. I selected this specific issue, reviewed and understand the parser change and generated baselines, and will personally respond to review feedback and revise the change as needed.
