### PR TITLE
Benchmark generator API, fix performance of nested `all` calls

### DIFF
--- a/packages/typescript/scripts/generateSync.ts
+++ b/packages/typescript/scripts/generateSync.ts
@@ -53,11 +53,13 @@ const SRC = join(ROOT, "src", "api");
 const TEST = join(ROOT, "test");
 
 type SourceTransform = (source: string, fileName: string) => string;
+type SyncVariant = "sync" | "generators";
 
 function generateSyncFile(
     srcPath: string,
     destPath: string,
     transform: SourceTransform,
+    variant: SyncVariant = "sync",
 ): string {
     const source = readFileSync(srcPath, "utf-8");
 
@@ -65,7 +67,7 @@ function generateSyncFile(
     const normalized = source.replace(/\r/g, "");
 
     // Phase 1: Process sync directives (text-based, operates on comments/lines)
-    const afterDirectives = processDirectives(normalized.split("\n")).join("\n");
+    const afterDirectives = processDirectives(normalized.split("\n"), variant).join("\n");
 
     // Phase 2: AST-based async→sync transforms
     const fileName = destPath.split("/").pop()!;
@@ -85,13 +87,23 @@ function generateSyncFile(
 
 // ── Directive processing ─────────────────────────────────────────
 
-function processDirectives(lines: string[]): string[] {
+function processDirectives(lines: string[], variant: SyncVariant): string[] {
     const output: string[] = [];
     let skipBlock = false;
     let syncOnlyBlock = false;
+    let generatorsOnlyBlock = false;
 
     for (const line of lines) {
         const trimmed = line.trim();
+
+        if (trimmed === "// @generators-skip-block-start") {
+            skipBlock = variant === "generators";
+            continue;
+        }
+        if (trimmed === "// @generators-skip-block-end") {
+            skipBlock = false;
+            continue;
+        }
 
         // Block-skip markers
         if (trimmed === "// @sync-skip-block-start") {
@@ -104,6 +116,20 @@ function processDirectives(lines: string[]): string[] {
         }
         if (skipBlock) continue;
 
+        if (trimmed === "// @generators-only-start") {
+            generatorsOnlyBlock = true;
+            continue;
+        }
+        if (trimmed === "// @generators-only-end") {
+            generatorsOnlyBlock = false;
+            continue;
+        }
+
+        if (generatorsOnlyBlock) {
+            if (variant === "generators") output.push(uncommentLine(line));
+            continue;
+        }
+
         // Sync-only markers (uncomment block)
         if (trimmed === "// @sync-only-start") {
             syncOnlyBlock = true;
@@ -115,17 +141,11 @@ function processDirectives(lines: string[]): string[] {
         }
 
         if (syncOnlyBlock) {
-            const indent = line.match(/^(\s*)/)![1];
-            const rest = line.slice(indent.length);
-            if (rest.startsWith("// ")) {
-                output.push(indent + rest.slice(3));
-            }
-            else if (rest === "//") {
-                output.push(indent);
-            }
-            else {
-                output.push(line);
-            }
+            output.push(uncommentLine(line));
+            continue;
+        }
+
+        if (variant === "generators" && line.includes("// @generators-skip")) {
             continue;
         }
 
@@ -135,17 +155,35 @@ function processDirectives(lines: string[]): string[] {
         }
 
         // Single-line replacement: // @sync: <replacement>
-        const syncReplaceMatch = line.match(/\/\/ @sync: (.+)$/);
-        if (syncReplaceMatch) {
+        const generatorsReplaceMatch = line.match(/\/\/ @generators: (.+)$/);
+        if (variant === "generators" && generatorsReplaceMatch) {
             const indent = line.match(/^(\s*)/)![1];
+            output.push(indent + generatorsReplaceMatch[1]);
+            continue;
+        }
+
+        const lineWithoutGeneratorsDirective = generatorsReplaceMatch
+            ? line.slice(0, generatorsReplaceMatch.index).trimEnd()
+            : line;
+        const syncReplaceMatch = lineWithoutGeneratorsDirective.match(/\/\/ @sync: (.+)$/);
+        if (syncReplaceMatch) {
+            const indent = lineWithoutGeneratorsDirective.match(/^(\s*)/)![1];
             output.push(indent + syncReplaceMatch[1]);
             continue;
         }
 
-        output.push(line);
+        output.push(lineWithoutGeneratorsDirective);
     }
 
     return output;
+}
+
+function uncommentLine(line: string): string {
+    const indent = line.match(/^(\s*)/)![1];
+    const rest = line.slice(indent.length);
+    if (rest.startsWith("// ")) return indent + rest.slice(3);
+    if (rest === "//") return indent;
+    return line;
 }
 
 // ── AST-based transforms ────────────────────────────────────────
@@ -623,6 +661,13 @@ export function generateSync(): void {
             (source, fileName) => transformAsyncSource(source, fileName, false),
         ));
     }
+
+    generatedFiles.push(generateSyncFile(
+        join(TEST, "async", "api.bench.ts"),
+        join(TEST, "generators", "api.bench.ts"),
+        (source, fileName) => transformAsyncSource(source, fileName, false),
+        "generators",
+    ));
 
     console.log("Formatting...");
     formatFiles(generatedFiles);

--- a/packages/typescript/src/api/async/api.ts
+++ b/packages/typescript/src/api/async/api.ts
@@ -221,7 +221,7 @@ export interface TranspileOutput {
 }
 
 // @sync-only-start
-// export { all, defer, type APIRequestGenerator, type AnyAPIRequestGenerator, type DeferredAPIRequestGenerator, type ExecutedGeneratorsResults } from "./generatorSupport.ts";
+// export { all, defer, type APIRequestGenerator, type AnyAPIRequestGenerator, type AllAPIRequestGenerator, type DeferredAPIRequestGenerator, type ExecutedGeneratorsResults } from "./generatorSupport.ts";
 // import {executeRequestGenerators, type ExecutedGeneratorsResults, type AnyAPIRequestGenerator} from "./generatorSupport.ts";
 // @sync-only-end
 

--- a/packages/typescript/src/api/sync/api.ts
+++ b/packages/typescript/src/api/sync/api.ts
@@ -237,7 +237,7 @@ export interface TranspileOutput {
     sourceMapText?: string;
 }
 
-export { all, type AnyAPIRequestGenerator, type APIRequestGenerator, defer, type DeferredAPIRequestGenerator, type ExecutedGeneratorsResults } from "./generatorSupport.ts";
+export { all, type AllAPIRequestGenerator, type AnyAPIRequestGenerator, type APIRequestGenerator, defer, type DeferredAPIRequestGenerator, type ExecutedGeneratorsResults } from "./generatorSupport.ts";
 import {
     type AnyAPIRequestGenerator,
     type ExecutedGeneratorsResults,

--- a/packages/typescript/src/api/sync/generatorSupport.ts
+++ b/packages/typescript/src/api/sync/generatorSupport.ts
@@ -23,6 +23,7 @@ export function* apiRequest(method: PropertyKey, params: unknown): Generator<{ m
     return yield { method, params };
 }
 const deferredGeneratorMarker: unique symbol = Symbol();
+const allGeneratorMarker: unique symbol = Symbol();
 interface DeferredAPIRequest {
     readonly method: "__defer";
     readonly deferred: APIRequestGenerator;
@@ -61,6 +62,7 @@ interface GeneratorGroup {
     parent: GeneratorState | undefined;
     children: GeneratorState[];
     results: unknown[];
+    wrappers?: AllRequestGenerator<unknown>[] | undefined;
     remaining: number;
     initializing: boolean;
     failed: boolean;
@@ -69,11 +71,54 @@ interface GeneratorGroup {
 
 export function all<const T extends readonly AnyAPIRequestGenerator[]>(
     ...requestGenerators: T
-): AllAPIRequestGenerator<ExecutedGeneratorsResults<T>>;
-export function* all<T extends readonly AnyAPIRequestGenerator[]>(
-    ...requestGenerators: T
 ): AllAPIRequestGenerator<ExecutedGeneratorsResults<T>> {
-    return yield { method: "__all", generators: requestGenerators };
+    return new AllRequestGenerator(requestGenerators);
+}
+
+/**
+ * This single-message iterator avoids native generator setup/resumption overhead.
+ * Keeping pending children on the instance also lets the executor collapse nested
+ * all helpers without allocating a scheduler group for each wrapper.
+ */
+class AllRequestGenerator<Return> implements AllAPIRequestGenerator<Return> {
+    readonly [allGeneratorMarker] = true;
+    generators: readonly AnyAPIRequestGenerator[] | undefined;
+    private done = false;
+
+    constructor(generators: readonly AnyAPIRequestGenerator[]) {
+        this.generators = generators;
+    }
+
+    next(value?: Return): IteratorResult<AllAPIRequest, Return> {
+        if (this.generators) {
+            const generators = this.generators;
+            this.generators = undefined;
+            return { done: false, value: { method: "__all", generators } };
+        }
+        if (this.done) return { done: true, value: undefined as Return };
+        this.done = true;
+        return { done: true, value: value as Return };
+    }
+
+    return(value: Return): IteratorResult<AllAPIRequest, Return> {
+        this.generators = undefined;
+        this.done = true;
+        return { done: true, value };
+    }
+
+    throw(error?: unknown): IteratorResult<AllAPIRequest, Return> {
+        this.generators = undefined;
+        this.done = true;
+        throw error;
+    }
+
+    [Symbol.iterator](): AllAPIRequestGenerator<Return> {
+        return this;
+    }
+
+    [Symbol.dispose](): void {
+        this.return(undefined as Return);
+    }
 }
 
 export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerator[]>(
@@ -120,7 +165,7 @@ export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerat
             }
         }
     }
-    return root.results as ExecutedGeneratorsResults<T>;
+    return getGroupResults(root) as ExecutedGeneratorsResults<T>;
 
     function advanceGenerator(state: GeneratorState, value?: unknown, failure?: { error: unknown; }): void {
         state.request = undefined;
@@ -143,8 +188,9 @@ export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerat
                 const parent = state.parent;
                 if (parent) {
                     if (state.resultIndex !== -1) parent.results[state.resultIndex] = next.value;
-                    if (--parent.remaining === 0 && !parent.initializing && parent.parent) {
-                        advanceGenerator(parent.parent, parent.results);
+                    if (--parent.remaining === 0 && !parent.initializing) {
+                        const results = getGroupResults(parent);
+                        if (parent.parent) advanceGenerator(parent.parent, results);
                     }
                 }
                 return;
@@ -162,7 +208,7 @@ export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerat
                     const group = startGroup(request.generators, state);
                     if (!group.failed && group.remaining) return;
                     state.group = undefined;
-                    value = group.results;
+                    value = group.failed ? undefined : getGroupResults(group);
                     failure = group.failed ? { error: group.error } : undefined;
                     break;
                 }
@@ -213,18 +259,59 @@ export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerat
     function startGroup(generators: readonly AnyAPIRequestGenerator[], parent?: GeneratorState): GeneratorGroup {
         const group: GeneratorGroup = { parent, children: [], results: [], remaining: generators.length, initializing: true, failed: false };
         if (parent) parent.group = group;
+        while (parent && generators.length === 1) {
+            const generator = generators[0];
+            if (!(allGeneratorMarker in generator)) break;
+            const wrapper = generator as AllRequestGenerator<unknown>;
+            const pending = wrapper.generators;
+            if (!pending) break;
+            if (registeredGenerators.has(wrapper)) {
+                failGroup(group, new Error("Cannot execute the same generator instance more than once"));
+                group.initializing = false;
+                return group;
+            }
+            registeredGenerators.add(wrapper);
+            wrapper.next();
+            (group.wrappers ??= []).push(wrapper);
+            generators = pending;
+        }
+        group.remaining = generators.length;
         for (const generator of generators) {
             addGenerator(generator, group);
             if (group.failed) break;
         }
         group.initializing = false;
+        if (!group.failed && !group.remaining) getGroupResults(group);
         return group;
+    }
+
+    function getGroupResults(group: GeneratorGroup): unknown[] {
+        let results = group.results;
+        if (group.wrappers) {
+            for (let index = group.wrappers.length - 1; index >= 0; index--) {
+                results = [group.wrappers[index].next(results).value];
+            }
+            group.results = results;
+            group.wrappers = undefined;
+        }
+        return results;
     }
 
     function failGroup(group: GeneratorGroup, error: unknown): void {
         group.failed = true;
         group.error = error;
         cancelGroup(group);
+        if (group.wrappers) {
+            for (let index = group.wrappers.length - 1; index >= 0; index--) {
+                try {
+                    group.wrappers[index].throw(error);
+                }
+                catch (failure) {
+                    error = failure;
+                }
+            }
+            group.error = error;
+        }
         if (!group.initializing) {
             if (!group.parent) throw error;
             advanceGenerator(group.parent, undefined, { error });
@@ -257,9 +344,46 @@ function getRequestDeduplicationKey(request: APIRequest): string | undefined {
 }
 
 export function defer(gen: APIRequestGenerator): DeferredAPIRequestGenerator {
-    const deferred = (function* (): Generator<DeferredAPIRequest, void, unknown> {
-        yield { method: "__defer", deferred: gen };
-    })() as DeferredAPIRequestGenerator;
-    Object.defineProperty(deferred, deferredGeneratorMarker, { value: true });
-    return deferred;
+    return new DeferredRequestGenerator(gen);
+}
+
+/**
+ * The API comparison benchmarks show this single-message iterator is cheaper than
+ * wrapping and branding a native generator, even with a shared generator factory.
+ * Shared prototype methods also avoid creating a generator function per defer call.
+ */
+class DeferredRequestGenerator implements DeferredAPIRequestGenerator {
+    readonly [deferredGeneratorMarker] = true;
+    private generator: APIRequestGenerator | undefined;
+
+    constructor(generator: APIRequestGenerator) {
+        this.generator = generator;
+    }
+
+    next(): IteratorResult<DeferredAPIRequest, void> {
+        if (this.generator) {
+            const generator = this.generator;
+            this.generator = undefined;
+            return { done: false, value: { method: "__defer", deferred: generator } };
+        }
+        return { done: true, value: undefined };
+    }
+
+    return(value: void): IteratorResult<DeferredAPIRequest, void> {
+        this.generator = undefined;
+        return { done: true, value };
+    }
+
+    throw(error?: unknown): IteratorResult<DeferredAPIRequest, void> {
+        this.generator = undefined;
+        throw error;
+    }
+
+    [Symbol.iterator](): DeferredAPIRequestGenerator {
+        return this;
+    }
+
+    [Symbol.dispose](): void {
+        this.return(undefined);
+    }
 }

--- a/packages/typescript/src/api/sync/generatorSupport.ts
+++ b/packages/typescript/src/api/sync/generatorSupport.ts
@@ -24,12 +24,18 @@ export function* apiRequest(method: PropertyKey, params: unknown): Generator<{ m
 }
 const deferredGeneratorMarker: unique symbol = Symbol();
 interface DeferredAPIRequest {
+    readonly method: "__defer";
     readonly deferred: APIRequestGenerator;
 }
-type APIRequestGeneratorYield = APIRequest | readonly APIRequest[] | DeferredAPIRequest;
+interface AllAPIRequest {
+    readonly method: "__all";
+    readonly generators: readonly AnyAPIRequestGenerator[];
+}
+type APIRequestGeneratorYield = APIRequest | readonly APIRequest[] | DeferredAPIRequest | AllAPIRequest;
 export type APIRequestGenerator<Return = any> = Generator<APIRequestGeneratorYield, Return, any>;
 export type DeferredAPIRequestGenerator = Generator<DeferredAPIRequest, void, unknown> & { readonly [deferredGeneratorMarker]: true; };
-export type AnyAPIRequestGenerator<Return = any> = APIRequestGenerator<Return> | DeferredAPIRequestGenerator;
+export type AllAPIRequestGenerator<Return = any> = Generator<AllAPIRequest, Return, Return>;
+export type AnyAPIRequestGenerator<Return = any> = APIRequestGenerator<Return> | DeferredAPIRequestGenerator | AllAPIRequestGenerator<Return>;
 type GeneratorReturn<T> = T extends Generator<any, infer R, any> ? R : never;
 export type ExecutedGeneratorsResults<T extends readonly AnyAPIRequestGenerator[]> = number extends T["length"] ? GeneratorReturn<Exclude<T[number], DeferredAPIRequestGenerator>>[]
     : T extends readonly [infer Head extends AnyAPIRequestGenerator, ...infer Tail extends readonly AnyAPIRequestGenerator[]] ? Head extends DeferredAPIRequestGenerator ? ExecutedGeneratorsResults<Tail> : [GeneratorReturn<Head>, ...ExecutedGeneratorsResults<Tail>]
@@ -40,129 +46,204 @@ interface GeneratorResponse {
     error?: string | undefined;
 }
 
-interface RequestRunnerOptions {
-    executeDeferred?: boolean;
+interface GeneratorState {
+    generator: AnyAPIRequestGenerator;
+    parent: GeneratorGroup | undefined;
+    resultIndex: number;
+    previous: GeneratorState | undefined;
+    next: GeneratorState | undefined;
+    active: boolean;
+    request?: APIRequest | readonly APIRequest[] | undefined;
+    group?: GeneratorGroup | undefined;
 }
 
-function createRequestRunner<T extends readonly AnyAPIRequestGenerator[]>(requestGenerators: T, options: RequestRunnerOptions = {}) {
-    const registeredGenerators = new Set<AnyAPIRequestGenerator>();
-    const requestsByGenerator = new Map<AnyAPIRequestGenerator, APIRequestGeneratorYield>();
-    const resultsByGenerator = new Map<AnyAPIRequestGenerator, unknown>();
-    for (const generator of requestGenerators) {
-        addGenerator(generator);
-    }
-    const requestRounds = runRequestRounds();
-    return { requestRounds, getResults };
-
-    function advanceGenerator(generator: AnyAPIRequestGenerator, value?: unknown, error?: string): void {
-        let state = error === undefined
-            ? generator.next(value)
-            : generator.throw(new Error(error));
-        while (!state.done && isDeferredAPIRequest(state.value) && options.executeDeferred) {
-            addGenerator(state.value.deferred);
-            state = generator.next();
-        }
-        if (state.done) {
-            requestsByGenerator.delete(generator);
-            resultsByGenerator.set(generator, state.value);
-        }
-        else {
-            requestsByGenerator.set(generator, state.value);
-        }
-    }
-
-    function addGenerator(generator: AnyAPIRequestGenerator): void {
-        if (registeredGenerators.has(generator)) throw new Error("Cannot execute the same generator instance more than once");
-        registeredGenerators.add(generator);
-        advanceGenerator(generator);
-    }
-
-    function* runRequestRounds(): Generator<APIRequest[] | DeferredAPIRequest, void, readonly GeneratorResponse[]> {
-        while (requestsByGenerator.size) {
-            for (const generator of registeredGenerators) {
-                let request = requestsByGenerator.get(generator);
-                while (request && isDeferredAPIRequest(request)) {
-                    yield request;
-                    advanceGenerator(generator);
-                    request = requestsByGenerator.get(generator);
-                }
-            }
-            if (!requestsByGenerator.size) break;
-
-            const requests: APIRequest[] = [];
-            const responseIndexByDeduplicationKey = new Map<string, number>();
-            const addRequest = (request: APIRequest): number => {
-                const deduplicationKey = getRequestDeduplicationKey(request);
-                let responseIndex = deduplicationKey === undefined ? undefined : responseIndexByDeduplicationKey.get(deduplicationKey);
-                if (responseIndex === undefined) {
-                    responseIndex = requests.length;
-                    requests.push(request);
-                    if (deduplicationKey !== undefined) responseIndexByDeduplicationKey.set(deduplicationKey, responseIndex);
-                }
-                return responseIndex;
-            };
-            // TODO: Use Iterator.prototype.filter when target >= ES2025
-            const roundGenerators = [...registeredGenerators].filter(generator => requestsByGenerator.has(generator));
-            const responseIndices = new Map<AnyAPIRequestGenerator, number | readonly number[]>();
-            for (const generator of roundGenerators) {
-                const request = requestsByGenerator.get(generator) as APIRequest | readonly APIRequest[];
-                responseIndices.set(generator, isRequestGroup(request) ? request.map(addRequest) : addRequest(request));
-            }
-
-            const responses = yield requests;
-            for (const generator of roundGenerators) {
-                const responseIndex = responseIndices.get(generator)!;
-                if (typeof responseIndex === "number") {
-                    const result = responses[responseIndex];
-                    advanceGenerator(generator, result.result, result.error || undefined);
-                }
-                else {
-                    advanceGenerator(generator, responseIndex.map(index => responses[index]));
-                }
-            }
-        }
-    }
-
-    function getResults(): ExecutedGeneratorsResults<T> {
-        return requestGenerators
-            .filter(generator => !isDeferredGenerator(generator))
-            .map(generator => resultsByGenerator.get(generator)) as ExecutedGeneratorsResults<T>;
-    }
+interface GeneratorGroup {
+    parent: GeneratorState | undefined;
+    children: GeneratorState[];
+    results: unknown[];
+    remaining: number;
+    initializing: boolean;
+    failed: boolean;
+    error?: unknown;
 }
 
 export function all<const T extends readonly AnyAPIRequestGenerator[]>(
     ...requestGenerators: T
-): APIRequestGenerator<ExecutedGeneratorsResults<T>>;
+): AllAPIRequestGenerator<ExecutedGeneratorsResults<T>>;
 export function* all<T extends readonly AnyAPIRequestGenerator[]>(
     ...requestGenerators: T
-): APIRequestGenerator<ExecutedGeneratorsResults<T>> {
-    const { requestRounds, getResults } = createRequestRunner(requestGenerators);
-    yield* requestRounds;
-    return getResults();
+): AllAPIRequestGenerator<ExecutedGeneratorsResults<T>> {
+    return yield { method: "__all", generators: requestGenerators };
 }
 
 export function executeRequestGenerators<T extends readonly AnyAPIRequestGenerator[]>(
     requestGenerators: T,
     executeRequests: (requests: APIRequest[]) => readonly GeneratorResponse[],
 ): ExecutedGeneratorsResults<T> {
-    const { requestRounds, getResults } = createRequestRunner(requestGenerators, { executeDeferred: true });
-    let state = requestRounds.next();
-    while (!state.done) {
-        if (isDeferredAPIRequest(state.value)) throw new Error("Unexpected deferred request");
-        state = requestRounds.next(executeRequests(state.value));
-    }
-    return getResults();
-}
+    const registeredGenerators = new WeakSet<AnyAPIRequestGenerator>();
+    let firstGenerator: GeneratorState | undefined;
+    let lastGenerator: GeneratorState | undefined;
+    const root = startGroup(requestGenerators);
+    if (root.failed) throw root.error;
+    while (firstGenerator) {
+        const requests: APIRequest[] = [];
+        const responseIndexByDeduplicationKey = new Map<string, number>();
+        const addRequest = (request: APIRequest): number => {
+            const deduplicationKey = getRequestDeduplicationKey(request);
+            let responseIndex = deduplicationKey === undefined ? undefined : responseIndexByDeduplicationKey.get(deduplicationKey);
+            if (responseIndex === undefined) {
+                responseIndex = requests.length;
+                requests.push(request);
+                if (deduplicationKey !== undefined) responseIndexByDeduplicationKey.set(deduplicationKey, responseIndex);
+            }
+            return responseIndex;
+        };
+        const roundGenerators: GeneratorState[] = [];
+        const responseIndices: (number | readonly number[])[] = [];
+        for (let state: GeneratorState | undefined = firstGenerator; state; state = state.next) {
+            if (state.request === undefined) continue;
+            roundGenerators.push(state);
+            responseIndices.push(isRequestGroup(state.request) ? state.request.map(addRequest) : addRequest(state.request));
+        }
 
-function isDeferredAPIRequest(request: APIRequestGeneratorYield): request is DeferredAPIRequest {
-    return !Array.isArray(request) && "deferred" in request;
+        const responses = requests.length ? executeRequests(requests) : [];
+        for (let index = 0; index < roundGenerators.length; index++) {
+            const state = roundGenerators[index];
+            if (!state.active) continue;
+            const responseIndex = responseIndices[index];
+            if (typeof responseIndex === "number") {
+                const response = responses[responseIndex];
+                advanceGenerator(state, response.result, response.error ? { error: new Error(response.error) } : undefined);
+            }
+            else {
+                advanceGenerator(state, responseIndex.map(index => responses[index]));
+            }
+        }
+    }
+    return root.results as ExecutedGeneratorsResults<T>;
+
+    function advanceGenerator(state: GeneratorState, value?: unknown, failure?: { error: unknown; }): void {
+        state.request = undefined;
+        state.group = undefined;
+        while (true) {
+            let next: IteratorResult<APIRequestGeneratorYield, unknown>;
+            try {
+                next = failure ? state.generator.throw(failure.error) : state.generator.next(value);
+            }
+            catch (error) {
+                removeGenerator(state);
+                if (!state.parent) throw error;
+                failGroup(state.parent, error);
+                return;
+            }
+            value = undefined;
+            failure = undefined;
+            if (next.done) {
+                removeGenerator(state);
+                const parent = state.parent;
+                if (parent) {
+                    if (state.resultIndex !== -1) parent.results[state.resultIndex] = next.value;
+                    if (--parent.remaining === 0 && !parent.initializing && parent.parent) {
+                        advanceGenerator(parent.parent, parent.results);
+                    }
+                }
+                return;
+            }
+            const request = next.value;
+            if (isRequestGroup(request)) {
+                state.request = request;
+                return;
+            }
+            switch (request.method) {
+                case "__defer":
+                    addGenerator(request.deferred);
+                    break;
+                case "__all": {
+                    const group = startGroup(request.generators, state);
+                    if (!group.failed && group.remaining) return;
+                    state.group = undefined;
+                    value = group.results;
+                    failure = group.failed ? { error: group.error } : undefined;
+                    break;
+                }
+                default:
+                    state.request = request;
+                    return;
+            }
+        }
+    }
+
+    function addGenerator(generator: AnyAPIRequestGenerator, parent?: GeneratorGroup): void {
+        if (registeredGenerators.has(generator)) {
+            const error = new Error("Cannot execute the same generator instance more than once");
+            if (!parent) throw error;
+            failGroup(parent, error);
+            return;
+        }
+        registeredGenerators.add(generator);
+        const next = parent?.parent;
+        const previous = next ? next.previous : lastGenerator;
+        const state: GeneratorState = {
+            generator,
+            parent,
+            resultIndex: parent && !isDeferredGenerator(generator) ? parent.results.push(undefined) - 1 : -1,
+            previous,
+            next,
+            active: true,
+        };
+        if (previous) previous.next = state;
+        else firstGenerator = state;
+        if (next) next.previous = state;
+        else lastGenerator = state;
+        parent?.children.push(state);
+        advanceGenerator(state);
+    }
+
+    function removeGenerator(state: GeneratorState): void {
+        if (!state.active) return;
+        if (state.previous) state.previous.next = state.next;
+        else firstGenerator = state.next;
+        if (state.next) state.next.previous = state.previous;
+        else lastGenerator = state.previous;
+        state.previous = undefined;
+        state.next = undefined;
+        state.active = false;
+    }
+
+    function startGroup(generators: readonly AnyAPIRequestGenerator[], parent?: GeneratorState): GeneratorGroup {
+        const group: GeneratorGroup = { parent, children: [], results: [], remaining: generators.length, initializing: true, failed: false };
+        if (parent) parent.group = group;
+        for (const generator of generators) {
+            addGenerator(generator, group);
+            if (group.failed) break;
+        }
+        group.initializing = false;
+        return group;
+    }
+
+    function failGroup(group: GeneratorGroup, error: unknown): void {
+        group.failed = true;
+        group.error = error;
+        cancelGroup(group);
+        if (!group.initializing) {
+            if (!group.parent) throw error;
+            advanceGenerator(group.parent, undefined, { error });
+        }
+    }
+
+    function cancelGroup(group: GeneratorGroup): void {
+        for (const child of group.children) {
+            removeGenerator(child);
+            if (child.group) cancelGroup(child.group);
+        }
+    }
 }
 
 function isDeferredGenerator(generator: AnyAPIRequestGenerator): generator is DeferredAPIRequestGenerator {
     return deferredGeneratorMarker in generator;
 }
 
-function isRequestGroup(request: APIRequest | readonly APIRequest[]): request is readonly APIRequest[] {
+function isRequestGroup(request: APIRequestGeneratorYield): request is readonly APIRequest[] {
     return Array.isArray(request);
 }
 
@@ -177,7 +258,7 @@ function getRequestDeduplicationKey(request: APIRequest): string | undefined {
 
 export function defer(gen: APIRequestGenerator): DeferredAPIRequestGenerator {
     const deferred = (function* (): Generator<DeferredAPIRequest, void, unknown> {
-        yield { deferred: gen };
+        yield { method: "__defer", deferred: gen };
     })() as DeferredAPIRequestGenerator;
     Object.defineProperty(deferred, deferredGeneratorMarker, { value: true });
     return deferred;

--- a/packages/typescript/test/api-comparison.bench.ts
+++ b/packages/typescript/test/api-comparison.bench.ts
@@ -5,6 +5,7 @@ import {
 import {
     all,
     API as SyncAPI,
+    defer,
     type Project as SyncProject,
 } from "@typescript/typescript/unstable/sync";
 import assert from "node:assert/strict";
@@ -54,6 +55,7 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
     addAsyncBenchmarks();
     addGeneratorBenchmarks();
     addExecutorBenchmarks();
+    addDeferBenchmarks();
 
     if (filter) {
         const pattern = filter.toLowerCase();
@@ -119,8 +121,17 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         addGeneratorTask("independent parallel requests", context => {
             context.api.batch(...positions.map(position => context.project.checker.getSymbolAtPosition.gen("program.ts", position)));
         });
+        addGeneratorTask("independent parallel requests (batch defer)", context => {
+            context.api.batch(...positions.map(position => defer(context.project.checker.getSymbolAtPosition.gen("program.ts", position))));
+        });
         addGeneratorTask("multiple flights of independent requests", context => {
             context.api.batch(...Array.from({ length: requestsPerFlight }, (_, lane) => runRequestLane(context.project, lane)));
+        });
+        addGeneratorTask("multiple flights of independent requests (batch defer)", context => {
+            context.api.batch(...Array.from({ length: requestsPerFlight }, (_, lane) => defer(runRequestLane(context.project, lane))));
+        });
+        addGeneratorTask("multiple flights of independent requests (yield* defer)", context => {
+            context.api.batch(runDeferredRequestLanes(context.project));
         });
         addGeneratorTask("multiple flights of independent requests (repeated all)", context => {
             context.api.batch(runRequestFlights(context.project));
@@ -200,6 +211,86 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         }
     }
 
+    function addDeferBenchmarks() {
+        const child = (function* () {
+            assert.fail("Lifecycle benchmark must not start the child");
+        })();
+        for (const helper of [all, defer]) {
+            let generators: APIRequestGenerator[] = [];
+            bench.add(`helper lifecycle - ${helper.name}`, () => {
+                generators = Array.from({ length: requestCount }, () => helper(child));
+                for (const generator of generators) {
+                    generator.next();
+                    generator.next();
+                }
+            }, {
+                async: false,
+                afterAll: () => {
+                    assert.equal(generators.length, requestCount);
+                    for (const generator of generators) assert.deepEqual(generator.next(), { done: true, value: undefined });
+                },
+            });
+        }
+
+        for (const rounds of [1, flightCount]) {
+            for (const mode of ["direct", "batch defer", "yield* defer"] as const) {
+                bench.add(`executor defer - ${rounds} flights (${mode})`, () => run(false), {
+                    async: false,
+                    beforeAll: () => {
+                        run(true);
+                    },
+                });
+
+                function run(verify: boolean) {
+                    let completed = 0;
+                    let checksum = 0;
+                    let executedRequests = 0;
+                    let executedRounds = 0;
+                    const generators = Array.from({ length: requestCount / rounds }, (_, lane) => runLane(lane));
+                    const results = executeRequestGenerators(
+                        mode === "direct" ? generators : mode === "batch defer" ? generators.map(generator => defer(generator)) : [schedule()],
+                        requests => {
+                            executedRequests += requests.length;
+                            executedRounds++;
+                            return requests.map(request => ({ result: request.params }));
+                        },
+                    );
+                    if (verify) {
+                        assert.equal(executedRequests, requestCount);
+                        assert.equal(executedRounds, rounds);
+                        assert.equal(completed, requestCount / rounds);
+                        assert.equal(checksum, requestCount * (requestCount - 1) / 2);
+                        if (mode === "batch defer") assert.deepEqual(results, []);
+                        else if (mode === "yield* defer") assert.deepEqual(results, [undefined]);
+                        else {
+                            assert.equal(
+                                results.reduce<number>((sum, value) => {
+                                    assert.ok(typeof value === "number");
+                                    return sum + value;
+                                }, 0),
+                                checksum,
+                            );
+                        }
+                    }
+
+                    function* runLane(lane: number): APIRequestGenerator<number> {
+                        let sum = 0;
+                        for (let flight = 0; flight < rounds; flight++) {
+                            sum += yield { method: "benchmark", params: flight * (requestCount / rounds) + lane } as unknown as APIRequest;
+                        }
+                        completed++;
+                        checksum += sum;
+                        return sum;
+                    }
+
+                    function* schedule() {
+                        for (const generator of generators) yield* defer(generator);
+                    }
+                }
+            }
+        }
+    }
+
     function* runDependentRequests(project: SyncProject) {
         let index = 0;
         for (let request = 0; request < requestCount; request++) {
@@ -218,6 +309,12 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         for (let flight = 0; flight < flightCount; flight++) {
             const start = flight * requestsPerFlight;
             yield* all(...positions.slice(start, start + requestsPerFlight).map(position => project.checker.getSymbolAtPosition.gen("program.ts", position)));
+        }
+    }
+
+    function* runDeferredRequestLanes(project: SyncProject) {
+        for (let lane = 0; lane < requestsPerFlight; lane++) {
+            yield* defer(runRequestLane(project, lane));
         }
     }
 

--- a/packages/typescript/test/api-comparison.bench.ts
+++ b/packages/typescript/test/api-comparison.bench.ts
@@ -1,0 +1,309 @@
+import {
+    API as AsyncAPI,
+    type Project as AsyncProject,
+} from "@typescript/typescript/unstable/async";
+import {
+    all,
+    API as SyncAPI,
+    type Project as SyncProject,
+} from "@typescript/typescript/unstable/sync";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { Bench } from "tinybench";
+import ts from "typescript";
+import type { APIRequest } from "../src/api/proto.ts";
+import {
+    type APIRequestGenerator,
+    executeRequestGenerators,
+} from "../src/api/sync/generatorSupport.ts";
+
+const requestCount = 128;
+const flightCount = 8;
+const requestsPerFlight = requestCount / flightCount;
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+    const { values } = parseArgs({
+        options: {
+            filter: { type: "string" },
+            singleIteration: { type: "boolean", default: false },
+        },
+    });
+    await runBenchmarks(values);
+}
+
+export async function runBenchmarks(options?: { filter?: string; singleIteration?: boolean; }) {
+    const { filter, singleIteration } = options ?? {};
+    const repoRoot = fileURLToPath(new URL("../../../", import.meta.url).toString());
+    const fixturePath = fileURLToPath(new URL("../../../tsc/testdata/fixtures/compiler/program.ts", import.meta.url).toString());
+    const positions = collectIdentifierPositions(fixturePath, requestCount);
+    const bench = new Bench({
+        name: "API comparison",
+        iterations: 10,
+        warmupIterations: 4,
+        ...singleIteration ? {
+            iterations: 1,
+            warmup: false,
+            time: 0,
+        } : undefined,
+    });
+
+    addSyncBenchmarks();
+    addAsyncBenchmarks();
+    addGeneratorBenchmarks();
+    addExecutorBenchmarks();
+
+    if (filter) {
+        const pattern = filter.toLowerCase();
+        for (const task of [...bench.tasks]) {
+            if (!task.name.toLowerCase().includes(pattern)) {
+                bench.remove(task.name);
+            }
+        }
+    }
+
+    await bench.run();
+    for (const task of bench.tasks) {
+        if (task.result && "error" in task.result) throw task.result.error;
+    }
+    console.table(bench.table());
+
+    function addSyncBenchmarks() {
+        addSyncTask("dependent sequential requests", context => {
+            let index = 0;
+            for (let request = 0; request < requestCount; request++) {
+                const symbol = context.project.checker.getSymbolAtPosition("program.ts", positions[index]);
+                index = nextPositionIndex(index, symbol?.flags ?? 0);
+            }
+        });
+        addSyncTask("independent parallel requests", context => {
+            for (const position of positions) {
+                context.project.checker.getSymbolAtPosition("program.ts", position);
+            }
+        });
+        addSyncTask("multiple flights of independent requests", context => {
+            for (let flight = 0; flight < flightCount; flight++) {
+                const start = flight * requestsPerFlight;
+                for (let request = 0; request < requestsPerFlight; request++) {
+                    context.project.checker.getSymbolAtPosition("program.ts", positions[start + request]);
+                }
+            }
+        });
+    }
+
+    function addAsyncBenchmarks() {
+        addAsyncTask("dependent sequential requests", async context => {
+            let index = 0;
+            for (let request = 0; request < requestCount; request++) {
+                const symbol = await context.project.checker.getSymbolAtPosition("program.ts", positions[index]);
+                index = nextPositionIndex(index, symbol?.flags ?? 0);
+            }
+        });
+        addAsyncTask("independent parallel requests", async context => {
+            await Promise.all(positions.map(position => context.project.checker.getSymbolAtPosition("program.ts", position)));
+        });
+        addAsyncTask("multiple flights of independent requests", async context => {
+            for (let flight = 0; flight < flightCount; flight++) {
+                const start = flight * requestsPerFlight;
+                await Promise.all(positions.slice(start, start + requestsPerFlight).map(position => context.project.checker.getSymbolAtPosition("program.ts", position)));
+            }
+        });
+    }
+
+    function addGeneratorBenchmarks() {
+        addGeneratorTask("dependent sequential requests", context => {
+            context.api.batch(runDependentRequests(context.project));
+        });
+        addGeneratorTask("independent parallel requests", context => {
+            context.api.batch(...positions.map(position => context.project.checker.getSymbolAtPosition.gen("program.ts", position)));
+        });
+        addGeneratorTask("multiple flights of independent requests", context => {
+            context.api.batch(...Array.from({ length: requestsPerFlight }, (_, lane) => runRequestLane(context.project, lane)));
+        });
+        addGeneratorTask("multiple flights of independent requests (repeated all)", context => {
+            context.api.batch(runRequestFlights(context.project));
+        });
+        for (const depth of [1, 4, 16]) {
+            addGeneratorTask(`independent parallel requests (all depth ${depth})`, context => {
+                context.api.batch(nestAll(positions.map(position => context.project.checker.getSymbolAtPosition.gen("program.ts", position)), depth));
+            });
+            addGeneratorTask(`multiple flights of independent requests (all depth ${depth})`, context => {
+                context.api.batch(nestAll(Array.from({ length: requestsPerFlight }, (_, lane) => runRequestLane(context.project, lane)), depth));
+            });
+        }
+    }
+
+    function nestAll(generators: APIRequestGenerator[], depth: number): APIRequestGenerator {
+        let generator = all(...generators);
+        for (let level = 1; level < depth; level++) {
+            generator = all(generator);
+        }
+        return generator;
+    }
+
+    function addExecutorBenchmarks() {
+        for (const rounds of [1, flightCount]) {
+            for (const depth of [0, 1, 4, 16]) {
+                bench.add(`executor only - ${rounds} flights (${depth ? `all depth ${depth}` : "direct batch"})`, () => run(false), {
+                    async: false,
+                    beforeAll: () => {
+                        run(true);
+                    },
+                });
+                if (depth && rounds > 1) {
+                    bench.add(`executor only - ${rounds} flights (repeated all depth ${depth})`, () => run(false, true), {
+                        async: false,
+                        beforeAll: () => {
+                            run(true, true);
+                        },
+                    });
+                }
+
+                function run(verify: boolean, repeatedJoins = false) {
+                    const generators = repeatedJoins ? [runFlights()] : Array.from({ length: requestCount / rounds }, (_, lane) => runLane(lane));
+                    let executedRequests = 0;
+                    let executedRounds = 0;
+                    const results = executeRequestGenerators(depth && !repeatedJoins ? [nestAll(generators, depth)] : generators, requests => {
+                        executedRequests += requests.length;
+                        executedRounds++;
+                        return requests.map(request => ({ result: request.params }));
+                    });
+                    if (verify) {
+                        assert.equal(executedRequests, requestCount);
+                        assert.equal(executedRounds, rounds);
+                        assert.equal(results.flat(Infinity).reduce((sum, value) => sum + value, 0), requestCount * (requestCount - 1) / 2);
+                    }
+                }
+
+                function* runLane(lane: number): APIRequestGenerator<number> {
+                    let sum = 0;
+                    for (let flight = 0; flight < rounds; flight++) {
+                        sum += yield { method: "benchmark", params: flight * (requestCount / rounds) + lane } as unknown as APIRequest;
+                    }
+                    return sum;
+                }
+
+                function* runFlights(): APIRequestGenerator {
+                    const results: unknown[] = [];
+                    for (let flight = 0; flight < rounds; flight++) {
+                        results.push(yield* nestAll(Array.from({ length: requestCount / rounds }, (_, lane) => runRequest(flight * (requestCount / rounds) + lane)), depth));
+                    }
+                    return results;
+                }
+
+                function* runRequest(index: number): APIRequestGenerator<number> {
+                    return yield { method: "benchmark", params: index } as unknown as APIRequest;
+                }
+            }
+        }
+    }
+
+    function* runDependentRequests(project: SyncProject) {
+        let index = 0;
+        for (let request = 0; request < requestCount; request++) {
+            const symbol = yield* project.checker.getSymbolAtPosition.gen("program.ts", positions[index]);
+            index = nextPositionIndex(index, symbol?.flags ?? 0);
+        }
+    }
+
+    function* runRequestLane(project: SyncProject, lane: number) {
+        for (let flight = 0; flight < flightCount; flight++) {
+            yield* project.checker.getSymbolAtPosition.gen("program.ts", positions[flight * requestsPerFlight + lane]);
+        }
+    }
+
+    function* runRequestFlights(project: SyncProject) {
+        for (let flight = 0; flight < flightCount; flight++) {
+            const start = flight * requestsPerFlight;
+            yield* all(...positions.slice(start, start + requestsPerFlight).map(position => project.checker.getSymbolAtPosition.gen("program.ts", position)));
+        }
+    }
+
+    function nextPositionIndex(index: number, symbolFlags: number): number {
+        return (index + symbolFlags + 1) % positions.length;
+    }
+
+    function addSyncTask(name: string, run: (context: SyncContext) => void) {
+        let context: SyncContext;
+        bench.add(`sync - ${name}`, () => run(context), {
+            async: false,
+            beforeAll: () => {
+                context = createSyncContext();
+            },
+            afterAll: () => context.api.close(),
+        });
+    }
+
+    function addAsyncTask(name: string, run: (context: AsyncContext) => Promise<void>) {
+        let context: AsyncContext;
+        bench.add(`async - ${name}`, () => run(context), {
+            async: true,
+            beforeAll: async () => {
+                context = await createAsyncContext();
+            },
+            afterAll: async () => context.api.close(),
+        });
+    }
+
+    function addGeneratorTask(name: string, run: (context: SyncContext) => void) {
+        let context: SyncContext;
+        bench.add(`generators - ${name}`, () => run(context), {
+            async: false,
+            beforeAll: () => {
+                context = createGeneratorContext();
+            },
+            afterAll: () => context.api.close(),
+        });
+    }
+
+    function createSyncContext(): SyncContext {
+        const api = new SyncAPI({ cwd: repoRoot });
+        const snapshot = api.updateSnapshot({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" });
+        const project = snapshot.getProjects()[0];
+        project.checker.getSymbolAtPosition("core.ts", 0);
+        return { api, project };
+    }
+
+    async function createAsyncContext(): Promise<AsyncContext> {
+        const api = new AsyncAPI({ cwd: repoRoot });
+        const snapshot = await api.updateSnapshot({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" });
+        const project = snapshot.getProjects()[0];
+        await project.checker.getSymbolAtPosition("core.ts", 0);
+        return { api, project };
+    }
+
+    function createGeneratorContext(): SyncContext {
+        const api = new SyncAPI({ cwd: repoRoot });
+        const [snapshot] = api.batch(api.updateSnapshot.gen({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" }));
+        const project = snapshot.getProjects()[0];
+        api.batch(project.checker.getSymbolAtPosition.gen("core.ts", 0));
+        return { api, project };
+    }
+}
+
+interface SyncContext {
+    api: SyncAPI;
+    project: SyncProject;
+}
+
+interface AsyncContext {
+    api: AsyncAPI;
+    project: AsyncProject;
+}
+
+function collectIdentifierPositions(fileName: string, count: number): number[] {
+    const sourceFile = ts.createSourceFile(fileName, readFileSync(fileName, "utf8"), ts.ScriptTarget.Latest, true);
+    const positions: number[] = [];
+    sourceFile.forEachChild(function visit(node) {
+        if (node.kind === ts.SyntaxKind.Identifier) {
+            positions.push(node.pos);
+        }
+        node.forEachChild(visit);
+    });
+    if (positions.length < count) {
+        throw new Error(`Expected at least ${count} identifiers in ${fileName}, found ${positions.length}`);
+    }
+    return Array.from({ length: count }, (_, index) => positions[Math.floor(index * positions.length / count)]);
+}

--- a/packages/typescript/test/api.bench.ts
+++ b/packages/typescript/test/api.bench.ts
@@ -1,9 +1,11 @@
 import { fileURLToPath } from "node:url";
 import { runBenchmarks as runAsyncBenchmarks } from "./async/api.bench.ts";
+import { runBenchmarks as runGeneratorBenchmarks } from "./generators/api.bench.ts";
 import { runBenchmarks as runSyncBenchmarks } from "./sync/api.bench.ts";
 
 const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
     await runAsyncBenchmarks();
     runSyncBenchmarks();
+    runGeneratorBenchmarks();
 }

--- a/packages/typescript/test/generators/api.bench.ts
+++ b/packages/typescript/test/generators/api.bench.ts
@@ -1,3 +1,11 @@
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!! THIS FILE IS AUTO-GENERATED - DO NOT EDIT !!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// Source: test/async/api.bench.ts
+// Regenerate: npm run generate (from packages/typescript)
+//
 import {
     type Node,
     type SourceFile,
@@ -7,7 +15,7 @@ import {
     API,
     type Project,
     type Snapshot,
-} from "@typescript/typescript/unstable/async"; // @sync: } from "@typescript/typescript/unstable/sync";
+} from "@typescript/typescript/unstable/sync";
 import { writeFileSync } from "node:fs";
 import inspector from "node:inspector";
 import path from "node:path";
@@ -26,15 +34,15 @@ if (isMain) {
             cpuprofile: { type: "boolean", default: false },
         },
     });
-    await runBenchmarks(values);
+    runBenchmarks(values);
 }
 
-export async function runBenchmarks(options?: { filter?: string; singleIteration?: boolean; cpuprofile?: boolean; }) {
+export function runBenchmarks(options?: { filter?: string; singleIteration?: boolean; cpuprofile?: boolean; }) {
     const { filter, singleIteration, cpuprofile } = options ?? {};
     const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url).toString());
 
     const bench = new Bench({
-        name: "Async API", // @sync: name: "Sync API", // @generators: name: "Generator API",
+        name: "Generator API",
         teardown,
         // Reduce iterations from the default 64 to 10.  Slow tasks
         // are dominated by the iteration minimum, not the time limit.
@@ -56,10 +64,10 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
     let file: SourceFile;
     let tsFile: ts.SourceFile;
 
-    const programIdentifierCount = await (async () => {
-        await spawnAPI();
-        await loadSnapshot();
-        await getProgramTS();
+    const programIdentifierCount = (() => {
+        spawnAPI();
+        loadSnapshot();
+        getProgramTS();
         let count = 0;
         file!.forEachChild(function visit(node) {
             if (node.kind === SyntaxKind.Identifier) {
@@ -67,7 +75,7 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
             }
             node.forEachChild(visit);
         });
-        await teardown();
+        teardown();
         return count;
     })();
 
@@ -77,41 +85,41 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
     // the probe actually executes the benchmarked code (spawning processes,
     // creating TS programs, etc.) wasting 30+ seconds.  Passing an explicit
     // `async` flag on every task skips the probe entirely.
-    const isAsync = true; // @sync: const isAsync = false;
+    const isAsync = false;
 
     bench
-        .add("spawn API", async () => {
-            await spawnAPI();
+        .add("spawn API", () => {
+            spawnAPI();
         }, { async: isAsync })
-        .add("load snapshot", async () => {
-            await loadSnapshot();
+        .add("load snapshot", () => {
+            loadSnapshot();
         }, { async: isAsync, beforeAll: spawnAPI })
         .add("TS - load project", () => {
             tsCreateProgram();
         }, { async: isAsync })
-        .add("transfer debug.ts", async () => {
-            await getDebugTS();
+        .add("transfer debug.ts", () => {
+            getDebugTS();
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot), beforeEach: clearSourceFileCache })
-        .add("transfer program.ts", async () => {
-            await getProgramTS();
+        .add("transfer program.ts", () => {
+            getProgramTS();
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot), beforeEach: clearSourceFileCache })
-        .add("transfer checker.ts", async () => {
-            await getCheckerTS();
+        .add("transfer checker.ts", () => {
+            getCheckerTS();
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot), beforeEach: clearSourceFileCache })
-        .add("materialize program.ts", async () => {
+        .add("materialize program.ts", () => {
             const { view, _decoder } = file as unknown as RemoteSourceFile;
             new RemoteSourceFile(new Uint8Array(view.buffer, view.byteOffset, view.byteLength), _decoder).forEachChild(function visit(node) {
                 node.forEachChild(visit);
             });
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, getProgramTS) })
-        .add("materialize checker.ts", async () => {
+        .add("materialize checker.ts", () => {
             const { view, _decoder } = file as unknown as RemoteSourceFile;
             new RemoteSourceFile(new Uint8Array(view.buffer, view.byteOffset, view.byteLength), _decoder).forEachChild(function visit(node) {
                 node.forEachChild(visit);
             });
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, getCheckerTS) })
-        .add("getSymbolAtPosition - one location", async () => {
-            await project.checker.getSymbolAtPosition("program.ts", 8895); // @generators: api.batch(project.checker.getSymbolAtPosition.gen("program.ts", 8895));
+        .add("getSymbolAtPosition - one location", () => {
+            api.batch(project.checker.getSymbolAtPosition.gen("program.ts", 8895));
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, createChecker) })
         .add("TS - getSymbolAtPosition - one location", () => {
             tsProgram.getTypeChecker().getSymbolAtLocation(
@@ -119,33 +127,19 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
                 ts.getTokenAtPosition(tsFile, 8895),
             );
         }, { async: isAsync, beforeAll: all(tsCreateProgram, tsCreateChecker, tsGetProgramTS) })
-        .add(`getSymbolAtPosition - ${programIdentifierCount} identifiers`, async () => {
-            // @generators-only-start
-            // api.batch(...collectIdentifiers(file).map(node => project.checker.getSymbolAtPosition.gen("program.ts", node.pos)));
-            // @generators-only-end
-            // @generators-skip-block-start
-            for (const node of collectIdentifiers(file)) {
-                await project.checker.getSymbolAtPosition("program.ts", node.pos);
-            }
-            // @generators-skip-block-end
+        .add(`getSymbolAtPosition - ${programIdentifierCount} identifiers`, () => {
+            api.batch(...collectIdentifiers(file).map(node => project.checker.getSymbolAtPosition.gen("program.ts", node.pos)));
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, createChecker, getProgramTS) })
-        .add(`getSymbolAtPosition - ${programIdentifierCount} identifiers (batched)`, async () => {
+        .add(`getSymbolAtPosition - ${programIdentifierCount} identifiers (batched)`, () => {
             const positions = collectIdentifiers(file).map(node => node.pos);
-            await project.checker.getSymbolAtPosition("program.ts", positions); // @generators: api.batch(project.checker.getSymbolAtPosition.gen("program.ts", positions));
+            api.batch(project.checker.getSymbolAtPosition.gen("program.ts", positions));
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, createChecker, getProgramTS) })
-        .add(`getSymbolAtLocation - ${programIdentifierCount} identifiers`, async () => {
-            // @generators-only-start
-            // api.batch(...collectIdentifiers(file).map(node => project.checker.getSymbolAtLocation.gen(node)));
-            // @generators-only-end
-            // @generators-skip-block-start
-            for (const node of collectIdentifiers(file)) {
-                await project.checker.getSymbolAtLocation(node);
-            }
-            // @generators-skip-block-end
+        .add(`getSymbolAtLocation - ${programIdentifierCount} identifiers`, () => {
+            api.batch(...collectIdentifiers(file).map(node => project.checker.getSymbolAtLocation.gen(node)));
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, createChecker, getProgramTS) })
-        .add(`getSymbolAtLocation - ${programIdentifierCount} identifiers (batched)`, async () => {
+        .add(`getSymbolAtLocation - ${programIdentifierCount} identifiers (batched)`, () => {
             const nodes = collectIdentifiers(file);
-            await project.checker.getSymbolAtLocation(nodes); // @generators: api.batch(project.checker.getSymbolAtLocation.gen(nodes));
+            api.batch(project.checker.getSymbolAtLocation.gen(nodes));
         }, { async: isAsync, beforeAll: all(spawnAPI, loadSnapshot, createChecker, getProgramTS) })
         .add(`TS - getSymbolAtLocation - ${programIdentifierCount} identifiers`, () => {
             const checker = tsProgram.getTypeChecker();
@@ -174,8 +168,8 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         session.post("Profiler.start");
     }
 
-    await bench.run(); // @sync: bench.runSync();
-    await teardown(); // @sync: teardown();
+    bench.runSync();
+    teardown();
 
     if (session) {
         session.post("Profiler.stop", (err, { profile }) => {
@@ -199,14 +193,14 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         return nodes;
     }
 
-    async function spawnAPI() {
+    function spawnAPI() {
         api = new API({
             cwd: repoRoot,
         });
     }
 
-    async function loadSnapshot() {
-        snapshot = await api.updateSnapshot({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" }); // @generators: [snapshot] = api.batch(api.updateSnapshot.gen({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" }));
+    function loadSnapshot() {
+        [snapshot] = api.batch(api.updateSnapshot.gen({ openProject: "tsc/testdata/fixtures/compiler/tsconfig.json" }));
         project = snapshot.getProjects()[0];
     }
 
@@ -222,38 +216,38 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         });
     }
 
-    async function createChecker() {
+    function createChecker() {
         // checker is created lazily, for measuring symbol time in a loop
         // we need to create it first.
-        await project.checker.getSymbolAtPosition("core.ts", 0); // @generators: api.batch(project.checker.getSymbolAtPosition.gen("core.ts", 0));
+        api.batch(project.checker.getSymbolAtPosition.gen("core.ts", 0));
     }
 
     function tsCreateChecker() {
         tsProgram.getTypeChecker();
     }
 
-    async function getDebugTS() {
-        file = (await project.program.getSourceFile("debug.ts"))!; // @generators: file = api.batch(project.program.getSourceFile.gen("debug.ts"))[0]!;
+    function getDebugTS() {
+        file = api.batch(project.program.getSourceFile.gen("debug.ts"))[0]!;
     }
 
-    async function getProgramTS() {
-        file = (await project.program.getSourceFile("program.ts"))!; // @generators: file = api.batch(project.program.getSourceFile.gen("program.ts"))[0]!;
+    function getProgramTS() {
+        file = api.batch(project.program.getSourceFile.gen("program.ts"))[0]!;
     }
 
     function tsGetProgramTS() {
         tsFile = tsProgram.getSourceFile(fileURLToPath(new URL("../../../../tsc/testdata/fixtures/compiler/program.ts", import.meta.url).toString()))!;
     }
 
-    async function getCheckerTS() {
-        file = (await project.program.getSourceFile("checker.ts"))!; // @generators: file = api.batch(project.program.getSourceFile.gen("checker.ts"))[0]!;
+    function getCheckerTS() {
+        file = api.batch(project.program.getSourceFile.gen("checker.ts"))[0]!;
     }
 
     function clearSourceFileCache() {
         api.clearSourceFileCache();
     }
 
-    async function teardown() {
-        await api?.close();
+    function teardown() {
+        api?.close();
         api = undefined!;
         snapshot = undefined!;
         project = undefined!;
@@ -262,10 +256,10 @@ export async function runBenchmarks(options?: { filter?: string; singleIteration
         tsFile = undefined!;
     }
 
-    function all(...fns: (() => void | Promise<void>)[]) {
-        return async () => {
+    function all(...fns: (() => void)[]) {
+        return () => {
             for (const fn of fns) {
-                await fn();
+                fn();
             }
         };
     }

--- a/packages/typescript/test/sync/api-generators.test.ts
+++ b/packages/typescript/test/sync/api-generators.test.ts
@@ -434,6 +434,89 @@ describe("API - generator batching", () => {
         assert.equal(started, false);
     });
 
+    test("all preserves generator protocol behavior", () => {
+        let started = false;
+        function* child() {
+            started = true;
+            return "child";
+        }
+        const generator = child();
+        const joined = all(generator);
+        assert.strictEqual(joined[globalThis.Symbol.iterator](), joined);
+        assert.deepEqual(joined.next(["ignored"]), { done: false, value: { method: "__all", generators: [generator] } });
+        const results: [string] = ["result"];
+        assert.deepEqual(joined.next(results), { done: true, value: results });
+        assert.deepEqual(joined.next(["ignored"]), { done: true, value: undefined });
+        assert.deepEqual(joined.return(results), { done: true, value: results });
+
+        for (const begin of [false, true]) {
+            const returned = all(generator);
+            const thrown = all(generator);
+            if (begin) {
+                returned.next();
+                thrown.next();
+            }
+            assert.deepEqual(returned.return(results), { done: true, value: results });
+            assert.deepEqual(returned.next(), { done: true, value: undefined });
+            const error = new Error("failed");
+            assert.throws(() => thrown.throw(error), actual => actual === error);
+            assert.deepEqual(thrown.next(), { done: true, value: undefined });
+        }
+        assert.equal(started, false);
+    });
+
+    test("defer preserves generator protocol behavior", () => {
+        let started = false;
+        function* child() {
+            started = true;
+            return "child";
+        }
+        const generator = child();
+        const deferred = defer(generator);
+        assert.strictEqual(deferred[globalThis.Symbol.iterator](), deferred);
+        assert.deepEqual(deferred.next("ignored"), { done: false, value: { method: "__defer", deferred: generator } });
+        assert.deepEqual(deferred.next("ignored"), { done: true, value: undefined });
+        assert.deepEqual(deferred.next("ignored"), { done: true, value: undefined });
+
+        for (const begin of [false, true]) {
+            const returned = defer(generator);
+            const thrown = defer(generator);
+            const disposed = defer(generator);
+            if (begin) {
+                returned.next();
+                thrown.next();
+                disposed.next();
+            }
+            assert.deepEqual(returned.return(undefined), { done: true, value: undefined });
+            assert.deepEqual(returned.next(), { done: true, value: undefined });
+            const error = new Error("failed");
+            assert.throws(() => thrown.throw(error), actual => actual === error);
+            assert.deepEqual(thrown.next(), { done: true, value: undefined });
+            assert.ok(globalThis.Symbol.dispose in disposed);
+            const dispose = disposed[globalThis.Symbol.dispose];
+            assert.ok(typeof dispose === "function");
+            dispose.call(disposed);
+            assert.deepEqual(disposed.next(), { done: true, value: undefined });
+        }
+        assert.equal(started, false);
+    });
+
+    test("retains deferred branding after completion", () => {
+        let completed = false;
+        function* child(): Generator<APIRequest, string, string> {
+            const result = yield { method: "request", params: null } as unknown as APIRequest;
+            completed = true;
+            return result;
+        }
+        const deferred = defer(child());
+        const results: [] = executeRequestGenerators([deferred] as const, requests => requests.map(request => ({ result: request.method })));
+        assert.deepEqual(results, []);
+        assert.equal(completed, true);
+        const noRequests = () => assert.fail("Unexpected request round");
+        assert.deepEqual(executeRequestGenerators([deferred], noRequests), []);
+        assert.throws(() => executeRequestGenerators([deferred, deferred], noRequests), /same generator instance more than once/);
+    });
+
     test("joins nested, empty, and synchronously completed groups in result order", () => {
         function* completed(value: string) {
             return value;
@@ -501,6 +584,92 @@ describe("API - generator batching", () => {
         assert.deepEqual(batches, Array.from({ length: 3 }, () => ["first", "second", "sibling"]));
     });
 
+    for (const failBackground of [false, true]) {
+        test(`preserves root all ordering with ${failBackground ? "failing" : "successful"} deferred work`, () => {
+            for (const depth of [1, 4]) {
+                const events: string[] = [];
+                const batches: string[][] = [];
+                function* request(method: string): Generator<APIRequest, string, string> {
+                    const result = yield { method, params: null } as unknown as APIRequest;
+                    events.push(method);
+                    return result;
+                }
+                function* foreground() {
+                    yield* defer(request("background"));
+                    return yield* request("foreground");
+                }
+                function* sibling() {
+                    try {
+                        return yield* request("sibling");
+                    }
+                    finally {
+                        events.push("sibling cleanup");
+                    }
+                }
+                let joined: APIRequestGenerator = all(foreground(), sibling());
+                let expected: unknown = ["foreground", "sibling"];
+                for (let level = 1; level < depth; level++) {
+                    joined = all(joined);
+                    expected = [expected];
+                }
+                const run = () =>
+                    executeRequestGenerators([joined], requests => {
+                        batches.push(requests.map(request => request.method));
+                        return requests.map(request =>
+                            failBackground && request.method as string === "background"
+                                ? { result: undefined, error: "background failed" }
+                                : { result: request.method }
+                        );
+                    });
+                if (failBackground) assert.throws(run, /background failed/);
+                else assert.deepEqual(run(), [expected]);
+                assert.deepEqual(batches, [["foreground", "sibling", "background"]]);
+                assert.deepEqual(
+                    events,
+                    failBackground
+                        ? ["foreground", "sibling", "sibling cleanup"]
+                        : ["foreground", "sibling", "sibling cleanup", "background"],
+                );
+            }
+        });
+    }
+
+    test("preserves singleton join continuations through requests, errors, and deferred work", () => {
+        const events: string[] = [];
+        function* request(method: string): Generator<APIRequest, string, string> {
+            return yield { method, params: null } as unknown as APIRequest;
+        }
+        function* recovering() {
+            try {
+                yield* all(all(request("bad")));
+                assert.fail("Expected the request to fail");
+            }
+            catch (error) {
+                assert.equal((error as Error).message, "failed");
+                return yield* all(request("recovered"), all(request("sibling")));
+            }
+        }
+        function* background() {
+            yield* request("background");
+            events.push("background finished");
+        }
+        function* foreground() {
+            const empty: [] = yield* all(defer(background()));
+            assert.deepEqual(empty, []);
+            const result = yield* all(all(recovering()));
+            events.push("foreground finished");
+            return result;
+        }
+        const batches: string[][] = [];
+        const results = executeRequestGenerators([foreground()], requests => {
+            batches.push(requests.map(request => request.method));
+            return requests.map(request => request.method as string === "bad" ? { result: undefined, error: "failed" } : { result: request.method });
+        });
+        assert.deepEqual(results, [[[["recovered", ["sibling"]]]]]);
+        assert.deepEqual(batches, [["bad", "background"], ["recovered", "sibling"]]);
+        assert.deepEqual(events, ["background finished", "foreground finished"]);
+    });
+
     test("finishes joined foreground cleanup before deferred request errors", () => {
         const events: string[] = [];
         function* request(method: string): Generator<APIRequest, void, unknown> {
@@ -521,6 +690,19 @@ describe("API - generator batching", () => {
             /background failed/,
         );
         assert.deepEqual(events, ["foreground finished", "foreground cleanup"]);
+    });
+
+    test("completes root all helpers before detached work finishes", () => {
+        let joined: AllAPIRequestGenerator<[string]>;
+        function* foreground(): Generator<APIRequest, string, string> {
+            return yield { method: "foreground", params: null } as unknown as APIRequest;
+        }
+        function* background(): Generator<APIRequest, void, unknown> {
+            yield { method: "background", params: null } as unknown as APIRequest;
+            assert.deepEqual(joined.next(["unexpected"]), { done: true, value: undefined });
+        }
+        joined = all(foreground(), defer(background()));
+        assert.deepEqual(executeRequestGenerators([joined], requests => requests.map(request => ({ result: request.method }))), [["foreground"]]);
     });
 
     test("throws nested all failures into the waiting parent", () => {
@@ -635,6 +817,25 @@ describe("API - generator batching", () => {
             );
             assert.equal(requestsExecuted, 1);
         }
+    });
+
+    test("tracks all identity independently across executors", () => {
+        const joined = all();
+        const noRequests = () => assert.fail("Unexpected request round");
+        function* parent() {
+            assert.deepEqual(yield* all(joined), [[]]);
+            assert.deepEqual(executeRequestGenerators([joined], noRequests), [undefined]);
+            try {
+                yield* all(joined);
+                assert.fail("Expected duplicate generator rejection");
+            }
+            catch (error) {
+                assert.match((error as Error).message, /same generator instance more than once/);
+            }
+        }
+        executeRequestGenerators([parent()], noRequests);
+        assert.deepEqual(executeRequestGenerators([joined], noRequests), [undefined]);
+        assert.throws(() => executeRequestGenerators([joined, joined], noRequests), /same generator instance more than once/);
     });
 
     test("deduplicates initialization across nested joins", () => {

--- a/packages/typescript/test/sync/api-generators.test.ts
+++ b/packages/typescript/test/sync/api-generators.test.ts
@@ -26,9 +26,12 @@ import type {
 } from "@typescript/typescript/unstable/proto";
 import {
     all,
+    type AllAPIRequestGenerator,
+    type AnyAPIRequestGenerator,
     type API,
     type ConditionalType,
     defer,
+    type DeferredAPIRequestGenerator,
     type IndexedAccessType,
     type IndexInfo,
     type InterfaceType,
@@ -54,8 +57,13 @@ import assert from "node:assert";
 import {
     describe,
     test,
+    type TestContext,
 } from "node:test";
-import { executeRequestGenerators } from "../../src/api/sync/generatorSupport.ts";
+import {
+    type APIRequestGenerator,
+    executeRequestGenerators,
+} from "../../src/api/sync/generatorSupport.ts";
+import { runBenchmarks } from "../generators/api.bench.ts";
 import { spawnAPI } from "./api.testUtils.ts";
 
 const parityFiles = {
@@ -365,22 +373,17 @@ function runParityBatch(api: API, cases: readonly ParityCase[]): void {
     }
 }
 
-function* observeRequestBatches<Result>(
-    requestGenerator: Generator<any, Result, any>,
+function observeRequestBatches(
+    api: API,
     requestBatches: string[][],
-): Generator<any, Result, any> {
-    let state = requestGenerator.next();
-    while (!state.done) {
-        const request = state.value;
-        if (!Array.isArray(request) && "deferred" in request) {
-            state = requestGenerator.next(yield request);
-            continue;
-        }
-        const requests = Array.isArray(request) ? request : [request as APIRequest];
-        requestBatches.push(requests.map(current => current.method));
-        state = requestGenerator.next(yield request);
-    }
-    return state.value;
+    context: TestContext,
+): void {
+    const client = api["client"];
+    const batchRequests = client.batchRequests.bind(client);
+    context.mock.method(client, "batchRequests", (requests: readonly APIRequest[]) => {
+        requestBatches.push(requests.map(request => request.method));
+        return batchRequests(requests);
+    });
 }
 
 function assertPublicGeneratorCoverage(owners: readonly { readonly name: string; readonly value: object; readonly own?: boolean; }[]): void {
@@ -401,9 +404,256 @@ function assertPublicGeneratorCoverage(owners: readonly { readonly name: string;
 }
 
 describe("API - generator batching", () => {
-    test("composes request generators with all", () => {
+    test("all and defer yield discriminated host messages without starting children", () => {
+        let started = false;
+        function* child() {
+            started = true;
+            return "child";
+        }
+        const joined = child();
+        const deferred = child();
+        assert.deepEqual(all(joined).next(), { done: false, value: { method: "__all", generators: [joined] } });
+        assert.deepEqual(defer(deferred).next(), { done: false, value: { method: "__defer", deferred } });
+        const generators: APIRequestGenerator[] = [all(joined), defer(deferred)];
+        for (const generator of generators) {
+            const state = generator.next();
+            if (state.done || !("method" in state.value)) assert.fail("Expected a host message");
+            switch (state.value.method) {
+                case "__all":
+                    assert.deepEqual(state.value.generators, [joined]);
+                    break;
+                case "__defer":
+                    assert.strictEqual(state.value.deferred, deferred);
+                    break;
+                default: {
+                    const request: APIRequest = state.value;
+                    assert.fail(`Unexpected API request: ${request.method}`);
+                }
+            }
+        }
+        assert.equal(started, false);
+    });
+
+    test("joins nested, empty, and synchronously completed groups in result order", () => {
+        function* completed(value: string) {
+            return value;
+        }
+        function* request(value: string, rounds: number): Generator<APIRequest, string, string> {
+            for (let round = 0; round < rounds; round++) {
+                yield { method: value, params: null } as unknown as APIRequest;
+            }
+            return value;
+        }
+        const batches: string[][] = [];
+        const results = executeRequestGenerators([
+            all(request("slow", 2), all(), completed("sync"), all(request("fast", 1), defer(request("background", 3)))),
+        ], requests => {
+            batches.push(requests.map(request => request.method));
+            return requests.map(request => ({ result: request.method }));
+        });
+        assert.deepEqual(results, [["slow", [], "sync", ["fast"]]]);
+        assert.equal(batches.length, 3);
+        assert.deepEqual(batches.map(batch => [...batch].sort()), [["background", "fast", "slow"], ["background", "slow"], ["background"]]);
+    });
+
+    test("preserves tuple results through all and any generator types", () => {
+        function* numberResult() {
+            return 42;
+        }
+        function* stringResult() {
+            return "result";
+        }
+        const joined: AllAPIRequestGenerator<[number, [string]]> = all(numberResult(), defer(stringResult()), all(stringResult()));
+        const generator: AnyAPIRequestGenerator<[number, [string]]> = joined;
+        const results: [[number, [string]]] = executeRequestGenerators([generator] as const, () => assert.fail("Unexpected request round"));
+        assert.deepEqual(results, [[42, ["result"]]]);
+
+        const mixed: (APIRequestGenerator<number> | AllAPIRequestGenerator<[string]> | DeferredAPIRequestGenerator)[] = [
+            numberResult(),
+            all(stringResult()),
+            defer(stringResult()),
+        ];
+        const arrayResults: (number | [string])[] = executeRequestGenerators(mixed, () => assert.fail("Unexpected request round"));
+        assert.deepEqual(arrayResults, [42, ["result"]]);
+
+        const variadic: readonly [APIRequestGenerator<number>, ...AllAPIRequestGenerator<[string]>[]] = [numberResult(), all(stringResult()), all(stringResult())];
+        const variadicResults: (number | [string])[] = executeRequestGenerators(variadic, () => assert.fail("Unexpected request round"));
+        assert.deepEqual(variadicResults, [42, ["result"], ["result"]]);
+    });
+
+    test("preserves sibling order across repeated nested joins", () => {
+        function* request(method: string): Generator<APIRequest, string, string> {
+            return yield { method, params: null } as unknown as APIRequest;
+        }
+        function* foreground() {
+            for (let round = 0; round < 3; round++) {
+                yield* all(all(request("first")), request("second"));
+            }
+        }
+        function* sibling() {
+            for (let round = 0; round < 3; round++) yield* request("sibling");
+        }
+        const batches: string[][] = [];
+        executeRequestGenerators([foreground(), sibling()], requests => {
+            batches.push(requests.map(request => request.method));
+            return requests.map(request => ({ result: request.method }));
+        });
+        assert.deepEqual(batches, Array.from({ length: 3 }, () => ["first", "second", "sibling"]));
+    });
+
+    test("finishes joined foreground cleanup before deferred request errors", () => {
+        const events: string[] = [];
+        function* request(method: string): Generator<APIRequest, void, unknown> {
+            yield { method, params: null } as unknown as APIRequest;
+        }
+        function* foreground() {
+            try {
+                yield* defer(request("background"));
+                yield* all(request("foreground"));
+                events.push("foreground finished");
+            }
+            finally {
+                events.push("foreground cleanup");
+            }
+        }
+        assert.throws(
+            () => executeRequestGenerators([foreground()], requests => requests.map(request => request.method as string === "background" ? { result: undefined, error: "background failed" } : { result: true })),
+            /background failed/,
+        );
+        assert.deepEqual(events, ["foreground finished", "foreground cleanup"]);
+    });
+
+    test("throws nested all failures into the waiting parent", () => {
+        const events: string[] = [];
+        function* failing(): Generator<APIRequest, void, unknown> {
+            yield { method: "bad", params: null } as unknown as APIRequest;
+        }
+        function* parent() {
+            try {
+                yield* all(all(failing()));
+            }
+            catch (error) {
+                events.push((error as Error).message);
+                return "recovered";
+            }
+            return "unexpected";
+        }
+        assert.deepEqual(executeRequestGenerators([parent()], requests => requests.map(() => ({ result: undefined, error: "failed" }))), ["recovered"]);
+        assert.deepEqual(events, ["failed"]);
+    });
+
+    test("cancels failed join siblings but finishes detached and unrelated work", () => {
+        const events: string[] = [];
+        function* request(method: string): Generator<APIRequest, string, string> {
+            const result = yield { method, params: null } as unknown as APIRequest;
+            events.push(method);
+            return result;
+        }
+        function* parent() {
+            try {
+                yield* all(defer(request("background")), request("bad"), all(request("cancelled")));
+            }
+            catch {
+                return yield* request("recovery");
+            }
+        }
+        assert.deepEqual(
+            executeRequestGenerators([parent(), request("unrelated")], requests => requests.map(request => request.method as string === "bad" ? { result: undefined, error: "failed" } : { result: request.method })),
+            ["recovery", "unrelated"],
+        );
+        assert.deepEqual(events, ["background", "unrelated", "recovery"]);
+    });
+
+    test("catches synchronous join failures including undefined", () => {
+        function* failing(): APIRequestGenerator {
+            throw undefined;
+        }
+        function* parent() {
+            try {
+                yield* all(all(failing()));
+            }
+            catch (error) {
+                assert.strictEqual(error, undefined);
+                return "recovered";
+            }
+            return "unexpected";
+        }
+        assert.deepEqual(executeRequestGenerators([parent()], () => assert.fail("Unexpected request round")), ["recovered"]);
+    });
+
+    test("does not route synchronous deferred failures through a waiting join", () => {
+        const events: string[] = [];
+        function* failing(): APIRequestGenerator {
+            throw new Error("deferred failure");
+        }
+        function* parent() {
+            try {
+                yield* all(defer(failing()));
+            }
+            catch {
+                events.push("caught by parent");
+            }
+        }
+        assert.throws(
+            () => executeRequestGenerators([parent()], () => assert.fail("Unexpected request round")),
+            /deferred failure/,
+        );
+        assert.deepEqual(events, []);
+    });
+
+    test("rejects generator reuse across joins and deferred work", () => {
+        function* request(): Generator<APIRequest, string, string> {
+            return yield { method: "request", params: null } as unknown as APIRequest;
+        }
+        for (const wrap of [all, defer]) {
+            const generator = request();
+            assert.throws(
+                () => executeRequestGenerators([all(generator), wrap(generator)], requests => requests.map(request => ({ result: request.method }))),
+                /same generator instance more than once/,
+            );
+        }
+    });
+
+    test("rejects completed generator reuse after a join finishes", () => {
+        function* request(): Generator<APIRequest, string, string> {
+            return yield { method: "request", params: null } as unknown as APIRequest;
+        }
+        for (const wrap of [all, defer]) {
+            const generator = request();
+            function* parent() {
+                yield* all(generator);
+                yield* wrap(generator);
+            }
+            let requestsExecuted = 0;
+            assert.throws(
+                () =>
+                    executeRequestGenerators([parent()], requests => {
+                        requestsExecuted += requests.length;
+                        return requests.map(request => ({ result: request.method }));
+                    }),
+                /same generator instance more than once/,
+            );
+            assert.equal(requestsExecuted, 1);
+        }
+    });
+
+    test("deduplicates initialization across nested joins", () => {
+        function* request(method: string): Generator<APIRequest, string, string> {
+            return yield { method, params: null } as unknown as APIRequest;
+        }
+        const batches: string[][] = [];
+        const results = executeRequestGenerators([all(request("initialize"), all(request("initialize"), request("other"))), request("other")], requests => {
+            batches.push(requests.map(request => request.method));
+            return requests.map((request, index) => ({ result: `${request.method}:${index}` }));
+        });
+        assert.deepEqual(batches, [["initialize", "other", "other"]]);
+        assert.deepEqual(results, [["initialize:0", ["initialize:0", "other:1"]], "other:2"]);
+    });
+
+    test("composes request generators with all", context => {
         const api = spawnAPI(parityFiles);
         const requestBatches: string[][] = [];
+        observeRequestBatches(api, requestBatches, context);
         function* getStrictOption() {
             const commandLine = yield* api.parseCommandLine.gen(["--strict"]);
             const config = yield* api.readConfigFile.gen("/tsconfig.json");
@@ -418,7 +668,7 @@ describe("API - generator batching", () => {
         }
 
         try {
-            const [[config, outputText]] = api.batch(observeRequestBatches(all(getStrictOption(), getTranspiledText()), requestBatches));
+            const [[config, outputText]] = api.batch(all(getStrictOption(), getTranspiledText()));
             assert.equal(config.strict, true);
             assert.deepEqual([...config.fileNames].sort(), ["/src/bind.ts", "/src/index.ts", "/src/models.ts", "/src/suggestions.ts", "/src/syntax.ts"]);
             assert.match(outputText, /const value = ['"]ok['"]/);
@@ -536,9 +786,10 @@ describe("API - generator batching", () => {
         }
     });
 
-    test("executes deferred generators without returning their results", () => {
+    test("executes deferred generators without returning their results", context => {
         const api = spawnAPI();
         const requestBatches: string[][] = [];
+        observeRequestBatches(api, requestBatches, context);
         function* runConcurrentRequests() {
             yield* defer(api.parseCommandLine.gen(["--strict"]));
             yield* defer(api.readConfigFile.gen("/tsconfig.json"));
@@ -549,12 +800,12 @@ describe("API - generator batching", () => {
         }
 
         try {
-            const [[[commandLine, config]]] = api.batch(observeRequestBatches(all(runConcurrentRequests()), requestBatches));
+            const [[[commandLine, config]]] = api.batch(all(runConcurrentRequests()));
             assert.equal(commandLine.options.target, 99);
             assert.deepEqual(config.config, {});
             assert.deepEqual(requestBatches, [
                 ["initialize"],
-                ["parseCommandLine", "readConfigFile"],
+                ["parseCommandLine", "readConfigFile", "parseCommandLine", "readConfigFile"],
             ]);
 
             const [onlyConfig] = api.batch(
@@ -1261,4 +1512,8 @@ describe("API - generator batching", () => {
             api.close();
         }
     });
+});
+
+test("Generator benchmarks", () => {
+    runBenchmarks({ singleIteration: true });
 });


### PR DESCRIPTION
Fixes an issue @dragomirtitian reported where on large batches he was seeing increased performance overhead of nested `all` calls in the generator executor. Perf tests proved it out that every layer of `all` nesting with `all` as a near-full executor in its own right was something like 30% reduced performance over inlining into the parent, stacking with increased depth. Presumably the extra generator states were difficult for the runtime to manage effectively or inline compared to managing it ourselves.

This change is basically deferring the `all` group handling to the host executor, which fixes that performance issue and makes the performance stable with highly nested `all` calls.