### PR TITLE
Fix getChildren() dropping opening '<' token when immediately followed by '<' (#64168)

### DIFF
--- a/packages/typescript/src/ast/astnav.ts
+++ b/packages/typescript/src/ast/astnav.ts
@@ -709,8 +709,12 @@ function addSyntheticNodes(children: Node[], pos: number, end: number, parent: N
     scanner.resetTokenState(pos);
     scanner.scan();
     while (pos < end) {
-        const token = scanner.getToken();
-        const tokenEnd = scanner.getTokenEnd();
+        let token = scanner.getToken();
+        let tokenEnd = scanner.getTokenEnd();
+        if (tokenEnd > end && token === SyntaxKind.LessThanLessThanToken) {
+            token = scanner.reScanLessThanToken();
+            tokenEnd = scanner.getTokenEnd();
+        }
         if (tokenEnd <= end) {
             // An identifier should never appear as trivia between AST children; skip defensively.
             if (token !== SyntaxKind.Identifier) {

--- a/packages/typescript/test/sync/ast.test.ts
+++ b/packages/typescript/test/sync/ast.test.ts
@@ -1319,6 +1319,7 @@ describe("RemoteNode + child/token getters", () => {
         { name: "JS with reparsed types on exported and nested functions", source: "/** @param {number} a */\nexport function outer(a) {\n    /** @returns {number} */\n    function inner() { return a; }\n    return inner();\n}\n", js: true },
         { name: "JSX component with reparsed @param props type", source: '/**\n * @param {{ name: string }} props\n * @returns {object}\n */\nexport function Greeting(props) {\n    return <div className="greeting">hello {props.name}<br /></div>;\n}\n', js: true, jsx: true },
         { name: "JSX with @type cast and @typedef around elements", source: '/**\n * @typedef {Object} Item\n * @property {string} label\n */\nconst item = /** @type {Item} */ ({ label: "x" });\nconst el = <span title={item.label}>{item.label}</span>;\n', js: true, jsx: true },
+        { name: "type argument lists with contiguous opening angles", source: "type Bar = ReturnType<<T>(x: T) => number>; const foo = bar<<T>(x: T) => number>();" },
     ];
 
     for (const entry of corpus) {


### PR DESCRIPTION
Fixes #64168

### Summary
* **What changed**: In `addSyntheticNodes` (`packages/typescript/src/ast/astnav.ts`), when a scanned token exceeds the gap end (`tokenEnd > end`) and is a `LessThanLessThanToken` (`<<`), `scanner.reScanLessThanToken()` is invoked to split `<<` into `<` (`LessThanToken`).
* **Why it changed**: Previously, when `getChildren()` was called on type argument lists immediately following another `<` (such as `ReturnType<<T>(x: T) => number>`), `addSyntheticNodes` scanned `<<` at `pos = 21` yielding `tokenEnd = 23`. Because `23 <= 22` evaluated to `false`, the `<` token was silently dropped, creating a gap between AST children.

### Tests
* **Executed**:
  - `./bin/tsc -b packages/typescript`
  - `go test ./internal/parser ./internal/ls/...`
  - AST invariant test corpus entry with `type Bar = ReturnType<<T>(x: T) => number>;`
* **Results**: Build succeeded cleanly (`exit code 0`) and all tests passed (`exit code 0`).