### PR TITLE
Fix add missing JSDoc to ES2015 Collection Map and WeakMap

### DIFF
--- a/tsc/internal/bundled/libs/lib.es2015.collection.d.ts
+++ b/tsc/internal/bundled/libs/lib.es2015.collection.d.ts
@@ -20,24 +20,31 @@ interface Map<K, V> {
      */
     clear(): void;
     /**
+     * @param key The key of the element to be removed.
      * @returns true if an element in the Map existed and has been removed, or false if the element does not exist.
      */
     delete(key: K): boolean;
     /**
      * Executes a provided function once per each key/value pair in the Map, in insertion order.
+     * @param callbackfn Callback Function that is to be executed on each key/value pair in the Map.
      */
     forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
     /**
      * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
+     * @param key The key of the element to be retrieved.
      * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
      */
     get(key: K): V | undefined;
     /**
-     * @returns boolean indicating whether an element with the specified key exists or not.
+     * Checks whether element with specified key exists.
+     * @param key The key of said element.
+     * @returns Boolean value indicating whether an element with the specified key exists or not.
      */
     has(key: K): boolean;
     /**
      * Adds a new element with a specified key and value to the Map. If an element with the same key already exists, the element will be updated.
+     * @param key Key of element that is to be added / updated.
+     * @param value New value for element.
      */
     set(key: K, value: V): this;
     /**

--- a/tsc/internal/bundled/libs/lib.es2015.collection.d.ts
+++ b/tsc/internal/bundled/libs/lib.es2015.collection.d.ts
@@ -69,21 +69,25 @@ interface ReadonlyMap<K, V> {
 
 interface WeakMap<K extends WeakKey, V> {
     /**
-     * Removes the specified element from the WeakMap.
-     * @returns true if the element was successfully removed, or false if it was not present.
+     * @param key The key of the element to be removed from the WeakMap.
+     * @returns true if an element in the WeakMap existed and has been removed, or false if the element does not exist.
      */
     delete(key: K): boolean;
     /**
+     * Returns a specified element from the WeakMap. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the WeakMap.
+     * @param key The key of the element to be retrieved.
      * @returns a specified element.
      */
     get(key: K): V | undefined;
     /**
-     * @returns a boolean indicating whether an element with the specified key exists or not.
+     * @param key The key of said element.
+     * @returns A boolean value indicating whether an element with the specified key exists or not.
      */
     has(key: K): boolean;
     /**
      * Adds a new element with a specified key and value.
      * @param key Must be an object or symbol.
+     * @param value New value for element.
      */
     set(key: K, value: V): this;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `npx hereby test`
* [ ] You've successfully run `npx hereby lint`
* [ ] You've successfully run `npx hereby check:format`
* [ ] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

### Summary
Adds missing `@param` JSDoc to several ES2015 `Map` and `WeakMap` methods in
`lib.es2015.collection.d.ts`. This improves IntelliSense and documentation
consistency without changing any types or behavior.

### Fixes
N/A – documentation-only change.

### Notes
No functional changes. No tests required.
