### PR TITLE
fix: report optional-chain tagged templates after non-null assertions

### DIFF
--- a/tsc/internal/checker/grammarchecks.go
+++ b/tsc/internal/checker/grammarchecks.go
@@ -857,7 +857,8 @@ func (c *Checker) checkGrammarTypeArguments(node *ast.Node, typeArguments *ast.N
 }
 
 func (c *Checker) checkGrammarTaggedTemplateChain(node *ast.TaggedTemplateExpression) bool {
-	if node.QuestionDotToken != nil || node.Flags&ast.NodeFlagsOptionalChain != 0 {
+	tag := ast.SkipOuterExpressions(node.Tag, ast.OEKNonNullAssertions)
+	if node.QuestionDotToken != nil || node.Flags&ast.NodeFlagsOptionalChain != 0 || tag.Flags&ast.NodeFlagsOptionalChain != 0 {
 		return c.grammarErrorOnNode(node.Template, diagnostics.Tagged_template_expressions_are_not_permitted_in_an_optional_chain)
 	}
 	return false

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).errors.txt
@@ -1,0 +1,34 @@
+nonNullAssertedOptionalChainTemplate.ts(3,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(4,7): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(5,8): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(6,7): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(7,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(8,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+
+
+==== nonNullAssertedOptionalChainTemplate.ts (6 errors) ====
+    var f: any;
+    
+    f?.x!`text`;
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!!`text`;
+          ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.[0]!`text${1}`;
+           ~~~~~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.()!`text`;
+          ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!`text`();
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!`text`.x;
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    
+    (f?.x)!`text`;
+    (f?.x!)`text`;
+    f.x!`text`;
+    

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).js
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).js
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+//// [nonNullAssertedOptionalChainTemplate.ts]
+var f: any;
+
+f?.x!`text`;
+f?.x!!`text`;
+f?.[0]!`text${1}`;
+f?.()!`text`;
+f?.x!`text`();
+f?.x!`text`.x;
+
+(f?.x)!`text`;
+(f?.x!)`text`;
+f.x!`text`;
+
+
+//// [nonNullAssertedOptionalChainTemplate.js]
+"use strict";
+var f;
+(f === null || f === void 0 ? void 0 : f.x) `text`;
+(f === null || f === void 0 ? void 0 : f.x) `text`;
+(f === null || f === void 0 ? void 0 : f[0]) `text${1}`;
+(f === null || f === void 0 ? void 0 : f()) `text`;
+(f === null || f === void 0 ? void 0 : f.x) `text`();
+(f === null || f === void 0 ? void 0 : f.x) `text`.x;
+(f === null || f === void 0 ? void 0 : f.x) `text`;
+(f === null || f === void 0 ? void 0 : f.x) `text`;
+f.x `text`;

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).symbols
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).symbols
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+=== nonNullAssertedOptionalChainTemplate.ts ===
+var f: any;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.[0]!`text${1}`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.()!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`();
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`.x;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+(f?.x)!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+(f?.x!)`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f.x!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).types
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=es2015).types
@@ -1,0 +1,84 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+=== nonNullAssertedOptionalChainTemplate.ts ===
+var f: any;
+>f : any
+
+f?.x!`text`;
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.x!!`text`;
+>f?.x!!`text` : any
+>f?.x!! : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.[0]!`text${1}`;
+>f?.[0]!`text${1}` : any
+>f?.[0]! : any
+>f?.[0] : any
+>f : any
+>0 : 0
+>`text${1}` : string
+>1 : 1
+
+f?.()!`text`;
+>f?.()!`text` : any
+>f?.()! : any
+>f?.() : any
+>f : any
+>`text` : "text"
+
+f?.x!`text`();
+>f?.x!`text`() : any
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.x!`text`.x;
+>f?.x!`text`.x : any
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+>x : any
+
+(f?.x)!`text`;
+>(f?.x)!`text` : any
+>(f?.x)! : any
+>(f?.x) : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+(f?.x!)`text`;
+>(f?.x!)`text` : any
+>(f?.x!) : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f.x!`text`;
+>f.x!`text` : any
+>f.x! : any
+>f.x : any
+>f : any
+>x : any
+>`text` : "text"
+

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).errors.txt
@@ -1,0 +1,34 @@
+nonNullAssertedOptionalChainTemplate.ts(3,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(4,7): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(5,8): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(6,7): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(7,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+nonNullAssertedOptionalChainTemplate.ts(8,6): error TS1358: Tagged template expressions are not permitted in an optional chain.
+
+
+==== nonNullAssertedOptionalChainTemplate.ts (6 errors) ====
+    var f: any;
+    
+    f?.x!`text`;
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!!`text`;
+          ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.[0]!`text${1}`;
+           ~~~~~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.()!`text`;
+          ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!`text`();
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    f?.x!`text`.x;
+         ~~~~~~
+!!! error TS1358: Tagged template expressions are not permitted in an optional chain.
+    
+    (f?.x)!`text`;
+    (f?.x!)`text`;
+    f.x!`text`;
+    

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).js
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).js
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+//// [nonNullAssertedOptionalChainTemplate.ts]
+var f: any;
+
+f?.x!`text`;
+f?.x!!`text`;
+f?.[0]!`text${1}`;
+f?.()!`text`;
+f?.x!`text`();
+f?.x!`text`.x;
+
+(f?.x)!`text`;
+(f?.x!)`text`;
+f.x!`text`;
+
+
+//// [nonNullAssertedOptionalChainTemplate.js]
+"use strict";
+var f;
+(f?.x) `text`;
+(f?.x) `text`;
+(f?.[0]) `text${1}`;
+(f?.()) `text`;
+(f?.x) `text`();
+(f?.x) `text`.x;
+(f?.x) `text`;
+(f?.x) `text`;
+f.x `text`;

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).symbols
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).symbols
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+=== nonNullAssertedOptionalChainTemplate.ts ===
+var f: any;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.[0]!`text${1}`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.()!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`();
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f?.x!`text`.x;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+(f?.x)!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+(f?.x!)`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+
+f.x!`text`;
+>f : Symbol(f, Decl(nonNullAssertedOptionalChainTemplate.ts, 0, 3))
+

--- a/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).types
+++ b/tsc/testdata/baselines/reference/compiler/nonNullAssertedOptionalChainTemplate(target=esnext).types
@@ -1,0 +1,84 @@
+//// [tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts] ////
+
+=== nonNullAssertedOptionalChainTemplate.ts ===
+var f: any;
+>f : any
+
+f?.x!`text`;
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.x!!`text`;
+>f?.x!!`text` : any
+>f?.x!! : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.[0]!`text${1}`;
+>f?.[0]!`text${1}` : any
+>f?.[0]! : any
+>f?.[0] : any
+>f : any
+>0 : 0
+>`text${1}` : string
+>1 : 1
+
+f?.()!`text`;
+>f?.()!`text` : any
+>f?.()! : any
+>f?.() : any
+>f : any
+>`text` : "text"
+
+f?.x!`text`();
+>f?.x!`text`() : any
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f?.x!`text`.x;
+>f?.x!`text`.x : any
+>f?.x!`text` : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+>x : any
+
+(f?.x)!`text`;
+>(f?.x)!`text` : any
+>(f?.x)! : any
+>(f?.x) : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+(f?.x!)`text`;
+>(f?.x!)`text` : any
+>(f?.x!) : any
+>f?.x! : any
+>f?.x : any
+>f : any
+>x : any
+>`text` : "text"
+
+f.x!`text`;
+>f.x!`text` : any
+>f.x! : any
+>f.x : any
+>f : any
+>x : any
+>`text` : "text"
+

--- a/tsc/testdata/tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts
+++ b/tsc/testdata/tests/cases/compiler/nonNullAssertedOptionalChainTemplate.ts
@@ -1,0 +1,13 @@
+// @target: es2015, esnext
+var f: any;
+
+f?.x!`text`;
+f?.x!!`text`;
+f?.[0]!`text${1}`;
+f?.()!`text`;
+f?.x!`text`();
+f?.x!`text`.x;
+
+(f?.x)!`text`;
+(f?.x!)`text`;
+f.x!`text`;


### PR DESCRIPTION
Non-null assertions currently allow tagged templates to bypass TS1358 errors:

```ts
var f: any;
f?.x!`text`; // Previously accepted; now reports TS1358 (Tagged template expressions are not permitted in an optional chain.).
```

Update the tagged-template grammar check to look through non-null assertions when checking for an optional chain. 