### PR TITLE
fix(checker): reject exports originating from global augmentations

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -5721,7 +5721,12 @@ func (c *Checker) checkExportSpecifier(node *ast.ExportSpecifierNode) {
 		}
 		// find immediate value referenced by exported name (SymbolFlags.Alias is set so we don't chase down aliases)
 		symbol := c.resolveName(exportedName, exportedName.Text(), ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias, nil /*nameNotFoundMessage*/, true /*isUse*/, false)
-		if symbol != nil && (symbol == c.undefinedSymbol || symbol == c.globalThisSymbol || symbol.Declarations != nil && ast.IsGlobalSourceFile(ast.GetDeclarationContainer(symbol.Declarations[0]))) {
+		isGlobalDeclaration := false
+		if symbol != nil && symbol.Declarations != nil {
+			declarationContainer := ast.GetDeclarationContainer(symbol.Declarations[0])
+			isGlobalDeclaration = ast.IsGlobalSourceFile(declarationContainer) || ast.IsModuleBlock(declarationContainer) && ast.IsGlobalScopeAugmentation(declarationContainer.Parent)
+		}
+		if symbol != nil && (symbol == c.undefinedSymbol || symbol == c.globalThisSymbol || isGlobalDeclaration) {
 			c.error(exportedName, diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, exportedName.Text())
 		} else {
 			c.markLinkedReferences(node, ReferenceHintExportSpecifier, nil /*propSymbol*/, nil /*parentType*/)

--- a/tsc/internal/checker/relater.go
+++ b/tsc/internal/checker/relater.go
@@ -3829,6 +3829,7 @@ func (r *Relater) structuredTypeRelatedToWorker(source *Type, target *Type, repo
 				}
 			}
 		}
+
 	default:
 		// An empty object type is related to any mapped type that includes a '?' modifier.
 		if r.relation != r.c.subtypeRelation && r.relation != r.c.strictSubtypeRelation && isPartialMappedType(target) && r.c.isEmptyObjectType(source) {

--- a/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.errors.txt
@@ -1,0 +1,12 @@
+exportSpecifierForAGlobalAugmentation.ts(5,10): error TS2661: Cannot export 'XYZ'. Only local declarations can be exported from a module.
+
+
+==== exportSpecifierForAGlobalAugmentation.ts (1 errors) ====
+    declare global {
+        var XYZ: number;
+    }
+    
+    export { XYZ };
+             ~~~
+!!! error TS2661: Cannot export 'XYZ'. Only local declarations can be exported from a module.
+    

--- a/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.js
+++ b/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/exportSpecifierForAGlobalAugmentation.ts] ////
+
+//// [exportSpecifierForAGlobalAugmentation.ts]
+declare global {
+    var XYZ: number;
+}
+
+export { XYZ };
+
+
+//// [exportSpecifierForAGlobalAugmentation.js]
+export { XYZ };

--- a/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.symbols
+++ b/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/exportSpecifierForAGlobalAugmentation.ts] ////
+
+=== exportSpecifierForAGlobalAugmentation.ts ===
+declare global {
+>global : Symbol(global, Decl(exportSpecifierForAGlobalAugmentation.ts, 0, 0))
+
+    var XYZ: number;
+>XYZ : Symbol(XYZ, Decl(exportSpecifierForAGlobalAugmentation.ts, 1, 7))
+}
+
+export { XYZ };
+>XYZ : Symbol(XYZ, Decl(exportSpecifierForAGlobalAugmentation.ts, 4, 8))
+

--- a/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.types
+++ b/tsc/testdata/baselines/reference/compiler/exportSpecifierForAGlobalAugmentation.types
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/exportSpecifierForAGlobalAugmentation.ts] ////
+
+=== exportSpecifierForAGlobalAugmentation.ts ===
+declare global {
+>global : typeof global
+
+    var XYZ: number;
+>XYZ : number
+}
+
+export { XYZ };
+>XYZ : number
+

--- a/tsc/testdata/tests/cases/compiler/exportSpecifierForAGlobalAugmentation.ts
+++ b/tsc/testdata/tests/cases/compiler/exportSpecifierForAGlobalAugmentation.ts
@@ -1,0 +1,5 @@
+declare global {
+    var XYZ: number;
+}
+
+export { XYZ };


### PR DESCRIPTION
Fixes #64152.

## Problem

When exporting bindings from a module without a local declaration (e.g. `export { Math };`), TypeScript correctly issues error TS2661 (`Cannot export '{0}'. Only local declarations can be exported from a module.`).

However, exports originating from a global scope augmentation (`declare global { ... }`) were previously permitted without error:

```ts
declare global {
    var XYZ: number;
}

export { XYZ }; // ❌ Permitted without error
```

## Root Cause

In `checkExportSpecifier` (`tsc/internal/checker/checker.go`), the global declaration check only tested whether the declaration container was a global source file (`ast.IsGlobalSourceFile(declarationContainer)`). Declarations inside a global augmentation have an `ast.ModuleBlock` declaration container whose parent is a global scope augmentation (`ast.IsGlobalScopeAugmentation(declarationContainer.Parent)`), bypassing the error check.

## Fix

Update `checkExportSpecifier` to treat declarations inside module blocks of global scope augmentations as non-local export sources:

```go
isGlobalDeclaration := false
if symbol != nil && symbol.Declarations != nil {
	declarationContainer := ast.GetDeclarationContainer(symbol.Declarations[0])
	isGlobalDeclaration = ast.IsGlobalSourceFile(declarationContainer) || ast.IsModuleBlock(declarationContainer) && ast.IsGlobalScopeAugmentation(declarationContainer.Parent)
}
```

Add compiler test case `exportSpecifierForAGlobalAugmentation.ts` and reference baselines.