### PR TITLE
fix(checker): emit TS2845 for exported enum member truthiness checks (#63565)

### DIFF
--- a/tsc/internal/checker/checker.go
+++ b/tsc/internal/checker/checker.go
@@ -3866,10 +3866,30 @@ func (c *Checker) checkTestingKnownTruthyType(condExpr *ast.Node, condType *Type
 	if location != condExpr {
 		t = c.checkExpression(location)
 	}
-	if t.flags&TypeFlagsEnumLiteral != 0 && ast.IsPropertyAccessExpression(location) && core.OrElse(c.getResolvedSymbolOrNil(location.Expression()), c.unknownSymbol).Flags&ast.SymbolFlagsEnum != 0 {
-		// EnumLiteral type at condition with known value is always truthy or always falsy, likely an error
-		c.error(location, diagnostics.This_condition_will_always_return_0, core.IfElse(evaluator.IsTruthy(t.AsLiteralType().value), "true", "false"))
-		return
+	if ast.IsPropertyAccessExpression(location) {
+		exprSym := core.OrElse(c.getResolvedSymbolOrNil(location.Expression()), c.unknownSymbol)
+		if exprSym.Flags&ast.SymbolFlagsAlias != 0 {
+			exprSym = c.resolveAlias(exprSym)
+		}
+		exprSym = c.getMergedSymbol(exprSym)
+		if exprSym.Flags&ast.SymbolFlagsEnum != 0 {
+			var val any
+			if t.flags&TypeFlagsEnumLiteral != 0 {
+				val = t.AsLiteralType().value
+			} else {
+				leftType := c.checkExpression(location.Expression())
+				propSym := c.getPropertyOfTypeEx(leftType, location.AsPropertyAccessExpression().Name().Text(), false, false)
+				if propSym != nil && len(propSym.Declarations) > 0 {
+					enumVal := c.getEnumMemberValue(propSym.Declarations[0])
+					val = enumVal.Value
+				}
+			}
+			if val != nil {
+				// EnumLiteral or Enum member with known constant value at condition is always truthy or always falsy, likely an error
+				c.error(location, diagnostics.This_condition_will_always_return_0, core.IfElse(evaluator.IsTruthy(val), "true", "false"))
+				return
+			}
+		}
 	}
 	isPropertyExpressionCast := ast.IsPropertyAccessExpression(location) && isTypeAssertion(location.Expression())
 	if !c.hasTypeFacts(t, TypeFactsTruthy) || isPropertyExpressionCast {

--- a/tsc/testdata/tests/cases/conformance/controlFlow/exportedEnumTruthinessTS2845.ts
+++ b/tsc/testdata/tests/cases/conformance/controlFlow/exportedEnumTruthinessTS2845.ts
@@ -1,0 +1,13 @@
+// @strictNullChecks: true
+
+export enum AdapterOutputType {
+  APP_PAGE,
+  PAGES,
+}
+
+declare const type: AdapterOutputType;
+
+const kind =
+  type === AdapterOutputType.APP_PAGE || AdapterOutputType.PAGES
+    ? 'left'
+    : 'right';


### PR DESCRIPTION
Fixes #63565

### Summary of Changes

This PR fixes a diagnostic bug where truthiness expressions evaluating constant `enum` members (e.g., `AdapterOutputType.PAGES`) failed to emit `TS2845: This condition will always return 'true'` when the `enum` declaration was marked with `export`.

#### Root Cause
In `tsc/internal/checker/checker.go`, `checkTestingKnownTruthyType` previously checked `t.flags & TypeFlagsEnumLiteral != 0`. While unexported enum members retain `TypeFlagsEnumLiteral`, exported enum members are widened to `TypeFlagsEnum`, causing the truthiness check to be skipped.

#### Fix
1. Refined `checkTestingKnownTruthyType` to inspect property access expressions on `Enum` symbols regardless of `export` widening.
2. Unaliased and merged symbols for enum entity lookups.
3. Evaluated the enum member's constant initializer via `c.getEnumMemberValue` to determine truthiness when `TypeFlagsEnumLiteral` is absent.
4. Correctly emitted diagnostic `TS2845` based on `evaluator.IsTruthy(val)`.

### Verification

- Verified against unexported `enum`: emits `TS2845`.
- Verified against exported `export enum`: now correctly emits `TS2845`.
- All internal checker unit tests pass cleanly.