### PR TITLE
Fix parsing of async() calls in conditional expressions

### DIFF
--- a/tsc/internal/parser/parser.go
+++ b/tsc/internal/parser/parser.go
@@ -4263,7 +4263,8 @@ func (p *Parser) isParenthesizedArrowFunctionExpression() core.Tristate {
 }
 
 func (p *Parser) nextIsParenthesizedArrowFunctionExpression() core.Tristate {
-	if p.token == ast.KindAsyncKeyword {
+	isAsync := p.token == ast.KindAsyncKeyword
+	if isAsync {
 		p.nextToken()
 		if p.hasPrecedingLineBreak() {
 			return core.TSFalse
@@ -4282,7 +4283,12 @@ func (p *Parser) nextIsParenthesizedArrowFunctionExpression() core.Tristate {
 			// but this is probably what the user intended.
 			third := p.nextToken()
 			switch third {
-			case ast.KindEqualsGreaterThanToken, ast.KindColonToken, ast.KindOpenBraceToken:
+			case ast.KindEqualsGreaterThanToken, ast.KindOpenBraceToken:
+				return core.TSTrue
+			case ast.KindColonToken:
+				if isAsync {
+					return core.TSUnknown
+				}
 				return core.TSTrue
 			}
 			return core.TSFalse

--- a/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.js
+++ b/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/asyncCallInConditionalExpression.ts] ////
+
+//// [a.ts]
+declare const a: boolean;
+declare function async(...args: any[]): number;
+
+const c1 = a ? async() : 0;
+const c2 = a ? async() : (x: number) => x;
+const c3 = a ? async(1) : 0;
+const c4 = a ? async() : a ? async() : 0;
+
+const f1 = async(): Promise<number> => 1;
+const f2 = async (): Promise<number> => 1;
+const f3 = a ? async(): Promise<number> => 1 : 2;
+const f4 = a ? async () => 1 : 2;
+const f5 = a ? 1 : async(): Promise<number> => 1;
+
+export {};
+
+//// [b.js]
+const t = true;
+function async() { return 1; }
+const j1 = t ? async() : 0;
+const j2 = t ? async() : x => x;
+
+export {};
+
+
+//// [a.js]
+const c1 = a ? async() : 0;
+const c2 = a ? async() : (x) => x;
+const c3 = a ? async(1) : 0;
+const c4 = a ? async() : a ? async() : 0;
+const f1 = async () => 1;
+const f2 = async () => 1;
+const f3 = a ? async () => 1 : 2;
+const f4 = a ? async () => 1 : 2;
+const f5 = a ? 1 : async () => 1;
+export {};
+//// [b.js]
+const t = true;
+function async() { return 1; }
+const j1 = t ? async() : 0;
+const j2 = t ? async() : x => x;
+export {};

--- a/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.symbols
+++ b/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.symbols
@@ -1,0 +1,79 @@
+//// [tests/cases/compiler/asyncCallInConditionalExpression.ts] ////
+
+=== a.ts ===
+declare const a: boolean;
+>a : Symbol(a, Decl(a.ts, 0, 13))
+
+declare function async(...args: any[]): number;
+>async : Symbol(async, Decl(a.ts, 0, 25))
+>args : Symbol(args, Decl(a.ts, 1, 23))
+
+const c1 = a ? async() : 0;
+>c1 : Symbol(c1, Decl(a.ts, 3, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>async : Symbol(async, Decl(a.ts, 0, 25))
+
+const c2 = a ? async() : (x: number) => x;
+>c2 : Symbol(c2, Decl(a.ts, 4, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>async : Symbol(async, Decl(a.ts, 0, 25))
+>x : Symbol(x, Decl(a.ts, 4, 26))
+>x : Symbol(x, Decl(a.ts, 4, 26))
+
+const c3 = a ? async(1) : 0;
+>c3 : Symbol(c3, Decl(a.ts, 5, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>async : Symbol(async, Decl(a.ts, 0, 25))
+
+const c4 = a ? async() : a ? async() : 0;
+>c4 : Symbol(c4, Decl(a.ts, 6, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>async : Symbol(async, Decl(a.ts, 0, 25))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>async : Symbol(async, Decl(a.ts, 0, 25))
+
+const f1 = async(): Promise<number> => 1;
+>f1 : Symbol(f1, Decl(a.ts, 8, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+const f2 = async (): Promise<number> => 1;
+>f2 : Symbol(f2, Decl(a.ts, 9, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+const f3 = a ? async(): Promise<number> => 1 : 2;
+>f3 : Symbol(f3, Decl(a.ts, 10, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+const f4 = a ? async () => 1 : 2;
+>f4 : Symbol(f4, Decl(a.ts, 11, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+
+const f5 = a ? 1 : async(): Promise<number> => 1;
+>f5 : Symbol(f5, Decl(a.ts, 12, 5))
+>a : Symbol(a, Decl(a.ts, 0, 13))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+export {};
+
+=== b.js ===
+const t = true;
+>t : Symbol(t, Decl(b.js, 0, 5))
+
+function async() { return 1; }
+>async : Symbol(async, Decl(b.js, 0, 15))
+
+const j1 = t ? async() : 0;
+>j1 : Symbol(j1, Decl(b.js, 2, 5))
+>t : Symbol(t, Decl(b.js, 0, 5))
+>async : Symbol(async, Decl(b.js, 0, 15))
+
+const j2 = t ? async() : x => x;
+>j2 : Symbol(j2, Decl(b.js, 3, 5))
+>t : Symbol(t, Decl(b.js, 0, 5))
+>async : Symbol(async, Decl(b.js, 0, 15))
+>x : Symbol(x, Decl(b.js, 3, 24))
+>x : Symbol(x, Decl(b.js, 3, 24))
+
+export {};
+

--- a/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.types
+++ b/tsc/testdata/baselines/reference/compiler/asyncCallInConditionalExpression.types
@@ -1,0 +1,114 @@
+//// [tests/cases/compiler/asyncCallInConditionalExpression.ts] ////
+
+=== a.ts ===
+declare const a: boolean;
+>a : boolean
+
+declare function async(...args: any[]): number;
+>async : (...args: any[]) => number
+>args : any[]
+
+const c1 = a ? async() : 0;
+>c1 : number
+>a ? async() : 0 : number
+>a : boolean
+>async() : number
+>async : (...args: any[]) => number
+>0 : 0
+
+const c2 = a ? async() : (x: number) => x;
+>c2 : number | ((x: number) => number)
+>a ? async() : (x: number) => x : number | ((x: number) => number)
+>a : boolean
+>async() : number
+>async : (...args: any[]) => number
+>(x: number) => x : (x: number) => number
+>x : number
+>x : number
+
+const c3 = a ? async(1) : 0;
+>c3 : number
+>a ? async(1) : 0 : number
+>a : boolean
+>async(1) : number
+>async : (...args: any[]) => number
+>1 : 1
+>0 : 0
+
+const c4 = a ? async() : a ? async() : 0;
+>c4 : number
+>a ? async() : a ? async() : 0 : number
+>a : boolean
+>async() : number
+>async : (...args: any[]) => number
+>a ? async() : 0 : number
+>a : false
+>async() : number
+>async : (...args: any[]) => number
+>0 : 0
+
+const f1 = async(): Promise<number> => 1;
+>f1 : () => Promise<number>
+>async(): Promise<number> => 1 : () => Promise<number>
+>1 : 1
+
+const f2 = async (): Promise<number> => 1;
+>f2 : () => Promise<number>
+>async (): Promise<number> => 1 : () => Promise<number>
+>1 : 1
+
+const f3 = a ? async(): Promise<number> => 1 : 2;
+>f3 : 2 | (() => Promise<number>)
+>a ? async(): Promise<number> => 1 : 2 : 2 | (() => Promise<number>)
+>a : boolean
+>async(): Promise<number> => 1 : () => Promise<number>
+>1 : 1
+>2 : 2
+
+const f4 = a ? async () => 1 : 2;
+>f4 : 2 | (() => Promise<number>)
+>a ? async () => 1 : 2 : 2 | (() => Promise<number>)
+>a : boolean
+>async () => 1 : () => Promise<number>
+>1 : 1
+>2 : 2
+
+const f5 = a ? 1 : async(): Promise<number> => 1;
+>f5 : 1 | (() => Promise<number>)
+>a ? 1 : async(): Promise<number> => 1 : 1 | (() => Promise<number>)
+>a : boolean
+>1 : 1
+>async(): Promise<number> => 1 : () => Promise<number>
+>1 : 1
+
+export {};
+
+=== b.js ===
+const t = true;
+>t : true
+>true : true
+
+function async() { return 1; }
+>async : () => number
+>1 : 1
+
+const j1 = t ? async() : 0;
+>j1 : number
+>t ? async() : 0 : number
+>t : true
+>async() : number
+>async : () => number
+>0 : 0
+
+const j2 = t ? async() : x => x;
+>j2 : number | ((x: any) => any)
+>t ? async() : x => x : number | ((x: any) => any)
+>t : true
+>async() : number
+>async : () => number
+>x => x : (x: any) => any
+>x : any
+>x : any
+
+export {};
+

--- a/tsc/testdata/tests/cases/compiler/asyncCallInConditionalExpression.ts
+++ b/tsc/testdata/tests/cases/compiler/asyncCallInConditionalExpression.ts
@@ -1,0 +1,27 @@
+// @target: esnext
+// @allowJs: true
+// @outDir: ./out
+// @filename: a.ts
+declare const a: boolean;
+declare function async(...args: any[]): number;
+
+const c1 = a ? async() : 0;
+const c2 = a ? async() : (x: number) => x;
+const c3 = a ? async(1) : 0;
+const c4 = a ? async() : a ? async() : 0;
+
+const f1 = async(): Promise<number> => 1;
+const f2 = async (): Promise<number> => 1;
+const f3 = a ? async(): Promise<number> => 1 : 2;
+const f4 = a ? async () => 1 : 2;
+const f5 = a ? 1 : async(): Promise<number> => 1;
+
+export {};
+
+// @filename: b.js
+const t = true;
+function async() { return 1; }
+const j1 = t ? async() : 0;
+const j2 = t ? async() : x => x;
+
+export {};


### PR DESCRIPTION
Fixes #64231

### Problem

Calling a function named async with no arguments in the true branch of a conditional expression gets parsed as the start of an async arrow function:

```
declare const a: boolean;
declare function async(): number;

const first = a ? async() : 0; // error TS1005: '=>' expected.

const second = a ? async() : x => x; // error TS1005: ':' expected.
```
async is not a reserved word, so async() is a plain call and the colon is the conditional's separator. Node runs the JavaScript version of this without complaint, but we reject it in both .ts and .js files. The issue says it fails in every version, and that matches: Strada has the same lookahead.



### Cause

nextIsParenthesizedArrowFunctionExpression has a shortcut for empty parameter lists. If it sees "()" followed by "=>", ":" or "{", it returns TSTrue, meaning "this is definitely an arrow function". When the parens come after async, it skips the async and takes the same shortcut. That is not safe, because "async()" followed by a colon can also be a call inside a conditional.

What happens in the repro:

1. parseConditionalExpressionRest parses the true branch with allowReturnTypeInArrowFunction set to false. That flag exists so "a ? (x) : y" does not read ": y" as a return type.
2. tryParseParenthesizedArrowFunctionExpression asks the lookahead, which skips async, sees "( ) :", and returns TSTrue.
3. On TSTrue, the parser calls parseParenthesizedArrowFunctionExpression with allowAmbiguity and allowReturnTypeInArrowFunction both true, which throws away the false passed down from the conditional.
4. It parses ": 0" as a return type annotation, then expects "=>" and reports TS1005. The guard that handles this case (!allowReturnTypeInArrowFunction && hasReturnColon) never runs, because the flag is now true.

The shortcut is correct for a bare "()", since that can never be an expression on its own. It is only wrong after async, where "async()" is a valid call.



### Solution

When the lookahead skipped async and sees "( ) :", return TSUnknown instead of TSTrue. That sends it through the same speculative path "(x):" already uses. It only commits to an arrow if "=>" or "{" follows, it respects the conditional's return type rule, and otherwise it rewinds and parses a call.

Nothing else changes. "()" followed by "=>", ":" or "{" without async is still TSTrue. "async() =>" and "async() {" are still TSTrue, since neither can be a call. "async(): T => x" still parses as an arrow outside a conditional and in either branch of one; "a ? async(): T => x : y" works through the existing second-colon check. The only extra cost is one speculative parse when "async():" shows up, and the existing notParenthesizedArrow cache already memoizes it.



### Tests

Added tsc/testdata/tests/cases/compiler/asyncCallInConditionalExpression.ts with three groups of cases:

- both repros from the issue, plus a call with arguments and a nested conditional, which must now be clean
- the same repros in a .js file, since the issue says JavaScript fails too
- real async arrows with and without a return type, with and without a space after async, and in both branches of a conditional, which must still parse as arrows

I ran the test before changing the parser to make sure it catches the bug. It produced 19 errors, with TS1005 on every repro. With the fix there are none, so there is no .errors.txt baseline. The .types baseline shows every async() in a conditional as a call returning number, and every arrow case still comes out as () => Promise<number>.

Across the full suite the only baselines written were the three for this new test, so nothing else moved. npx hereby test:all passed clean. npx hereby test had one failure, TestFSEventsNFDOnDiskNFCSubscribe in internal/fswatch. That package does not depend on the parser and the test passed on 3 of 3 reruns, so it looks like a flake.


### Checklist

- [ ] There is an associated issue in the Backlog milestone (required)
  #64231 has not been triaged yet, so it has no milestone. I cannot set one. Happy to wait for triage if you would rather look at the issue first.
- [x] Code is up-to-date with the main branch
- [x] You've successfully run npx hereby test
- [x] You've successfully run npx hereby lint
- [x] You've successfully run npx hereby check:format
- [x] There are new or updated tests validating the change