### PR TITLE
Verify `go test` works without node installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,18 +72,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-go
-      - name: Prepare Node.js-free PATH
+      - name: Prepare standalone tsc module
         run: |
           mkdir "$RUNNER_TEMP/go-test-bin"
           ln -s "$(go env GOROOT)/bin/go" "$RUNNER_TEMP/go-test-bin/go"
+          cp -R tsc "$RUNNER_TEMP/tsc"
       - name: Tests without Node.js
         run: |
           export PATH="$RUNNER_TEMP/go-test-bin"
           export GOEXPERIMENT=ms_nocgo_opensslcrypto
           export CGO_ENABLED=0
           ! command -v node
-          go test ./tsc/... ./tools/...
-          go test -run=- -bench=. -benchtime=1x ./tsc/... ./tools/...
+          cd "$RUNNER_TEMP/tsc"
+          go test ./...
+          go test -run=- -bench=. -benchtime=1x ./...
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,11 @@ jobs:
       - name: Tests without Node.js
         run: |
           export PATH="$RUNNER_TEMP/go-test-bin"
+          export GOEXPERIMENT=ms_nocgo_opensslcrypto
+          export CGO_ENABLED=0
           ! command -v node
-          CGO_ENABLED=0 go test ./tsc/... ./tools/...
-      - name: Benchmarks without Node.js
-        run: |
-          export PATH="$RUNNER_TEMP/go-test-bin"
-          ! command -v node
-          CGO_ENABLED=0 go test -run=- -bench=. -benchtime=1x ./tsc/... ./tools/...
+          go test ./tsc/... ./tools/...
+          go test -run=- -bench=. -benchtime=1x ./tsc/... ./tools/...
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
         run: |
           mkdir "$RUNNER_TEMP/go-test-bin"
           ln -s "$(go env GOROOT)/bin/go" "$RUNNER_TEMP/go-test-bin/go"
-          ln -s "$(command -v sh)" "$RUNNER_TEMP/go-test-bin/sh"
-          ln -s "$(command -v nohup)" "$RUNNER_TEMP/go-test-bin/nohup"
-          ln -s "$(command -v sleep)" "$RUNNER_TEMP/go-test-bin/sleep"
       - name: Tests without Node.js
         run: |
           export PATH="$RUNNER_TEMP/go-test-bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,29 @@ jobs:
           package-manager-cache: false
       - run: npm ci --registry=https://packagefeedproxy.microsoft.io/npm/
 
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-go
+      - name: Prepare Node.js-free PATH
+        run: |
+          mkdir "$RUNNER_TEMP/go-test-bin"
+          ln -s "$(go env GOROOT)/bin/go" "$RUNNER_TEMP/go-test-bin/go"
+          ln -s "$(command -v sh)" "$RUNNER_TEMP/go-test-bin/sh"
+          ln -s "$(command -v nohup)" "$RUNNER_TEMP/go-test-bin/nohup"
+          ln -s "$(command -v sleep)" "$RUNNER_TEMP/go-test-bin/sleep"
+      - name: Tests without Node.js
+        run: |
+          export PATH="$RUNNER_TEMP/go-test-bin"
+          ! command -v node
+          CGO_ENABLED=0 go test ./tsc/... ./tools/...
+      - name: Benchmarks without Node.js
+        run: |
+          export PATH="$RUNNER_TEMP/go-test-bin"
+          ! command -v node
+          CGO_ENABLED=0 go test -run=- -bench=. -benchtime=1x ./tsc/... ./tools/...
+
   test:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
@@ -307,6 +330,7 @@ jobs:
       - extension
       - format
       - generate
+      - go-test
       - lint
       - misc
       - package-feed-proxy

--- a/tsc/cmd/tsc/sys_unix_test.go
+++ b/tsc/cmd/tsc/sys_unix_test.go
@@ -5,6 +5,9 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -15,8 +18,32 @@ import (
 )
 
 func TestChildProcessCloseDoesNotWaitForLauncherDescendants(t *testing.T) {
+	const (
+		launcherArg   = "child-process-launcher"
+		descendantArg = "child-process-descendant"
+	)
+	if len(os.Args) > 1 {
+		switch os.Args[len(os.Args)-1] {
+		case launcherArg:
+			cmd := exec.Command(os.Args[0], "-test.run=^TestChildProcessCloseDoesNotWaitForLauncherDescendants$", "--", descendantArg)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			assert.NilError(t, cmd.Start())
+			fmt.Println(cmd.Process.Pid)
+			assert.NilError(t, cmd.Wait())
+			return
+		case descendantArg:
+			time.Sleep(time.Minute)
+			return
+		}
+	}
+
 	t.Parallel()
-	process, err := spawnProcess([]string{"sh", "-c", "nohup sleep 60 & echo $!; wait"}, "", &bytes.Buffer{})
+	process, err := spawnProcess(
+		[]string{os.Args[0], "-test.run=^TestChildProcessCloseDoesNotWaitForLauncherDescendants$", "--", launcherArg},
+		"",
+		&bytes.Buffer{},
+	)
 	assert.NilError(t, err)
 	pidText, err := bufio.NewReader(process).ReadString('\n')
 	assert.NilError(t, err)


### PR DESCRIPTION
Thinking ahead to contributing our tests/benchmarks upstream to Go itself.

So, verify that the code works when the `tsc` module is pulled out (like a go get) and tested with _only_ `go` on `PATH`.