### PR TITLE
Skip object classification for shared type facts

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -31402,16 +31402,17 @@ func (c *Checker) getTypeFactsWorker(t *Type, callerOnlyNeeds TypeFacts) TypeFac
 		}
 		return TypeFactsTrueFacts
 	case flags&TypeFlagsObject != 0:
-		var possibleFacts TypeFacts
+		var possibleFacts, commonFacts TypeFacts
 		if c.strictNullChecks {
 			possibleFacts = TypeFactsEmptyObjectStrictFacts | TypeFactsFunctionStrictFacts | TypeFactsObjectStrictFacts
+			commonFacts = TypeFactsEmptyObjectStrictFacts & TypeFactsFunctionStrictFacts & TypeFactsObjectStrictFacts
 		} else {
 			possibleFacts = TypeFactsEmptyObjectFacts | TypeFactsFunctionFacts | TypeFactsObjectFacts
+			commonFacts = TypeFactsEmptyObjectFacts & TypeFactsFunctionFacts & TypeFactsObjectFacts
 		}
-		if (callerOnlyNeeds & possibleFacts) == 0 {
-			// If the caller doesn't care about any of the facts that we could possibly produce,
-			// return zero so we can skip resolving members.
-			return TypeFactsNone
+		if callerOnlyNeeds&(possibleFacts&^commonFacts) == 0 {
+			// If the requested facts don't distinguish between object kinds, skip classifying the object.
+			return commonFacts
 		}
 		switch {
 		case t.objectFlags&ObjectFlagsAnonymous != 0 && c.isEmptyObjectType(t):


### PR DESCRIPTION
This allows the compiler to skip some work at times. Some of the `isEmptyObjectType`, `isFunctionObjectType`  calls and alikes performed down the line can be skipped.