### PR TITLE
Fix TestContentMapperOpenFileExcludedByConfigChange race

### DIFF
--- a/tsc/internal/project/contentmapper_test.go
+++ b/tsc/internal/project/contentmapper_test.go
@@ -679,6 +679,13 @@ func TestContentMapperOpenFileExcludedByConfigChange(t *testing.T) {
 		Uri:  "file:///home/project/tsconfig.json",
 		Type: lsproto.FileChangeTypeChanged,
 	}})
+	session.WaitForBackgroundTasks()
+
+	// The background update removes app.box from the configured project, but inferred
+	// project cleanup is deferred until the next file open.
+	assert.Assert(t, session.Snapshot().GetDefaultProject(boxURI) == nil)
+	mainURI := lsproto.DocumentUri("file:///home/project/src/main.ts")
+	session.DidOpenFile(ctx, mainURI, 1, files["/home/project/src/main.ts"].(string), lsproto.LanguageKindTypeScript)
 
 	languageService, err = session.GetLanguageService(ctx, boxURI)
 	assert.NilError(t, err)


### PR DESCRIPTION
This is the same thing as #64081 fixed, but in another test: https://github.com/microsoft/TypeScript/actions/runs/33623965145/job/100227239918