### PR TITLE
test: add regression coverage for await in computed member names of namespace classes (#63712)

### DIFF
--- a/tsc/testdata/tests/cases/conformance/async/namespaceAwaitComputedName.ts
+++ b/tsc/testdata/tests/cases/conformance/async/namespaceAwaitComputedName.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// @module: esnext
+
+declare const x: string;
+
+namespace N {
+  class A { [await x]() {} }
+  export class B { [await x]() {} }
+}
+
+export {};


### PR DESCRIPTION
Resolves #63712

### Summary of Changes

Adds a regression test case to verify that diagnostic `TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules` is reported consistently for both exported and unexported classes within namespace declarations.

### Test Coverage

- Added `tsc/testdata/tests/cases/conformance/async/namespaceAwaitComputedName.ts`
- Verifies TS1308 emission for `class A { [await x]() {} }` and `export class B { [await x]() {} }` within a namespace scope.