### PR TITLE
fix(tsoptions): don't mutate ParsedCommandLine errors when computing CommonSourceDirectory

### DIFF
--- a/tsc/internal/tsoptions/parsedcommandline.go
+++ b/tsc/internal/tsoptions/parsedcommandline.go
@@ -10,7 +10,6 @@ import (
 	"github.com/microsoft/TypeScript/tsc/internal/ast"
 	"github.com/microsoft/TypeScript/tsc/internal/contentmapper"
 	"github.com/microsoft/TypeScript/tsc/internal/core"
-	"github.com/microsoft/TypeScript/tsc/internal/diagnostics"
 	"github.com/microsoft/TypeScript/tsc/internal/glob"
 	"github.com/microsoft/TypeScript/tsc/internal/locale"
 	"github.com/microsoft/TypeScript/tsc/internal/module"
@@ -167,24 +166,12 @@ func (p *ParsedCommandLine) CommonSourceDirectory() string {
 			files,
 			p.GetCurrentDirectory(),
 			p.UseCaseSensitiveFileNames(),
-			p.checkSourceFilesBelongToPath,
+			nil,
 		)
 	})
 	return p.commonSourceDirectory
 }
 
-func (p *ParsedCommandLine) checkSourceFilesBelongToPath(sourceFiles []string, rootDirectory string) bool {
-	allFilesBelongToPath := true
-	for _, file := range sourceFiles {
-		absoluteSourceFilePath := tspath.GetCanonicalFileName(tspath.GetNormalizedAbsolutePath(file, p.GetCurrentDirectory()), p.UseCaseSensitiveFileNames())
-		if !tspath.ContainsPath(rootDirectory, file, p.comparePathsOptions) {
-			p.Errors = append(p.Errors, ast.NewCompilerDiagnostic(diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, absoluteSourceFilePath, rootDirectory))
-			allFilesBelongToPath = false
-		}
-	}
-
-	return allFilesBelongToPath
-}
 
 func (p *ParsedCommandLine) GetCurrentDirectory() string {
 	return p.comparePathsOptions.CurrentDirectory

--- a/tsc/internal/tsoptions/parsedcommandline_test.go
+++ b/tsc/internal/tsoptions/parsedcommandline_test.go
@@ -234,4 +234,33 @@ func TestParsedCommandLine(t *testing.T) {
 			assert.DeepEqual(t, withTypings.FileNames(), []string{"/dev/index.ts", "/cache/@types/pkg/index.d.ts"})
 		})
 	})
+
+	t.Run("CommonSourceDirectory does not mutate errors", func(t *testing.T) {
+		t.Parallel()
+
+		configFileName := "/dev/tsconfig.json"
+		tsconfigSourceFile := tsoptions.NewTsconfigSourceFileFromFilePath(configFileName, tspath.Path(configFileName), `{
+			"compilerOptions": {
+				"rootDir": "./src"
+			},
+			"files": ["src/index.ts"]
+		}`)
+		parsedCommandLine := tsoptions.ParseJsonSourceFileConfigFileContent(
+			tsconfigSourceFile,
+			tsoptionstest.NewVFSParseConfigHost(map[string]string{
+				"/dev/src/index.ts": "",
+			}, "/dev", true),
+			"/dev",
+			nil,
+			nil,
+			configFileName,
+			nil,
+			nil,
+		)
+
+		initialErrorsLen := len(parsedCommandLine.Errors)
+		commonDir := parsedCommandLine.CommonSourceDirectory()
+		assert.Equal(t, commonDir, "/dev/src/")
+		assert.Equal(t, len(parsedCommandLine.Errors), initialErrorsLen)
+	})
 }


### PR DESCRIPTION
Fixes #62436

### Problem

When `CommonSourceDirectory()` is evaluated on a `ParsedCommandLine` (such as when calculating relative root/out directories across project references during resolution checks), `outputpaths.GetCommonSourceDirectory` was invoked with `p.checkSourceFilesBelongToPath`.

This caused `ParsedCommandLine.Errors` to be mutated with configuration diagnostics, which in turn caused `tsc -b` / solution builds to report diagnostics on `tsconfig.json` without source file location context.

### Solution

- Pass `nil` for `checkSourceFilesBelongToPath` in `ParsedCommandLine.CommonSourceDirectory()`, matching the TypeScript compiler reference implementation (`getCommonSourceDirectoryOfConfig`).
- Added unit test coverage verifying that calling `CommonSourceDirectory()` computes the directory without mutating `ParsedCommandLine.Errors`.