### PR TITLE
Preserve `<` in `getChildren()` when type arguments begin with `<`

### DIFF
--- a/packages/typescript/src/ast/astnav.ts
+++ b/packages/typescript/src/ast/astnav.ts
@@ -711,7 +711,7 @@ function addSyntheticNodes(children: Node[], pos: number, end: number, parent: N
     while (pos < end) {
         let token = scanner.getToken();
         let tokenEnd = scanner.getTokenEnd();
-        if (tokenEnd > end) {
+        if (token === SyntaxKind.LessThanLessThanToken && scanner.getTokenStart() < end && tokenEnd > end) {
             // The parser rescans `<<` as `<` when opening type arguments; mirror that split
             // when the combined token crosses the next AST child's boundary.
             token = scanner.reScanLessThanToken();

--- a/packages/typescript/src/ast/astnav.ts
+++ b/packages/typescript/src/ast/astnav.ts
@@ -709,8 +709,14 @@ function addSyntheticNodes(children: Node[], pos: number, end: number, parent: N
     scanner.resetTokenState(pos);
     scanner.scan();
     while (pos < end) {
-        const token = scanner.getToken();
-        const tokenEnd = scanner.getTokenEnd();
+        let token = scanner.getToken();
+        let tokenEnd = scanner.getTokenEnd();
+        if (tokenEnd > end) {
+            // The parser rescans `<<` as `<` when opening type arguments; mirror that split
+            // when the combined token crosses the next AST child's boundary.
+            token = scanner.reScanLessThanToken();
+            tokenEnd = scanner.getTokenEnd();
+        }
         if (tokenEnd <= end) {
             // An identifier should never appear as trivia between AST children; skip defensively.
             if (token !== SyntaxKind.Identifier) {

--- a/packages/typescript/test/sync/ast.test.ts
+++ b/packages/typescript/test/sync/ast.test.ts
@@ -1072,6 +1072,38 @@ describe("RemoteNode + child/token getters", () => {
         });
     });
 
+    test("public getChildren API preserves leaf tokens when type arguments begin with less-than", () => {
+        for (
+            const source of [
+                "type X = ReturnType<<T>(x: T) => number>;",
+                "type X = ReturnType <<T>(x: T) => number>;",
+                "type X = ReturnType/* c */ <<T>(x: T) => number>;",
+                "const x = foo<<T>(x: T) => T>();",
+            ]
+        ) {
+            withFirstStatement(source, (stmt, sf) => {
+                const node = findFirstOfKind(stmt, SyntaxKind.CallExpression)
+                    ?? findFirstOfKind(stmt, SyntaxKind.TypeReference)!;
+                const leafTokens: Node[] = [];
+                const collectLeafTokens = (current: Node): void => {
+                    const children = current.getChildren(sf);
+                    if (children.length === 0) {
+                        leafTokens.push(current);
+                    }
+                    else {
+                        children.forEach(collectLeafTokens);
+                    }
+                };
+                collectLeafTokens(node);
+
+                const firstLessThan = leafTokens.find(child => child.kind === SyntaxKind.LessThanToken);
+                assert.ok(firstLessThan, "expected the public API to expose the opening less-than token");
+                assert.strictEqual(firstLessThan.getStart(sf), source.indexOf("<<"));
+                assert.strictEqual(leafTokens.map(child => child.getFullText(sf)).join(""), node.getFullText(sf));
+            });
+        }
+    });
+
     test("getChildCount and getChildAt agree with getChildren", () => {
         withFirstStatement("if (x) {}", stmt => {
             const children = stmt.getChildren();

--- a/packages/typescript/test/sync/ast.test.ts
+++ b/packages/typescript/test/sync/ast.test.ts
@@ -1065,11 +1065,6 @@ describe("RemoteNode + child/token getters", () => {
         return found;
     }
 
-    function getLeafTokens(node: Node, sourceFile: SourceFile): Node[] {
-        const children = node.getChildren(sourceFile);
-        return children.length === 0 ? [node] : children.flatMap(child => getLeafTokens(child, sourceFile));
-    }
-
     test("getChildren materializes the punctuation/keyword tokens the AST omits", () => {
         withFirstStatement("if (x) {}", stmt => {
             const texts = stmt.getChildren().map(c => c.getText());
@@ -1089,21 +1084,23 @@ describe("RemoteNode + child/token getters", () => {
             withFirstStatement(source, (stmt, sf) => {
                 const node = findFirstOfKind(stmt, SyntaxKind.CallExpression)
                     ?? findFirstOfKind(stmt, SyntaxKind.TypeReference)!;
-                const leafTokens = getLeafTokens(node, sf);
+                const children = node.getChildren(sf);
+                assertChildInvariants(node, sf);
 
-                const firstLessThan = leafTokens.find(child => child.kind === SyntaxKind.LessThanToken);
+                const firstLessThan = children.find(child => child.kind === SyntaxKind.LessThanToken);
                 assert.ok(firstLessThan, "expected the public API to expose the opening less-than token");
                 assert.strictEqual(firstLessThan.getStart(sf), source.indexOf("<<"));
-                assert.strictEqual(leafTokens.map(child => child.getFullText(sf)).join(""), node.getFullText(sf));
+                assert.strictEqual(children.map(child => child.getFullText(sf)).join(""), node.getFullText(sf));
             });
         }
     });
 
     test("public getChildren API preserves ordinary left-shift tokens", () => {
         withFirstStatement("const x = a << b;", (stmt, sf) => {
-            const leafTokens = getLeafTokens(stmt, sf);
-            assert.strictEqual(leafTokens.filter(child => child.kind === SyntaxKind.LessThanLessThanToken).length, 1);
-            assert.strictEqual(leafTokens.filter(child => child.kind === SyntaxKind.LessThanToken).length, 0);
+            const binary = findFirstOfKind(stmt, SyntaxKind.BinaryExpression)!;
+            const children = binary.getChildren(sf);
+            assert.strictEqual(children.filter(child => child.kind === SyntaxKind.LessThanLessThanToken).length, 1);
+            assert.strictEqual(children.filter(child => child.kind === SyntaxKind.LessThanToken).length, 0);
         });
     });
 

--- a/packages/typescript/test/sync/ast.test.ts
+++ b/packages/typescript/test/sync/ast.test.ts
@@ -1065,6 +1065,11 @@ describe("RemoteNode + child/token getters", () => {
         return found;
     }
 
+    function getLeafTokens(node: Node, sourceFile: SourceFile): Node[] {
+        const children = node.getChildren(sourceFile);
+        return children.length === 0 ? [node] : children.flatMap(child => getLeafTokens(child, sourceFile));
+    }
+
     test("getChildren materializes the punctuation/keyword tokens the AST omits", () => {
         withFirstStatement("if (x) {}", stmt => {
             const texts = stmt.getChildren().map(c => c.getText());
@@ -1084,17 +1089,7 @@ describe("RemoteNode + child/token getters", () => {
             withFirstStatement(source, (stmt, sf) => {
                 const node = findFirstOfKind(stmt, SyntaxKind.CallExpression)
                     ?? findFirstOfKind(stmt, SyntaxKind.TypeReference)!;
-                const leafTokens: Node[] = [];
-                const collectLeafTokens = (current: Node): void => {
-                    const children = current.getChildren(sf);
-                    if (children.length === 0) {
-                        leafTokens.push(current);
-                    }
-                    else {
-                        children.forEach(collectLeafTokens);
-                    }
-                };
-                collectLeafTokens(node);
+                const leafTokens = getLeafTokens(node, sf);
 
                 const firstLessThan = leafTokens.find(child => child.kind === SyntaxKind.LessThanToken);
                 assert.ok(firstLessThan, "expected the public API to expose the opening less-than token");
@@ -1102,6 +1097,14 @@ describe("RemoteNode + child/token getters", () => {
                 assert.strictEqual(leafTokens.map(child => child.getFullText(sf)).join(""), node.getFullText(sf));
             });
         }
+    });
+
+    test("public getChildren API preserves ordinary left-shift tokens", () => {
+        withFirstStatement("const x = a << b;", (stmt, sf) => {
+            const leafTokens = getLeafTokens(stmt, sf);
+            assert.strictEqual(leafTokens.filter(child => child.kind === SyntaxKind.LessThanLessThanToken).length, 1);
+            assert.strictEqual(leafTokens.filter(child => child.kind === SyntaxKind.LessThanToken).length, 0);
+        });
     });
 
     test("getChildCount and getChildAt agree with getChildren", () => {


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/64168