### PR TITLE
Fix typos and grammatical issues across codebase

### DIFF
--- a/tools/pipelines/typescript-build.yml
+++ b/tools/pipelines/typescript-build.yml
@@ -78,7 +78,7 @@ extends:
                 condition: eq(variables['Build.Reason'], 'Schedule')
 
               # This is copied from https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml
-              # With the difference that we install .NET Core becuase DDSignFiles needs it.
+              # With the difference that we install .NET Core because DDSignFiles needs it.
               - task: NuGetAuthenticate@1
                 displayName: '🔩 NuGet Authenticate'
               - task: UsePythonVersion@0

--- a/tsc/internal/ast/parseoptions.go
+++ b/tsc/internal/ast/parseoptions.go
@@ -31,7 +31,7 @@ func GetExternalModuleIndicatorOptions(fileName string, options *core.CompilerOp
 	case core.ModuleDetectionKindAuto:
 		// If module is nodenext or node16, all esm format files are modules
 		// If jsx is react-jsx or react-jsxdev then jsx tags force module-ness
-		// otherwise, the presence of import or export statments (or import.meta) implies module-ness
+		// otherwise, the presence of import or export statements (or import.meta) implies module-ness
 		return ExternalModuleIndicatorOptions{
 			JSX:   options.Jsx == core.JsxEmitReactJSX || options.Jsx == core.JsxEmitReactJSXDev,
 			Force: isFileForcedToBeModuleByFormat(fileName, options, metadata),

--- a/tsc/internal/ast/utilities.go
+++ b/tsc/internal/ast/utilities.go
@@ -1924,7 +1924,7 @@ func IsImportNode(node *Node) bool {
 	return IsAnyImportSyntax(node) || NodeKindIs(node, KindJSImportDeclaration)
 }
 
-// Checks if the node is a genuine import declation. In particular the re-parsed KindJSImportDeclaration
+// Checks if the node is a genuine import declaration. In particular the re-parsed KindJSImportDeclaration
 // is explicitly excluded because the callers of this function are typically not prepared to handle it properly.
 // For more permissive check, use IsImportNode.
 func IsAnyImportSyntax(node *Node) bool {

--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -873,7 +873,6 @@ type Checker struct {
 	getGlobalClassMethodDecoratorContextType    func() *Type
 	getGlobalClassGetterDecoratorContextType    func() *Type
 	getGlobalClassSetterDecoratorContextType    func() *Type
-	getGlobalClassAccessorDecoratorContxtType   func() *Type
 	getGlobalClassAccessorDecoratorContextType  func() *Type
 	getGlobalClassAccessorDecoratorTargetType   func() *Type
 	getGlobalClassAccessorDecoratorResultType   func() *Type
@@ -8585,7 +8584,7 @@ func (c *Checker) getResolvedSignature(node *ast.Node, candidatesOutArray *[]*Si
 	if cached == nil {
 		// If we haven't already done so, temporarily reset the resolution stack. This allows us to
 		// handle "inverted" situations where, for example, an API client asks for the type of a symbol
-		// containined in a function call argument whose contextual type depends on the symbol itself
+		// contained in a function call argument whose contextual type depends on the symbol itself
 		// through resolution of the containing function call. By resetting the resolution stack we'll
 		// retry the symbol type resolution with the resolvingSignature marker in place to suppress
 		// the contextual type circularity.
@@ -15429,8 +15428,8 @@ func (c *Checker) resolveExternalModule(
 		if ancestor == nil {
 			ancestor = ast.FindAncestor(location, ast.IsImportEqualsDeclaration)
 			if ancestor != nil {
-				if moduleRefrence := ancestor.AsImportEqualsDeclaration().ModuleReference; moduleRefrence.Kind == ast.KindExternalModuleReference {
-					contextSpecifier = moduleRefrence.Expression()
+				if moduleReference := ancestor.AsImportEqualsDeclaration().ModuleReference; moduleReference.Kind == ast.KindExternalModuleReference {
+					contextSpecifier = moduleReference.Expression()
 				}
 			}
 		}
@@ -16386,7 +16385,7 @@ func (c *Checker) lateBindIndexSignature(parent *ast.Symbol, earlySymbols ast.Sy
 	}
 }
 
-func isNotReplacableByMethod(decl *ast.Node) bool {
+func isNotReplaceableByMethod(decl *ast.Node) bool {
 	return decl.Symbol().Flags&ast.SymbolFlagsReplaceableByMethod == 0
 }
 
@@ -16400,8 +16399,8 @@ func (c *Checker) addDeclarationToLateBoundSymbol(symbol *ast.Symbol, member *as
 		symbol.Flags |= symbolFlags
 		symbol.Declarations = append(symbol.Declarations, member)
 	} else if symbol.Flags&ast.SymbolFlagsReplaceableByMethod != 0 && member.Symbol().Flags&ast.SymbolFlagsMethod != 0 {
-		// Remove all replacable-by-method members, along with their flags.
-		symbol.Declarations = append(core.Filter(symbol.Declarations, isNotReplacableByMethod), member)
+		// Remove all replaceable-by-method members, along with their flags.
+		symbol.Declarations = append(core.Filter(symbol.Declarations, isNotReplaceableByMethod), member)
 		oldFlags := symbol.Flags
 		symbol.Flags = ast.SymbolFlagsNone
 		for _, d := range symbol.Declarations {

--- a/tsc/internal/checker/nodebuilderimpl.go
+++ b/tsc/internal/checker/nodebuilderimpl.go
@@ -890,7 +890,7 @@ func (b *NodeBuilderImpl) createExpressionFromSymbolChain(chain []*ast.Symbol, i
 		b.ctx.approximateLength += len(literalText) + 2
 		expression = b.newStringLiteralEx(literalText, symbolName[0] == '\'')
 	} else if jsnum.FromString(symbolName).String() == symbolName {
-		// TODO: the follwing in strada would assert if the number is negative, but no such assertion exists here
+		// TODO: the following in strada would assert if the number is negative, but no such assertion exists here
 		// Moreover, what's even guaranteeing the name *isn't* -1 here anyway? Needs double-checking.
 		b.ctx.approximateLength += len(symbolName)
 		expression = b.f.NewNumericLiteral(symbolName, ast.TokenFlagsNone)

--- a/tsc/internal/checker/nodecopy.go
+++ b/tsc/internal/checker/nodecopy.go
@@ -79,7 +79,7 @@ func (b *NodeBuilderImpl) walkNodeForExpandability(node *ast.Node) {
 	if b.ctx.canIncreaseExpansionDepth || node == nil {
 		return
 	}
-	// Check these explicitly so we look into type arguments wehther or not they are in the tree or not.
+	// Check these explicitly so we look into type arguments whether they are in the tree or not.
 	if ast.IsTypeReferenceNode(node) || ast.IsExpressionWithTypeArguments(node) || ast.IsTypePredicateNode(node) || ast.IsImportTypeNode(node) {
 		t := b.getTypeFromTypeNode(node, false)
 		if t != nil {
@@ -364,7 +364,7 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 		}
 
 		if sym != nil {
-			// If a parameter is resolvable in the current context it is also visible, so no need to go to symbol accesibility
+			// If a parameter is resolvable in the current context it is also visible, so no need to go to symbol accessibility
 			if sym.Flags&ast.SymbolFlagsFunctionScopedVariable != 0 && sym.ValueDeclaration != nil {
 				if ast.IsPartOfParameterDeclaration(sym.ValueDeclaration) || ast.IsJSDocParameterTag(sym.ValueDeclaration) {
 					return introducesError, attachSymbolToLeftmostIdentifier(leftmost, node, sym), nil
@@ -480,7 +480,7 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 		if node.Kind == ast.KindJSDocAllType /* || node.Kind == ast.JSDocNamepathType */ {
 			return factory.NewKeywordTypeNode(ast.KindAnyKeyword)
 		}
-		// !!! TODO: verify JSDocUnknwonType is hopefully just parsed into `unknown` upfront; the kind no longer exists
+		// !!! TODO: verify JSDocUnknownType is hopefully just parsed into `unknown` upfront; the kind no longer exists
 		// if node.Kind == ast.KindJSDocUnknownType {
 		// 	return factory.NewKeywordTypeNode(ast.KindUnknownKeyword)
 		// }
@@ -524,13 +524,13 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 				if shouldBeOptional {
 					question = factory.NewToken(ast.KindQuestionToken)
 				}
-				ty := visitor.VisitNode(t.TypeExpression()) // !!! TODO: alternate lookup locations for the type? serialize on demand if it doesn't serialze? strada does something funky here.
+				ty := visitor.VisitNode(t.TypeExpression()) // !!! TODO: alternate lookup locations for the type? serialize on demand if it doesn't serialize? strada does something funky here.
 
 				members = append(members, factory.NewPropertySignatureDeclaration(nil, name, question, ty, nil))
 			}
 			return factory.NewTypeLiteralNode(factory.NewNodeList(members))
 		}
-		// if (ast.IsExpressionWithTypeArguments(node) || ast.IsTypeReferenceNode(node)) && ast.IsJSDocIndexSignature(node) { /// !!! TODO: JSDocIndexSignature handling hasn't been ported - readd if it's readded
+		// if (ast.IsExpressionWithTypeArguments(node) || ast.IsTypeReferenceNode(node)) && ast.IsJSDocIndexSignature(node) { /// !!! TODO: JSDocIndexSignature handling hasn't been ported - re-add if it's re-added
 		// 	args := node.TypeArguments()
 		// 	if len(args) != 2 {
 		// 		return factory.NewKeywordTypeNode(ast.KindAnyKeyword) // shouldn't be flagged as a jsdoc index signature in the first place
@@ -860,7 +860,7 @@ func getExistingNodeTreeVisitor(b *NodeBuilderImpl, bound *recoveryBoundary) *as
 		//  the position information if the node comes from a different file than the one the node builder
 		//  is set to build for (even though we are reusing the node structure, the position information
 		//  would make the printer print invalid spans for literals and identifiers, and the formatter would
-		//  choke on the mismatched positonal spans between a parent and an injected child from another file).
+		//  choke on the mismatched positional spans between a parent and an injected child from another file).
 		result = b.setTextRange(result, node)
 
 		if bound.hadError {

--- a/tsc/internal/compiler/projectreferencedtsfakinghost.go
+++ b/tsc/internal/compiler/projectreferencedtsfakinghost.go
@@ -70,7 +70,7 @@ func (fs *projectReferenceDtsFakingVfs) FileExists(path string) bool {
 
 // ReadFile implements vfs.FS.
 func (fs *projectReferenceDtsFakingVfs) ReadFile(path string) (contents string, ok bool) {
-	// Dont need to override as we cannot mimick read file
+	// Dont need to override as we cannot mimic read file
 	return fs.projectReferenceFileMapper.opts.Host.FS().ReadFile(path)
 }
 

--- a/tsc/internal/compiler/projectreferencedtsfakinghost.go
+++ b/tsc/internal/compiler/projectreferencedtsfakinghost.go
@@ -70,7 +70,7 @@ func (fs *projectReferenceDtsFakingVfs) FileExists(path string) bool {
 
 // ReadFile implements vfs.FS.
 func (fs *projectReferenceDtsFakingVfs) ReadFile(path string) (contents string, ok bool) {
-	// Dont need to override as we cannot mimic read file
+	// Delegate to the host because we cannot mimic reading files.
 	return fs.projectReferenceFileMapper.opts.Host.FS().ReadFile(path)
 }
 

--- a/tsc/internal/execute/incremental/affectedfileshandler.go
+++ b/tsc/internal/execute/incremental/affectedfileshandler.go
@@ -88,7 +88,7 @@ func (h *affectedFilesHandler) updateShapeSignature(file *ast.SourceFile, useFil
 	update := &updatedSignature{}
 	update.mu.Lock()
 	defer update.mu.Unlock()
-	// If we have cached the result for this file, that means hence forth we should assume file shape is up to date
+	// If we have cached the result for this file, that means henceforth we should assume the file shape is up to date
 	if existing, ok := h.updatedSignatures.LoadOrStore(file.Path(), update); ok {
 		// Ensure calculations for existing ones are complete before using the value
 		existing.mu.Lock()

--- a/tsc/internal/execute/incremental/affectedfileshandler.go
+++ b/tsc/internal/execute/incremental/affectedfileshandler.go
@@ -88,7 +88,7 @@ func (h *affectedFilesHandler) updateShapeSignature(file *ast.SourceFile, useFil
 	update := &updatedSignature{}
 	update.mu.Lock()
 	defer update.mu.Unlock()
-	// If we have cached the result for this file, that means hence forth we should assume file shape is uptodate
+	// If we have cached the result for this file, that means hence forth we should assume file shape is up to date
 	if existing, ok := h.updatedSignatures.LoadOrStore(file.Path(), update); ok {
 		// Ensure calculations for existing ones are complete before using the value
 		existing.mu.Lock()

--- a/tsc/internal/execute/incremental/buildInfo.go
+++ b/tsc/internal/execute/incremental/buildInfo.go
@@ -196,7 +196,7 @@ func (b *BuildInfoReferenceMapEntry) UnmarshalJSON(data []byte) error {
 }
 
 type BuildInfoDiagnostic struct {
-	// BuildInfoFileId if it is for a File that's other than its stored for
+	// BuildInfoFileId if this diagnostic is for a file other than the one it is stored under
 	File               BuildInfoFileId          `json:"file,omitzero"`
 	NoFile             bool                     `json:"noFile,omitzero"`
 	Pos                int                      `json:"pos,omitzero"`

--- a/tsc/internal/execute/incremental/buildInfo.go
+++ b/tsc/internal/execute/incremental/buildInfo.go
@@ -196,7 +196,7 @@ func (b *BuildInfoReferenceMapEntry) UnmarshalJSON(data []byte) error {
 }
 
 type BuildInfoDiagnostic struct {
-	// BuildInfoFileId if it is for a File thats other than its stored for
+	// BuildInfoFileId if it is for a File that's other than its stored for
 	File               BuildInfoFileId          `json:"file,omitzero"`
 	NoFile             bool                     `json:"noFile,omitzero"`
 	Pos                int                      `json:"pos,omitzero"`

--- a/tsc/internal/execute/incremental/programtosnapshot.go
+++ b/tsc/internal/execute/incremental/programtosnapshot.go
@@ -74,7 +74,7 @@ func (t *toProgramSnapshot) computeProgramFileChanges() {
 	canCopySemanticDiagnostics := t.oldProgram != nil &&
 		!tsoptions.CompilerOptionsAffectSemanticDiagnostics(t.oldProgram.snapshot.options, t.program.Options())
 	// We can only reuse emit signatures (i.e. .d.ts signatures) if the .d.ts file is unchanged,
-	// which will eg be depedent on change in options like declarationDir and outDir options are unchanged.
+	// which will eg be dependent on change in options like declarationDir and outDir options are unchanged.
 	// We need to look in oldState.compilerOptions, rather than oldCompilerOptions (i.e.we need to disregard useOldState) because
 	// oldCompilerOptions can be undefined if there was change in say module from None to some other option
 	// which would make useOldState as false since we can now use reference maps that are needed to track what to emit, what to check etc

--- a/tsc/internal/execute/incremental/programtosnapshot.go
+++ b/tsc/internal/execute/incremental/programtosnapshot.go
@@ -74,7 +74,7 @@ func (t *toProgramSnapshot) computeProgramFileChanges() {
 	canCopySemanticDiagnostics := t.oldProgram != nil &&
 		!tsoptions.CompilerOptionsAffectSemanticDiagnostics(t.oldProgram.snapshot.options, t.program.Options())
 	// We can only reuse emit signatures (i.e. .d.ts signatures) if the .d.ts file is unchanged,
-	// which will eg be dependent on change in options like declarationDir and outDir options are unchanged.
+	// which depends, for example, on options such as declarationDir and outDir remaining unchanged.
 	// We need to look in oldState.compilerOptions, rather than oldCompilerOptions (i.e.we need to disregard useOldState) because
 	// oldCompilerOptions can be undefined if there was change in say module from None to some other option
 	// which would make useOldState as false since we can now use reference maps that are needed to track what to emit, what to check etc

--- a/tsc/internal/execute/incremental/snapshot.go
+++ b/tsc/internal/execute/incremental/snapshot.go
@@ -131,7 +131,7 @@ func (e *emitSignature) getNewEmitSignature(oldOptions *core.CompilerOptions, ne
 }
 
 type buildInfoDiagnosticWithFileName struct {
-	// filename if it is for a File that's other than its stored for
+	// filename if this diagnostic is for a file other than the one it is stored under
 	file               tspath.Path
 	noFile             bool
 	pos                int

--- a/tsc/internal/execute/incremental/snapshot.go
+++ b/tsc/internal/execute/incremental/snapshot.go
@@ -113,7 +113,7 @@ type emitSignature struct {
 	signatureWithDifferentOptions []string
 }
 
-// Covert to Emit signature based on oldOptions and EmitSignature format
+// Convert to Emit signature based on oldOptions and EmitSignature format
 // If d.ts map options differ then swap the format, otherwise use as is
 func (e *emitSignature) getNewEmitSignature(oldOptions *core.CompilerOptions, newOptions *core.CompilerOptions) *emitSignature {
 	if oldOptions.DeclarationMap.IsTrue() == newOptions.DeclarationMap.IsTrue() {
@@ -131,7 +131,7 @@ func (e *emitSignature) getNewEmitSignature(oldOptions *core.CompilerOptions, ne
 }
 
 type buildInfoDiagnosticWithFileName struct {
-	// filename if it is for a File thats other than its stored for
+	// filename if it is for a File that's other than its stored for
 	file               tspath.Path
 	noFile             bool
 	pos                int

--- a/tsc/internal/execute/tsc/help.go
+++ b/tsc/internal/execute/tsc/help.go
@@ -194,8 +194,8 @@ func generateSectionOptionsOutput(
 func generateGroupOptionOutput(sys System, locale locale.Locale, optionsList []*tsoptions.CommandLineOption) []string {
 	var maxLength int
 	for _, option := range optionsList {
-		curLenght := len(getDisplayNameTextOfOption(option))
-		maxLength = max(curLenght, maxLength)
+		curLength := len(getDisplayNameTextOfOption(option))
+		maxLength = max(curLength, maxLength)
 	}
 
 	// left part should be right align, right part should be left align

--- a/tsc/internal/execute/tsctests/readablebuildinfo.go
+++ b/tsc/internal/execute/tsctests/readablebuildinfo.go
@@ -57,7 +57,7 @@ type readableBuildInfoFileInfo struct {
 }
 
 type readableBuildInfoDiagnostic struct {
-	// incrementalBuildInfoFileId if it is for a File that's other than its stored for
+	// incrementalBuildInfoFileId if this diagnostic is for a file other than the one it is stored under
 	File               string                           `json:"file,omitzero"`
 	NoFile             bool                             `json:"noFile,omitzero"`
 	Pos                int                              `json:"pos,omitzero"`

--- a/tsc/internal/execute/tsctests/readablebuildinfo.go
+++ b/tsc/internal/execute/tsctests/readablebuildinfo.go
@@ -57,7 +57,7 @@ type readableBuildInfoFileInfo struct {
 }
 
 type readableBuildInfoDiagnostic struct {
-	// incrementalBuildInfoFileId if it is for a File thats other than its stored for
+	// incrementalBuildInfoFileId if it is for a File that's other than its stored for
 	File               string                           `json:"file,omitzero"`
 	NoFile             bool                             `json:"noFile,omitzero"`
 	Pos                int                              `json:"pos,omitzero"`

--- a/tsc/internal/execute/tsctests/sys.go
+++ b/tsc/internal/execute/tsctests/sys.go
@@ -269,7 +269,7 @@ func (s *TestSys) OnEmittedFiles(result *compiler.EmitResult, mTimesCache *colle
 			if err := s.fsFromFileMap().Chtimes(file, time.Time{}, now); err != nil {
 				panic("Failed to change time for emitted file: " + file + ": " + err.Error())
 			}
-			// Update the mTime cache in --b mode to store the updated timestamp so tests will behave deteministically when finding newest output
+			// Update the mTime cache in --b mode to store the updated timestamp so tests will behave deterministically when finding newest output
 			if mTimesCache != nil {
 				path := tspath.ToPath(file, s.GetCurrentDirectory(), s.FS().UseCaseSensitiveFileNames())
 				if _, found := mTimesCache.Load(path); found {

--- a/tsc/internal/format/indent.go
+++ b/tsc/internal/format/indent.go
@@ -375,7 +375,7 @@ func getIndentationForNodeWorker(
 /*
 * Function returns -1 if actual indentation for node should not be used (i.e because node is nested expression)
  */
-func getActualIndentationForNode(current *ast.Node, parent *ast.Node, cuurentLine int, currentChar int, parentAndChildShareLine bool, sourceFile *ast.SourceFile, options lsutil.FormatCodeSettings) int {
+func getActualIndentationForNode(current *ast.Node, parent *ast.Node, currentLine int, currentChar int, parentAndChildShareLine bool, sourceFile *ast.SourceFile, options lsutil.FormatCodeSettings) int {
 	// actual indentation is used for statements\declarations if one of cases below is true:
 	// - parent is SourceFile - by default immediate children of SourceFile are not indented except when user indents them manually
 	// - parent and child are not on the same line
@@ -385,7 +385,7 @@ func getActualIndentationForNode(current *ast.Node, parent *ast.Node, cuurentLin
 		return -1
 	}
 
-	return findColumnForFirstNonWhitespaceCharacterInLine(cuurentLine, currentChar, sourceFile, options)
+	return findColumnForFirstNonWhitespaceCharacterInLine(currentLine, currentChar, sourceFile, options)
 }
 
 func isArgumentAndStartLineOverlapsExpressionBeingCalled(parent *ast.Node, child *ast.Node, childStartLine int, sourceFile *ast.SourceFile) bool {

--- a/tsc/internal/format/span.go
+++ b/tsc/internal/format/span.go
@@ -793,16 +793,16 @@ func (w *formatSpanWorker) processTrivia(trivia []TextRangeWithKind, parent *ast
 * Trimming will be done for lines after the previous range.
 * Exclude comments as they had been previously processed.
  */
-func (w *formatSpanWorker) trimTrailingWhitespacesForRemainingRange(trivias []TextRangeWithKind) {
+func (w *formatSpanWorker) trimTrailingWhitespacesForRemainingRange(triviaList []TextRangeWithKind) {
 	startPos := w.originalRange.Pos()
 	if w.previousRange != NewTextRangeWithKind(0, 0, 0) {
 		startPos = w.previousRange.Loc.End()
 	}
 
-	for _, trivia := range trivias {
+	for _, trivia := range triviaList {
 		if isComment(trivia.Kind) {
 			if startPos < trivia.Loc.Pos() {
-				w.trimTrailingWitespacesForPositions(startPos, trivia.Loc.Pos()-1, w.previousRange)
+				w.trimTrailingWhitespacesForPositions(startPos, trivia.Loc.Pos()-1, w.previousRange)
 			}
 
 			startPos = trivia.Loc.End() + 1
@@ -810,11 +810,11 @@ func (w *formatSpanWorker) trimTrailingWhitespacesForRemainingRange(trivias []Te
 	}
 
 	if startPos < w.originalRange.End() {
-		w.trimTrailingWitespacesForPositions(startPos, w.originalRange.End(), w.previousRange)
+		w.trimTrailingWhitespacesForPositions(startPos, w.originalRange.End(), w.previousRange)
 	}
 }
 
-func (w *formatSpanWorker) trimTrailingWitespacesForPositions(startPos int, endPos int, previousRange TextRangeWithKind) {
+func (w *formatSpanWorker) trimTrailingWhitespacesForPositions(startPos int, endPos int, previousRange TextRangeWithKind) {
 	startLine := scanner.GetECMALineOfPosition(w.sourceFile, startPos)
 	endLine := scanner.GetECMALineOfPosition(w.sourceFile, endPos)
 
@@ -1039,13 +1039,13 @@ func (w *formatSpanWorker) recordInsert(start int, text string) {
 	}
 }
 
-func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo tokenInfo, parent *ast.Node, dynamicIndenation *dynamicIndenter, container *ast.Node, isListEndToken bool) {
+func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo tokenInfo, parent *ast.Node, dynamicIndentation *dynamicIndenter, container *ast.Node, isListEndToken bool) {
 	// assert(currentTokenInfo.token.Loc.ContainedBy(parent.Loc)) // !!!
 	lastTriviaWasNewLine := w.formattingScanner.lastTrailingTriviaWasNewLine()
 	indentToken := false
 
 	if len(currentTokenInfo.leadingTrivia) > 0 {
-		w.processTrivia(currentTokenInfo.leadingTrivia, parent, w.childContextNode, dynamicIndenation)
+		w.processTrivia(currentTokenInfo.leadingTrivia, parent, w.childContextNode, dynamicIndentation)
 	}
 
 	lineAction := LineActionNone
@@ -1057,7 +1057,7 @@ func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo tokenI
 		rangeHasError := w.rangeContainsError(currentTokenInfo.token.Loc)
 		// save previousRange since processRange will overwrite this value with current one
 		savePreviousRange := w.previousRange
-		lineAction = w.processRange(currentTokenInfo.token, tokenStartLine, tokenStartChar, parent, w.childContextNode, dynamicIndenation)
+		lineAction = w.processRange(currentTokenInfo.token, tokenStartLine, tokenStartChar, parent, w.childContextNode, dynamicIndentation)
 		// do not indent comments\token if token range overlaps with some error
 		if !rangeHasError {
 			if lineAction == LineActionNone {
@@ -1088,17 +1088,17 @@ func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo tokenI
 				break
 			}
 		}
-		w.processTrivia(currentTokenInfo.trailingTrivia, parent, w.childContextNode, dynamicIndenation)
+		w.processTrivia(currentTokenInfo.trailingTrivia, parent, w.childContextNode, dynamicIndentation)
 	}
 
 	if indentToken {
 		tokenIndentation := -1
 		if isTokenInRange && !w.rangeContainsError(currentTokenInfo.token.Loc) {
-			tokenIndentation = dynamicIndenation.getIndentationForToken(tokenStartLine, currentTokenInfo.token.Kind, container, !!isListEndToken)
+			tokenIndentation = dynamicIndentation.getIndentationForToken(tokenStartLine, currentTokenInfo.token.Kind, container, !!isListEndToken)
 		}
 		indentNextTokenOrTrivia := true
 		if len(currentTokenInfo.leadingTrivia) > 0 {
-			commentIndentation := dynamicIndenation.getIndentationForComment(currentTokenInfo.token.Kind, tokenIndentation, container)
+			commentIndentation := dynamicIndentation.getIndentationForComment(currentTokenInfo.token.Kind, tokenIndentation, container)
 			indentNextTokenOrTrivia = w.indentTriviaItems(currentTokenInfo.leadingTrivia, commentIndentation, indentNextTokenOrTrivia, func(item TextRangeWithKind) {
 				w.insertIndentation(item.Loc.Pos(), commentIndentation, false)
 			})

--- a/tsc/internal/fourslash/baselineutil.go
+++ b/tsc/internal/fourslash/baselineutil.go
@@ -489,7 +489,7 @@ func (f *FourslashTest) getBaselineContentForFile(
 							break
 						}
 					}
-					// Skip contextId on span thats surrounded by context span immediately
+					// Skip contextId on span that's surrounded by context span immediately
 					if !isAfterContextStart {
 						if text == "" {
 							text = fmt.Sprintf(`contextId: %v`, contextId)

--- a/tsc/internal/fourslash/baselineutil.go
+++ b/tsc/internal/fourslash/baselineutil.go
@@ -489,7 +489,7 @@ func (f *FourslashTest) getBaselineContentForFile(
 							break
 						}
 					}
-					// Skip contextId on span that's surrounded by context span immediately
+					// Skip contextId on a span that's immediately surrounded by a context span
 					if !isAfterContextStart {
 						if text == "" {
 							text = fmt.Sprintf(`contextId: %v`, contextId)

--- a/tsc/internal/fourslash/fourslash.go
+++ b/tsc/internal/fourslash/fourslash.go
@@ -1360,7 +1360,7 @@ func (f *FourslashTest) verifyCompletionsResult(
 		if len(actual.Items) == 0 {
 			return
 		}
-		// !!! cmp.Diff(actual, nil) should probably be a .String() call here and elswhere
+		// !!! cmp.Diff(actual, nil) should probably be a .String() call here and elsewhere
 		t.Fatalf(prefix+"Expected nil completion list but got non-nil: %s", cmp.Diff(actual, nil))
 	}
 	assert.Equal(t, actual.IsIncomplete, expected.IsIncomplete, prefix+"IsIncomplete mismatch")
@@ -3930,7 +3930,7 @@ func (f *FourslashTest) Paste(t *testing.T, text string) {
 	f.baselineState(t)
 	f.editScriptAndUpdateMarkers(t, f.activeFilename, start, start, text)
 
-	// post-paste fomatting
+	// post-paste formatting
 	if f.stateEnableFormatting {
 		result := sendRequestAndBaselineWorker(t, f, lsproto.TextDocumentRangeFormattingInfo, &lsproto.DocumentRangeFormattingParams{
 			TextDocument: lsproto.TextDocumentIdentifier{
@@ -4037,7 +4037,7 @@ func (f *FourslashTest) replaceWorker(t *testing.T, start int, length int, text 
 
 // Inserts the text currently at the caret position character by character, as if the user typed it.
 func (f *FourslashTest) typeText(t *testing.T, text string) {
-	// temprorary -- this disables tests failing if format crashes; this unblocks unrelated tests such as codefixes
+	// temporary -- this disables tests failing if format crashes; this unblocks unrelated tests such as codefixes
 	f.reportFormatOnTypeCrash = false
 	defer func() {
 		f.reportFormatOnTypeCrash = true

--- a/tsc/internal/ls/completions.go
+++ b/tsc/internal/ls/completions.go
@@ -766,7 +766,7 @@ func (l *LanguageService) getCompletionData(
 					case ast.KindIdentifier:
 						isJsxIdentifierExpected = true
 						// For `<div x=[|f/**/|]`, `parent` will be `x` and `previousToken.parent` will be `f` (which is its own JsxAttribute).
-						// Note for `<div someBool f>` we don't want to treat this as a jsx initializer, instead it's the attribute name.
+						// Note: for `<div someBool f>`, we don't want to treat this as a JSX initializer; instead, `f` is the attribute name.
 						if parent != previousToken.Parent &&
 							parent.Initializer() == nil &&
 							astnav.FindChildOfKind(parent, ast.KindEqualsToken, file) != nil {

--- a/tsc/internal/ls/completions.go
+++ b/tsc/internal/ls/completions.go
@@ -766,7 +766,7 @@ func (l *LanguageService) getCompletionData(
 					case ast.KindIdentifier:
 						isJsxIdentifierExpected = true
 						// For `<div x=[|f/**/|]`, `parent` will be `x` and `previousToken.parent` will be `f` (which is its own JsxAttribute).
-						// Note for `<div someBool f>` we don't want to treat this as a jsx inializer, instead it's the attribute name.
+						// Note for `<div someBool f>` we don't want to treat this as a jsx initializer, instead it's the attribute name.
 						if parent != previousToken.Parent &&
 							parent.Initializer() == nil &&
 							astnav.FindChildOfKind(parent, ast.KindEqualsToken, file) != nil {
@@ -940,7 +940,7 @@ func (l *LanguageService) getCompletionData(
 					exportedSymbols := typeChecker.GetExportsOfModule(symbol)
 					for _, exportedSymbol := range exportedSymbols {
 						if exportedSymbol == nil {
-							panic("getExporsOfModule() should all be defined")
+							panic("getExportsOfModule() should all be defined")
 						}
 						isValidValueAccess := func(s *ast.Symbol) bool {
 							return typeChecker.IsValidPropertyAccess(valueAccessNode, s.Name)
@@ -998,7 +998,7 @@ func (l *LanguageService) getCompletionData(
 
 		if !isTypeLocation || checker.IsInTypeQuery(node) {
 			// microsoft/TypeScript#39946. Pulling on the type of a node inside of a function with a contextual `this` parameter can result in a circularity
-			// if the `node` is part of the exprssion of a `yield` or `return`. This circularity doesn't exist at compile time because
+			// if the `node` is part of the expression of a `yield` or `return`. This circularity doesn't exist at compile time because
 			// we will check (and cache) the type of `this` *before* checking the type of the node.
 			typeChecker.TryGetThisTypeAtEx(node, false /*includeGlobalThis*/, nil)
 			t := typeChecker.GetNonOptionalType(typeChecker.GetTypeAtLocation(node))
@@ -3261,7 +3261,7 @@ func getSourceFromOrigin(origin *symbolOriginInfo) string {
 	return ""
 }
 
-// In a scenarion such as `const x = 1 * |`, the context and previous tokens are both `*`.
+// In a scenario such as `const x = 1 * |`, the context and previous tokens are both `*`.
 // In `const x = 1 * o|`, the context token is *, and the previous token is `o`.
 // `contextToken` and `previousToken` can both be nil if we are at the beginning of the file.
 func getRelevantTokens(position int, file *ast.SourceFile) (contextToken *ast.Node, previousToken *ast.Node) {
@@ -5068,7 +5068,7 @@ func (l *LanguageService) createLSPCompletionItem(
 		filterText = getFilterText(file, position, insertText, name, wordStart, dotAccessor)
 	}
 
-	// Adjustements based on kind modifiers.
+	// Adjustments based on kind modifiers.
 	var tags *[]lsproto.CompletionItemTag
 	// Copied from vscode ts extension: `MyCompletionItem.constructor`.
 	if isMemberCompletion && kindModifiers&lsutil.ScriptElementKindModifierOptional != 0 {

--- a/tsc/internal/ls/crossproject.go
+++ b/tsc/internal/ls/crossproject.go
@@ -80,7 +80,7 @@ func handleCrossProject[Req lsproto.HasTextDocumentPosition, Resp any](
 	wg := core.NewWorkGroup(false)
 	var errMu sync.Mutex
 	var enqueueItem func(item projectAndTextDocumentPosition)
-	var panicsOccured []string
+	var panicsOccurred []string
 	var panicMu sync.Mutex
 	enqueueItem = func(item projectAndTextDocumentPosition) {
 		var response response[Resp]
@@ -94,9 +94,9 @@ func handleCrossProject[Req lsproto.HasTextDocumentPosition, Resp any](
 			defer func() {
 				if r := recover(); r != nil {
 					stack := debug.Stack()
-					panicOccured := fmt.Sprintf("panic handling request: %v\n%s", r, string(stack))
+					panicOccurred := fmt.Sprintf("panic handling request: %v\n%s", r, string(stack))
 					panicMu.Lock()
-					panicsOccured = append(panicsOccured, panicOccured)
+					panicsOccurred = append(panicsOccurred, panicOccurred)
 					panicMu.Unlock()
 				}
 			}()
@@ -222,8 +222,8 @@ func handleCrossProject[Req lsproto.HasTextDocumentPosition, Resp any](
 		// Process existing known projects first
 		wg.RunAndWait()
 		// No need to use mu here since we are not in parallel at this point
-		if panicsOccured != nil {
-			panic(fmt.Sprintf("Panics occurred during cross-project handling: %v", panicsOccured))
+		if panicsOccurred != nil {
+			panic(fmt.Sprintf("Panics occurred during cross-project handling: %v", panicsOccurred))
 		}
 		if ctx.Err() != nil {
 			return resp, ctx.Err()

--- a/tsc/internal/module/resolver.go
+++ b/tsc/internal/module/resolver.go
@@ -900,7 +900,7 @@ func (r *resolutionState) tryLoadInputFileForPath(finalPath string, entry string
 		)) {
 
 		// Note: this differs from Strada's tryLoadInputFileForPath in that it
-		// does not attempt to perform "guesses", instead requring a clear root indicator.
+		// does not attempt to perform "guesses", instead requiring a clear root indicator.
 
 		var rootDir string
 		if r.compilerOptions.RootDir != "" {

--- a/tsc/internal/parser/parser.go
+++ b/tsc/internal/parser/parser.go
@@ -5737,7 +5737,7 @@ func (p *Parser) parseFunctionExpression() *ast.Expression {
 	//
 	// FunctionExpression:
 	//      function BindingIdentifier[opt](FormalParameters){ FunctionBody }
-	saveContexFlags := p.contextFlags
+	saveContextFlags := p.contextFlags
 	p.setContextFlags(ast.NodeFlagsDecoratorContext, false)
 	pos := p.nodePos()
 	jsdoc := p.jsdocScannerInfo()
@@ -5762,7 +5762,7 @@ func (p *Parser) parseFunctionExpression() *ast.Expression {
 	parameters := p.parseParameters(signatureFlags)
 	returnType := p.parseReturnType(ast.KindColonToken, false /*isType*/)
 	body := p.parseFunctionBlock(signatureFlags, nil /*diagnosticMessage*/)
-	p.contextFlags = saveContexFlags
+	p.contextFlags = saveContextFlags
 	result := p.factory.NewFunctionExpression(modifiers, asteriskToken, name, typeParameters, parameters, returnType, nil /*fullSignature*/, body)
 	p.finishNode(result, pos)
 	p.withJSDoc(result, jsdoc)

--- a/tsc/internal/project/ata/ata.go
+++ b/tsc/internal/project/ata/ata.go
@@ -393,12 +393,12 @@ type npmConfig struct {
 	DevDependencies map[string]any `json:"devDependencies"`
 }
 
-type npmDependecyEntry struct {
+type npmDependencyEntry struct {
 	Version string `json:"version"`
 }
 type npmLock struct {
-	Dependencies map[string]npmDependecyEntry `json:"dependencies"`
-	Packages     map[string]npmDependecyEntry `json:"packages"`
+	Dependencies map[string]npmDependencyEntry `json:"dependencies"`
+	Packages     map[string]npmDependencyEntry `json:"packages"`
 }
 
 func (ti *TypingsInstaller) processCacheLocation(projectID string, fs vfs.FS, logger logging.Logger) {

--- a/tsc/internal/transformers/declarations/transform.go
+++ b/tsc/internal/transformers/declarations/transform.go
@@ -222,7 +222,7 @@ const declarationEmitNodeBuilderFlags = nodebuilder.FlagsMultilineObjectLiterals
 
 const declarationEmitInternalNodeBuilderFlags = nodebuilder.InternalFlagsAllowUnresolvedNames
 
-// functions as both `visitDeclarationStatements` and `transformRoot`, utilitzing SyntaxList nodes
+// functions as both `visitDeclarationStatements` and `transformRoot`, utilizing SyntaxList nodes
 func (tx *DeclarationTransformer) visit(node *ast.Node) *ast.Node {
 	if node == nil {
 		return nil
@@ -418,7 +418,7 @@ func (tx *DeclarationTransformer) transformAndReplaceLatePaintedStatements(state
 	}
 
 	// And lastly, we need to get the final form of all those indetermine import declarations from before and add them to the output list
-	// (and remove them from the set to examine for outter declarations)
+	// (and remove them from the set to examine for outer declarations)
 	results := make([]*ast.Node, 0, len(statements.Nodes))
 	for _, statement := range statements.Nodes {
 		if !ast.IsLateVisibilityPaintedStatement(statement) {
@@ -635,7 +635,7 @@ func (tx *DeclarationTransformer) visitDeclarationSubtree(input *ast.Node) *ast.
 	case ast.KindConstructor:
 		result = tx.transformConstructorDeclaration(input.AsConstructorDeclaration())
 	case ast.KindGetAccessor:
-		result = tx.transformGetAccesorDeclaration(input.AsGetAccessorDeclaration())
+		result = tx.transformGetAccessorDeclaration(input.AsGetAccessorDeclaration())
 	case ast.KindSetAccessor:
 		result = tx.transformSetAccessorDeclaration(input.AsSetAccessorDeclaration())
 	case ast.KindPropertyDeclaration:
@@ -1018,7 +1018,7 @@ func (tx *DeclarationTransformer) transformSetAccessorDeclaration(input *ast.Set
 	)
 }
 
-func (tx *DeclarationTransformer) transformGetAccesorDeclaration(input *ast.GetAccessorDeclaration) *ast.Node {
+func (tx *DeclarationTransformer) transformGetAccessorDeclaration(input *ast.GetAccessorDeclaration) *ast.Node {
 	if ast.IsPrivateIdentifier(input.Name()) {
 		return nil
 	}

--- a/tsc/internal/transformers/estransforms/objectrestspread.go
+++ b/tsc/internal/transformers/estransforms/objectrestspread.go
@@ -50,7 +50,7 @@ func (ch *objectRestSpreadTransformer) visit(node *ast.Node) *ast.Node {
 	case ast.KindParameter:
 		return ch.visitParameter(node.AsParameterDeclaration())
 	case ast.KindConstructor:
-		return ch.visitContructorDeclaration(node.AsConstructorDeclaration())
+		return ch.visitConstructorDeclaration(node.AsConstructorDeclaration())
 	case ast.KindGetAccessor:
 		return ch.visitGetAccessorDeclaration(node.AsGetAccessorDeclaration())
 	case ast.KindSetAccessor:
@@ -132,7 +132,7 @@ func (ch *objectRestSpreadTransformer) exitParameterListContext(scope oldParamSc
 	ch.parametersWithPrecedingObjectRestOrSpread = map[*ast.Node]struct{}(scope)
 }
 
-func (ch *objectRestSpreadTransformer) visitContructorDeclaration(node *ast.ConstructorDeclaration) *ast.Node {
+func (ch *objectRestSpreadTransformer) visitConstructorDeclaration(node *ast.ConstructorDeclaration) *ast.Node {
 	old := ch.enterParameterListContext(node.AsNode())
 	defer ch.exitParameterListContext(old)
 	return ch.Factory().UpdateConstructorDeclaration(

--- a/tsc/internal/transformers/jsxtransforms/jsx.go
+++ b/tsc/internal/transformers/jsxtransforms/jsx.go
@@ -320,9 +320,9 @@ func (tx *JSXTransformer) transformJsxChildToExpression(node *ast.Node) *ast.Nod
 }
 
 func (tx *JSXTransformer) convertJsxChildrenToChildrenPropAssignment(children []*ast.JsxChild) *ast.Node {
-	nonWhitespceChildren := ast.GetSemanticJsxChildren(children)
-	if len(nonWhitespceChildren) == 1 && (nonWhitespceChildren[0].Kind != ast.KindJsxExpression || nonWhitespceChildren[0].AsJsxExpression().DotDotDotToken == nil) {
-		result := tx.transformJsxChildToExpression(nonWhitespceChildren[0])
+	nonWhitespaceChildren := ast.GetSemanticJsxChildren(children)
+	if len(nonWhitespaceChildren) == 1 && (nonWhitespaceChildren[0].Kind != ast.KindJsxExpression || nonWhitespaceChildren[0].AsJsxExpression().DotDotDotToken == nil) {
+		result := tx.transformJsxChildToExpression(nonWhitespaceChildren[0])
 		if result == nil {
 			return nil
 		}
@@ -330,8 +330,8 @@ func (tx *JSXTransformer) convertJsxChildrenToChildrenPropAssignment(children []
 	}
 	// For multiple children in the children property array, don't set StartOnNewLine
 	// on child elements — the array literal is single-line.
-	results := make([]*ast.Node, 0, len(nonWhitespceChildren))
-	for _, child := range nonWhitespceChildren {
+	results := make([]*ast.Node, 0, len(nonWhitespaceChildren))
+	for _, child := range nonWhitespaceChildren {
 		res := tx.transformJsxChildToExpression(child)
 		if res == nil {
 			continue

--- a/tsc/internal/transformers/moduletransforms/externalmoduleinfo.go
+++ b/tsc/internal/transformers/moduletransforms/externalmoduleinfo.go
@@ -378,7 +378,7 @@ func getImportNeedsImportStarHelper(node *ast.ImportDeclaration) bool {
 			defaultRefCount++
 		}
 	}
-	// Import star is required if there's default named refs mixed with non-default refs, or if there's non-default refs and it has a default import
+	// Import star is required if there are default named refs mixed with non-default refs, or if there are non-default refs and the declaration has a default import
 	return (defaultRefCount > 0 && defaultRefCount != len(namedImports.Elements.Nodes)) || ((len(namedImports.Elements.Nodes)-defaultRefCount) != 0 && ast.IsDefaultImport(node.AsNode()))
 }
 

--- a/tsc/internal/transformers/moduletransforms/externalmoduleinfo.go
+++ b/tsc/internal/transformers/moduletransforms/externalmoduleinfo.go
@@ -378,7 +378,7 @@ func getImportNeedsImportStarHelper(node *ast.ImportDeclaration) bool {
 			defaultRefCount++
 		}
 	}
-	// Import star is required if there's default named refs mixed with non-default refs, or if theres non-default refs and it has a default import
+	// Import star is required if there's default named refs mixed with non-default refs, or if there's non-default refs and it has a default import
 	return (defaultRefCount > 0 && defaultRefCount != len(namedImports.Elements.Nodes)) || ((len(namedImports.Elements.Nodes)-defaultRefCount) != 0 && ast.IsDefaultImport(node.AsNode()))
 }
 

--- a/tsc/internal/transformers/tstransforms/legacydecorators.go
+++ b/tsc/internal/transformers/tstransforms/legacydecorators.go
@@ -56,7 +56,7 @@ func (tx *LegacyDecoratorsTransformer) visit(node *ast.Node) *ast.Node {
 	case ast.KindPropertyDeclaration:
 		return tx.visitPropertyDeclaration(node.AsPropertyDeclaration())
 	case ast.KindParameter:
-		return tx.visitParamerDeclaration(node.AsParameterDeclaration())
+		return tx.visitParameterDeclaration(node.AsParameterDeclaration())
 	case ast.KindSourceFile:
 		tx.classAliases = make(map[*ast.Node]*ast.Node)
 		tx.enclosingClasses = nil
@@ -125,7 +125,7 @@ func (tx *LegacyDecoratorsTransformer) finishClassElement(updated *ast.Node, ori
 	return updated
 }
 
-func (tx *LegacyDecoratorsTransformer) visitParamerDeclaration(node *ast.ParameterDeclaration) *ast.Node {
+func (tx *LegacyDecoratorsTransformer) visitParameterDeclaration(node *ast.ParameterDeclaration) *ast.Node {
 	updated := tx.Factory().UpdateParameterDeclaration(
 		node,
 		elideModifiers(tx.Factory(), node.Modifiers()),

--- a/tsc/internal/tsoptions/tsconfigparsing.go
+++ b/tsc/internal/tsoptions/tsconfigparsing.go
@@ -1939,7 +1939,7 @@ func getFileNamesFromConfigSpecs(
 	extraExtensions []string,
 ) ([]string, int) {
 	basePath = tspath.NormalizePath(basePath)
-	keyMappper := func(value string) string { return tspath.GetCanonicalFileName(value, host.UseCaseSensitiveFileNames()) }
+	keyMapper := func(value string) string { return tspath.GetCanonicalFileName(value, host.UseCaseSensitiveFileNames()) }
 	// Literal file names (provided via the "files" array in tsconfig.json) are stored in a
 	// file map with a possibly case insensitive key. We use this map later when when including
 	// wildcard paths.
@@ -1963,7 +1963,7 @@ func getFileNamesFromConfigSpecs(
 	// remove a literal file.
 	for _, fileName := range validatedFilesSpec {
 		file := tspath.GetNormalizedAbsolutePath(fileName, basePath)
-		literalFileMap.Set(keyMappper(fileName), file)
+		literalFileMap.Set(keyMapper(fileName), file)
 	}
 
 	var jsonOnlyIncludeMatchers *vfsmatch.SpecMatcher
@@ -1980,7 +1980,7 @@ func getFileNamesFromConfigSpecs(
 					includeIndex = jsonOnlyIncludeMatchers.MatchIndex(file)
 				}
 				if includeIndex != -1 {
-					key := keyMappper(file)
+					key := keyMapper(file)
 					if !literalFileMap.Has(key) && !wildCardJsonFileMap.Has(key) {
 						wildCardJsonFileMap.Set(key, file)
 					}
@@ -1994,7 +1994,7 @@ func getFileNamesFromConfigSpecs(
 			// <file>.d.ts (or <file>.js if "allowJs" is enabled) in the same
 			// directory when they are compilation outputs.
 			if hasFileWithHigherPriorityExtension(file, supportedExtensions, func(fileName string) bool {
-				canonicalFileName := keyMappper(fileName)
+				canonicalFileName := keyMapper(fileName)
 				return literalFileMap.Has(canonicalFileName) || wildcardFileMap.Has(canonicalFileName)
 			}) {
 				continue
@@ -2003,8 +2003,8 @@ func getFileNamesFromConfigSpecs(
 			// extension due to the user-defined order of entries in the
 			// "include" array. If there is a lower priority extension in the
 			// same directory, we should remove it.
-			removeWildcardFilesWithLowerPriorityExtension(file, &wildcardFileMap, supportedExtensions, keyMappper)
-			key := keyMappper(file)
+			removeWildcardFilesWithLowerPriorityExtension(file, &wildcardFileMap, supportedExtensions, keyMapper)
+			key := keyMapper(file)
 			if !literalFileMap.Has(key) && !wildcardFileMap.Has(key) {
 				wildcardFileMap.Set(key, file)
 			}

--- a/tsc/internal/tsoptions/wildcarddirectories.go
+++ b/tsc/internal/tsoptions/wildcarddirectories.go
@@ -13,7 +13,7 @@ func getWildcardDirectories(include []string, exclude []string, comparePathsOpti
 	//
 	//  /a/b/**/d   - Watch /a/b recursively to catch changes to any d in any subfolder recursively
 	//  /a/b/*/d    - Watch /a/b recursively to catch any d in any immediate subfolder, even if a new subfolder is added
-	//  /a/b        - Watch /a/b recursively to catch changes to anything in any recursive subfoler
+	//  /a/b        - Watch /a/b recursively to catch changes to anything in any recursive subfolder
 	//
 	// We watch a directory without recursion if it contains a wildcard in the file segment of
 	// the pattern:


### PR DESCRIPTION
Fixes miscellaneous spelling, typo, and grammatical issues found across compiler internals, transformers, language service components, and build pipelines.