### PR TITLE
fix: disallow NoSubstitutionTemplate in module import attribute types

### DIFF
--- a/tsc/internal/checker/grammarchecks.go
+++ b/tsc/internal/checker/grammarchecks.go
@@ -2229,7 +2229,7 @@ func (c *Checker) checkGrammarImportAttributesType(attributes *ast.TypeLiteralNo
 		}
 
 		typeNode := propertySignature.Type
-		if !ast.IsStringLiteralLikeType(typeNode) {
+		if !ast.IsLiteralTypeNode(typeNode) || !ast.IsStringLiteral(typeNode.AsLiteralTypeNode().Literal) {
 			return c.grammarErrorOnNode(typeNode, diagnostics.An_import_attributes_property_must_have_a_string_literal_type_annotation)
 		}
 	}

--- a/tsc/testdata/baselines/reference/compiler/importAttributeType1.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/importAttributeType1.errors.txt
@@ -7,7 +7,8 @@
   Property 'type' is incompatible with index signature.
     Type '{ name: string; }' is not assignable to type 'string'.
 /checkErrors.d.ts(2,45): error TS1555: An import attributes property must have a string literal type annotation.
-/checkErrors.d.ts(3,33): error TS1555: An import attributes property must have a string literal type annotation.
+/checkErrors.d.ts(3,37): error TS1555: An import attributes property must have a string literal type annotation.
+/checkErrors.d.ts(4,33): error TS1555: An import attributes property must have a string literal type annotation.
 /valid.d.ts(11,38): error TS1555: An import attributes property must have a string literal type annotation.
 
 
@@ -41,7 +42,7 @@
     text.toUpperCase();
     data.version.toFixed();
     
-==== /checkErrors.d.ts (5 errors) ====
+==== /checkErrors.d.ts (6 errors) ====
     declare module "*.numberValue" with { type: number } {}
                                         ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ type: number; }' is not assignable to type 'ImportAttributes'.
@@ -55,6 +56,9 @@
 !!! error TS2322:   Property 'type' is incompatible with index signature.
 !!! error TS2322:     Type '{ name: string; }' is not assignable to type 'string'.
                                                 ~~~~~~~~~~~~~~~~
+!!! error TS1555: An import attributes property must have a string literal type annotation.
+    declare module "*.css" with { type: `css` } {}
+                                        ~~~~~
 !!! error TS1555: An import attributes property must have a string literal type annotation.
     declare module "*" with { type: "md" | "markdown" } {}
                                     ~~~~~~~~~~~~~~~~~

--- a/tsc/testdata/baselines/reference/compiler/importAttributeType1.errors.txt
+++ b/tsc/testdata/baselines/reference/compiler/importAttributeType1.errors.txt
@@ -8,7 +8,8 @@
     Type '{ name: string; }' is not assignable to type 'string'.
 /checkErrors.d.ts(2,45): error TS1555: An import attributes property must have a string literal type annotation.
 /checkErrors.d.ts(3,37): error TS1555: An import attributes property must have a string literal type annotation.
-/checkErrors.d.ts(4,33): error TS1555: An import attributes property must have a string literal type annotation.
+/checkErrors.d.ts(4,37): error TS1555: An import attributes property must have a string literal type annotation.
+/checkErrors.d.ts(5,33): error TS1555: An import attributes property must have a string literal type annotation.
 /valid.d.ts(11,38): error TS1555: An import attributes property must have a string literal type annotation.
 
 
@@ -42,7 +43,7 @@
     text.toUpperCase();
     data.version.toFixed();
     
-==== /checkErrors.d.ts (6 errors) ====
+==== /checkErrors.d.ts (7 errors) ====
     declare module "*.numberValue" with { type: number } {}
                                         ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ type: number; }' is not assignable to type 'ImportAttributes'.
@@ -59,6 +60,9 @@
 !!! error TS1555: An import attributes property must have a string literal type annotation.
     declare module "*.css" with { type: `css` } {}
                                         ~~~~~
+!!! error TS1555: An import attributes property must have a string literal type annotation.
+    declare module "*.css" with { type: `css${''}` } {}
+                                        ~~~~~~~~~~
 !!! error TS1555: An import attributes property must have a string literal type annotation.
     declare module "*" with { type: "md" | "markdown" } {}
                                     ~~~~~~~~~~~~~~~~~

--- a/tsc/testdata/tests/cases/compiler/importAttributeType1.ts
+++ b/tsc/testdata/tests/cases/compiler/importAttributeType1.ts
@@ -34,6 +34,7 @@ data.version.toFixed();
 // @filename: /checkErrors.d.ts
 declare module "*.numberValue" with { type: number } {}
 declare module "*.objectValue" with { type: { name: string } } {}
+declare module "*.css" with { type: `css` } {}
 declare module "*" with { type: "md" | "markdown" } {}
 // @filename: /augmentation.ts
 export {};

--- a/tsc/testdata/tests/cases/compiler/importAttributeType1.ts
+++ b/tsc/testdata/tests/cases/compiler/importAttributeType1.ts
@@ -35,6 +35,7 @@ data.version.toFixed();
 declare module "*.numberValue" with { type: number } {}
 declare module "*.objectValue" with { type: { name: string } } {}
 declare module "*.css" with { type: `css` } {}
+declare module "*.css" with { type: `css${''}` } {}
 declare module "*" with { type: "md" | "markdown" } {}
 // @filename: /augmentation.ts
 export {};


### PR DESCRIPTION
Module declarations currently accept template literals without substitutions in import attribute types.

This behaviour is incorrect as every other case rejects these empty template literals.

```typescript
import mycss from "./mycss.css" with { type: `css` };
//                                           ^^^^^ TS2858: Import attribute values must be string literal expressions.
import mycs2 from "./mycss.css" with { type: `css${''}` };
//                                           ^^^^^^^^^^ TS2858: Import attribute values must be string literal expressions.
type t1 = typeof import('foo', { with: { x: `` }})
//                                          ^^ TS2858: Import attribute values must be string literal expressions.
type t2 = typeof import('foo', { with: { x: `${''}` }})
//                                          ^^^^^^^ TS2858: Import attribute values must be string literal expressions.
declare module "*.css" with { type: `css` } {}
//                                   ^^^^^ Currently allowed.
declare module "*.css" with { type: `css${''}` } {}
//                                   ^^^^^^^^^^ TS1555: An import attributes property must have a string literal type annotation.
```

This PR now rejects the remaining case with TS1555, consistently requiring a quoted string literal.


Original Typescript PR: https://github.com/microsoft/TypeScript/pull/63931