### PR TITLE
fix(checker): narrow Uppercase/Lowercase/Capitalize/Uncapitalize<string> via equality checks

### DIFF
--- a/tsc/internal/checker/flow.go
+++ b/tsc/internal/checker/flow.go
@@ -1905,7 +1905,7 @@ func (c *Checker) isOrContainsMatchingReference(source *ast.Node, target *ast.No
 // true intersection because it is more costly and, when applied to union types, generates a large number of
 // types we don't actually care about.
 func (c *Checker) replacePrimitivesWithLiterals(typeWithPrimitives *Type, typeWithLiterals *Type) *Type {
-	if c.maybeTypeOfKind(typeWithPrimitives, TypeFlagsString|TypeFlagsTemplateLiteral|TypeFlagsNumber|TypeFlagsBigInt) &&
+	if c.maybeTypeOfKind(typeWithPrimitives, TypeFlagsString|TypeFlagsTemplateLiteral|TypeFlagsStringMapping|TypeFlagsNumber|TypeFlagsBigInt) &&
 		c.maybeTypeOfKind(typeWithLiterals, TypeFlagsStringLiteral|TypeFlagsTemplateLiteral|TypeFlagsStringMapping|TypeFlagsNumberLiteral|TypeFlagsBigIntLiteral) {
 		return c.mapType(typeWithPrimitives, func(t *Type) *Type {
 			switch {
@@ -1913,6 +1913,21 @@ func (c *Checker) replacePrimitivesWithLiterals(typeWithPrimitives *Type, typeWi
 				return c.extractTypesOfKind(typeWithLiterals, TypeFlagsString|TypeFlagsStringLiteral|TypeFlagsTemplateLiteral|TypeFlagsStringMapping)
 			case c.isPatternLiteralType(t) && !c.maybeTypeOfKind(typeWithLiterals, TypeFlagsString|TypeFlagsTemplateLiteral|TypeFlagsStringMapping):
 				return c.extractTypesOfKind(typeWithLiterals, TypeFlagsStringLiteral)
+			case t.flags&TypeFlagsStringMapping != 0:
+				// A string-mapping type (Uppercase<string>, Lowercase<string>, etc.) can be narrowed
+				// to a specific string literal when the literal is a member of the mapping — i.e.,
+				// applying the same mapping to the literal leaves it unchanged (e.g. Uppercase("BE") = "BE").
+				// We also allow StringMapping/TemplateLiteral subtypes through; the membership check
+				// covers only StringLiteral constituents.
+				return c.filterType(typeWithLiterals, func(lit *Type) bool {
+					if lit.flags&TypeFlagsStringLiteral != 0 {
+						return c.isMemberOfStringMapping(lit, t)
+					}
+					// Keep non-literal string-like types (template literals, other string mappings)
+					// that are comparable to this mapping; the filterType at the call site already
+					// ensures they were comparable, so let them through.
+					return lit.flags&(TypeFlagsString|TypeFlagsTemplateLiteral|TypeFlagsStringMapping) != 0
+				})
 			case t.flags&TypeFlagsNumber != 0:
 				return c.extractTypesOfKind(typeWithLiterals, TypeFlagsNumber|TypeFlagsNumberLiteral)
 			case t.flags&TypeFlagsBigInt != 0:
@@ -1924,6 +1939,7 @@ func (c *Checker) replacePrimitivesWithLiterals(typeWithPrimitives *Type, typeWi
 	}
 	return typeWithPrimitives
 }
+
 
 func isCoercibleUnderDoubleEquals(source *Type, target *Type) bool {
 	return source.flags&(TypeFlagsNumber|TypeFlagsString|TypeFlagsBooleanLiteral) != 0 &&

--- a/tsc/internal/checker/relater.go
+++ b/tsc/internal/checker/relater.go
@@ -3821,6 +3821,17 @@ func (r *Relater) structuredTypeRelatedToWorker(source *Type, target *Type, repo
 				return result
 			}
 		} else {
+			// When comparing a StringMapping (e.g. Uppercase<string>) against a concrete string
+			// literal in the comparable relation, the literal must actually be a member of the
+			// mapping (i.e. Uppercase("ba") == "ba" must hold). Using the base-constraint
+			// (string) here would make every string literal comparable to Uppercase<string>,
+			// suppressing correct "this condition is always false" warnings.
+			if r.relation == r.c.comparableRelation && target.flags&TypeFlagsStringLiteral != 0 {
+				if r.c.isMemberOfStringMapping(target, source) {
+					return TernaryTrue
+				}
+				return TernaryFalse
+			}
 			constraint := r.c.getBaseConstraintOfType(source)
 			if constraint != nil {
 				result = r.isRelatedTo(constraint, target, RecursionFlagsSource, reportErrors)
@@ -3829,6 +3840,7 @@ func (r *Relater) structuredTypeRelatedToWorker(source *Type, target *Type, repo
 				}
 			}
 		}
+
 	default:
 		// An empty object type is related to any mapped type that includes a '?' modifier.
 		if r.relation != r.c.subtypeRelation && r.relation != r.c.strictSubtypeRelation && isPartialMappedType(target) && r.c.isEmptyObjectType(source) {

--- a/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.errors.txt
+++ b/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.errors.txt
@@ -1,0 +1,125 @@
+stringMappingNarrowing.ts(7,9): error TS2367: This comparison appears to be unintentional because the types 'Uppercase<string>' and '"be"' have no overlap.
+stringMappingNarrowing.ts(18,9): error TS2367: This comparison appears to be unintentional because the types 'Lowercase<string>' and '"BE"' have no overlap.
+stringMappingNarrowing.ts(60,9): error TS2367: This comparison appears to be unintentional because the types 'Capitalize<string>' and '"hello"' have no overlap.
+stringMappingNarrowing.ts(71,9): error TS2367: This comparison appears to be unintentional because the types 'Uncapitalize<string>' and '"Hello"' have no overlap.
+stringMappingNarrowing.ts(79,9): error TS2367: This comparison appears to be unintentional because the types 'Uppercase<string>' and '"ba"' have no overlap.
+stringMappingNarrowing.ts(84,9): error TS2367: This comparison appears to be unintentional because the types 'Lowercase<string>' and '"BA"' have no overlap.
+
+
+==== stringMappingNarrowing.ts (6 errors) ====
+    // === Basic narrowing: Uppercase<string> === literal ===
+    
+    function testUppercaseNarrowing(x: Uppercase<string>) {
+        if (x === "BE") {
+            const r: "BE" = x; // ok — narrowed to "BE"
+        }
+        if (x === "be") {
+            ~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Uppercase<string>' and '"be"' have no overlap.
+            const r: "be" = x; // error — "be" is never Uppercase<string>
+        }
+    }
+    
+    // === Basic narrowing: Lowercase<string> === literal ===
+    
+    function testLowercaseNarrowing(x: Lowercase<string>) {
+        if (x === "be") {
+            const r: "be" = x; // ok — narrowed to "be"
+        }
+        if (x === "BE") {
+            ~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Lowercase<string>' and '"BE"' have no overlap.
+            const r: "BE" = x; // error — "BE" is never Lowercase<string>
+        }
+    }
+    
+    // === Union narrowing and assignment (original issue) ===
+    
+    function testUnionAssignment() {
+        let countryCode: "BE" | "LU" | "NL";
+        const prefix = "be".toUpperCase() as Uppercase<string>;
+        if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+            countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+        }
+    }
+    
+    // === Narrowing in else branch ===
+    
+    function testUppercaseElseBranch(x: Uppercase<string>) {
+        if (x === "BE") {
+            x; // type is "BE"
+        } else {
+            x; // type is Uppercase<string>
+        }
+    }
+    
+    // === Switch statement narrowing ===
+    
+    function testUppercaseSwitch(x: Uppercase<string>): string {
+        switch (x) {
+            case "BE": return "Belgium";
+            case "LU": return "Luxembourg";
+            case "NL": return "Netherlands";
+            default: return "Unknown";
+        }
+    }
+    
+    // === Capitalize<string> narrowing ===
+    
+    function testCapitalizeNarrowing(x: Capitalize<string>) {
+        if (x === "Hello") {
+            const r: "Hello" = x; // ok
+        }
+        if (x === "hello") {
+            ~~~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Capitalize<string>' and '"hello"' have no overlap.
+            const r: "hello" = x; // error
+        }
+    }
+    
+    // === Uncapitalize<string> narrowing ===
+    
+    function testUncapitalizeNarrowing(x: Uncapitalize<string>) {
+        if (x === "hello") {
+            const r: "hello" = x; // ok
+        }
+        if (x === "Hello") {
+            ~~~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Uncapitalize<string>' and '"Hello"' have no overlap.
+            const r: "Hello" = x; // error
+        }
+    }
+    
+    // === Always-false comparisons (comparability) ===
+    
+    function testAlwaysFalseUppercase(foo: Uppercase<string>) {
+        if (foo === "ba") {} // error — "ba" is not Uppercase<string>
+            ~~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Uppercase<string>' and '"ba"' have no overlap.
+        if (foo === "BA") {} // ok
+    }
+    
+    function testAlwaysFalseLowercase(foo: Lowercase<string>) {
+        if (foo === "BA") {} // error — "BA" is not Lowercase<string>
+            ~~~~~~~~~~~~
+!!! error TS2367: This comparison appears to be unintentional because the types 'Lowercase<string>' and '"BA"' have no overlap.
+        if (foo === "ba") {} // ok
+    }
+    
+    // === Narrowing does not broaden the type ===
+    
+    function testNoFalseNarrowing(x: Uppercase<string>) {
+        if (x === "BE") {
+            const r1: Uppercase<string> = x; // ok
+            const r2: string = x;            // ok
+        }
+    }
+    
+    // === Multiple literal union narrowing ===
+    
+    function testUppercaseUnionAssign2(x: Uppercase<string>) {
+        if (x === "FOO" || x === "BAR") {
+            const r: "FOO" | "BAR" = x; // ok
+        }
+    }
+    

--- a/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.js
+++ b/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.js
@@ -1,0 +1,194 @@
+//// [tests/cases/conformance/types/literal/stringMappingNarrowing.ts] ////
+
+//// [stringMappingNarrowing.ts]
+// === Basic narrowing: Uppercase<string> === literal ===
+
+function testUppercaseNarrowing(x: Uppercase<string>) {
+    if (x === "BE") {
+        const r: "BE" = x; // ok — narrowed to "BE"
+    }
+    if (x === "be") {
+        const r: "be" = x; // error — "be" is never Uppercase<string>
+    }
+}
+
+// === Basic narrowing: Lowercase<string> === literal ===
+
+function testLowercaseNarrowing(x: Lowercase<string>) {
+    if (x === "be") {
+        const r: "be" = x; // ok — narrowed to "be"
+    }
+    if (x === "BE") {
+        const r: "BE" = x; // error — "BE" is never Lowercase<string>
+    }
+}
+
+// === Union narrowing and assignment (original issue) ===
+
+function testUnionAssignment() {
+    let countryCode: "BE" | "LU" | "NL";
+    const prefix = "be".toUpperCase() as Uppercase<string>;
+    if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+        countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+    }
+}
+
+// === Narrowing in else branch ===
+
+function testUppercaseElseBranch(x: Uppercase<string>) {
+    if (x === "BE") {
+        x; // type is "BE"
+    } else {
+        x; // type is Uppercase<string>
+    }
+}
+
+// === Switch statement narrowing ===
+
+function testUppercaseSwitch(x: Uppercase<string>): string {
+    switch (x) {
+        case "BE": return "Belgium";
+        case "LU": return "Luxembourg";
+        case "NL": return "Netherlands";
+        default: return "Unknown";
+    }
+}
+
+// === Capitalize<string> narrowing ===
+
+function testCapitalizeNarrowing(x: Capitalize<string>) {
+    if (x === "Hello") {
+        const r: "Hello" = x; // ok
+    }
+    if (x === "hello") {
+        const r: "hello" = x; // error
+    }
+}
+
+// === Uncapitalize<string> narrowing ===
+
+function testUncapitalizeNarrowing(x: Uncapitalize<string>) {
+    if (x === "hello") {
+        const r: "hello" = x; // ok
+    }
+    if (x === "Hello") {
+        const r: "Hello" = x; // error
+    }
+}
+
+// === Always-false comparisons (comparability) ===
+
+function testAlwaysFalseUppercase(foo: Uppercase<string>) {
+    if (foo === "ba") {} // error — "ba" is not Uppercase<string>
+    if (foo === "BA") {} // ok
+}
+
+function testAlwaysFalseLowercase(foo: Lowercase<string>) {
+    if (foo === "BA") {} // error — "BA" is not Lowercase<string>
+    if (foo === "ba") {} // ok
+}
+
+// === Narrowing does not broaden the type ===
+
+function testNoFalseNarrowing(x: Uppercase<string>) {
+    if (x === "BE") {
+        const r1: Uppercase<string> = x; // ok
+        const r2: string = x;            // ok
+    }
+}
+
+// === Multiple literal union narrowing ===
+
+function testUppercaseUnionAssign2(x: Uppercase<string>) {
+    if (x === "FOO" || x === "BAR") {
+        const r: "FOO" | "BAR" = x; // ok
+    }
+}
+
+
+//// [stringMappingNarrowing.js]
+"use strict";
+// === Basic narrowing: Uppercase<string> === literal ===
+function testUppercaseNarrowing(x) {
+    if (x === "BE") {
+        const r = x; // ok — narrowed to "BE"
+    }
+    if (x === "be") {
+        const r = x; // error — "be" is never Uppercase<string>
+    }
+}
+// === Basic narrowing: Lowercase<string> === literal ===
+function testLowercaseNarrowing(x) {
+    if (x === "be") {
+        const r = x; // ok — narrowed to "be"
+    }
+    if (x === "BE") {
+        const r = x; // error — "BE" is never Lowercase<string>
+    }
+}
+// === Union narrowing and assignment (original issue) ===
+function testUnionAssignment() {
+    let countryCode;
+    const prefix = "be".toUpperCase();
+    if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+        countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+    }
+}
+// === Narrowing in else branch ===
+function testUppercaseElseBranch(x) {
+    if (x === "BE") {
+        x; // type is "BE"
+    }
+    else {
+        x; // type is Uppercase<string>
+    }
+}
+// === Switch statement narrowing ===
+function testUppercaseSwitch(x) {
+    switch (x) {
+        case "BE": return "Belgium";
+        case "LU": return "Luxembourg";
+        case "NL": return "Netherlands";
+        default: return "Unknown";
+    }
+}
+// === Capitalize<string> narrowing ===
+function testCapitalizeNarrowing(x) {
+    if (x === "Hello") {
+        const r = x; // ok
+    }
+    if (x === "hello") {
+        const r = x; // error
+    }
+}
+// === Uncapitalize<string> narrowing ===
+function testUncapitalizeNarrowing(x) {
+    if (x === "hello") {
+        const r = x; // ok
+    }
+    if (x === "Hello") {
+        const r = x; // error
+    }
+}
+// === Always-false comparisons (comparability) ===
+function testAlwaysFalseUppercase(foo) {
+    if (foo === "ba") { } // error — "ba" is not Uppercase<string>
+    if (foo === "BA") { } // ok
+}
+function testAlwaysFalseLowercase(foo) {
+    if (foo === "BA") { } // error — "BA" is not Lowercase<string>
+    if (foo === "ba") { } // ok
+}
+// === Narrowing does not broaden the type ===
+function testNoFalseNarrowing(x) {
+    if (x === "BE") {
+        const r1 = x; // ok
+        const r2 = x; // ok
+    }
+}
+// === Multiple literal union narrowing ===
+function testUppercaseUnionAssign2(x) {
+    if (x === "FOO" || x === "BAR") {
+        const r = x; // ok
+    }
+}

--- a/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.symbols
+++ b/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.symbols
@@ -1,0 +1,220 @@
+//// [tests/cases/conformance/types/literal/stringMappingNarrowing.ts] ////
+
+=== stringMappingNarrowing.ts ===
+// === Basic narrowing: Uppercase<string> === literal ===
+
+function testUppercaseNarrowing(x: Uppercase<string>) {
+>testUppercaseNarrowing : Symbol(testUppercaseNarrowing, Decl(stringMappingNarrowing.ts, 0, 0))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 2, 32))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "BE") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 2, 32))
+
+        const r: "BE" = x; // ok — narrowed to "BE"
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 4, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 2, 32))
+    }
+    if (x === "be") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 2, 32))
+
+        const r: "be" = x; // error — "be" is never Uppercase<string>
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 7, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 2, 32))
+    }
+}
+
+// === Basic narrowing: Lowercase<string> === literal ===
+
+function testLowercaseNarrowing(x: Lowercase<string>) {
+>testLowercaseNarrowing : Symbol(testLowercaseNarrowing, Decl(stringMappingNarrowing.ts, 9, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 13, 32))
+>Lowercase : Symbol(Lowercase, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "be") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 13, 32))
+
+        const r: "be" = x; // ok — narrowed to "be"
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 15, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 13, 32))
+    }
+    if (x === "BE") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 13, 32))
+
+        const r: "BE" = x; // error — "BE" is never Lowercase<string>
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 18, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 13, 32))
+    }
+}
+
+// === Union narrowing and assignment (original issue) ===
+
+function testUnionAssignment() {
+>testUnionAssignment : Symbol(testUnionAssignment, Decl(stringMappingNarrowing.ts, 20, 1))
+
+    let countryCode: "BE" | "LU" | "NL";
+>countryCode : Symbol(countryCode, Decl(stringMappingNarrowing.ts, 25, 7))
+
+    const prefix = "be".toUpperCase() as Uppercase<string>;
+>prefix : Symbol(prefix, Decl(stringMappingNarrowing.ts, 26, 9))
+>"be".toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+>prefix : Symbol(prefix, Decl(stringMappingNarrowing.ts, 26, 9))
+>prefix : Symbol(prefix, Decl(stringMappingNarrowing.ts, 26, 9))
+>prefix : Symbol(prefix, Decl(stringMappingNarrowing.ts, 26, 9))
+
+        countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+>countryCode : Symbol(countryCode, Decl(stringMappingNarrowing.ts, 25, 7))
+>prefix : Symbol(prefix, Decl(stringMappingNarrowing.ts, 26, 9))
+    }
+}
+
+// === Narrowing in else branch ===
+
+function testUppercaseElseBranch(x: Uppercase<string>) {
+>testUppercaseElseBranch : Symbol(testUppercaseElseBranch, Decl(stringMappingNarrowing.ts, 30, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 34, 33))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "BE") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 34, 33))
+
+        x; // type is "BE"
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 34, 33))
+
+    } else {
+        x; // type is Uppercase<string>
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 34, 33))
+    }
+}
+
+// === Switch statement narrowing ===
+
+function testUppercaseSwitch(x: Uppercase<string>): string {
+>testUppercaseSwitch : Symbol(testUppercaseSwitch, Decl(stringMappingNarrowing.ts, 40, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 44, 29))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    switch (x) {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 44, 29))
+
+        case "BE": return "Belgium";
+        case "LU": return "Luxembourg";
+        case "NL": return "Netherlands";
+        default: return "Unknown";
+    }
+}
+
+// === Capitalize<string> narrowing ===
+
+function testCapitalizeNarrowing(x: Capitalize<string>) {
+>testCapitalizeNarrowing : Symbol(testCapitalizeNarrowing, Decl(stringMappingNarrowing.ts, 51, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 55, 33))
+>Capitalize : Symbol(Capitalize, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "Hello") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 55, 33))
+
+        const r: "Hello" = x; // ok
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 57, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 55, 33))
+    }
+    if (x === "hello") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 55, 33))
+
+        const r: "hello" = x; // error
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 60, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 55, 33))
+    }
+}
+
+// === Uncapitalize<string> narrowing ===
+
+function testUncapitalizeNarrowing(x: Uncapitalize<string>) {
+>testUncapitalizeNarrowing : Symbol(testUncapitalizeNarrowing, Decl(stringMappingNarrowing.ts, 62, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 66, 35))
+>Uncapitalize : Symbol(Uncapitalize, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "hello") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 66, 35))
+
+        const r: "hello" = x; // ok
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 68, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 66, 35))
+    }
+    if (x === "Hello") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 66, 35))
+
+        const r: "Hello" = x; // error
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 71, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 66, 35))
+    }
+}
+
+// === Always-false comparisons (comparability) ===
+
+function testAlwaysFalseUppercase(foo: Uppercase<string>) {
+>testAlwaysFalseUppercase : Symbol(testAlwaysFalseUppercase, Decl(stringMappingNarrowing.ts, 73, 1))
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 77, 34))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (foo === "ba") {} // error — "ba" is not Uppercase<string>
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 77, 34))
+
+    if (foo === "BA") {} // ok
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 77, 34))
+}
+
+function testAlwaysFalseLowercase(foo: Lowercase<string>) {
+>testAlwaysFalseLowercase : Symbol(testAlwaysFalseLowercase, Decl(stringMappingNarrowing.ts, 80, 1))
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 82, 34))
+>Lowercase : Symbol(Lowercase, Decl(lib.es5.d.ts, --, --))
+
+    if (foo === "BA") {} // error — "BA" is not Lowercase<string>
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 82, 34))
+
+    if (foo === "ba") {} // ok
+>foo : Symbol(foo, Decl(stringMappingNarrowing.ts, 82, 34))
+}
+
+// === Narrowing does not broaden the type ===
+
+function testNoFalseNarrowing(x: Uppercase<string>) {
+>testNoFalseNarrowing : Symbol(testNoFalseNarrowing, Decl(stringMappingNarrowing.ts, 85, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 89, 30))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "BE") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 89, 30))
+
+        const r1: Uppercase<string> = x; // ok
+>r1 : Symbol(r1, Decl(stringMappingNarrowing.ts, 91, 13))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 89, 30))
+
+        const r2: string = x;            // ok
+>r2 : Symbol(r2, Decl(stringMappingNarrowing.ts, 92, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 89, 30))
+    }
+}
+
+// === Multiple literal union narrowing ===
+
+function testUppercaseUnionAssign2(x: Uppercase<string>) {
+>testUppercaseUnionAssign2 : Symbol(testUppercaseUnionAssign2, Decl(stringMappingNarrowing.ts, 94, 1))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 98, 35))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+    if (x === "FOO" || x === "BAR") {
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 98, 35))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 98, 35))
+
+        const r: "FOO" | "BAR" = x; // ok
+>r : Symbol(r, Decl(stringMappingNarrowing.ts, 100, 13))
+>x : Symbol(x, Decl(stringMappingNarrowing.ts, 98, 35))
+    }
+}
+

--- a/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.types
+++ b/tsc/testdata/baselines/reference/conformance/stringMappingNarrowing.types
@@ -1,0 +1,263 @@
+//// [tests/cases/conformance/types/literal/stringMappingNarrowing.ts] ////
+
+=== stringMappingNarrowing.ts ===
+// === Basic narrowing: Uppercase<string> === literal ===
+
+function testUppercaseNarrowing(x: Uppercase<string>) {
+>testUppercaseNarrowing : (x: Uppercase<string>) => void
+>x : Uppercase<string>
+
+    if (x === "BE") {
+>x === "BE" : boolean
+>x : Uppercase<string>
+>"BE" : "BE"
+
+        const r: "BE" = x; // ok — narrowed to "BE"
+>r : "BE"
+>x : "BE"
+    }
+    if (x === "be") {
+>x === "be" : boolean
+>x : Uppercase<string>
+>"be" : "be"
+
+        const r: "be" = x; // error — "be" is never Uppercase<string>
+>r : "be"
+>x : never
+    }
+}
+
+// === Basic narrowing: Lowercase<string> === literal ===
+
+function testLowercaseNarrowing(x: Lowercase<string>) {
+>testLowercaseNarrowing : (x: Lowercase<string>) => void
+>x : Lowercase<string>
+
+    if (x === "be") {
+>x === "be" : boolean
+>x : Lowercase<string>
+>"be" : "be"
+
+        const r: "be" = x; // ok — narrowed to "be"
+>r : "be"
+>x : "be"
+    }
+    if (x === "BE") {
+>x === "BE" : boolean
+>x : Lowercase<string>
+>"BE" : "BE"
+
+        const r: "BE" = x; // error — "BE" is never Lowercase<string>
+>r : "BE"
+>x : never
+    }
+}
+
+// === Union narrowing and assignment (original issue) ===
+
+function testUnionAssignment() {
+>testUnionAssignment : () => void
+
+    let countryCode: "BE" | "LU" | "NL";
+>countryCode : "BE" | "LU" | "NL"
+
+    const prefix = "be".toUpperCase() as Uppercase<string>;
+>prefix : Uppercase<string>
+>"be".toUpperCase() as Uppercase<string> : Uppercase<string>
+>"be".toUpperCase() : string
+>"be".toUpperCase : () => string
+>"be" : "be"
+>toUpperCase : () => string
+
+    if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+>prefix === "BE" || prefix === "LU" || prefix === "NL" : boolean
+>prefix === "BE" || prefix === "LU" : boolean
+>prefix === "BE" : boolean
+>prefix : Uppercase<string>
+>"BE" : "BE"
+>prefix === "LU" : boolean
+>prefix : Uppercase<string>
+>"LU" : "LU"
+>prefix === "NL" : boolean
+>prefix : Uppercase<string>
+>"NL" : "NL"
+
+        countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+>countryCode = prefix : "BE" | "LU" | "NL"
+>countryCode : "BE" | "LU" | "NL"
+>prefix : "BE" | "LU" | "NL"
+    }
+}
+
+// === Narrowing in else branch ===
+
+function testUppercaseElseBranch(x: Uppercase<string>) {
+>testUppercaseElseBranch : (x: Uppercase<string>) => void
+>x : Uppercase<string>
+
+    if (x === "BE") {
+>x === "BE" : boolean
+>x : Uppercase<string>
+>"BE" : "BE"
+
+        x; // type is "BE"
+>x : "BE"
+
+    } else {
+        x; // type is Uppercase<string>
+>x : Uppercase<string>
+    }
+}
+
+// === Switch statement narrowing ===
+
+function testUppercaseSwitch(x: Uppercase<string>): string {
+>testUppercaseSwitch : (x: Uppercase<string>) => string
+>x : Uppercase<string>
+
+    switch (x) {
+>x : Uppercase<string>
+
+        case "BE": return "Belgium";
+>"BE" : "BE"
+>"Belgium" : "Belgium"
+
+        case "LU": return "Luxembourg";
+>"LU" : "LU"
+>"Luxembourg" : "Luxembourg"
+
+        case "NL": return "Netherlands";
+>"NL" : "NL"
+>"Netherlands" : "Netherlands"
+
+        default: return "Unknown";
+>"Unknown" : "Unknown"
+    }
+}
+
+// === Capitalize<string> narrowing ===
+
+function testCapitalizeNarrowing(x: Capitalize<string>) {
+>testCapitalizeNarrowing : (x: Capitalize<string>) => void
+>x : Capitalize<string>
+
+    if (x === "Hello") {
+>x === "Hello" : boolean
+>x : Capitalize<string>
+>"Hello" : "Hello"
+
+        const r: "Hello" = x; // ok
+>r : "Hello"
+>x : "Hello"
+    }
+    if (x === "hello") {
+>x === "hello" : boolean
+>x : Capitalize<string>
+>"hello" : "hello"
+
+        const r: "hello" = x; // error
+>r : "hello"
+>x : never
+    }
+}
+
+// === Uncapitalize<string> narrowing ===
+
+function testUncapitalizeNarrowing(x: Uncapitalize<string>) {
+>testUncapitalizeNarrowing : (x: Uncapitalize<string>) => void
+>x : Uncapitalize<string>
+
+    if (x === "hello") {
+>x === "hello" : boolean
+>x : Uncapitalize<string>
+>"hello" : "hello"
+
+        const r: "hello" = x; // ok
+>r : "hello"
+>x : "hello"
+    }
+    if (x === "Hello") {
+>x === "Hello" : boolean
+>x : Uncapitalize<string>
+>"Hello" : "Hello"
+
+        const r: "Hello" = x; // error
+>r : "Hello"
+>x : never
+    }
+}
+
+// === Always-false comparisons (comparability) ===
+
+function testAlwaysFalseUppercase(foo: Uppercase<string>) {
+>testAlwaysFalseUppercase : (foo: Uppercase<string>) => void
+>foo : Uppercase<string>
+
+    if (foo === "ba") {} // error — "ba" is not Uppercase<string>
+>foo === "ba" : boolean
+>foo : Uppercase<string>
+>"ba" : "ba"
+
+    if (foo === "BA") {} // ok
+>foo === "BA" : boolean
+>foo : Uppercase<string>
+>"BA" : "BA"
+}
+
+function testAlwaysFalseLowercase(foo: Lowercase<string>) {
+>testAlwaysFalseLowercase : (foo: Lowercase<string>) => void
+>foo : Lowercase<string>
+
+    if (foo === "BA") {} // error — "BA" is not Lowercase<string>
+>foo === "BA" : boolean
+>foo : Lowercase<string>
+>"BA" : "BA"
+
+    if (foo === "ba") {} // ok
+>foo === "ba" : boolean
+>foo : Lowercase<string>
+>"ba" : "ba"
+}
+
+// === Narrowing does not broaden the type ===
+
+function testNoFalseNarrowing(x: Uppercase<string>) {
+>testNoFalseNarrowing : (x: Uppercase<string>) => void
+>x : Uppercase<string>
+
+    if (x === "BE") {
+>x === "BE" : boolean
+>x : Uppercase<string>
+>"BE" : "BE"
+
+        const r1: Uppercase<string> = x; // ok
+>r1 : Uppercase<string>
+>x : "BE"
+
+        const r2: string = x;            // ok
+>r2 : string
+>x : "BE"
+    }
+}
+
+// === Multiple literal union narrowing ===
+
+function testUppercaseUnionAssign2(x: Uppercase<string>) {
+>testUppercaseUnionAssign2 : (x: Uppercase<string>) => void
+>x : Uppercase<string>
+
+    if (x === "FOO" || x === "BAR") {
+>x === "FOO" || x === "BAR" : boolean
+>x === "FOO" : boolean
+>x : Uppercase<string>
+>"FOO" : "FOO"
+>x === "BAR" : boolean
+>x : Uppercase<string>
+>"BAR" : "BAR"
+
+        const r: "FOO" | "BAR" = x; // ok
+>r : "BAR" | "FOO"
+>x : "BAR" | "FOO"
+    }
+}
+

--- a/tsc/testdata/tests/cases/conformance/types/literal/stringMappingNarrowing.ts
+++ b/tsc/testdata/tests/cases/conformance/types/literal/stringMappingNarrowing.ts
@@ -1,0 +1,106 @@
+// @strict: true
+// @target: es2022
+
+// === Basic narrowing: Uppercase<string> === literal ===
+
+function testUppercaseNarrowing(x: Uppercase<string>) {
+    if (x === "BE") {
+        const r: "BE" = x; // ok — narrowed to "BE"
+    }
+    if (x === "be") {
+        const r: "be" = x; // error — "be" is never Uppercase<string>
+    }
+}
+
+// === Basic narrowing: Lowercase<string> === literal ===
+
+function testLowercaseNarrowing(x: Lowercase<string>) {
+    if (x === "be") {
+        const r: "be" = x; // ok — narrowed to "be"
+    }
+    if (x === "BE") {
+        const r: "BE" = x; // error — "BE" is never Lowercase<string>
+    }
+}
+
+// === Union narrowing and assignment (original issue) ===
+
+function testUnionAssignment() {
+    let countryCode: "BE" | "LU" | "NL";
+    const prefix = "be".toUpperCase() as Uppercase<string>;
+    if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
+        countryCode = prefix; // ok — narrowed to "BE" | "LU" | "NL"
+    }
+}
+
+// === Narrowing in else branch ===
+
+function testUppercaseElseBranch(x: Uppercase<string>) {
+    if (x === "BE") {
+        x; // type is "BE"
+    } else {
+        x; // type is Uppercase<string>
+    }
+}
+
+// === Switch statement narrowing ===
+
+function testUppercaseSwitch(x: Uppercase<string>): string {
+    switch (x) {
+        case "BE": return "Belgium";
+        case "LU": return "Luxembourg";
+        case "NL": return "Netherlands";
+        default: return "Unknown";
+    }
+}
+
+// === Capitalize<string> narrowing ===
+
+function testCapitalizeNarrowing(x: Capitalize<string>) {
+    if (x === "Hello") {
+        const r: "Hello" = x; // ok
+    }
+    if (x === "hello") {
+        const r: "hello" = x; // error
+    }
+}
+
+// === Uncapitalize<string> narrowing ===
+
+function testUncapitalizeNarrowing(x: Uncapitalize<string>) {
+    if (x === "hello") {
+        const r: "hello" = x; // ok
+    }
+    if (x === "Hello") {
+        const r: "Hello" = x; // error
+    }
+}
+
+// === Always-false comparisons (comparability) ===
+
+function testAlwaysFalseUppercase(foo: Uppercase<string>) {
+    if (foo === "ba") {} // error — "ba" is not Uppercase<string>
+    if (foo === "BA") {} // ok
+}
+
+function testAlwaysFalseLowercase(foo: Lowercase<string>) {
+    if (foo === "BA") {} // error — "BA" is not Lowercase<string>
+    if (foo === "ba") {} // ok
+}
+
+// === Narrowing does not broaden the type ===
+
+function testNoFalseNarrowing(x: Uppercase<string>) {
+    if (x === "BE") {
+        const r1: Uppercase<string> = x; // ok
+        const r2: string = x;            // ok
+    }
+}
+
+// === Multiple literal union narrowing ===
+
+function testUppercaseUnionAssign2(x: Uppercase<string>) {
+    if (x === "FOO" || x === "BAR") {
+        const r: "FOO" | "BAR" = x; // ok
+    }
+}


### PR DESCRIPTION
Fixes #63724.

## Problem

`Uppercase<string>` (and its siblings `Lowercase`, `Capitalize`, `Uncapitalize`) could not be narrowed by equality checks against specific string literals:

```ts
const prefix = "be".toUpperCase() as Uppercase<string>;
if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
    countryCode = prefix; // ❌ Type 'Uppercase<string>' is not assignable to '"BE" | "LU" | "NL"'
}
```

Additionally, always-false comparisons were not flagged:

```ts
function fn(foo: Uppercase<string>) {
    if (foo === "ba") {} // ❌ No error, but "ba" can never be Uppercase<string>
}
```

## Root Cause

**Bug 1 — `replacePrimitivesWithLiterals` in `flow.go`:** The narrowing pipeline calls `filterType` (correctly retaining `Uppercase<string>` as comparable to `"BE"`), then calls `replacePrimitivesWithLiterals` to substitute the mapping with the literal. That function guards on `TypeFlagsString | TypeFlagsTemplateLiteral` but **not `TypeFlagsStringMapping`**, so `Uppercase<string>` fell through the switch and was returned unchanged.

**Bug 2 — Comparable relation in `relater.go`:** When checking `isTypeComparableTo(Uppercase<string>, "ba")`, the code hit the `source=StringMapping, target≠StringMapping` branch, which fell through to the base-constraint (`string`). Since `"ba"` is assignable to `string`, the comparison was deemed comparable in both directions, suppressing the TS2367 diagnostic.

## Fix

**`tsc/internal/checker/flow.go`** — `replacePrimitivesWithLiterals`:
- Added `TypeFlagsStringMapping` to the outer guard.
- Added a `case t.flags&TypeFlagsStringMapping != 0` branch that uses `isMemberOfStringMapping` to filter the right-hand side: only string literals whose mapped form equals themselves are kept (e.g. `Uppercase("BE") = "BE"` ✓, `Uppercase("be") = "BE" ≠ "be"` ✗).

**`tsc/internal/checker/relater.go`** — structured-type comparable relation:
- In the `source=StringMapping, target=StringLiteral` path within the comparable relation specifically, delegated to `isMemberOfStringMapping` instead of the base-constraint fallthrough.

## Result

```ts
const prefix: Uppercase<string> = ...;
if (prefix === "BE" || prefix === "LU" || prefix === "NL") {
    countryCode = prefix; // ✅ narrowed to "BE" | "LU" | "NL"
}

function fn(foo: Uppercase<string>) {
    if (foo === "ba") {} // ✅ TS2367: types 'Uppercase<string>' and '"ba"' have no overlap
    if (foo === "BA") {} // ✅ no error
}
```

All four string-mapping intrinsics (`Uppercase`, `Lowercase`, `Capitalize`, `Uncapitalize`) benefit from the same fix.