### PR TITLE
Handle tuple rest parameters in legacy decorator arity checks

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -9373,7 +9373,7 @@ func (c *Checker) getLegacyDecoratorArgumentCount(node *ast.Node, signature *Sig
 		return 2
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
 		// For decorators with only two parameters we supply only two arguments
-		if len(signature.parameters) <= 2 {
+		if c.getParameterCount(signature) <= 2 {
 			return 2
 		}
 		return 3

--- a/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.errors.txt
@@ -1,0 +1,15 @@
+decoratorRestNoCrash1.ts(4,29): error TS2339: Property 'greeting' does not exist on type 'Greeter'.
+
+
+==== decoratorRestNoCrash1.ts (1 errors) ====
+    class Greeter {
+      @deco
+      greet1() {
+        return "Hello, " + this.greeting;
+                                ~~~~~~~~
+!!! error TS2339: Property 'greeting' does not exist on type 'Greeter'.
+      }
+    }
+    
+    declare function deco(...args: [any, any, any]): any;
+    

--- a/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.symbols
+++ b/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/decoratorRestNoCrash1.ts] ////
+
+=== decoratorRestNoCrash1.ts ===
+class Greeter {
+>Greeter : Symbol(Greeter, Decl(decoratorRestNoCrash1.ts, 0, 0))
+
+  @deco
+>deco : Symbol(deco, Decl(decoratorRestNoCrash1.ts, 5, 1))
+
+  greet1() {
+>greet1 : Symbol(Greeter.greet1, Decl(decoratorRestNoCrash1.ts, 0, 15))
+
+    return "Hello, " + this.greeting;
+>this : Symbol(Greeter, Decl(decoratorRestNoCrash1.ts, 0, 0))
+  }
+}
+
+declare function deco(...args: [any, any, any]): any;
+>deco : Symbol(deco, Decl(decoratorRestNoCrash1.ts, 5, 1))
+>args : Symbol(args, Decl(decoratorRestNoCrash1.ts, 7, 22))
+

--- a/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.types
+++ b/tsc/testdata/baselines/reference/compiler/decoratorRestNoCrash1.types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/decoratorRestNoCrash1.ts] ////
+
+=== decoratorRestNoCrash1.ts ===
+class Greeter {
+>Greeter : Greeter
+
+  @deco
+>deco : (args_0: any, args_1: any, args_2: any) => any
+
+  greet1() {
+>greet1 : () => string
+
+    return "Hello, " + this.greeting;
+>"Hello, " + this.greeting : string
+>"Hello, " : "Hello, "
+>this.greeting : any
+>this : this
+>greeting : any
+  }
+}
+
+declare function deco(...args: [any, any, any]): any;
+>deco : (args_0: any, args_1: any, args_2: any) => any
+>args : [any, any, any]
+

--- a/tsc/testdata/tests/cases/compiler/decoratorRestNoCrash1.ts
+++ b/tsc/testdata/tests/cases/compiler/decoratorRestNoCrash1.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+// @experimentalDecorators: true
+
+class Greeter {
+  @deco
+  greet1() {
+    return "Hello, " + this.greeting;
+  }
+}
+
+declare function deco(...args: [any, any, any]): any;


### PR DESCRIPTION
At the moment, the test sample reports:
```
main.ts(6,3): error TS1241: Unable to resolve signature of method decorator when called as an expression.
  The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.
```

That is not correct here.

This PR relates to a closed issue that reported a crash (see [here](https://github.com/microsoft/TypeScript/issues/63094)), Corsa no longer crashes but I noticed now it doesn't quite report correct errors here so I decided to put out this PR for it