### PR TITLE
Fix: disallow optional call chaining on import.defer expressions (#63679)

### DIFF
--- a/tsc/internal/checker/grammarchecks.go
+++ b/tsc/internal/checker/grammarchecks.go
@@ -2168,8 +2168,11 @@ func (c *Checker) checkGrammarImportCallExpression(node *ast.Node) bool {
 	}
 
 	nodeAsCall := node.AsCallExpression()
-	if nodeAsCall.TypeArguments != nil || nodeAsCall.QuestionDotToken != nil {
+	if nodeAsCall.TypeArguments != nil {
 		return c.grammarErrorOnNode(node, diagnostics.This_use_of_import_is_invalid_import_calls_can_be_written_but_they_must_have_parentheses_and_cannot_have_type_arguments)
+	}
+	if nodeAsCall.QuestionDotToken != nil {
+		return c.grammarErrorOnNode(node, diagnostics.Calls_to_import_are_not_permitted_in_an_optional_chain)
 	}
 
 	nodeArguments := nodeAsCall.Arguments

--- a/tsc/internal/checker/grammarchecks.go
+++ b/tsc/internal/checker/grammarchecks.go
@@ -2168,7 +2168,7 @@ func (c *Checker) checkGrammarImportCallExpression(node *ast.Node) bool {
 	}
 
 	nodeAsCall := node.AsCallExpression()
-	if nodeAsCall.TypeArguments != nil {
+	if nodeAsCall.TypeArguments != nil || nodeAsCall.QuestionDotToken != nil {
 		return c.grammarErrorOnNode(node, diagnostics.This_use_of_import_is_invalid_import_calls_can_be_written_but_they_must_have_parentheses_and_cannot_have_type_arguments)
 	}
 

--- a/tsc/internal/diagnostics/diagnostics_generated.go
+++ b/tsc/internal/diagnostics/diagnostics_generated.go
@@ -4426,6 +4426,8 @@ var The_invalid_diagnostic_directive_is_in_supplemental_output_0_returned_by_the
 
 var Diagnostic_directive_0_returned_by_the_content_mapper_has_an_invalid_unusedExpectDirectiveIndex = &Message{code: 100068, category: CategoryMessage, key: "Diagnostic_directive_0_returned_by_the_content_mapper_has_an_invalid_unusedExpectDirectiveIndex_100068", text: "Diagnostic directive {0} returned by the content mapper has an invalid 'unusedExpectDirectiveIndex'."}
 
+var Calls_to_import_are_not_permitted_in_an_optional_chain = &Message{code: 100069, category: CategoryError, key: "Calls_to_import_are_not_permitted_in_an_optional_chain_100069", text: "Calls to 'import()' are not permitted in an optional chain."}
+
 func keyToMessage(key Key) *Message {
 	switch key {
 	case "Unterminated_string_literal_1002":
@@ -8852,6 +8854,8 @@ func keyToMessage(key Key) *Message {
 		return The_invalid_diagnostic_directive_is_in_supplemental_output_0_returned_by_the_content_mapper
 	case "Diagnostic_directive_0_returned_by_the_content_mapper_has_an_invalid_unusedExpectDirectiveIndex_100068":
 		return Diagnostic_directive_0_returned_by_the_content_mapper_has_an_invalid_unusedExpectDirectiveIndex
+	case "Calls_to_import_are_not_permitted_in_an_optional_chain_100069":
+		return Calls_to_import_are_not_permitted_in_an_optional_chain
 	default:
 		return nil
 	}

--- a/tsc/internal/diagnostics/extraDiagnosticMessages.json
+++ b/tsc/internal/diagnostics/extraDiagnosticMessages.json
@@ -338,5 +338,9 @@
     "Diagnostic directive {0} returned by the content mapper has an invalid 'unusedExpectDirectiveIndex'.": {
         "category": "Message",
         "code": 100068
+    },
+    "Calls to 'import()' are not permitted in an optional chain.": {
+        "category": "Error",
+        "code": 100069
     }
 }

--- a/tsc/internal/diagnostics/loc_generated.go
+++ b/tsc/internal/diagnostics/loc_generated.go
@@ -5,11 +5,10 @@ package diagnostics
 import (
 	"compress/gzip"
 	_ "embed"
-	"strings"
-	"sync"
-
 	"github.com/microsoft/TypeScript/tsc/internal/json"
 	"golang.org/x/text/language"
+	"strings"
+	"sync"
 )
 
 var matcher = language.NewMatcher([]language.Tag{

--- a/tsc/internal/parser/parser.go
+++ b/tsc/internal/parser/parser.go
@@ -5245,7 +5245,7 @@ func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
 			p.nextToken() // advance past the dot
 			expression = p.finishNode(p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName()), pos)
 			if expression.Text() == "defer" {
-				if p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken {
+				if p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken || p.token == ast.KindQuestionDotToken {
 					p.sourceFlags |= ast.NodeFlagsPossiblyContainsDynamicImport
 				}
 			} else {

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.errors.txt
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.errors.txt
@@ -1,11 +1,11 @@
-importDeferOptionalChain.ts(1,1): error TS1326: This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.
+importDeferOptionalChain.ts(1,1): error TS100069: Calls to 'import()' are not permitted in an optional chain.
 importDeferOptionalChain.ts(1,16): error TS2307: Cannot find module './a' or its corresponding type declarations.
 
 
 ==== importDeferOptionalChain.ts (2 errors) ====
     import.defer?.("./a");
     ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1326: This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.
+!!! error TS100069: Calls to 'import()' are not permitted in an optional chain.
                    ~~~~~
 !!! error TS2307: Cannot find module './a' or its corresponding type declarations.
     

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.errors.txt
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.errors.txt
@@ -1,0 +1,11 @@
+importDeferOptionalChain.ts(1,1): error TS1326: This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.
+importDeferOptionalChain.ts(1,16): error TS2307: Cannot find module './a' or its corresponding type declarations.
+
+
+==== importDeferOptionalChain.ts (2 errors) ====
+    import.defer?.("./a");
+    ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1326: This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.
+                   ~~~~~
+!!! error TS2307: Cannot find module './a' or its corresponding type declarations.
+    

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.js
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.js
@@ -1,0 +1,9 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalChain.ts] ////
+
+//// [importDeferOptionalChain.ts]
+import.defer?.("./a");
+
+
+//// [importDeferOptionalChain.js]
+"use strict";
+import.defer?.("./a");

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.symbols
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalChain.ts] ////
+
+=== importDeferOptionalChain.ts ===
+
+import.defer?.("./a");
+

--- a/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.types
+++ b/tsc/testdata/baselines/reference/conformance/importDeferOptionalChain.types
@@ -1,0 +1,8 @@
+//// [tests/cases/conformance/importDefer/importDeferOptionalChain.ts] ////
+
+=== importDeferOptionalChain.ts ===
+import.defer?.("./a");
+>import.defer?.("./a") : Promise<any>
+>defer : any
+>"./a" : "./a"
+

--- a/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalChain.ts
+++ b/tsc/testdata/tests/cases/conformance/importDefer/importDeferOptionalChain.ts
@@ -1,0 +1,4 @@
+// @target: esnext
+// @module: esnext
+
+import.defer?.("./a");


### PR DESCRIPTION
Fixes #63679.

### Problem
`import.defer` (part of TC39 Stage 3 Deferred Import Evaluation proposal) is a syntactic call construct, not a function reference. Previously, optional call chaining syntax like `import.defer?.('x')` was accepted without grammar errors during parsing and type checking.

### Solution
- Updated `checkGrammarImportCallExpression` to check for non-nil `QuestionDotToken` (`?.`) and emit error `TS1326` (`This use of 'import' is invalid...`).
- Updated parser flag setting for `import.defer` when followed by `?.` to ensure dynamic import statements with optional chaining are visited and grammar-checked.
- Added test case `importDeferOptionalChain.ts` and reference baselines.

---
*AI Disclosure: This patch was developed with AI assistance using Google Antigravity. I have reviewed, tested, and verified the implementation and baselines, and will shepherd this PR through review.*