### PR TITLE
fix(checker): cap template literal type size to avoid unbounded growth

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -29492,6 +29492,14 @@ func (c *Checker) getConstraintDeclaration(t *Type) *ast.Node {
 	return nil
 }
 
+// Limits on the size of a template literal type produced by getTemplateLiteralType. Recursive instantiations
+// such as `Recur<any, `${S}_${S}`>` double the text (or the number of placeholders) on every iteration and
+// exhaust memory long before the tail recursion limit in getConditionalType is reached (see #63271).
+const (
+	maxTemplateLiteralTypeLength = 50_000_000
+	maxTemplateLiteralTypeSpans  = 100_000
+)
+
 func (c *Checker) getTemplateLiteralType(texts []string, types []*Type) *Type {
 	unionIndex := core.FindIndex(types, func(t *Type) bool {
 		return t.flags&(TypeFlagsNever|TypeFlagsUnion) != 0
@@ -29511,6 +29519,7 @@ func (c *Checker) getTemplateLiteralType(texts []string, types []*Type) *Type {
 	var newTexts []string
 	var sb strings.Builder
 	sb.WriteString(texts[0])
+	tooLarge := false
 	var addSpans func([]string, []*Type) bool
 	addSpans = func(texts []string, types []*Type) bool {
 		for i, t := range types {
@@ -29532,10 +29541,18 @@ func (c *Checker) getTemplateLiteralType(texts []string, types []*Type) *Type {
 			default:
 				return false
 			}
+			if sb.Len() > maxTemplateLiteralTypeLength || len(newTypes) > maxTemplateLiteralTypeSpans {
+				tooLarge = true
+				return false
+			}
 		}
 		return true
 	}
 	if !addSpans(texts, types) {
+		if tooLarge {
+			c.error(c.currentNode, diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite)
+			return c.errorType
+		}
 		return c.stringType
 	}
 	if len(newTypes) == 0 {

--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -29519,6 +29519,7 @@ func (c *Checker) getTemplateLiteralType(texts []string, types []*Type) *Type {
 	var newTexts []string
 	var sb strings.Builder
 	sb.WriteString(texts[0])
+	textLength := 0 // combined length of the segments already moved into newTexts
 	tooLarge := false
 	var addSpans func([]string, []*Type) bool
 	addSpans = func(texts []string, types []*Type) bool {
@@ -29536,12 +29537,13 @@ func (c *Checker) getTemplateLiteralType(texts []string, types []*Type) *Type {
 			case c.isGenericIndexType(t) || c.isPatternLiteralPlaceholderType(t):
 				newTypes = append(newTypes, t)
 				newTexts = append(newTexts, stringutil.CombineSurrogatePairs(sb.String()))
+				textLength += sb.Len()
 				sb.Reset()
 				sb.WriteString(texts[i+1])
 			default:
 				return false
 			}
-			if sb.Len() > maxTemplateLiteralTypeLength || len(newTypes) > maxTemplateLiteralTypeSpans {
+			if textLength+sb.Len() > maxTemplateLiteralTypeLength || len(newTypes) > maxTemplateLiteralTypeSpans {
 				tooLarge = true
 				return false
 			}

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.errors.txt
@@ -1,0 +1,31 @@
+templateLiteralTypeExcessiveLength.ts(15,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
+templateLiteralTypeExcessiveLength.ts(20,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
+
+
+==== templateLiteralTypeExcessiveLength.ts (2 errors) ====
+    // Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+    // keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+    // template literal type.
+    
+    type Dec<N extends number> =
+        N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
+        N extends 2 ? any :
+        N extends 1 ? 0 : 0;
+    
+    type Recur<N extends number, S extends string> =
+        N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;
+    
+    // The string literal doubles on every iteration.
+    type Explode = {
+        [P in Recur<5, "a"> as `${P}_key`]: any;
+              ~~~~~~~~~~~~~
+!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
+    };
+    
+    // The number of placeholders doubles on every iteration.
+    type ExplodeSpans = {
+        [P in Recur<5, string> as `${P}_key`]: any;
+              ~~~~~~~~~~~~~~~~
+!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
+    };
+    

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.errors.txt
@@ -1,8 +1,9 @@
 templateLiteralTypeExcessiveLength.ts(15,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
 templateLiteralTypeExcessiveLength.ts(20,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
+templateLiteralTypeExcessiveLength.ts(34,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
 
 
-==== templateLiteralTypeExcessiveLength.ts (2 errors) ====
+==== templateLiteralTypeExcessiveLength.ts (3 errors) ====
     // Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
     // keeps tail-recursing forever. The checker must report an error instead of building an unbounded
     // template literal type.
@@ -26,6 +27,22 @@ templateLiteralTypeExcessiveLength.ts(20,11): error TS2589: Type instantiation i
     type ExplodeSpans = {
         [P in Recur<5, string> as `${P}_key`]: any;
               ~~~~~~~~~~~~~~~~
+!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
+    };
+    
+    // Every text segment stays small, but the number of segments doubles on every iteration,
+    // so the combined text length grows without bound.
+    type A16 = "aaaaaaaaaaaaaaaa";
+    type A64 = `${A16}${A16}${A16}${A16}`;
+    type A256 = `${A64}${A64}${A64}${A64}`;
+    type A1024 = `${A256}${A256}${A256}${A256}`;
+    
+    type RecurSegments<N extends number, S extends string> =
+        N extends 0 ? S : RecurSegments<Dec<N>, `${S}${string}${S}`>;
+    
+    type ExplodeSegments = {
+        [P in RecurSegments<5, A1024> as `${P}_key`]: any;
+              ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2589: Type instantiation is excessively deep and possibly infinite.
     };
     

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.js
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/templateLiteralTypeExcessiveLength.ts] ////
+
+//// [templateLiteralTypeExcessiveLength.ts]
+// Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+// keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+// template literal type.
+
+type Dec<N extends number> =
+    N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
+    N extends 2 ? any :
+    N extends 1 ? 0 : 0;
+
+type Recur<N extends number, S extends string> =
+    N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;
+
+// The string literal doubles on every iteration.
+type Explode = {
+    [P in Recur<5, "a"> as `${P}_key`]: any;
+};
+
+// The number of placeholders doubles on every iteration.
+type ExplodeSpans = {
+    [P in Recur<5, string> as `${P}_key`]: any;
+};
+
+
+//// [templateLiteralTypeExcessiveLength.js]
+"use strict";
+// Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+// keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+// template literal type.

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.js
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.js
@@ -23,6 +23,20 @@ type ExplodeSpans = {
     [P in Recur<5, string> as `${P}_key`]: any;
 };
 
+// Every text segment stays small, but the number of segments doubles on every iteration,
+// so the combined text length grows without bound.
+type A16 = "aaaaaaaaaaaaaaaa";
+type A64 = `${A16}${A16}${A16}${A16}`;
+type A256 = `${A64}${A64}${A64}${A64}`;
+type A1024 = `${A256}${A256}${A256}${A256}`;
+
+type RecurSegments<N extends number, S extends string> =
+    N extends 0 ? S : RecurSegments<Dec<N>, `${S}${string}${S}`>;
+
+type ExplodeSegments = {
+    [P in RecurSegments<5, A1024> as `${P}_key`]: any;
+};
+
 
 //// [templateLiteralTypeExcessiveLength.js]
 "use strict";

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.symbols
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.symbols
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/templateLiteralTypeExcessiveLength.ts] ////
+
+=== templateLiteralTypeExcessiveLength.ts ===
+// Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+// keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+// template literal type.
+
+type Dec<N extends number> =
+>Dec : Symbol(Dec, Decl(templateLiteralTypeExcessiveLength.ts, 0, 0))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+
+    N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+
+    N extends 2 ? any :
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+
+    N extends 1 ? 0 : 0;
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 4, 9))
+
+type Recur<N extends number, S extends string> =
+>Recur : Symbol(Recur, Decl(templateLiteralTypeExcessiveLength.ts, 7, 24))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 9, 11))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 9, 28))
+
+    N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 9, 11))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 9, 28))
+>Recur : Symbol(Recur, Decl(templateLiteralTypeExcessiveLength.ts, 7, 24))
+>Dec : Symbol(Dec, Decl(templateLiteralTypeExcessiveLength.ts, 0, 0))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 9, 11))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 9, 28))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 9, 28))
+
+// The string literal doubles on every iteration.
+type Explode = {
+>Explode : Symbol(Explode, Decl(templateLiteralTypeExcessiveLength.ts, 10, 49))
+
+    [P in Recur<5, "a"> as `${P}_key`]: any;
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 14, 5))
+>Recur : Symbol(Recur, Decl(templateLiteralTypeExcessiveLength.ts, 7, 24))
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 14, 5))
+
+};
+
+// The number of placeholders doubles on every iteration.
+type ExplodeSpans = {
+>ExplodeSpans : Symbol(ExplodeSpans, Decl(templateLiteralTypeExcessiveLength.ts, 15, 2))
+
+    [P in Recur<5, string> as `${P}_key`]: any;
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 19, 5))
+>Recur : Symbol(Recur, Decl(templateLiteralTypeExcessiveLength.ts, 7, 24))
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 19, 5))
+
+};
+

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.symbols
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.symbols
@@ -56,3 +56,54 @@ type ExplodeSpans = {
 
 };
 
+// Every text segment stays small, but the number of segments doubles on every iteration,
+// so the combined text length grows without bound.
+type A16 = "aaaaaaaaaaaaaaaa";
+>A16 : Symbol(A16, Decl(templateLiteralTypeExcessiveLength.ts, 20, 2))
+
+type A64 = `${A16}${A16}${A16}${A16}`;
+>A64 : Symbol(A64, Decl(templateLiteralTypeExcessiveLength.ts, 24, 30))
+>A16 : Symbol(A16, Decl(templateLiteralTypeExcessiveLength.ts, 20, 2))
+>A16 : Symbol(A16, Decl(templateLiteralTypeExcessiveLength.ts, 20, 2))
+>A16 : Symbol(A16, Decl(templateLiteralTypeExcessiveLength.ts, 20, 2))
+>A16 : Symbol(A16, Decl(templateLiteralTypeExcessiveLength.ts, 20, 2))
+
+type A256 = `${A64}${A64}${A64}${A64}`;
+>A256 : Symbol(A256, Decl(templateLiteralTypeExcessiveLength.ts, 25, 38))
+>A64 : Symbol(A64, Decl(templateLiteralTypeExcessiveLength.ts, 24, 30))
+>A64 : Symbol(A64, Decl(templateLiteralTypeExcessiveLength.ts, 24, 30))
+>A64 : Symbol(A64, Decl(templateLiteralTypeExcessiveLength.ts, 24, 30))
+>A64 : Symbol(A64, Decl(templateLiteralTypeExcessiveLength.ts, 24, 30))
+
+type A1024 = `${A256}${A256}${A256}${A256}`;
+>A1024 : Symbol(A1024, Decl(templateLiteralTypeExcessiveLength.ts, 26, 39))
+>A256 : Symbol(A256, Decl(templateLiteralTypeExcessiveLength.ts, 25, 38))
+>A256 : Symbol(A256, Decl(templateLiteralTypeExcessiveLength.ts, 25, 38))
+>A256 : Symbol(A256, Decl(templateLiteralTypeExcessiveLength.ts, 25, 38))
+>A256 : Symbol(A256, Decl(templateLiteralTypeExcessiveLength.ts, 25, 38))
+
+type RecurSegments<N extends number, S extends string> =
+>RecurSegments : Symbol(RecurSegments, Decl(templateLiteralTypeExcessiveLength.ts, 27, 44))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 29, 19))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 29, 36))
+
+    N extends 0 ? S : RecurSegments<Dec<N>, `${S}${string}${S}`>;
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 29, 19))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 29, 36))
+>RecurSegments : Symbol(RecurSegments, Decl(templateLiteralTypeExcessiveLength.ts, 27, 44))
+>Dec : Symbol(Dec, Decl(templateLiteralTypeExcessiveLength.ts, 0, 0))
+>N : Symbol(N, Decl(templateLiteralTypeExcessiveLength.ts, 29, 19))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 29, 36))
+>S : Symbol(S, Decl(templateLiteralTypeExcessiveLength.ts, 29, 36))
+
+type ExplodeSegments = {
+>ExplodeSegments : Symbol(ExplodeSegments, Decl(templateLiteralTypeExcessiveLength.ts, 30, 65))
+
+    [P in RecurSegments<5, A1024> as `${P}_key`]: any;
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 33, 5))
+>RecurSegments : Symbol(RecurSegments, Decl(templateLiteralTypeExcessiveLength.ts, 27, 44))
+>A1024 : Symbol(A1024, Decl(templateLiteralTypeExcessiveLength.ts, 26, 39))
+>P : Symbol(P, Decl(templateLiteralTypeExcessiveLength.ts, 33, 5))
+
+};
+

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.types
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.types
@@ -31,3 +31,28 @@ type ExplodeSpans = {
     [P in Recur<5, string> as `${P}_key`]: any;
 };
 
+// Every text segment stays small, but the number of segments doubles on every iteration,
+// so the combined text length grows without bound.
+type A16 = "aaaaaaaaaaaaaaaa";
+>A16 : "aaaaaaaaaaaaaaaa"
+
+type A64 = `${A16}${A16}${A16}${A16}`;
+>A64 : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type A256 = `${A64}${A64}${A64}${A64}`;
+>A256 : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type A1024 = `${A256}${A256}${A256}${A256}`;
+>A1024 : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type RecurSegments<N extends number, S extends string> =
+>RecurSegments : RecurSegments<N, S>
+
+    N extends 0 ? S : RecurSegments<Dec<N>, `${S}${string}${S}`>;
+
+type ExplodeSegments = {
+>ExplodeSegments : ExplodeSegments
+
+    [P in RecurSegments<5, A1024> as `${P}_key`]: any;
+};
+

--- a/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.types
+++ b/tsc/testdata/baselines/reference/compiler/templateLiteralTypeExcessiveLength.types
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/templateLiteralTypeExcessiveLength.ts] ////
+
+=== templateLiteralTypeExcessiveLength.ts ===
+// Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+// keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+// template literal type.
+
+type Dec<N extends number> =
+>Dec : Dec<N>
+
+    N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
+    N extends 2 ? any :
+    N extends 1 ? 0 : 0;
+
+type Recur<N extends number, S extends string> =
+>Recur : Recur<N, S>
+
+    N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;
+
+// The string literal doubles on every iteration.
+type Explode = {
+>Explode : Explode
+
+    [P in Recur<5, "a"> as `${P}_key`]: any;
+};
+
+// The number of placeholders doubles on every iteration.
+type ExplodeSpans = {
+>ExplodeSpans : ExplodeSpans
+
+    [P in Recur<5, string> as `${P}_key`]: any;
+};
+

--- a/tsc/testdata/tests/cases/compiler/templateLiteralTypeExcessiveLength.ts
+++ b/tsc/testdata/tests/cases/compiler/templateLiteralTypeExcessiveLength.ts
@@ -21,3 +21,17 @@ type Explode = {
 type ExplodeSpans = {
     [P in Recur<5, string> as `${P}_key`]: any;
 };
+
+// Every text segment stays small, but the number of segments doubles on every iteration,
+// so the combined text length grows without bound.
+type A16 = "aaaaaaaaaaaaaaaa";
+type A64 = `${A16}${A16}${A16}${A16}`;
+type A256 = `${A64}${A64}${A64}${A64}`;
+type A1024 = `${A256}${A256}${A256}${A256}`;
+
+type RecurSegments<N extends number, S extends string> =
+    N extends 0 ? S : RecurSegments<Dec<N>, `${S}${string}${S}`>;
+
+type ExplodeSegments = {
+    [P in RecurSegments<5, A1024> as `${P}_key`]: any;
+};

--- a/tsc/testdata/tests/cases/compiler/templateLiteralTypeExcessiveLength.ts
+++ b/tsc/testdata/tests/cases/compiler/templateLiteralTypeExcessiveLength.ts
@@ -1,0 +1,23 @@
+// @strict: true
+
+// Regression test for #63271: `Dec<2>` is `any`, so `Recur` produces both conditional branches and
+// keeps tail-recursing forever. The checker must report an error instead of building an unbounded
+// template literal type.
+
+type Dec<N extends number> =
+    N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
+    N extends 2 ? any :
+    N extends 1 ? 0 : 0;
+
+type Recur<N extends number, S extends string> =
+    N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;
+
+// The string literal doubles on every iteration.
+type Explode = {
+    [P in Recur<5, "a"> as `${P}_key`]: any;
+};
+
+// The number of placeholders doubles on every iteration.
+type ExplodeSpans = {
+    [P in Recur<5, string> as `${P}_key`]: any;
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `npx hereby test`
* [x] You've successfully run `npx hereby lint`
* [x] You've successfully run `npx hereby check:format`
* [x] There are new or updated tests validating the change

Refer to CONTRIBUTING.md for more details:
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

Please don't send a PR solely to fix a typo unless it materially improves
understanding. Each PR represents review and maintenance work.
-->

Fixes #63271

The repro from the issue is a recursive conditional type whose check type becomes `any` after a few iterations:

```ts
type Dec<N extends number> =
    N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 :
    N extends 2 ? any :
    N extends 1 ? 0 : 0;

type Recur<N extends number, S extends string> =
    N extends 0 ? S : Recur<Dec<N>, `${S}_${S}`>;

type Explode = {
    [P in Recur<5, "a"> as `${P}_key`]: any;
};
```

With `N = any`, `getConditionalType` includes both branches and keeps tail-recursing with `Dec<any> = any`, while `S` doubles on every iteration. The tail recursion limit of 1000 iterations is never reached, because the string grows exponentially and memory runs out first.

The JS compiler threw `RangeError: Invalid string length`. The Go port has no string length limit, so it never terminates: after 45 seconds the process was at 9.8 GB RSS and still growing.

## Fix

`getTemplateLiteralType` now bounds the size of the type it produces and reports TS2589 (`Type instantiation is excessively deep and possibly infinite`) when a limit is exceeded, returning `errorType`. This mirrors how `checkCrossProductUnion` bounds union sizes.

Two limits are needed:

- **Text length** (50,000,000 characters). This is the case from the issue.
- **Number of placeholders** (100,000). Once the length guard returns `errorType`, `any` is a valid placeholder, so `${any}_${any}` starts doubling the number of spans instead of the text. The same growth happens in tsc.js for `Recur<5, string>`.

After the guard fires, the conditional loop continues cheaply on cached types until the existing tail recursion limit produces the final TS2589. Duplicate diagnostics at the same location are deduplicated, so the user sees a single error.

## Choice of limits

The type-challenges test suite for "Length of String 3" (#31824) builds string literal types of up to ~10^7 characters and compiles today, so the length limit keeps a 5x margin over it. Going higher makes the regression test proportionally more expensive: at 100,000,000 it took 55 s and 2.2 GB under `-race`.

## Test

`templateLiteralTypeExcessiveLength.ts` covers both growth patterns. Each reports exactly one TS2589.

| Case | Wall time | Peak RSS |
|---|---|---|
| String doubling (issue repro) | ~1 s | 430 MB |
| Placeholder doubling | ~0.7 s | 182 MB |

`hereby test` and `hereby lint` pass. No existing baselines changed.