### PR TITLE
fix(auto-import): don't suggest # imports that only resolve via condition fallback

### DIFF
--- a/tsc/internal/fourslash/tests/autoImportPackageJsonImportsInvalidSpecifier_test.go
+++ b/tsc/internal/fourslash/tests/autoImportPackageJsonImportsInvalidSpecifier_test.go
@@ -1,0 +1,44 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/internal/fourslash"
+	"github.com/microsoft/TypeScript/tsc/internal/ls/lsutil"
+	"github.com/microsoft/TypeScript/tsc/internal/testutil"
+)
+
+func TestAutoImportPackageJsonImportsInvalidSpecifier(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}
+// @Filename: /package.json
+{
+  "imports": {
+    "#*": {
+      "node": "./dist/*/index.js",
+      "default": "./dist/*.js"
+    }
+  }
+}
+// @Filename: /dist/utils/summarize/index.ts
+export function summarize(): void;
+// @Filename: /dist/utils/summarize/summarize.ts
+export function summarize(): void;
+// @Filename: /src/index.ts
+summarize/*a*/`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	// #utils/summarize resolves via the active "node" condition.
+	// #utils/summarize/summarize would only resolve via "default" fallback after
+	// "node" misses, which Node never tries at runtime (ERR_MODULE_NOT_FOUND),
+	// so its # specifier must not be suggested; only a relative fallback remains
+	// for that file. See https://github.com/microsoft/TypeScript/issues/64171.
+	f.VerifyImportFixModuleSpecifiers(t, "a", []string{"#utils/summarize", "../dist/utils/summarize/summarize"}, &lsutil.UserPreferences{ImportModuleSpecifierPreference: "non-relative"})
+}

--- a/tsc/internal/modulespecifiers/specifiers.go
+++ b/tsc/internal/modulespecifiers/specifiers.go
@@ -1213,9 +1213,28 @@ func tryGetModuleNameFromExportsOrImports(
 	isImports bool,
 	preferTsExtension bool,
 ) string {
+	result, _ := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, exports, conditions, mode, isImports, preferTsExtension)
+	return result
+}
+
+// Inner returns (specifier, blocked). Blocked means a runtime-active target was
+// tried but didn't match the file, so Node would stop here and callers must not
+// fall through to later conditions or array elements.
+func tryGetModuleNameFromExportsOrImportsInner(
+	options *core.CompilerOptions,
+	host ModuleSpecifierGenerationHost,
+	targetFilePath string,
+	packageDirectory string,
+	packageName string,
+	exports packagejson.ExportsOrImports,
+	conditions []string,
+	mode MatchingMode,
+	isImports bool,
+	preferTsExtension bool,
+) (string, bool) {
 	switch exports.Type {
 	case packagejson.JSONValueTypeNotPresent:
-		return ""
+		return "", false
 	case packagejson.JSONValueTypeString:
 		strValue := exports.Value.(string)
 
@@ -1245,68 +1264,77 @@ func tryGetModuleNameFromExportsOrImports(
 				tspath.ComparePaths(targetFilePath, pathOrPattern, compareOpts) == 0 ||
 				len(outputFile) > 0 && tspath.ComparePaths(outputFile, pathOrPattern, compareOpts) == 0 ||
 				len(declarationFile) > 0 && tspath.ComparePaths(declarationFile, pathOrPattern, compareOpts) == 0 {
-				return packageName
+				return packageName, false
 			}
 		case MatchingModeDirectory:
 			if canTryTsExtension && tspath.ContainsPath(targetFilePath, pathOrPattern, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, targetFilePath, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), "")
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
 			}
 			if len(extensionSwappedTarget) > 0 && tspath.ContainsPath(pathOrPattern, extensionSwappedTarget, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, extensionSwappedTarget, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), "")
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
 			}
 			if !canTryTsExtension && tspath.ContainsPath(pathOrPattern, targetFilePath, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, targetFilePath, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), "")
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
 			}
 			if len(outputFile) > 0 && tspath.ContainsPath(pathOrPattern, outputFile, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, outputFile, compareOpts)
-				return tspath.CombinePaths(packageName, fragment)
+				return tspath.CombinePaths(packageName, fragment), false
 			}
 			if len(declarationFile) > 0 && tspath.ContainsPath(pathOrPattern, declarationFile, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, declarationFile, compareOpts)
 				jsExtension := getJSExtensionForFile(declarationFile, options)
 				fragmentWithJsExtension := tspath.ChangeExtension(fragment, jsExtension)
-				return tspath.CombinePaths(packageName, fragmentWithJsExtension)
+				return tspath.CombinePaths(packageName, fragmentWithJsExtension), false
 			}
 		case MatchingModePattern:
 			leadingSlice, trailingSlice, _ := strings.Cut(pathOrPattern, "*")
 			caseSensitive := host.UseCaseSensitiveFileNames()
 			if canTryTsExtension && stringutil.HasPrefixAndSuffixWithoutOverlap(targetFilePath, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := targetFilePath[len(leadingSlice) : len(targetFilePath)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement)
+				return replaceFirstStar(packageName, starReplacement), false
 			}
 			if len(extensionSwappedTarget) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(extensionSwappedTarget, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := extensionSwappedTarget[len(leadingSlice) : len(extensionSwappedTarget)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement)
+				return replaceFirstStar(packageName, starReplacement), false
 			}
 			if !canTryTsExtension && stringutil.HasPrefixAndSuffixWithoutOverlap(targetFilePath, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := targetFilePath[len(leadingSlice) : len(targetFilePath)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement)
+				return replaceFirstStar(packageName, starReplacement), false
 			}
 			if len(outputFile) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(outputFile, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := outputFile[len(leadingSlice) : len(outputFile)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement)
+				return replaceFirstStar(packageName, starReplacement), false
 			}
 			if len(declarationFile) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(declarationFile, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := declarationFile[len(leadingSlice) : len(declarationFile)-len(trailingSlice)]
 				substituted := replaceFirstStar(packageName, starReplacement)
 				jsExtension := module.TryGetJSExtensionForFile(declarationFile, options)
 				if len(jsExtension) > 0 {
-					return tspath.ChangeFullExtension(substituted, jsExtension)
+					return tspath.ChangeFullExtension(substituted, jsExtension), false
 				}
 			}
 		}
-		return ""
+		// String is an unconditional valid target: if it doesn't match the file,
+		// Node would still select it and fail, so it's terminal.
+		return "", true
 	case packagejson.JSONValueTypeArray:
+		// Arrays are ordered fallbacks for undefined/invalid entries only. A valid
+		// string target that doesn't match the file still selects that URL at
+		// runtime and throws on miss, so it blocks later elements.
 		arr := exports.AsArray()
 		for _, e := range arr {
-			result := tryGetModuleNameFromExportsOrImports(options, host, targetFilePath, packageDirectory, packageName, e, conditions, mode, isImports, preferTsExtension)
+			result, blocked := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, e, conditions, mode, isImports, preferTsExtension)
 			if len(result) > 0 {
-				return result
+				return result, false
+			}
+			if blocked {
+				return "", true
 			}
 		}
+		return "", false
 	case packagejson.JSONValueTypeObject:
 		// conditional mapping.
 		// Node.js resolves conditionals by picking the first key (in object order) that
@@ -1320,50 +1348,33 @@ func tryGetModuleNameFromExportsOrImports(
 		obj := exports.AsObject()
 		for key, value := range obj.Entries() {
 			if key == "default" || slices.Contains(conditions, key) || slices.Contains(conditions, "types") && module.IsApplicableVersionedTypesKey(key) {
-				result := tryGetModuleNameFromExportsOrImports(options, host, targetFilePath, packageDirectory, packageName, value, conditions, mode, isImports, preferTsExtension)
+				result, blocked := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, value, conditions, mode, isImports, preferTsExtension)
 				if len(result) > 0 {
-					return result
+					return result, false
 				}
 				// If this key would be tried at runtime (i.e. it is not a types-only
-				// condition, which Node ignores) but the target file does not match
-				// its target, Node would stop here and fail. A later matching
-				// condition (e.g. "default" after "node") would never be reached,
-				// so the candidate specifier is invalid and must not be suggested.
-				// Custom conditions from tsconfig are assumed active at runtime
-				// (per GetConditions), so they also block.
-				if isRuntimeCondition(key) {
-					// If the value is itself a conditional object with no active
-					// runtime key, Node would skip it (return undefined) and try the
-					// next outer condition, so do not block in that case.
-					if value.Type == packagejson.JSONValueTypeObject && !hasActiveRuntimeCondition(value, conditions) {
-						continue
-					}
-					return ""
+				// condition, which Node ignores) and its target was terminal
+				// (tried but didn't match), Node would stop here and fail. A later
+				// matching condition (e.g. "default" after "node") would never be
+				// reached, so the candidate is invalid. If the nested value was
+				// undefined (no active runtime key inside), Node proceeds to the
+				// next outer condition, so continue. Custom conditions from
+				// tsconfig are assumed active at runtime (per GetConditions).
+				if blocked && isRuntimeCondition(key) {
+					return "", true
 				}
 			}
 		}
+		return "", false
 	case packagejson.JSONValueTypeNull:
-		return ""
+		// Explicit null is terminal at runtime.
+		return "", true
 	}
-	return ""
+	return "", false
 }
 
 func isRuntimeCondition(key string) bool {
 	return key != "types" && !module.IsApplicableVersionedTypesKey(key)
-}
-
-func hasActiveRuntimeCondition(exports packagejson.ExportsOrImports, conditions []string) bool {
-	if exports.Type != packagejson.JSONValueTypeObject {
-		return false
-	}
-	for key := range exports.AsObject().Keys() {
-		if key == "default" || slices.Contains(conditions, key) {
-			if isRuntimeCondition(key) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // `importingSourceFile` and `importingSourceFileName`? Why not just use `importingSourceFile.path`?

--- a/tsc/internal/modulespecifiers/specifiers.go
+++ b/tsc/internal/modulespecifiers/specifiers.go
@@ -1308,7 +1308,15 @@ func tryGetModuleNameFromExportsOrImports(
 			}
 		}
 	case packagejson.JSONValueTypeObject:
-		// conditional mapping
+		// conditional mapping.
+		// Node.js resolves conditionals by picking the first key (in object order) that
+		// matches the active conditions and stopping there: if that target fails to
+		// resolve, it throws instead of falling through to the next matching condition
+		// (except fallback arrays, which do try each element - see case Array above,
+		// which intentionally still loops).
+		// The reverse mapping below must mirror that, otherwise auto-import suggests
+		// specifiers that only resolve in TS (via fallback) but crash at runtime.
+		// See https://github.com/microsoft/TypeScript/issues/64171.
 		obj := exports.AsObject()
 		for key, value := range obj.Entries() {
 			if key == "default" || slices.Contains(conditions, key) || slices.Contains(conditions, "types") && module.IsApplicableVersionedTypesKey(key) {
@@ -1316,12 +1324,46 @@ func tryGetModuleNameFromExportsOrImports(
 				if len(result) > 0 {
 					return result
 				}
+				// If this key would be tried at runtime (i.e. it is not a types-only
+				// condition, which Node ignores) but the target file does not match
+				// its target, Node would stop here and fail. A later matching
+				// condition (e.g. "default" after "node") would never be reached,
+				// so the candidate specifier is invalid and must not be suggested.
+				// Custom conditions from tsconfig are assumed active at runtime
+				// (per GetConditions), so they also block.
+				if isRuntimeCondition(key) {
+					// If the value is itself a conditional object with no active
+					// runtime key, Node would skip it (return undefined) and try the
+					// next outer condition, so do not block in that case.
+					if value.Type == packagejson.JSONValueTypeObject && !hasActiveRuntimeCondition(value, conditions) {
+						continue
+					}
+					return ""
+				}
 			}
 		}
 	case packagejson.JSONValueTypeNull:
 		return ""
 	}
 	return ""
+}
+
+func isRuntimeCondition(key string) bool {
+	return key != "types" && !module.IsApplicableVersionedTypesKey(key)
+}
+
+func hasActiveRuntimeCondition(exports packagejson.ExportsOrImports, conditions []string) bool {
+	if exports.Type != packagejson.JSONValueTypeObject {
+		return false
+	}
+	for key := range exports.AsObject().Keys() {
+		if key == "default" || slices.Contains(conditions, key) {
+			if isRuntimeCondition(key) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // `importingSourceFile` and `importingSourceFileName`? Why not just use `importingSourceFile.path`?

--- a/tsc/internal/modulespecifiers/specifiers.go
+++ b/tsc/internal/modulespecifiers/specifiers.go
@@ -1213,13 +1213,39 @@ func tryGetModuleNameFromExportsOrImports(
 	isImports bool,
 	preferTsExtension bool,
 ) string {
-	result, _ := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, exports, conditions, mode, isImports, preferTsExtension)
+	result, _ := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, exports, conditions, mode, isImports, preferTsExtension, false /*inTypesOnly*/)
 	return result
 }
 
-// Inner returns (specifier, blocked). Blocked means a runtime-active target was
+// targetStatus distinguishes how Node would treat a non-matching target, so
+// callers know whether later conditions or array elements may still be tried.
+//
+//   - statusMatched: path matched, return the specifier.
+//   - statusBlocked: a valid runtime target was selected but didn't match the
+//     file (or null/empty/all-invalid array). Node would stop here and fail,
+//     so callers must not fall through.
+//   - statusInvalid: syntactically invalid package target (e.g. missing "./"
+//     prefix in exports, ".."/"."/"node_modules" segments, number/boolean).
+//     Node skips these inside fallback arrays but throws inside conditionals,
+//     so arrays continue (tracking for all-invalid terminal) while conditionals
+//     with a runtime-active key stop.
+//   - statusSkipped: undefined (no active condition key, NotPresent). Node
+//     proceeds to the next condition or array element.
+type targetStatus int8
+
+const (
+	statusSkipped targetStatus = iota
+	statusInvalid
+	statusBlocked
+	statusMatched
+)
+
+// Inner returns (specifier, status). Blocked means a runtime-active target was
 // tried but didn't match the file, so Node would stop here and callers must not
-// fall through to later conditions or array elements.
+// fall through to later conditions or array elements. inTypesOnly tracks whether
+// the current subtree sits under a types-only condition (types/types@*), which
+// Node ignores at runtime: misses there never block, preserving TypeScript's
+// declaration fallback (see resolver.go:869-873).
 func tryGetModuleNameFromExportsOrImportsInner(
 	options *core.CompilerOptions,
 	host ModuleSpecifierGenerationHost,
@@ -1231,10 +1257,14 @@ func tryGetModuleNameFromExportsOrImportsInner(
 	mode MatchingMode,
 	isImports bool,
 	preferTsExtension bool,
-) (string, bool) {
+	inTypesOnly bool,
+) (string, targetStatus) {
 	switch exports.Type {
 	case packagejson.JSONValueTypeNotPresent:
-		return "", false
+		return "", statusSkipped
+	case packagejson.JSONValueTypeNumber, packagejson.JSONValueTypeBoolean:
+		// Invalid package targets: skipped in arrays, terminal in conditionals.
+		return "", statusInvalid
 	case packagejson.JSONValueTypeString:
 		strValue := exports.Value.(string)
 
@@ -1264,77 +1294,118 @@ func tryGetModuleNameFromExportsOrImportsInner(
 				tspath.ComparePaths(targetFilePath, pathOrPattern, compareOpts) == 0 ||
 				len(outputFile) > 0 && tspath.ComparePaths(outputFile, pathOrPattern, compareOpts) == 0 ||
 				len(declarationFile) > 0 && tspath.ComparePaths(declarationFile, pathOrPattern, compareOpts) == 0 {
-				return packageName, false
+				return packageName, statusMatched
 			}
 		case MatchingModeDirectory:
 			if canTryTsExtension && tspath.ContainsPath(targetFilePath, pathOrPattern, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, targetFilePath, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), statusMatched
 			}
 			if len(extensionSwappedTarget) > 0 && tspath.ContainsPath(pathOrPattern, extensionSwappedTarget, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, extensionSwappedTarget, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), statusMatched
 			}
 			if !canTryTsExtension && tspath.ContainsPath(pathOrPattern, targetFilePath, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, targetFilePath, compareOpts)
-				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), false
+				return tspath.GetNormalizedAbsolutePath(tspath.CombinePaths(tspath.CombinePaths(packageName, strValue), fragment), ""), statusMatched
 			}
 			if len(outputFile) > 0 && tspath.ContainsPath(pathOrPattern, outputFile, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, outputFile, compareOpts)
-				return tspath.CombinePaths(packageName, fragment), false
+				return tspath.CombinePaths(packageName, fragment), statusMatched
 			}
 			if len(declarationFile) > 0 && tspath.ContainsPath(pathOrPattern, declarationFile, compareOpts) {
 				fragment := tspath.GetRelativePathFromDirectory(pathOrPattern, declarationFile, compareOpts)
 				jsExtension := getJSExtensionForFile(declarationFile, options)
 				fragmentWithJsExtension := tspath.ChangeExtension(fragment, jsExtension)
-				return tspath.CombinePaths(packageName, fragmentWithJsExtension), false
+				return tspath.CombinePaths(packageName, fragmentWithJsExtension), statusMatched
 			}
 		case MatchingModePattern:
 			leadingSlice, trailingSlice, _ := strings.Cut(pathOrPattern, "*")
 			caseSensitive := host.UseCaseSensitiveFileNames()
 			if canTryTsExtension && stringutil.HasPrefixAndSuffixWithoutOverlap(targetFilePath, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := targetFilePath[len(leadingSlice) : len(targetFilePath)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement), false
+				return replaceFirstStar(packageName, starReplacement), statusMatched
 			}
 			if len(extensionSwappedTarget) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(extensionSwappedTarget, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := extensionSwappedTarget[len(leadingSlice) : len(extensionSwappedTarget)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement), false
+				return replaceFirstStar(packageName, starReplacement), statusMatched
 			}
 			if !canTryTsExtension && stringutil.HasPrefixAndSuffixWithoutOverlap(targetFilePath, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := targetFilePath[len(leadingSlice) : len(targetFilePath)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement), false
+				return replaceFirstStar(packageName, starReplacement), statusMatched
 			}
 			if len(outputFile) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(outputFile, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := outputFile[len(leadingSlice) : len(outputFile)-len(trailingSlice)]
-				return replaceFirstStar(packageName, starReplacement), false
+				return replaceFirstStar(packageName, starReplacement), statusMatched
 			}
 			if len(declarationFile) > 0 && stringutil.HasPrefixAndSuffixWithoutOverlap(declarationFile, leadingSlice, trailingSlice, caseSensitive) {
 				starReplacement := declarationFile[len(leadingSlice) : len(declarationFile)-len(trailingSlice)]
 				substituted := replaceFirstStar(packageName, starReplacement)
 				jsExtension := module.TryGetJSExtensionForFile(declarationFile, options)
 				if len(jsExtension) > 0 {
-					return tspath.ChangeFullExtension(substituted, jsExtension), false
+					return tspath.ChangeFullExtension(substituted, jsExtension), statusMatched
 				}
 			}
 		}
-		// String is an unconditional valid target: if it doesn't match the file,
-		// Node would still select it and fail, so it's terminal.
-		return "", true
+		// No path match. Under a types-only subtree, never block: TypeScript's
+		// forward resolver falls through declaration targets (resolver.go:869-873)
+		// and Node ignores the whole subtree at runtime.
+		if inTypesOnly {
+			return "", statusSkipped
+		}
+		// Distinguish invalid targets (skipped in arrays, terminal in conditionals)
+		// from valid targets that Node would select and then fail on (terminal
+		// everywhere). Mirrors resolver.go:750-794.
+		if !isValidPackageTarget(strValue, isImports) {
+			return "", statusInvalid
+		}
+		// Valid string target that doesn't match the file: Node would still select
+		// it and fail (ERR_MODULE_NOT_FOUND), so it's terminal.
+		return "", statusBlocked
 	case packagejson.JSONValueTypeArray:
 		// Arrays are ordered fallbacks for undefined/invalid entries only. A valid
 		// string target that doesn't match the file still selects that URL at
-		// runtime and throws on miss, so it blocks later elements.
+		// runtime and throws on miss, so it blocks later elements. Empty arrays
+		// are terminal at runtime (like null); only all-undefined arrays fall
+		// through. Under types-only, always fall through (TS declaration fallback).
 		arr := exports.AsArray()
-		for _, e := range arr {
-			result, blocked := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, e, conditions, mode, isImports, preferTsExtension)
-			if len(result) > 0 {
-				return result, false
+		if len(arr) == 0 {
+			if inTypesOnly {
+				return "", statusSkipped
 			}
-			if blocked {
-				return "", true
+			return "", statusBlocked
+		}
+		sawInvalid := false
+		for _, e := range arr {
+			result, status := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, e, conditions, mode, isImports, preferTsExtension, inTypesOnly)
+			if status == statusMatched {
+				return result, statusMatched
+			}
+			switch status {
+			case statusBlocked:
+				// Valid miss (or null/empty/all-invalid nested): terminal at
+				// runtime, but swallowed under types-only to preserve TS fallback.
+				if inTypesOnly {
+					continue
+				}
+				return "", statusBlocked
+			case statusInvalid:
+				// Node skips invalid entries inside arrays and only throws if
+				// every entry is invalid. Track and continue.
+				sawInvalid = true
+			case statusSkipped:
+				// Undefined (e.g. nested conditional with no active key): try next.
 			}
 		}
-		return "", false
+		if inTypesOnly {
+			return "", statusSkipped
+		}
+		if sawInvalid {
+			// All entries were invalid (any valid miss would have returned blocked
+			// above): Node throws the last invalid-target error, so terminal.
+			return "", statusBlocked
+		}
+		return "", statusSkipped
 	case packagejson.JSONValueTypeObject:
 		// conditional mapping.
 		// Node.js resolves conditionals by picking the first key (in object order) that
@@ -1348,33 +1419,85 @@ func tryGetModuleNameFromExportsOrImportsInner(
 		obj := exports.AsObject()
 		for key, value := range obj.Entries() {
 			if key == "default" || slices.Contains(conditions, key) || slices.Contains(conditions, "types") && module.IsApplicableVersionedTypesKey(key) {
-				result, blocked := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, value, conditions, mode, isImports, preferTsExtension)
-				if len(result) > 0 {
-					return result, false
+				childInTypes := inTypesOnly || !isRuntimeCondition(key)
+				result, status := tryGetModuleNameFromExportsOrImportsInner(options, host, targetFilePath, packageDirectory, packageName, value, conditions, mode, isImports, preferTsExtension, childInTypes)
+				if status == statusMatched {
+					return result, statusMatched
 				}
 				// If this key would be tried at runtime (i.e. it is not a types-only
-				// condition, which Node ignores) and its target was terminal
-				// (tried but didn't match), Node would stop here and fail. A later
-				// matching condition (e.g. "default" after "node") would never be
-				// reached, so the candidate is invalid. If the nested value was
-				// undefined (no active runtime key inside), Node proceeds to the
-				// next outer condition, so continue. Custom conditions from
-				// tsconfig are assumed active at runtime (per GetConditions).
-				if blocked && isRuntimeCondition(key) {
-					return "", true
+				// condition, which Node ignores) Node would stop here on both valid
+				// misses and invalid targets: a later matching condition (e.g.
+				// "default" after "node") would never be reached, so the candidate
+				// is invalid. If the nested value was undefined (no active runtime
+				// key inside), Node proceeds to the next outer condition, so
+				// continue. Custom conditions from tsconfig are assumed active at
+				// runtime (per GetConditions). Under types-only, swallow everything
+				// (childInTypes already true) to preserve TS declaration fallback.
+				if inTypesOnly {
+					continue
+				}
+				if status == statusBlocked && isRuntimeCondition(key) {
+					return "", statusBlocked
+				}
+				if status == statusInvalid && isRuntimeCondition(key) {
+					// Invalid target inside a conditional throws at runtime instead
+					// of falling through. Propagate as invalid so an enclosing
+					// array can still catch it, while an enclosing conditional will
+					// stop (see above). Top-level callers treat any non-match as "".
+					return "", statusInvalid
 				}
 			}
 		}
-		return "", false
+		return "", statusSkipped
 	case packagejson.JSONValueTypeNull:
-		// Explicit null is terminal at runtime.
-		return "", true
+		// Explicit null is terminal at runtime (ERR_PACKAGE_PATH_NOT_EXPORTED),
+		// but swallowed under types-only since Node ignores that subtree.
+		if inTypesOnly {
+			return "", statusSkipped
+		}
+		return "", statusBlocked
 	}
-	return "", false
+	return "", statusSkipped
 }
 
 func isRuntimeCondition(key string) bool {
 	return key != "types" && !module.IsApplicableVersionedTypesKey(key)
+}
+
+// isValidPackageTarget mirrors the target-validity rules of the forward resolver
+// (resolver.go:loadModuleFromTargetExportOrImport) without filesystem probing: it
+// reports whether Node would select the target URL (and then fail if the file is
+// missing) versus skipping it as an invalid package target.
+//
+//   - exports targets must start with "./" (resolver.go:750,777-780).
+//   - imports targets may additionally be bare specifiers (e.g. "lodash"), which
+//     are delegated to node-like resolution (resolver.go:751-775) and count as valid.
+//   - relative targets with ".."/"."/"node_modules" after the first segment are
+//     invalid (resolver.go:789-794).
+func isValidPackageTarget(target string, isImports bool) bool {
+	if len(target) == 0 {
+		return false
+	}
+	if !strings.HasPrefix(target, "./") {
+		if isImports && !strings.HasPrefix(target, "../") && !strings.HasPrefix(target, "/") && !tspath.IsRootedDiskPath(target) {
+			// Bare specifier for imports (e.g. "dep-native"): valid, resolved via
+			// node-like lookup. A non-matching file still means Node selected this
+			// target, so callers must block later fallback.
+			return true
+		}
+		return false
+	}
+	var parts []string
+	if tspath.PathIsRelative(target) {
+		parts = tspath.GetPathComponents(target, "")[1:]
+	} else {
+		parts = tspath.GetPathComponents(target, "")
+	}
+	if len(parts) <= 1 {
+		return true
+	}
+	partsAfterFirst := parts[1:]
+	return !slices.Contains(partsAfterFirst, "..") && !slices.Contains(partsAfterFirst, ".") && !slices.Contains(partsAfterFirst, "node_modules")
 }
 
 // `importingSourceFile` and `importingSourceFileName`? Why not just use `importingSourceFile.path`?

--- a/tsc/internal/modulespecifiers/specifiers_test.go
+++ b/tsc/internal/modulespecifiers/specifiers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/internal/ast"
+	"github.com/microsoft/TypeScript/tsc/internal/collections"
 	"github.com/microsoft/TypeScript/tsc/internal/core"
 	"github.com/microsoft/TypeScript/tsc/internal/module"
 	"github.com/microsoft/TypeScript/tsc/internal/packagejson"
@@ -342,6 +343,170 @@ func TestTryGetModuleNameFromExportsOrImports(t *testing.T) {
 					t.Errorf("tryGetModuleNameFromExportsOrImports(targetFilePath = %q) = %v, expected %v", tt.targetFilePath, result, tt.expected)
 				}
 			})
+		}
+	})
+	t.Run("with conditional fallback blocked (issue 64171)", func(t *testing.T) {
+		t.Parallel()
+
+		strExports := func(s string) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeString,
+					Value: s,
+				},
+			}
+		}
+		condExports := func(entries ...collections.MapEntry[string, packagejson.ExportsOrImports]) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeObject,
+					Value: collections.NewOrderedMapFromList(entries),
+				},
+			}
+		}
+		// "#*": { "node": "./dist/*/index.js", "default": "./dist/*.js" }
+		conditional := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: strExports("./dist/*/index.js")},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/*.js")},
+		)
+		conditions := []string{"import", "types", "node"}
+
+		tests := []struct {
+			name           string
+			targetFilePath string
+			expected       string
+		}{
+			{
+				name:           "node condition matches, valid specifier",
+				targetFilePath: "/pkg/dist/utils/summarize/index.js",
+				expected:       "#utils/summarize",
+			},
+			{
+				name:           "node condition shadows default, invalid specifier blocked",
+				targetFilePath: "/pkg/dist/utils/summarize/summarize.js",
+				expected:       "",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := tryGetModuleNameFromExportsOrImports(
+					&core.CompilerOptions{},
+					&mockModuleSpecifierGenerationHost{currentDir: "/pkg", useCaseSensitiveFileNames: true},
+					tt.targetFilePath,
+					"/pkg",
+					"#*",
+					conditional,
+					conditions,
+					MatchingModePattern,
+					true,
+					false,
+				)
+				if result != tt.expected {
+					t.Errorf("tryGetModuleNameFromExportsOrImports(targetFilePath = %q) = %q, expected %q", tt.targetFilePath, result, tt.expected)
+				}
+			})
+		}
+	})
+	t.Run("types-only condition does not shadow runtime (issue 64171 follow-up)", func(t *testing.T) {
+		t.Parallel()
+		strExports := func(s string) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeString,
+					Value: s,
+				},
+			}
+		}
+		conditional := packagejson.ExportsOrImports{
+			JSONValue: packagejson.JSONValue{
+				Type: packagejson.JSONValueTypeObject,
+				Value: collections.NewOrderedMapFromList([]collections.MapEntry[string, packagejson.ExportsOrImports]{
+					{Key: "types", Value: strExports("./types/*.d.ts")},
+					{Key: "default", Value: strExports("./dist/*.js")},
+				}),
+			},
+		}
+		result := tryGetModuleNameFromExportsOrImports(
+			&core.CompilerOptions{},
+			&mockModuleSpecifierGenerationHost{currentDir: "/pkg", useCaseSensitiveFileNames: true},
+			"/pkg/dist/foo.js",
+			"/pkg",
+			"#*",
+			conditional,
+			[]string{"import", "types", "node"},
+			MatchingModePattern,
+			true,
+			false,
+		)
+		if result != "#foo" {
+			t.Errorf("expected #foo for runtime file when types misses, got %q", result)
+		}
+	})
+	t.Run("conditional edge cases (issue 64171)", func(t *testing.T) {
+		t.Parallel()
+		strExports := func(s string) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeString,
+					Value: s,
+				},
+			}
+		}
+		condExports := func(entries ...collections.MapEntry[string, packagejson.ExportsOrImports]) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeObject,
+					Value: collections.NewOrderedMapFromList(entries),
+				},
+			}
+		}
+		arrExports := func(elems ...packagejson.ExportsOrImports) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeArray,
+					Value: elems,
+				},
+			}
+		}
+		host := &mockModuleSpecifierGenerationHost{currentDir: "/pkg", useCaseSensitiveFileNames: true}
+		conditions := []string{"import", "types", "node"}
+
+		// Array fallback is allowed at runtime: second element match is valid.
+		arrayCond := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports(strExports("./dist/a.js"), strExports("./dist/b.js"))},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/c.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("array second-element match should be valid, got %q", got)
+		}
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/c.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "" {
+			t.Errorf("array miss under node should block default, got %q", got)
+		}
+
+		// Nested conditional with no active runtime key should not block outer default.
+		// Outer node -> inner { import: ... } with CJS conditions (require, no import): inner skipped, outer default valid.
+		nestedNoMatch := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: condExports(
+				collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "import", Value: strExports("./dist/a.js")},
+			)},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/b.js")},
+		)
+		cjsConditions := []string{"require", "types", "node"}
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", nestedNoMatch, cjsConditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("nested no-active-key should fallback to outer default, got %q", got)
+		}
+
+		// Default-first is terminal: later node unreachable.
+		defaultFirst := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/a.js")},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: strExports("./dist/b.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/a.js", "/pkg", "#a", defaultFirst, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("default-first match should be valid, got %q", got)
+		}
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", defaultFirst, conditions, MatchingModeExact, true, false); got != "" {
+			t.Errorf("default-first miss should block later node, got %q", got)
 		}
 	})
 }

--- a/tsc/internal/modulespecifiers/specifiers_test.go
+++ b/tsc/internal/modulespecifiers/specifiers_test.go
@@ -471,17 +471,34 @@ func TestTryGetModuleNameFromExportsOrImports(t *testing.T) {
 		}
 		host := &mockModuleSpecifierGenerationHost{currentDir: "/pkg", useCaseSensitiveFileNames: true}
 		conditions := []string{"import", "types", "node"}
+		cjsConditions := []string{"require", "types", "node"}
 
-		// Array fallback is allowed at runtime: second element match is valid.
+		// Arrays are not file-existence fallbacks in Node: first valid string wins,
+		// even if the file is missing. Only undefined/invalid entries fall through.
 		arrayCond := condExports(
 			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports(strExports("./dist/a.js"), strExports("./dist/b.js"))},
 			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/c.js")},
 		)
-		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "#a" {
-			t.Errorf("array second-element match should be valid, got %q", got)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/a.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("array first-element match should be valid, got %q", got)
+		}
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "" {
+			t.Errorf("array second-element match should be blocked (first valid string wins at runtime), got %q", got)
 		}
 		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/c.js", "/pkg", "#a", arrayCond, conditions, MatchingModeExact, true, false); got != "" {
 			t.Errorf("array miss under node should block default, got %q", got)
+		}
+
+		// Array with undefined first entry falls through: [{ import: ... }] skipped when import inactive.
+		arrayUndefinedFirst := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports(
+				condExports(collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "import", Value: strExports("./dist/a.js")}),
+				strExports("./dist/b.js"),
+			)},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/c.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", arrayUndefinedFirst, cjsConditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("array undefined first entry should fallback to second element, got %q", got)
 		}
 
 		// Nested conditional with no active runtime key should not block outer default.
@@ -492,9 +509,22 @@ func TestTryGetModuleNameFromExportsOrImports(t *testing.T) {
 			)},
 			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/b.js")},
 		)
-		cjsConditions := []string{"require", "types", "node"}
 		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", nestedNoMatch, cjsConditions, MatchingModeExact, true, false); got != "#a" {
 			t.Errorf("nested no-active-key should fallback to outer default, got %q", got)
+		}
+
+		// Deeper nesting: { node: { import: { browser: ./a.js } }, default: ./b.js }
+		// with active node/import but inactive browser -> undefined, fallback to default valid.
+		deepNested := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: condExports(
+				collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "import", Value: condExports(
+					collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "browser", Value: strExports("./dist/a.js")},
+				)},
+			)},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/b.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", deepNested, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("deep nested undefined should fallback to outer default, got %q", got)
 		}
 
 		// Default-first is terminal: later node unreachable.

--- a/tsc/internal/modulespecifiers/specifiers_test.go
+++ b/tsc/internal/modulespecifiers/specifiers_test.go
@@ -539,4 +539,96 @@ func TestTryGetModuleNameFromExportsOrImports(t *testing.T) {
 			t.Errorf("default-first miss should block later node, got %q", got)
 		}
 	})
+	t.Run("copilot review follow-up: invalid vs valid, types arrays, empty/all-invalid (issue 64171)", func(t *testing.T) {
+		t.Parallel()
+		strExports := func(s string) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeString,
+					Value: s,
+				},
+			}
+		}
+		condExports := func(entries ...collections.MapEntry[string, packagejson.ExportsOrImports]) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeObject,
+					Value: collections.NewOrderedMapFromList(entries),
+				},
+			}
+		}
+		arrExports := func(elems ...packagejson.ExportsOrImports) packagejson.ExportsOrImports {
+			return packagejson.ExportsOrImports{
+				JSONValue: packagejson.JSONValue{
+					Type:  packagejson.JSONValueTypeArray,
+					Value: elems,
+				},
+			}
+		}
+		nullExports := packagejson.ExportsOrImports{
+			JSONValue: packagejson.JSONValue{Type: packagejson.JSONValueTypeNull},
+		}
+		host := &mockModuleSpecifierGenerationHost{currentDir: "/pkg", useCaseSensitiveFileNames: true}
+		conditions := []string{"import", "types", "node"}
+
+		// Invalid strings are skipped inside arrays (exports context: no "./" prefix).
+		// ["invalid", "./dist/b.js"] targeting b.js must match via the second element.
+		invalidSkipped := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports(strExports("invalid"), strExports("./dist/b.js"))},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/c.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", invalidSkipped, conditions, MatchingModeExact, false, false); got != "#a" {
+			t.Errorf("array invalid first entry should fallback to valid second element, got %q", got)
+		}
+		// Same array targeting c.js: second element is a valid miss, so it blocks default.
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/c.js", "/pkg", "#a", invalidSkipped, conditions, MatchingModeExact, false, false); got != "" {
+			t.Errorf("array valid miss should block default even after invalid skip, got %q", got)
+		}
+
+		// Types-only arrays preserve TS fallback: first declaration miss falls through.
+		typesArray := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "types", Value: arrExports(strExports("./missing.d.ts"), strExports("./index.d.ts"))},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/index.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/index.d.ts", "/pkg", "#a", typesArray, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("types array second-element match should be valid, got %q", got)
+		}
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/index.js", "/pkg", "#a", typesArray, conditions, MatchingModeExact, true, false); got != "#a" {
+			t.Errorf("types miss should not block default, got %q", got)
+		}
+
+		// Empty array is terminal at runtime (like null), so default is unreachable.
+		emptyArray := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports()},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/index.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/index.js", "/pkg", "#a", emptyArray, conditions, MatchingModeExact, false, false); got != "" {
+			t.Errorf("empty array under node should block default, got %q", got)
+		}
+
+		// All-invalid array is terminal at runtime: Node throws last invalid-target error.
+		allInvalid := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: arrExports(strExports("../evil"), strExports("not-relative"))},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/index.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/index.js", "/pkg", "#a", allInvalid, conditions, MatchingModeExact, false, false); got != "" {
+			t.Errorf("all-invalid array under node should block default, got %q", got)
+		}
+
+		// Explicit null is terminal at runtime but swallowed under types-only.
+		nullBlocked := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "node", Value: nullExports},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/b.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", nullBlocked, conditions, MatchingModeExact, false, false); got != "" {
+			t.Errorf("null under node should block default, got %q", got)
+		}
+		nullUnderTypes := condExports(
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "types", Value: nullExports},
+			collections.MapEntry[string, packagejson.ExportsOrImports]{Key: "default", Value: strExports("./dist/b.js")},
+		)
+		if got := tryGetModuleNameFromExportsOrImports(&core.CompilerOptions{}, host, "/pkg/dist/b.js", "/pkg", "#a", nullUnderTypes, conditions, MatchingModeExact, false, false); got != "#a" {
+			t.Errorf("null under types should not block default, got %q", got)
+		}
+	})
 }


### PR DESCRIPTION
With `imports": { "#*": { "node": "./dist/*/index.js", "default": "./dist/*.js" } }` and nodenext, auto-import offered both `#utils/summarize` and `#utils/summarize/summarize`. The second only resolves in TS by falling back from `node` to `default` after the `node` target misses. Node picks the first matching condition and throws `ERR_MODULE_NOT_FOUND` instead, so picking that suggestion crashes at runtime.

Reverse mapping in `tryGetModuleNameFromExportsOrImports` did the same fallback as the resolver. It now mirrors Node first-match: when a runtime-active condition misses, later conditions aren't tried. `types`/`types@` don't block since Node ignores them, nested objects with no active runtime key still fall through, and array fallback still works.

Added cases alongside the existing ones in `tsc/internal/modulespecifiers/specifiers_test.go`.

Fixes #64171
Related #62439, #50762

Disclosure: I used AI assistance to draft this patch and reviewed and tested it myself.