### PR TITLE
Fix completions inside tuple types suggesting value symbols

### DIFF
--- a/tsc/internal/fourslash/tests/completionsInEmptyTupleType_test.go
+++ b/tsc/internal/fourslash/tests/completionsInEmptyTupleType_test.go
@@ -14,6 +14,7 @@ func TestCompletionsInEmptyTupleType(t *testing.T) {
 	const content = `type UserTuple = [["name", string], ["age", number], ["address", string]];
 type AdminTuple = [/*1*/];
 type OtherTuple = [string, /*2*/];
+type QueryTuple = [typeof /*3*/];
 
 const User: UserTuple = [["name", "2333"], ["age", 2333], ["address", "2333"]];`
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
@@ -30,6 +31,23 @@ const User: UserTuple = [["name", "2333"], ["age", 2333], ["address", "2333"]];`
 			},
 			Excludes: []string{
 				"User",
+			},
+		},
+	})
+
+	// After `typeof` in a tuple type we are back in a value location, so type-only symbols shouldn't be offered.
+	f.VerifyCompletions(t, "3", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &DefaultCommitCharacters,
+			EditRange:        Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{
+			Includes: []fourslash.CompletionsExpectedItem{
+				"User",
+			},
+			Excludes: []string{
+				"UserTuple",
 			},
 		},
 	})

--- a/tsc/internal/fourslash/tests/completionsInEmptyTupleType_test.go
+++ b/tsc/internal/fourslash/tests/completionsInEmptyTupleType_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/internal/fourslash"
+	. "github.com/microsoft/TypeScript/tsc/internal/fourslash/tests/util"
+	"github.com/microsoft/TypeScript/tsc/internal/testutil"
+)
+
+func TestCompletionsInEmptyTupleType(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `type UserTuple = [["name", string], ["age", number], ["address", string]];
+type AdminTuple = [/*1*/];
+type OtherTuple = [string, /*2*/];
+
+const User: UserTuple = [["name", "2333"], ["age", 2333], ["address", "2333"]];`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyCompletions(t, []string{"1", "2"}, &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &DefaultCommitCharacters,
+			EditRange:        Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{
+			Includes: []fourslash.CompletionsExpectedItem{
+				"UserTuple",
+			},
+			Excludes: []string{
+				"User",
+			},
+		},
+	})
+}

--- a/tsc/internal/ls/completions.go
+++ b/tsc/internal/ls/completions.go
@@ -3361,6 +3361,8 @@ func isContextTokenTypeLocation(contextToken *ast.Node) bool {
 			return parentKind == ast.KindTypeParameter
 		case ast.KindSatisfiesKeyword:
 			return parentKind == ast.KindSatisfiesExpression
+		case ast.KindOpenBracketToken, ast.KindCommaToken:
+			return parentKind == ast.KindTupleType
 		}
 	}
 	return false


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `npx hereby test`
* [x] You've successfully run `npx hereby lint`
* [x] You've successfully run `npx hereby check:format`
* [x] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

Fixes #64145