### PR TITLE
Fix swapped charCodeAt/codePointAt JSDoc descriptions

### DIFF
--- a/tsc/internal/bundled/libs/lib.es2015.core.d.ts
+++ b/tsc/internal/bundled/libs/lib.es2015.core.d.ts
@@ -399,9 +399,10 @@ interface RegExpConstructor {
 
 interface String {
     /**
-     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
-     * value of the UTF-16 encoded code point starting at the string element at position pos in
-     * the String resulting from converting this object to a String.
+     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the Unicode
+     * code point value starting at the string element at position pos in the String resulting
+     * from converting this object to a String. Note that this is the code point starting at pos,
+     * not the pos-th code point of the string.
      * If there is no element at that position, the result is undefined.
      * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
      */

--- a/tsc/internal/bundled/libs/lib.es5.d.ts
+++ b/tsc/internal/bundled/libs/lib.es5.d.ts
@@ -416,8 +416,8 @@ interface String {
     charAt(pos: number): string;
 
     /**
-     * Returns the Unicode value of the character at the specified location, or NaN if the index is out of bounds.
-     * @param index The zero-based index of the desired character.
+     * Returns the UTF-16 code unit at the specified index, or NaN if the index is out of bounds.
+     * @param index The zero-based index of the desired code unit.
      */
     charCodeAt(index: number): number;
 


### PR DESCRIPTION
## What was wrong

`String.prototype.charCodeAt`'s JSDoc said it returns the "Unicode value" of
the character, which is ambiguous and actually describes what
`codePointAt` does. Meanwhile `codePointAt`'s JSDoc led with "the code
point value of the UTF-16 encoded code point", which buries the fact that
it returns the full decoded Unicode code point (surrogate pairs handled),
the very thing that distinguishes it from `charCodeAt`. Per MDN:

- `charCodeAt()` returns the UTF-16 **code unit** at the given index.
- `codePointAt()` returns the **Unicode code point** value at the given
  position (decoding a surrogate pair if one starts there).

The repo's `src/lib/*.d.ts` paths from the original issue have since moved
under the Go-port restructuring; the current source of truth for these
declarations is `tsc/internal/bundled/libs/lib.es5.d.ts` (`charCodeAt`) and
`tsc/internal/bundled/libs/lib.es2015.core.d.ts` (`codePointAt`). The
`hereby lib` task only copies these files into `built/local`, it does not
generate them, so they're the correct place to fix.

## What changed

- `charCodeAt`: doc now says it returns the UTF-16 code unit at the index.
- `codePointAt`: doc now leads with "Unicode code point value" instead of
  "UTF-16 encoded code point", and keeps the existing surrogate-pair detail
  (undefined semantics preserved, no behavior/signature change).

Doc comments only, no code or signature changes.

Fixes #49561

## How it was verified

```
npm ci
npx hereby lib
git diff --stat
```

- `npm ci` completed cleanly.
- `npx hereby lib` ran successfully and copied the updated declaration
  files into `built/local`, confirming the fix propagates through the
  repo's lib-copy task without errors.
- Confirmed via `git diff` that only the two doc comment blocks changed
  (no generated output is committed; `built/` is gitignored).
- `tsc/internal/bundled/libs/**` is excluded from `dprint fmt`/`dprint
  check` by `.dprint.jsonc`, and `hereby lint` runs golangci-lint over the
  Go modules only, so neither tool applies to these `.d.ts` files; I did
  not run the full Go build/test suite per the task scope (docs-only
  change, no compiler behavior affected).

## Disclosure

This PR was authored with Claude Code, operated by me (the account owner
who forked and opened this PR). I read and reviewed the diff before
opening this PR, chose this specific issue deliberately, and will handle
CLA acceptance and any review feedback myself.