### PR TITLE
Add typed array constructor regression coverage

### DIFF
--- a/tsc/testdata/tests/cases/compiler/typedArrayConstructorOverloads.ts
+++ b/tsc/testdata/tests/cases/compiler/typedArrayConstructorOverloads.ts
@@ -22,3 +22,13 @@ export function makeTypedArray(buffer: ArrayBuffer, ctr: TypedArrayConstructor) 
     new ctr(buffer);
     new ctr(buffer, 0, 0);
 }
+
+// https://github.com/microsoft/TypeScript/issues/44191
+
+const uint8Array = new Uint8Array(4);
+// @ts-expect-error typed array inputs do not accept byteOffset and length
+new Uint8Array(uint8Array, 0, 1);
+
+const bigInt64Array = new BigInt64Array(4);
+// @ts-expect-error typed array inputs do not accept byteOffset and length
+new BigInt64Array(bigInt64Array, 0, 1);


### PR DESCRIPTION
Fixes #44191

The current library declarations already reject byteOffset and length when the first argument is another typed array. This adds focused regression coverage so that behavior cannot silently change.

I used Uint8Array as a representative numeric typed array and BigInt64Array for the separate BigInt family. The small values (4, 0, and 1) only keep the invalid constructor calls easy to read; they do not affect type checking.

Test evidence:
- Focused compiler test passed: go -C ./tsc test -run='TestLocal/typedArrayConstructorOverloads' ./internal/testrunner
- npx hereby generate, build, lint, check:format, test:benchmarks, test:tools, and test:api passed
- API tests: 645 passed
- Native-preview tests: 12 passed
- Go module tidy and workspace sync checks passed
- The unfiltered npx hereby test run reached only two failures: TestSubscribeSymlinkCreate/windows and TestSubscribeSymlinkDelete/windows could not create symlinks because this Windows session lacks that privilege. The complete Go suite passed when only those two environment-dependent tests were skipped.

Checklist:
- [x] Associated issue is in the Backlog milestone
- [x] Branch is up to date with main
- [ ] npx hereby test (Windows symlink privilege limitation described above)
- [x] npx hereby lint
- [x] npx hereby check:format
- [x] New regression tests cover the change

AI assistance: I used OpenAI Codex to research the issue, prepare the regression test, and run the checks. I understand the final one-file change and will handle review feedback myself.